### PR TITLE
Fixed code artifact in GHA being stored unnecessary long leading to hitting storage rate limits.

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -228,6 +228,7 @@ jobs:
           path: "/tmp/workspace/code"
           include-hidden-files: true
           if-no-files-found: error
+          retention-days: 1
 
       - name: Validate Composer configuration
         run: docker compose exec cli composer validate --strict


### PR DESCRIPTION
Code artifact created during `build` and passed to `deploy` was stored for a full retention period as other artifacts, which filled in the storage:

```
Error: Failed to CreateArtifact: Artifact storage quota has been hit. Unable to upload any new artifacts. Usage is recalculated every 6-12 hours.
More info on storage limits: https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#calculating-minute-and-storage-spending
```

This artifact is only required for a duration of the build, so the storage period should be only 1 day.