### PR TITLE
Minor installer fixes.

### DIFF
--- a/.vortex/installer/src/Command/InstallCommand.php
+++ b/.vortex/installer/src/Command/InstallCommand.php
@@ -29,7 +29,7 @@ class InstallCommand extends Command {
 
   const OPTION_ROOT = 'root';
 
-  const OPTION_NO_ITERACTION = 'no-interaction';
+  const OPTION_NO_INTERACTION = 'no-interaction';
 
   const OPTION_CONFIG = 'config';
 
@@ -75,7 +75,7 @@ EOF
     $this->addArgument(static::ARG_DESTINATION, InputArgument::OPTIONAL, 'Destination directory. Optional. Defaults to the current directory.');
 
     $this->addOption(static::OPTION_ROOT, NULL, InputOption::VALUE_REQUIRED, 'Path to the root for file path resolution. If not specified, current directory is used.');
-    $this->addOption(static::OPTION_NO_ITERACTION, 'n', InputOption::VALUE_NONE, 'Do not ask any interactive question.');
+    $this->addOption(static::OPTION_NO_INTERACTION, 'n', InputOption::VALUE_NONE, 'Do not ask any interactive question.');
     $this->addOption(static::OPTION_CONFIG, 'c', InputOption::VALUE_REQUIRED, 'A JSON string with options.');
     $this->addOption(static::OPTION_URI, 'l', InputOption::VALUE_REQUIRED, 'Remote or local repository URI with an optional git ref set after @.');
   }
@@ -201,7 +201,7 @@ EOF
     $this->config = Config::fromString($config);
 
     $this->config->setQuiet($options[static::OPTION_QUIET]);
-    $this->config->setNoInteraction($options[static::OPTION_NO_ITERACTION]);
+    $this->config->setNoInteraction($options[static::OPTION_NO_INTERACTION]);
 
     // Set root directory to resolve relative paths.
     $root = !empty($options[static::OPTION_ROOT]) && is_scalar($options[static::OPTION_ROOT]) ? strval($options[static::OPTION_ROOT]) : NULL;

--- a/.vortex/installer/src/Utils/Downloader.php
+++ b/.vortex/installer/src/Utils/Downloader.php
@@ -66,6 +66,9 @@ class Downloader {
   }
 
   protected function downloadFromRemote(string $repo, string $ref, ?string $destination): string {
+    if ($destination === null) {
+      throw new \InvalidArgumentException('Destination cannot be null for remote downloads.');
+    }
     $repo_url = str_ends_with($repo, '.git') ? substr($repo, 0, -4) : $repo;
 
     $version = $ref;
@@ -93,6 +96,9 @@ class Downloader {
   }
 
   protected function downloadFromLocal(string $repo, string $ref, ?string $destination): string {
+    if ($destination === null) {
+      throw new \InvalidArgumentException('Destination cannot be null for local downloads.');
+    }
     // Local download does not support version discovery.
     $ref = $ref === Downloader::REF_STABLE ? Downloader::REF_HEAD : $ref;
     $version = $ref;

--- a/.vortex/installer/src/Utils/Downloader.php
+++ b/.vortex/installer/src/Utils/Downloader.php
@@ -66,7 +66,7 @@ class Downloader {
   }
 
   protected function downloadFromRemote(string $repo, string $ref, ?string $destination): string {
-    if ($destination === null) {
+    if ($destination === NULL) {
       throw new \InvalidArgumentException('Destination cannot be null for remote downloads.');
     }
     $repo_url = str_ends_with($repo, '.git') ? substr($repo, 0, -4) : $repo;
@@ -96,7 +96,7 @@ class Downloader {
   }
 
   protected function downloadFromLocal(string $repo, string $ref, ?string $destination): string {
-    if ($destination === null) {
+    if ($destination === NULL) {
       throw new \InvalidArgumentException('Destination cannot be null for local downloads.');
     }
     // Local download does not support version discovery.

--- a/.vortex/installer/src/Utils/Downloader.php
+++ b/.vortex/installer/src/Utils/Downloader.php
@@ -65,7 +65,7 @@ class Downloader {
     return [$repo, $ref];
   }
 
-  protected function downloadFromRemote(string $repo, string $ref, string $destination): string {
+  protected function downloadFromRemote(string $repo, string $ref, ?string $destination): string {
     $repo_url = str_ends_with($repo, '.git') ? substr($repo, 0, -4) : $repo;
 
     $version = $ref;
@@ -92,7 +92,7 @@ class Downloader {
     return $version;
   }
 
-  protected function downloadFromLocal(string $repo, string $ref, string $destination): string {
+  protected function downloadFromLocal(string $repo, string $ref, ?string $destination): string {
     // Local download does not support version discovery.
     $ref = $ref === Downloader::REF_STABLE ? Downloader::REF_HEAD : $ref;
     $version = $ref;

--- a/.vortex/installer/src/Utils/File.php
+++ b/.vortex/installer/src/Utils/File.php
@@ -37,7 +37,6 @@ class File extends UpstreamFile {
       '/LICENSE',
       '/CODE_OF_CONDUCT.md',
       '/CONTRIBUTING.md',
-      '/LICENSE',
       '/SECURITY.md',
       '/.vortex/docs',
       '/.vortex/tests',

--- a/.vortex/installer/src/Utils/Strings.php
+++ b/.vortex/installer/src/Utils/Strings.php
@@ -6,7 +6,7 @@ namespace DrevOps\Installer\Utils;
 
 class Strings {
 
-  public static function utfPos(string $string): ?int {
+  public static function isAsciiStart(string $string): ?int {
     $pos = preg_match('/^[\x00-\x7F]/', $string);
     return $pos !== FALSE ? $pos : NULL;
   }

--- a/.vortex/installer/src/Utils/Tui.php
+++ b/.vortex/installer/src/Utils/Tui.php
@@ -58,7 +58,7 @@ class Tui {
     // @phpstan-ignore-next-line
     $return = spin($action, static::yellow($label));
 
-    static::label($label, $hint && is_callable($hint) ? $hint() : $hint, is_array($return) ? $return : NULL, Strings::utfPos($label) === 0 ? 3 : 2);
+    static::label($label, $hint && is_callable($hint) ? $hint() : $hint, is_array($return) ? $return : NULL, Strings::isAsciiStart($label) === 0 ? 3 : 2);
 
     if ($return === FALSE) {
       $failure = $failure && is_callable($failure) ? $failure() : $failure;
@@ -202,7 +202,7 @@ class Tui {
   }
 
   public static function normalizeText(string $text): string {
-    if (is_null(Strings::utfPos($text))) {
+    if (is_null(Strings::isAsciiStart($text))) {
       return $text;
     }
 
@@ -211,7 +211,7 @@ class Tui {
     preg_match_all('/\X/u', $text, $matches);
 
     $utf8_chars = $matches[0];
-    $utf8_chars = array_map(fn($char): string => Strings::utfPos($char) === 0 ? $char . static::utfPadding($char) : $char, $utf8_chars);
+    $utf8_chars = array_map(fn($char): string => Strings::isAsciiStart($char) === 0 ? $char . static::utfPadding($char) : $char, $utf8_chars);
 
     return implode('', $utf8_chars);
   }

--- a/.vortex/installer/tests/Functional/FunctionalTestCase.php
+++ b/.vortex/installer/tests/Functional/FunctionalTestCase.php
@@ -93,7 +93,7 @@ abstract class FunctionalTestCase extends UnitTestCase {
     }
 
     $defaults = [
-      InstallCommand::OPTION_NO_ITERACTION => TRUE,
+      InstallCommand::OPTION_NO_INTERACTION => TRUE,
       InstallCommand::OPTION_URI => File::dir(static::$root),
     ];
     $options += $defaults;
@@ -108,7 +108,7 @@ abstract class FunctionalTestCase extends UnitTestCase {
   }
 
   protected function runInteractiveInstall(array $answers = [], ?string $dst = NULL, array $options = [], bool $expect_fail = FALSE): void {
-    $this->runNonInteractiveInstall($dst, $options + [InstallCommand::OPTION_NO_ITERACTION => FALSE], $expect_fail);
+    $this->runNonInteractiveInstall($dst, $options + [InstallCommand::OPTION_NO_INTERACTION => FALSE], $expect_fail);
   }
 
   protected function assertSutContains(string $needle): void {

--- a/.vortex/installer/tests/Unit/StringsTest.php
+++ b/.vortex/installer/tests/Unit/StringsTest.php
@@ -14,12 +14,12 @@ use DrevOps\Installer\Utils\Strings;
 #[CoversClass(Strings::class)]
 class StringsTest extends UnitTestCase {
 
-  #[DataProvider('dataProviderUtfPos')]
-  public function testUtfPos(string $input, ?int $expected): void {
-    $this->assertEquals($expected, Strings::utfPos($input));
+  #[DataProvider('dataProviderIsAsciiStart')]
+  public function testIsAsciiStart(string $input, ?int $expected): void {
+    $this->assertEquals($expected, Strings::isAsciiStart($input));
   }
 
-  public static function dataProviderUtfPos(): array {
+  public static function dataProviderIsAsciiStart(): array {
     return [
       ['Hello', 1],
       ['Ångström', 0],


### PR DESCRIPTION
- Changed wording for utfPos() to isAsciiStart() because this method checks if the string starts with Ascii.
- Removed duplicate from .vortex/installer/src/Utils/File.php
- Fixed typo in OPTION_NO_ITERACTION
- Made $destination optional in protected function `downloadFromRemote(string $repo, string $ref, ?string $destination): string {` because it is optional in the calling method `public function download(string $repo, string $ref, ?string $dst = NULL): string {`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the "no-interaction" command-line option, ensuring it works as expected during installations.
	- Removed a duplicate entry from the internal file paths list to prevent redundancy.
- **Refactor**
	- Renamed a method for checking if a string starts with an ASCII character, improving code clarity.
	- Updated internal logic to use the new method name for ASCII detection in text processing.
	- Allowed destination paths to be nullable in certain download operations, enforcing non-null destinations.
- **Tests**
	- Updated test method names and logic to align with the renamed ASCII detection method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->