### PR TITLE
Updated CI Runner to 25.5.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ aliases:
       # This container has all the necessary tools to run a dockerized environment.
       # https://github.com/drevops/ci-runner
       # https://hub.docker.com/repository/docker/drevops/ci-runner/tags
-      - image: drevops/ci-runner:25.3.0
+      - image: drevops/ci-runner:25.5.0
         auth:
           username: ${VORTEX_CONTAINER_REGISTRY_USER}
           password: ${VORTEX_CONTAINER_REGISTRY_PASS}

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: drevops/ci-runner:25.3.0
+      image: drevops/ci-runner:25.5.0
 
       env:
         TZ: Australia/Melbourne
@@ -165,7 +165,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: drevops/ci-runner:25.3.0
+      image: drevops/ci-runner:25.5.0
 
       env:
         TZ: Australia/Melbourne
@@ -363,7 +363,7 @@ jobs:
     #;> !PROVISION_TYPE_PROFILE
 
     container:
-      image: drevops/ci-runner:25.3.0
+      image: drevops/ci-runner:25.5.0
       env:
         TZ: Australia/Melbourne
         TERM: xterm-256color

--- a/.github/workflows/vortex-test-common.yml
+++ b/.github/workflows/vortex-test-common.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: drevops/ci-runner:25.3.0
+      image: drevops/ci-runner:25.5.0
       env:
         # Prevent GitHub overriding the Docker config.
         DOCKER_CONFIG: /root/.docker
@@ -101,7 +101,7 @@ jobs:
         batch: [0, 1, 2, 3]
 
     container:
-      image: drevops/ci-runner:25.3.0
+      image: drevops/ci-runner:25.5.0
       env:
         # Prevent GitHub overriding the Docker config.
         DOCKER_CONFIG: /root/.docker
@@ -161,7 +161,7 @@ jobs:
         batch: [0, 1]
 
     container:
-      image: drevops/ci-runner:25.3.0
+      image: drevops/ci-runner:25.5.0
       env:
         # Prevent GitHub overriding the Docker config.
         DOCKER_CONFIG: /root/.docker


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the Docker container image version used in CI/CD pipelines to ensure all related jobs run with the latest stable runner environment. No changes were made to job steps or configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->