### PR TITLE
[#1678] Updated PHPCS configuration to remove Generic.Debug.ESLint rule

### DIFF
--- a/.vortex/installer/tests/Fixtures/install/_baseline/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/phpcs.xml
@@ -11,7 +11,6 @@
     <rule ref="Drupal"/>
     <rule ref="DrupalPractice"/>
     <rule ref="Generic.PHP.RequireStrictTypes" />
-    <rule ref="Generic.Debug.ESLint"/>
     <rule ref="PHPCompatibility"/>
 
     <arg name="extensions" value="inc,info,install,module,php,profile,test,theme,js,css"/>

--- a/.vortex/installer/tests/Fixtures/install/hosting_acquia/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/install/hosting_acquia/phpcs.xml
@@ -13,7 +13,7 @@
      <file>tests</file>
  
      <rule ref="Drupal"/>
-@@ -23,10 +23,10 @@
+@@ -22,10 +22,10 @@
      <config name="testVersion" value="8.3"/>
  
      <!-- Exclude theme assets. -->

--- a/.vortex/installer/tests/Fixtures/install/theme_absent/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/install/theme_absent/phpcs.xml
@@ -6,7 +6,7 @@
      <file>web/sites/default/settings.php</file>
      <file>web/sites/default/includes</file>
      <file>tests</file>
-@@ -23,10 +22,6 @@
+@@ -22,10 +21,6 @@
      <config name="testVersion" value="8.3"/>
  
      <!-- Exclude theme assets. -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,7 +11,6 @@
     <rule ref="Drupal"/>
     <rule ref="DrupalPractice"/>
     <rule ref="Generic.PHP.RequireStrictTypes" />
-    <rule ref="Generic.Debug.ESLint"/>
     <rule ref="PHPCompatibility"/>
 
     <arg name="extensions" value="inc,info,install,module,php,profile,test,theme,js,css"/>


### PR DESCRIPTION
Closes #1678 

## Summary
- Removed `Generic.Debug.ESLint` rule from phpcs.xml configuration
- Updated all installer test fixtures to match the configuration change
- Fixed baseline and scenario-specific fixtures across all hosting and theme combinations

## Test plan
- [x] All 233 installer tests pass
- [x] All 8 BATS provision tests pass
- [x] PHPCS configuration validates correctly
- [x] Test fixtures regenerated and verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated PHPCS configuration files to remove specific rule references and adjust directory paths.
  - Refined file and exclude patterns for improved standards coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->