### PR TITLE
[#1688] Allow to run Renovate from GHA UI.

### DIFF
--- a/.github/workflows/deps-updates.yml
+++ b/.github/workflows/deps-updates.yml
@@ -3,6 +3,7 @@ name: Dependency updates
 on:
   schedule:
     - cron: '45 11,23 * * *'
+  workflow_dispatch:
 
 jobs:
   deps-updates:

--- a/.vortex/docs/content/tools/renovate.mdx
+++ b/.vortex/docs/content/tools/renovate.mdx
@@ -22,6 +22,7 @@ project.
 4. Automatically adds a `dependencies` label to a pull request.
 5. Automatically adds assignees to a pull request.
 6. Configuration for running Renovate self-hosted instance using CircleCI.
+7. Manual trigger from GitHub Actions UI.
 
 ## Self-hosted vs GitHub app
 

--- a/.vortex/installer/tests/Fixtures/install/_baseline/.github/workflows/deps-updates.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/.github/workflows/deps-updates.yml
@@ -3,6 +3,7 @@ name: Dependency updates
 on:
   schedule:
     - cron: '45 11,23 * * *'
+  workflow_dispatch:
 
 jobs:
   deps-updates:

--- a/.vortex/installer/tests/Fixtures/install/names/.github/workflows/deps-updates.yml
+++ b/.vortex/installer/tests/Fixtures/install/names/.github/workflows/deps-updates.yml
@@ -1,4 +1,4 @@
-@@ -39,4 +39,4 @@
+@@ -40,4 +40,4 @@
            RENOVATE_DEPENDENCY_DASHBOARD_TITLE: 'Renovate Dependency Dashboard (self-hosted) by GitHub Actions'
            RENOVATE_DEPENDENCY_DASHBOARD: ${{ vars.RENOVATE_DEPENDENCY_DASHBOARD || 'false' }}
            RENOVATE_DRY_RUN: ${{ vars.RENOVATE_DRY_RUN || 'false' }}


### PR DESCRIPTION
closes #1688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to manually trigger dependency update workflows from the GitHub Actions UI.

- **Documentation**
  - Updated Renovate documentation to highlight the new manual trigger feature.

- **Chores**
  - Updated workflow configuration to support manual runs and changed the default email address for workflow commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->