### PR TITLE
Added debug log level for Renovate in GHA.

### DIFF
--- a/.github/workflows/deps-updates.yml
+++ b/.github/workflows/deps-updates.yml
@@ -41,3 +41,4 @@ jobs:
           RENOVATE_DEPENDENCY_DASHBOARD: ${{ vars.RENOVATE_DEPENDENCY_DASHBOARD || 'false' }}
           RENOVATE_DRY_RUN: ${{ vars.RENOVATE_DRY_RUN || 'false' }}
           RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR || 'Renovate Self Hosted <renovatebot@your-site-domain.example>' }}
+          LOG_LEVEL: 'debug'

--- a/.vortex/installer/composer.json
+++ b/.vortex/installer/composer.json
@@ -90,7 +90,7 @@
             "rector --clear-cache",
             "phpcbf"
         ],
-        "reset": "rm -Rf vendor vendor-bin composer.lock",
+        "reset": "rm -Rf vendor vendor-bin",
         "test": "phpunit --no-coverage",
         "test-coverage": "php -d pcov.directory=. vendor/bin/phpunit"
     }

--- a/.vortex/installer/tests/Fixtures/install/_baseline/.github/workflows/deps-updates.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/.github/workflows/deps-updates.yml
@@ -41,3 +41,4 @@ jobs:
           RENOVATE_DEPENDENCY_DASHBOARD: ${{ vars.RENOVATE_DEPENDENCY_DASHBOARD || 'false' }}
           RENOVATE_DRY_RUN: ${{ vars.RENOVATE_DRY_RUN || 'false' }}
           RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR || 'Renovate Self Hosted <renovatebot@star-wars-domain.example>' }}
+          LOG_LEVEL: 'debug'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enabled debug-level logging for the Renovate process in the dependency update workflow.
- **Refactor**
  - Updated the reset script to preserve the composer.lock file when resetting dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->