### PR TITLE
[#1668] Allow to import from a custom file using `ahoy import`.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -148,7 +148,7 @@ commands:
 
   import-db:
     usage: Import database from dump.
-    cmd: VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ahoy cli ./scripts/vortex/provision.sh
+    cmd: VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 VORTEX_PROVISION_DB="$@" ahoy cli ./scripts/vortex/provision.sh
 
   pull-db:
     usage: Download database image with the latest nightly dump. Run "ahoy reload-db" to reload DB in the running stack.

--- a/.vortex/docs/content/workflows/variables.mdx
+++ b/.vortex/docs/content/workflows/variables.mdx
@@ -1481,6 +1481,14 @@ Default value: `UNDEFINED`
 
 Defined in: `ACQUIA ENVIRONMENT`
 
+### `VORTEX_PROVISION_DB`
+
+Provision database dump file.<br/>If not set, it will be auto-discovered from the VORTEX_DB_DIR directory using<br/>the VORTEX_DB_FILE name.
+
+Default value: `UNDEFINED`
+
+Defined in: `scripts/vortex/provision.sh`
+
 ### `VORTEX_PROVISION_OVERRIDE_DB`
 
 Overwrite a database if it exists.
@@ -1544,6 +1552,14 @@ Database sanitization is enabled by default in all non-production<br/>environmen
 Default value: `UNDEFINED`
 
 Defined in: `.env`, `scripts/vortex/provision.sh`
+
+### `VORTEX_PROVISION_SCRIPTS_DIR`
+
+Directory with custom provision scripts.
+
+Default value: `./scripts/custom`
+
+Defined in: `scripts/vortex/provision.sh`
 
 ### `VORTEX_PROVISION_SKIP`
 

--- a/.vortex/installer/tests/Fixtures/install/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/.ahoy.yml
@@ -141,7 +141,7 @@ commands:
 
   import-db:
     usage: Import database from dump.
-    cmd: VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ahoy cli ./scripts/vortex/provision.sh
+    cmd: VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 VORTEX_PROVISION_DB="$@" ahoy cli ./scripts/vortex/provision.sh
 
   pull-db:
     usage: Download database image with the latest nightly dump. Run "ahoy reload-db" to reload DB in the running stack.

--- a/.vortex/tests/bats/_helper.workflow.bash
+++ b/.vortex/tests/bats/_helper.workflow.bash
@@ -325,8 +325,10 @@ assert_ahoy_login() {
 
 assert_ahoy_export_db() {
   step "Export DB"
-  file="${1:-mydb.sql}"
+
+  file="${1:-}"
   run ahoy export-db "${file}"
+
   assert_success
   assert_output_not_contains "Containers are not running."
   sync_to_host
@@ -335,7 +337,9 @@ assert_ahoy_export_db() {
 
 assert_ahoy_import_db() {
   step "Import DB"
-  run ahoy import-db
+
+  run ahoy import-db "${1-}"
+
   assert_success
   assert_output_contains "Provisioning site from the database dump file."
   assert_output_not_contains "Running deployment operations via 'drush deploy:hook'."

--- a/.vortex/tests/bats/workflow.install.db.bats
+++ b/.vortex/tests/bats/workflow.install.db.bats
@@ -34,9 +34,17 @@ load _helper.workflow.bash
 
   assert_ahoy_login
 
+  # Export to default file.
   assert_ahoy_export_db
 
+  # Export to custom file.
+  assert_ahoy_export_db "mydb.sql"
+
+  # Import from default file.
   assert_ahoy_import_db
+
+  # Import from custom file.
+  assert_ahoy_import_db "mydb.sql"
 
   assert_ahoy_lint
 


### PR DESCRIPTION
Closes #1668
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for specifying a custom database dump file and custom provision scripts directory via new environment variables.
- **Documentation**
	- Updated documentation to describe the new environment variables for database provisioning and custom scripts.
- **Tests**
	- Improved test coverage and clarity for database import/export commands, including handling of optional file arguments and enhanced test comments for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->