### PR TITLE
[#1672] Added support for database charset and collation to be taken from the env variables.

### DIFF
--- a/.vortex/docs/.utils/variables/extra/docker-compose.variables.sh
+++ b/.vortex/docs/.utils/variables/extra/docker-compose.variables.sh
@@ -14,16 +14,36 @@ DRUPAL_PRIVATE_FILES="${DRUPAL_PRIVATE_FILES:-${DRUPAL_PUBLIC_FILES}/private}"
 DRUPAL_TEMPORARY_FILES="${DRUPAL_TEMPORARY_FILES:-${DRUPAL_PRIVATE_FILES}/tmp}"
 
 # Local database host.
+#
+# Variable is not used in hosting environment.
 DATABASE_HOST=database
 
 # Local database name.
+#
+# Variable is not used in hosting environment.
 DATABASE_NAME=drupal
 
 # Local database user.
+#
+# Variable is not used in hosting environment.
 DATABASE_USERNAME=drupal
 
 # Local database password.
+#
+# Variable is not used in hosting environment.
 DATABASE_PASSWORD=drupal
 
 # Local database port.
+#
+# Variable is not used in hosting environment.
 DATABASE_PORT=3306
+
+# Local database charset.
+#
+# Variable is not used in hosting environment.
+DATABASE_CHARSET=utf8mb4
+
+# Local database collation.
+#
+# Variable is not used in hosting environment.
+DATABASE_COLLATION=utf8mb4_general_ci

--- a/.vortex/docs/content/workflows/variables.mdx
+++ b/.vortex/docs/content/workflows/variables.mdx
@@ -44,6 +44,26 @@ Default value: `UNDEFINED`
 
 Defined in: `ENVIRONMENT`
 
+### `DATABASE_CHARSET`
+
+Local database charset.
+
+Variable is not used in hosting environment.
+
+Default value: `utf8mb4`
+
+Defined in: `docker-compose.yml`
+
+### `DATABASE_COLLATION`
+
+Local database collation.
+
+Variable is not used in hosting environment.
+
+Default value: `utf8mb4_general_ci`
+
+Defined in: `docker-compose.yml`
+
 ### `DATABASE_DATABASE`
 
 Database name.
@@ -56,6 +76,8 @@ Defined in: `LAGOON ENVIRONMENT`
 
 Local database host.
 
+Variable is not used in hosting environment.
+
 Default value: `database`
 
 Defined in: `docker-compose.yml`, `scripts/vortex/info.sh`
@@ -63,6 +85,8 @@ Defined in: `docker-compose.yml`, `scripts/vortex/info.sh`
 ### `DATABASE_NAME`
 
 Local database name.
+
+Variable is not used in hosting environment.
 
 Default value: `drupal`
 
@@ -72,6 +96,8 @@ Defined in: `docker-compose.yml`
 
 Local database password.
 
+Variable is not used in hosting environment.
+
 Default value: `drupal`
 
 Defined in: `docker-compose.yml`, `scripts/vortex/info.sh`
@@ -80,6 +106,8 @@ Defined in: `docker-compose.yml`, `scripts/vortex/info.sh`
 
 Local database port.
 
+Variable is not used in hosting environment.
+
 Default value: `3306`
 
 Defined in: `docker-compose.yml`, `scripts/vortex/info.sh`
@@ -87,6 +115,8 @@ Defined in: `docker-compose.yml`, `scripts/vortex/info.sh`
 ### `DATABASE_USERNAME`
 
 Local database user.
+
+Variable is not used in hosting environment.
 
 Default value: `drupal`
 

--- a/.vortex/installer/tests/Fixtures/install/_baseline/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/docker-compose.yml
@@ -34,24 +34,28 @@ x-user: &default-user
 # Environment variables set in all containers during build and runtime.
 x-environment: &default-environment
   TZ: ${TZ:-Australia/Melbourne}
+  # Pass-through 'CI' variable used to identify the CI environment.
+  CI: ${CI:-}
+  # Pass-through 'XDEBUG_ENABLE' to enable XDebug with "ahoy debug" or "XDEBUG_ENABLE=true docker compose up -d".
+  XDEBUG_ENABLE: ${XDEBUG_ENABLE:-}
   # Local development URL.
   VORTEX_LOCALDEV_URL: &default-url ${COMPOSE_PROJECT_NAME:-example-site}.docker.amazee.io
   # Local development route used in Lagoon images and Pygmy to route requests.
   LAGOON_ROUTE: *default-url
-  # Local database host (not used in production).
+  # Local database host (variable is not used in hosting environment).
   DATABASE_HOST: database
-  # Local database name (not used in production).
+  # Local database name (variable is not used in hosting environment).
   DATABASE_NAME: drupal
-  # Local database user (not used in production).
+  # Local database user (variable is not used in hosting environment).
   DATABASE_USERNAME: drupal
-  # Local database password (not used in production).
+  # Local database password (variable is not used in hosting environment).
   DATABASE_PASSWORD: drupal
-  # Local database port (not used in production).
+  # Local database port (variable is not used in hosting environment).
   DATABASE_PORT: 3306
-  # Pass-through 'XDEBUG_ENABLE' to enable XDebug with "ahoy debug" or "XDEBUG_ENABLE=true docker compose up -d".
-  XDEBUG_ENABLE: ${XDEBUG_ENABLE:-}
-  # Pass-through 'CI' variable used to identify the CI environment.
-  CI: ${CI:-}
+  # Local database charset (variable is not used in hosting environment).
+  DATABASE_CHARSET: utf8mb4
+  # Local database collation (variable is not used in hosting environment).
+  DATABASE_COLLATION: utf8mb4_general_ci
   DRUPAL_THEME: ${DRUPAL_THEME:-}
   # Path to configuration files.
   DRUPAL_CONFIG_PATH: ${DRUPAL_CONFIG_PATH:-/app/config/default}

--- a/.vortex/installer/tests/Fixtures/install/_baseline/tests/phpunit/Drupal/DatabaseSettingsTest.php
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/tests/phpunit/Drupal/DatabaseSettingsTest.php
@@ -41,6 +41,8 @@ class DatabaseSettingsTest extends SettingsTestCase {
               'password' => 'drupal',
               'host' => 'localhost',
               'port' => '',
+              'charset' => 'utf8mb4',
+              'collation' => 'utf8mb4_general_ci',
               'driver' => 'mysql',
               'prefix' => '',
             ],
@@ -50,20 +52,24 @@ class DatabaseSettingsTest extends SettingsTestCase {
 
       [
         [
-          'DATABASE_NAME' => 'test_db_name',
-          'DATABASE_USERNAME' => 'test_db_user',
-          'DATABASE_PASSWORD' => 'test_db_pass',
-          'DATABASE_HOST' => 'test_db_host',
-          'DATABASE_PORT' => 'test_db_port',
+          'DATABASE_NAME' => 'database_db_name',
+          'DATABASE_USERNAME' => 'database_db_user',
+          'DATABASE_PASSWORD' => 'database_db_pass',
+          'DATABASE_HOST' => 'database_db_host',
+          'DATABASE_PORT' => 'database_db_port',
+          'DATABASE_CHARSET' => 'database_utf8',
+          'DATABASE_COLLATION' => 'database_utf8_unicode_ci',
         ],
         [
           'default' => [
             'default' => [
-              'database' => 'test_db_name',
-              'username' => 'test_db_user',
-              'password' => 'test_db_pass',
-              'host' => 'test_db_host',
-              'port' => 'test_db_port',
+              'database' => 'database_db_name',
+              'username' => 'database_db_user',
+              'password' => 'database_db_pass',
+              'host' => 'database_db_host',
+              'port' => 'database_db_port',
+              'charset' => 'database_utf8',
+              'collation' => 'database_utf8_unicode_ci',
               'driver' => 'mysql',
               'prefix' => '',
             ],
@@ -73,20 +79,51 @@ class DatabaseSettingsTest extends SettingsTestCase {
 
       [
         [
-          'DATABASE_DATABASE' => 'test_db_name',
-          'DATABASE_USERNAME' => 'test_db_user',
-          'DATABASE_PASSWORD' => 'test_db_pass',
-          'DATABASE_HOST' => 'test_db_host',
-          'DATABASE_PORT' => 'test_db_port',
+          'MARIADB_DATABASE' => 'mariadb_db_name',
+          'MARIADB_USERNAME' => 'mariadb_db_user',
+          'MARIADB_PASSWORD' => 'mariadb_db_pass',
+          'MARIADB_HOST' => 'mariadb_db_host',
+          'MARIADB_PORT' => 'mariadb_db_port',
+          'MARIADB_CHARSET' => 'mariadb_latin1',
+          'MARIADB_COLLATION' => 'mariadb_latin1_swedish_ci',
         ],
         [
           'default' => [
             'default' => [
-              'database' => 'test_db_name',
-              'username' => 'test_db_user',
-              'password' => 'test_db_pass',
-              'host' => 'test_db_host',
-              'port' => 'test_db_port',
+              'database' => 'mariadb_db_name',
+              'username' => 'mariadb_db_user',
+              'password' => 'mariadb_db_pass',
+              'host' => 'mariadb_db_host',
+              'port' => 'mariadb_db_port',
+              'charset' => 'mariadb_latin1',
+              'collation' => 'mariadb_latin1_swedish_ci',
+              'driver' => 'mysql',
+              'prefix' => '',
+            ],
+          ],
+        ],
+      ],
+
+      [
+        [
+          'DATABASE_DATABASE' => 'database_db_name',
+          'DATABASE_USERNAME' => 'database_db_user',
+          'DATABASE_PASSWORD' => 'database_db_pass',
+          'DATABASE_HOST' => 'database_db_host',
+          'DATABASE_PORT' => 'database_db_port',
+          'MYSQL_CHARSET' => 'mysql_utf8mb3',
+          'MYSQL_COLLATION' => 'mysql_utf8mb3_bin',
+        ],
+        [
+          'default' => [
+            'default' => [
+              'database' => 'database_db_name',
+              'username' => 'database_db_user',
+              'password' => 'database_db_pass',
+              'host' => 'database_db_host',
+              'port' => 'database_db_port',
+              'charset' => 'mysql_utf8mb3',
+              'collation' => 'mysql_utf8mb3_bin',
               'driver' => 'mysql',
               'prefix' => '',
             ],

--- a/.vortex/installer/tests/Fixtures/install/_baseline/web/sites/default/settings.php
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/web/sites/default/settings.php
@@ -123,6 +123,8 @@ $databases = [
           'password' => getenv('DATABASE_PASSWORD') ?: getenv('MARIADB_PASSWORD') ?: 'drupal',
           'host' => getenv('DATABASE_HOST') ?: getenv('MARIADB_HOST') ?: 'localhost',
           'port' => getenv('DATABASE_PORT') ?: getenv('MARIADB_PORT') ?: '',
+          'charset' => getenv('DATABASE_CHARSET') ?: getenv('MARIADB_CHARSET') ?: getenv('MYSQL_CHARSET') ?: 'utf8mb4',
+          'collation' => getenv('DATABASE_COLLATION') ?: getenv('MARIADB_COLLATION') ?: getenv('MYSQL_COLLATION') ?: 'utf8mb4_general_ci',
           'prefix' => '',
           'driver' => 'mysql',
         ],

--- a/.vortex/installer/tests/Fixtures/install/hosting_acquia/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/hosting_acquia/docker-compose.yml
@@ -11,7 +11,7 @@
  
  # The default user under which the containers should run.
  x-user: &default-user
-@@ -56,8 +56,8 @@
+@@ -60,8 +60,8 @@
    # Path to configuration files.
    DRUPAL_CONFIG_PATH: ${DRUPAL_CONFIG_PATH:-/app/config/default}
    # Drupal file paths.
@@ -22,7 +22,7 @@
    DRUPAL_TEMPORARY_FILES: ${DRUPAL_TEMPORARY_FILES:-/tmp}
    # Drupal Shield credentials.
    DRUPAL_SHIELD_USER: ${DRUPAL_SHIELD_USER:-}
-@@ -95,8 +95,8 @@
+@@ -99,8 +99,8 @@
          CLI_IMAGE: *cli-image
          WEBROOT: "${WEBROOT:-web}"
          DRUPAL_CONFIG_PATH: ${DRUPAL_CONFIG_PATH:-/app/config/default}

--- a/.vortex/installer/tests/Fixtures/install/hosting_acquia/docroot/sites/default/settings.php
+++ b/.vortex/installer/tests/Fixtures/install/hosting_acquia/docroot/sites/default/settings.php
@@ -123,6 +123,8 @@ $databases = [
           'password' => getenv('DATABASE_PASSWORD') ?: getenv('MARIADB_PASSWORD') ?: 'drupal',
           'host' => getenv('DATABASE_HOST') ?: getenv('MARIADB_HOST') ?: 'localhost',
           'port' => getenv('DATABASE_PORT') ?: getenv('MARIADB_PORT') ?: '',
+          'charset' => getenv('DATABASE_CHARSET') ?: getenv('MARIADB_CHARSET') ?: getenv('MYSQL_CHARSET') ?: 'utf8mb4',
+          'collation' => getenv('DATABASE_COLLATION') ?: getenv('MARIADB_COLLATION') ?: getenv('MYSQL_COLLATION') ?: 'utf8mb4_general_ci',
           'prefix' => '',
           'driver' => 'mysql',
         ],

--- a/.vortex/installer/tests/Fixtures/install/hosting_lagoon/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/hosting_lagoon/docker-compose.yml
@@ -5,8 +5,8 @@
 +# Note that these variables are not read from here in Lagoon environment.
  x-environment: &default-environment
    TZ: ${TZ:-Australia/Melbourne}
-   # Local development URL.
-@@ -86,6 +87,10 @@
+   # Pass-through 'CI' variable used to identify the CI environment.
+@@ -90,6 +91,10 @@
      # Mount volumes from the ssh-agent running in Pygmy to inject host SSH key into container. See https://pygmy.readthedocs.io/en/master/ssh_agent/
      volumes_from: ### Local overrides to mount host SSH keys. Automatically removed in CI.
        - container:amazeeio-ssh-agent ### Local overrides to mount host SSH keys. Automatically removed in CI.
@@ -17,7 +17,7 @@
  
    nginx:
      build:
-@@ -106,6 +111,11 @@
+@@ -110,6 +115,11 @@
      networks:
        - default # This is a standard network and is used for all other environments, where requests routing is not required and/or not supported.
        - amazeeio-network ### This network is supported by Pygmy and used to route all requests to host machine locally. Removed in CI.
@@ -29,7 +29,7 @@
  
    # PHP FPM container. All web requests are going through this container.
    php:
-@@ -119,6 +129,11 @@
+@@ -123,6 +133,11 @@
        <<: *default-environment
      depends_on:
        - cli
@@ -41,7 +41,7 @@
  
    database:
      build:
-@@ -131,9 +146,13 @@
+@@ -135,9 +150,13 @@
        <<: *default-environment
      ports:
        - "3306" # Database port in a container. Find port on host with `ahoy info` or `docker compose port database 3306`.
@@ -55,7 +55,7 @@
  
    solr:
      build:
-@@ -149,6 +168,8 @@
+@@ -153,6 +172,8 @@
        - "8983" # Solr port in a container. Find port on host with `ahoy info` or `docker compose port solr 8983`.
      volumes:
        - solr:/var/solr
@@ -64,7 +64,7 @@
  
    clamav:
      build:
-@@ -161,6 +182,10 @@
+@@ -165,6 +186,10 @@
        << : *default-environment
      networks:
        - default
@@ -75,7 +75,7 @@
  
    # Chrome container, used for browser testing.
    chrome:
-@@ -173,6 +198,8 @@
+@@ -177,6 +202,8 @@
        <<: *default-environment
      depends_on:
        - cli
@@ -84,7 +84,7 @@
  
    # Helper container to wait for services to become available.
    wait_dependencies:
-@@ -182,6 +209,8 @@
+@@ -186,6 +213,8 @@
        - database
        - clamav
      command: database:3306 clamav:3310

--- a/.vortex/installer/tests/Fixtures/install/provision_database_lagoon/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/provision_database_lagoon/docker-compose.yml
@@ -5,8 +5,8 @@
 +# Note that these variables are not read from here in Lagoon environment.
  x-environment: &default-environment
    TZ: ${TZ:-Australia/Melbourne}
-   # Local development URL.
-@@ -86,6 +87,10 @@
+   # Pass-through 'CI' variable used to identify the CI environment.
+@@ -90,6 +91,10 @@
      # Mount volumes from the ssh-agent running in Pygmy to inject host SSH key into container. See https://pygmy.readthedocs.io/en/master/ssh_agent/
      volumes_from: ### Local overrides to mount host SSH keys. Automatically removed in CI.
        - container:amazeeio-ssh-agent ### Local overrides to mount host SSH keys. Automatically removed in CI.
@@ -17,7 +17,7 @@
  
    nginx:
      build:
-@@ -106,6 +111,11 @@
+@@ -110,6 +115,11 @@
      networks:
        - default # This is a standard network and is used for all other environments, where requests routing is not required and/or not supported.
        - amazeeio-network ### This network is supported by Pygmy and used to route all requests to host machine locally. Removed in CI.
@@ -29,7 +29,7 @@
  
    # PHP FPM container. All web requests are going through this container.
    php:
-@@ -119,6 +129,11 @@
+@@ -123,6 +133,11 @@
        <<: *default-environment
      depends_on:
        - cli
@@ -41,7 +41,7 @@
  
    database:
      build:
-@@ -131,9 +146,13 @@
+@@ -135,9 +150,13 @@
        <<: *default-environment
      ports:
        - "3306" # Database port in a container. Find port on host with `ahoy info` or `docker compose port database 3306`.
@@ -55,7 +55,7 @@
  
    solr:
      build:
-@@ -149,6 +168,8 @@
+@@ -153,6 +172,8 @@
        - "8983" # Solr port in a container. Find port on host with `ahoy info` or `docker compose port solr 8983`.
      volumes:
        - solr:/var/solr
@@ -64,7 +64,7 @@
  
    clamav:
      build:
-@@ -161,6 +182,10 @@
+@@ -165,6 +186,10 @@
        << : *default-environment
      networks:
        - default
@@ -75,7 +75,7 @@
  
    # Chrome container, used for browser testing.
    chrome:
-@@ -173,6 +198,8 @@
+@@ -177,6 +202,8 @@
        <<: *default-environment
      depends_on:
        - cli
@@ -84,7 +84,7 @@
  
    # Helper container to wait for services to become available.
    wait_dependencies:
-@@ -182,6 +209,8 @@
+@@ -186,6 +213,8 @@
        - database
        - clamav
      command: database:3306 clamav:3310

--- a/.vortex/installer/tests/Fixtures/install/services_no_clamav/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_no_clamav/docker-compose.yml
@@ -1,4 +1,4 @@
-@@ -150,18 +150,6 @@
+@@ -154,18 +154,6 @@
      volumes:
        - solr:/var/solr
  
@@ -17,7 +17,7 @@
    # Chrome container, used for browser testing.
    chrome:
      image: selenium/standalone-chromium:__VERSION__
-@@ -180,8 +168,7 @@
+@@ -184,8 +172,7 @@
      depends_on:
        - cli
        - database

--- a/.vortex/installer/tests/Fixtures/install/services_no_solr/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_no_solr/docker-compose.yml
@@ -1,4 +1,4 @@
-@@ -135,21 +135,6 @@
+@@ -139,21 +139,6 @@
    valkey:
      image: uselagoon/valkey-8:__VERSION__
  
@@ -20,7 +20,7 @@
    clamav:
      build:
        context: .
-@@ -190,4 +175,3 @@
+@@ -194,4 +179,3 @@
  volumes:
    app: {}
    files: {}

--- a/.vortex/installer/tests/Fixtures/install/services_no_valkey/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_no_valkey/docker-compose.yml
@@ -1,4 +1,4 @@
-@@ -62,8 +62,6 @@
+@@ -66,8 +66,6 @@
    # Drupal Shield credentials.
    DRUPAL_SHIELD_USER: ${DRUPAL_SHIELD_USER:-}
    DRUPAL_SHIELD_PASS: ${DRUPAL_SHIELD_PASS:-}
@@ -7,7 +7,7 @@
  
  # ------------------------------------------------------------------------------
  # Services.
-@@ -131,9 +129,6 @@
+@@ -135,9 +133,6 @@
        <<: *default-environment
      ports:
        - "3306" # Database port in a container. Find port on host with `ahoy info` or `docker compose port database 3306`.

--- a/.vortex/installer/tests/Fixtures/install/services_none/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_none/docker-compose.yml
@@ -1,4 +1,4 @@
-@@ -62,8 +62,6 @@
+@@ -66,8 +66,6 @@
    # Drupal Shield credentials.
    DRUPAL_SHIELD_USER: ${DRUPAL_SHIELD_USER:-}
    DRUPAL_SHIELD_PASS: ${DRUPAL_SHIELD_PASS:-}
@@ -7,7 +7,7 @@
  
  # ------------------------------------------------------------------------------
  # Services.
-@@ -132,36 +130,6 @@
+@@ -136,36 +134,6 @@
      ports:
        - "3306" # Database port in a container. Find port on host with `ahoy info` or `docker compose port database 3306`.
  
@@ -44,7 +44,7 @@
    # Chrome container, used for browser testing.
    chrome:
      image: selenium/standalone-chromium:__VERSION__
-@@ -180,8 +148,7 @@
+@@ -184,8 +152,7 @@
      depends_on:
        - cli
        - database
@@ -54,7 +54,7 @@
  
  networks:           ### Use external networks locally. Automatically removed in CI.
    amazeeio-network: ### Automatically removed in CI.
-@@ -190,4 +157,3 @@
+@@ -194,4 +161,3 @@
  volumes:
    app: {}
    files: {}

--- a/.vortex/installer/tests/Fixtures/install/theme_absent/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/theme_absent/docker-compose.yml
@@ -1,7 +1,7 @@
-@@ -52,7 +52,6 @@
-   XDEBUG_ENABLE: ${XDEBUG_ENABLE:-}
-   # Pass-through 'CI' variable used to identify the CI environment.
-   CI: ${CI:-}
+@@ -56,7 +56,6 @@
+   DATABASE_CHARSET: utf8mb4
+   # Local database collation (variable is not used in hosting environment).
+   DATABASE_COLLATION: utf8mb4_general_ci
 -  DRUPAL_THEME: ${DRUPAL_THEME:-}
    # Path to configuration files.
    DRUPAL_CONFIG_PATH: ${DRUPAL_CONFIG_PATH:-/app/config/default}

--- a/.vortex/tests/bats/fixtures/docker-compose.env.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.env.json
@@ -18,6 +18,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -75,6 +77,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -123,6 +127,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -178,6 +184,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -234,6 +242,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -295,6 +305,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -356,6 +368,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",

--- a/.vortex/tests/bats/fixtures/docker-compose.env_local.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.env_local.json
@@ -18,6 +18,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -75,6 +77,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -123,6 +127,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -178,6 +184,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -234,6 +242,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -295,6 +305,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -356,6 +368,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",

--- a/.vortex/tests/bats/fixtures/docker-compose.env_mod.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.env_mod.json
@@ -18,6 +18,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -75,6 +77,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -123,6 +127,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -178,6 +184,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -234,6 +242,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -295,6 +305,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -356,6 +368,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",

--- a/.vortex/tests/bats/fixtures/docker-compose.noenv.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.noenv.json
@@ -18,6 +18,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -75,6 +77,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -123,6 +127,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -178,6 +184,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -234,6 +242,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -295,6 +305,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",
@@ -356,6 +368,8 @@
             "entrypoint": null,
             "environment": {
                 "CI": "true",
+                "DATABASE_CHARSET": "utf8mb4",
+                "DATABASE_COLLATION": "utf8mb4_general_ci",
                 "DATABASE_HOST": "database",
                 "DATABASE_NAME": "drupal",
                 "DATABASE_PASSWORD": "drupal",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,24 +42,28 @@ x-user: &default-user
 #;> HOSTING_LAGOON
 x-environment: &default-environment
   TZ: ${TZ:-Australia/Melbourne}
+  # Pass-through 'CI' variable used to identify the CI environment.
+  CI: ${CI:-}
+  # Pass-through 'XDEBUG_ENABLE' to enable XDebug with "ahoy debug" or "XDEBUG_ENABLE=true docker compose up -d".
+  XDEBUG_ENABLE: ${XDEBUG_ENABLE:-}
   # Local development URL.
   VORTEX_LOCALDEV_URL: &default-url ${COMPOSE_PROJECT_NAME:-example-site}.docker.amazee.io
   # Local development route used in Lagoon images and Pygmy to route requests.
   LAGOON_ROUTE: *default-url
-  # Local database host (not used in production).
+  # Local database host (variable is not used in hosting environment).
   DATABASE_HOST: database
-  # Local database name (not used in production).
+  # Local database name (variable is not used in hosting environment).
   DATABASE_NAME: drupal
-  # Local database user (not used in production).
+  # Local database user (variable is not used in hosting environment).
   DATABASE_USERNAME: drupal
-  # Local database password (not used in production).
+  # Local database password (variable is not used in hosting environment).
   DATABASE_PASSWORD: drupal
-  # Local database port (not used in production).
+  # Local database port (variable is not used in hosting environment).
   DATABASE_PORT: 3306
-  # Pass-through 'XDEBUG_ENABLE' to enable XDebug with "ahoy debug" or "XDEBUG_ENABLE=true docker compose up -d".
-  XDEBUG_ENABLE: ${XDEBUG_ENABLE:-}
-  # Pass-through 'CI' variable used to identify the CI environment.
-  CI: ${CI:-}
+  # Local database charset (variable is not used in hosting environment).
+  DATABASE_CHARSET: utf8mb4
+  # Local database collation (variable is not used in hosting environment).
+  DATABASE_COLLATION: utf8mb4_general_ci
   #;< DRUPAL_THEME
   DRUPAL_THEME: ${DRUPAL_THEME:-}
   #;> DRUPAL_THEME

--- a/tests/phpunit/Drupal/DatabaseSettingsTest.php
+++ b/tests/phpunit/Drupal/DatabaseSettingsTest.php
@@ -41,6 +41,8 @@ class DatabaseSettingsTest extends SettingsTestCase {
               'password' => 'drupal',
               'host' => 'localhost',
               'port' => '',
+              'charset' => 'utf8mb4',
+              'collation' => 'utf8mb4_general_ci',
               'driver' => 'mysql',
               'prefix' => '',
             ],
@@ -50,20 +52,24 @@ class DatabaseSettingsTest extends SettingsTestCase {
 
       [
         [
-          'DATABASE_NAME' => 'test_db_name',
-          'DATABASE_USERNAME' => 'test_db_user',
-          'DATABASE_PASSWORD' => 'test_db_pass',
-          'DATABASE_HOST' => 'test_db_host',
-          'DATABASE_PORT' => 'test_db_port',
+          'DATABASE_NAME' => 'database_db_name',
+          'DATABASE_USERNAME' => 'database_db_user',
+          'DATABASE_PASSWORD' => 'database_db_pass',
+          'DATABASE_HOST' => 'database_db_host',
+          'DATABASE_PORT' => 'database_db_port',
+          'DATABASE_CHARSET' => 'database_utf8',
+          'DATABASE_COLLATION' => 'database_utf8_unicode_ci',
         ],
         [
           'default' => [
             'default' => [
-              'database' => 'test_db_name',
-              'username' => 'test_db_user',
-              'password' => 'test_db_pass',
-              'host' => 'test_db_host',
-              'port' => 'test_db_port',
+              'database' => 'database_db_name',
+              'username' => 'database_db_user',
+              'password' => 'database_db_pass',
+              'host' => 'database_db_host',
+              'port' => 'database_db_port',
+              'charset' => 'database_utf8',
+              'collation' => 'database_utf8_unicode_ci',
               'driver' => 'mysql',
               'prefix' => '',
             ],
@@ -73,20 +79,51 @@ class DatabaseSettingsTest extends SettingsTestCase {
 
       [
         [
-          'DATABASE_DATABASE' => 'test_db_name',
-          'DATABASE_USERNAME' => 'test_db_user',
-          'DATABASE_PASSWORD' => 'test_db_pass',
-          'DATABASE_HOST' => 'test_db_host',
-          'DATABASE_PORT' => 'test_db_port',
+          'MARIADB_DATABASE' => 'mariadb_db_name',
+          'MARIADB_USERNAME' => 'mariadb_db_user',
+          'MARIADB_PASSWORD' => 'mariadb_db_pass',
+          'MARIADB_HOST' => 'mariadb_db_host',
+          'MARIADB_PORT' => 'mariadb_db_port',
+          'MARIADB_CHARSET' => 'mariadb_latin1',
+          'MARIADB_COLLATION' => 'mariadb_latin1_swedish_ci',
         ],
         [
           'default' => [
             'default' => [
-              'database' => 'test_db_name',
-              'username' => 'test_db_user',
-              'password' => 'test_db_pass',
-              'host' => 'test_db_host',
-              'port' => 'test_db_port',
+              'database' => 'mariadb_db_name',
+              'username' => 'mariadb_db_user',
+              'password' => 'mariadb_db_pass',
+              'host' => 'mariadb_db_host',
+              'port' => 'mariadb_db_port',
+              'charset' => 'mariadb_latin1',
+              'collation' => 'mariadb_latin1_swedish_ci',
+              'driver' => 'mysql',
+              'prefix' => '',
+            ],
+          ],
+        ],
+      ],
+
+      [
+        [
+          'DATABASE_DATABASE' => 'database_db_name',
+          'DATABASE_USERNAME' => 'database_db_user',
+          'DATABASE_PASSWORD' => 'database_db_pass',
+          'DATABASE_HOST' => 'database_db_host',
+          'DATABASE_PORT' => 'database_db_port',
+          'MYSQL_CHARSET' => 'mysql_utf8mb3',
+          'MYSQL_COLLATION' => 'mysql_utf8mb3_bin',
+        ],
+        [
+          'default' => [
+            'default' => [
+              'database' => 'database_db_name',
+              'username' => 'database_db_user',
+              'password' => 'database_db_pass',
+              'host' => 'database_db_host',
+              'port' => 'database_db_port',
+              'charset' => 'mysql_utf8mb3',
+              'collation' => 'mysql_utf8mb3_bin',
               'driver' => 'mysql',
               'prefix' => '',
             ],

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -123,6 +123,8 @@ $databases = [
           'password' => getenv('DATABASE_PASSWORD') ?: getenv('MARIADB_PASSWORD') ?: 'drupal',
           'host' => getenv('DATABASE_HOST') ?: getenv('MARIADB_HOST') ?: 'localhost',
           'port' => getenv('DATABASE_PORT') ?: getenv('MARIADB_PORT') ?: '',
+          'charset' => getenv('DATABASE_CHARSET') ?: getenv('MARIADB_CHARSET') ?: getenv('MYSQL_CHARSET') ?: 'utf8mb4',
+          'collation' => getenv('DATABASE_COLLATION') ?: getenv('MARIADB_COLLATION') ?: getenv('MYSQL_COLLATION') ?: 'utf8mb4_general_ci',
           'prefix' => '',
           'driver' => 'mysql',
         ],


### PR DESCRIPTION
closes #1672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying database character set and collation via environment variables, with sensible defaults if not set.

- **Documentation**
  - Updated comments in configuration files to clarify usage and defaults for new and existing database-related environment variables.
  - Extended environment variable documentation to include new charset and collation settings and clarify their non-usage in hosting environments.

- **Tests**
  - Expanded test coverage to include scenarios for database charset and collation settings across multiple environment variable naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->