### PR TITLE
[#1741] Added `pcntl` PHP extension to CLI container to allow PHPCS parallel runs.

### DIFF
--- a/.docker/cli.dockerfile
+++ b/.docker/cli.dockerfile
@@ -52,6 +52,7 @@ ENV COMPOSER_ALLOW_SUPERUSER=1 \
 RUN apk add --no-cache ncurses pv tzdata autoconf g++ make \
   && pecl install pcov \
   && docker-php-ext-enable pcov \
+  && docker-php-ext-install pcntl \
   && apk del g++ make autoconf
 
 # Add patches and scripts.

--- a/.vortex/.ahoy.yml
+++ b/.vortex/.ahoy.yml
@@ -87,9 +87,11 @@ commands:
 
   update-fixtures-no-install:
     cmd: |
-      UPDATE_FIXTURES=1 tests/node_modules/.bin/bats tests/bats/docker-compose.bats \
-      || UPDATE_FIXTURES=1 tests/node_modules/.bin/bats tests/bats/docker-compose.bats
-      cd installer && XDEBUG_MODE=off UPDATE_FIXTURES=1 composer test || XDEBUG_MODE=off composer test && cd -
+      export UPDATE_FIXTURES=1
+      tests/node_modules/.bin/bats tests/bats/docker-compose.bats || tests/node_modules/.bin/bats tests/bats/docker-compose.bats
+      export XDEBUG_MODE=off
+      export COMPOSER_PROCESS_TIMEOUT=600
+      composer --working-dir=installer test -- --filter=testInstall || composer --working-dir=installer test -- --filter=testInstall
 
   update-docs:
     usage: Update the documentation.

--- a/.vortex/installer/tests/Fixtures/install/_baseline/.docker/cli.dockerfile
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/.docker/cli.dockerfile
@@ -50,6 +50,7 @@ ENV COMPOSER_ALLOW_SUPERUSER=1 \
 RUN apk add --no-cache ncurses pv tzdata autoconf g++ make \
   && pecl install pcov \
   && docker-php-ext-enable pcov \
+  && docker-php-ext-install pcntl \
   && apk del g++ make autoconf
 
 # Add patches and scripts.

--- a/.vortex/installer/tests/Fixtures/install/_baseline/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/phpcs.xml
@@ -16,7 +16,9 @@
     <arg name="extensions" value="inc,info,install,module,php,profile,test,theme,js,css"/>
     <arg name="colors"/>
     <arg value="sp"/>
-    <arg name="parallel" value="75"/>
+
+    <!-- Adjust the number of parallel processes to run based on the number of CPU cores available. -->
+    <arg name="parallel" value="10"/>
 
     <!-- Lint code against platform version specified in composer.json key "config.platform.php". -->
     <config name="testVersion" value="8.3"/>

--- a/.vortex/installer/tests/Fixtures/install/hosting_acquia/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/install/hosting_acquia/phpcs.xml
@@ -13,7 +13,7 @@
      <file>tests</file>
  
      <rule ref="Drupal"/>
-@@ -22,10 +22,10 @@
+@@ -24,10 +24,10 @@
      <config name="testVersion" value="8.3"/>
  
      <!-- Exclude theme assets. -->

--- a/.vortex/installer/tests/Fixtures/install/theme_absent/.docker/cli.dockerfile
+++ b/.vortex/installer/tests/Fixtures/install/theme_absent/.docker/cli.dockerfile
@@ -8,7 +8,7 @@
  ENV COMPOSER_ALLOW_SUPERUSER=1 \
      COMPOSER_CACHE_DIR=/tmp/.composer/cache \
      SIMPLETEST_DB=mysql://drupal:drupal@database/drupal \
-@@ -71,21 +68,6 @@
+@@ -72,21 +69,6 @@
  RUN if [ -n "${GITHUB_TOKEN}" ]; then export COMPOSER_AUTH="{\"github-oauth\": {\"github.com\": \"${GITHUB_TOKEN}\"}}"; fi && \
      COMPOSER_MEMORY_LIMIT=-1 composer install -n --no-dev --ansi --prefer-dist --optimize-autoloader
  
@@ -30,7 +30,7 @@
  # Copy all files into the application source directory. Existing files are
  # always overwritten.
  COPY . /app
-@@ -93,9 +75,5 @@
+@@ -94,9 +76,5 @@
  # Create file directories and set correct permissions.
  RUN mkdir -p "/app/${WEBROOT}/${DRUPAL_PUBLIC_FILES}" "/app/${WEBROOT}/${DRUPAL_PRIVATE_FILES}" "${DRUPAL_TEMPORARY_FILES}" && \
   chmod 0770 "/app/${WEBROOT}/${DRUPAL_PUBLIC_FILES}" "/app/${WEBROOT}/${DRUPAL_PRIVATE_FILES}" "${DRUPAL_TEMPORARY_FILES}"

--- a/.vortex/installer/tests/Fixtures/install/theme_absent/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/install/theme_absent/phpcs.xml
@@ -6,7 +6,7 @@
      <file>web/sites/default/settings.php</file>
      <file>web/sites/default/includes</file>
      <file>tests</file>
-@@ -22,10 +21,6 @@
+@@ -24,10 +23,6 @@
      <config name="testVersion" value="8.3"/>
  
      <!-- Exclude theme assets. -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,7 +16,9 @@
     <arg name="extensions" value="inc,info,install,module,php,profile,test,theme,js,css"/>
     <arg name="colors"/>
     <arg value="sp"/>
-    <arg name="parallel" value="75"/>
+
+    <!-- Adjust the number of parallel processes to run based on the number of CPU cores available. -->
+    <arg name="parallel" value="10"/>
 
     <!-- Lint code against platform version specified in composer.json key "config.platform.php". -->
     <config name="testVersion" value="8.3"/>


### PR DESCRIPTION
closes #1741


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the CLI Docker container to include the PHP pcntl extension.
  - Improved environment variable handling and command invocation in the update-fixtures-no-install command.
  - Adjusted the parallel process setting in the PHPCS configuration for better compatibility with available CPU cores and added an explanatory comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->