### PR TITLE
Added alias command `test-behat` for `test-bdd`.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -241,6 +241,7 @@ commands:
 
   test-bdd:
     usage: Run BDD tests.
+    aliases: ['test-behat']
     cmd: ahoy cli php -d memory_limit=-1 vendor/bin/behat --colors "$@"
 
   debug:

--- a/.vortex/installer/tests/Fixtures/install/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/.ahoy.yml
@@ -228,6 +228,7 @@ commands:
 
   test-bdd:
     usage: Run BDD tests.
+    aliases: ['test-behat']
     cmd: ahoy cli php -d memory_limit=-1 vendor/bin/behat --colors "$@"
 
   debug:

--- a/.vortex/tests/bats/_helper.workflow.bash
+++ b/.vortex/tests/bats/_helper.workflow.bash
@@ -603,6 +603,10 @@ assert_ahoy_test_bdd_fast() {
   assert_dir_not_empty .logs/test_results
   assert_file_exists .logs/test_results/behat/default.xml
 
+  substep "Run all BDD tests via an alias"
+  run ahoy test-behat
+  assert_success
+
   rm -rf .logs/test_results/*
   ahoy cli rm -rf /app/.logs/test_results/*
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new alias, `test-behat`, for running BDD tests, making it interchangeable with the existing `test-bdd` command.

- **Tests**
  - Updated test workflows to verify the new `test-behat` alias runs BDD tests successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->