### PR TITLE
[#1779] Fixed Docker parallel build order.

### DIFF
--- a/.vortex/installer/tests/Fixtures/install/_baseline/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/docker-compose.yml
@@ -101,6 +101,8 @@ services:
       args:
         CLI_IMAGE: *cli-image
         WEBROOT: "${WEBROOT:-web}"
+      additional_contexts:
+        cli: "service:cli"
     <<: [*default-volumes, *default-user]
     environment:
       <<: *default-environment
@@ -117,6 +119,8 @@ services:
       dockerfile: .docker/php.dockerfile
       args:
         CLI_IMAGE: *cli-image
+      additional_contexts:
+        cli: "service:cli"
     <<: [*default-volumes, *default-user]
     environment:
       <<: *default-environment
@@ -144,6 +148,8 @@ services:
       dockerfile: .docker/solr.dockerfile
       args:
         CLI_IMAGE: *cli-image
+      additional_contexts:
+        cli: "service:cli"
     environment:
       <<: *default-environment
     depends_on:

--- a/.vortex/installer/tests/Fixtures/install/hosting_lagoon/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/hosting_lagoon/docker-compose.yml
@@ -17,7 +17,7 @@
  
    nginx:
      build:
-@@ -109,6 +114,11 @@
+@@ -111,6 +116,11 @@
      networks:
        - default # This is a standard network and is used for all other environments, where requests routing is not required and/or not supported.
        - amazeeio-network ### This network is supported by Pygmy and used to route all requests to host machine locally. Removed in CI.
@@ -29,7 +29,7 @@
  
    # PHP FPM container. All web requests are going through this container.
    php:
-@@ -122,6 +132,11 @@
+@@ -126,6 +136,11 @@
        <<: *default-environment
      depends_on:
        - cli
@@ -41,7 +41,7 @@
  
    database:
      build:
-@@ -134,9 +149,13 @@
+@@ -138,9 +153,13 @@
        <<: *default-environment
      ports:
        - "3306" # Database port in a container. Find port on host with `ahoy info` or `docker compose port database 3306`.
@@ -55,7 +55,7 @@
  
    solr:
      build:
-@@ -152,6 +171,8 @@
+@@ -158,6 +177,8 @@
        - "8983" # Solr port in a container. Find port on host with `ahoy info` or `docker compose port solr 8983`.
      volumes:
        - solr:/var/solr
@@ -64,7 +64,7 @@
  
    clamav:
      build:
-@@ -164,6 +185,10 @@
+@@ -170,6 +191,10 @@
        << : *default-environment
      networks:
        - default
@@ -75,7 +75,7 @@
  
    # Chrome container, used for browser testing.
    chrome:
-@@ -176,6 +201,8 @@
+@@ -182,6 +207,8 @@
        <<: *default-environment
      depends_on:
        - cli
@@ -84,7 +84,7 @@
  
    # Helper container to wait for services to become available.
    wait_dependencies:
-@@ -185,6 +212,8 @@
+@@ -191,6 +218,8 @@
        - database
        - clamav
      command: database:3306 clamav:3310

--- a/.vortex/installer/tests/Fixtures/install/provision_database_lagoon/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/provision_database_lagoon/docker-compose.yml
@@ -17,7 +17,7 @@
  
    nginx:
      build:
-@@ -109,6 +114,11 @@
+@@ -111,6 +116,11 @@
      networks:
        - default # This is a standard network and is used for all other environments, where requests routing is not required and/or not supported.
        - amazeeio-network ### This network is supported by Pygmy and used to route all requests to host machine locally. Removed in CI.
@@ -29,7 +29,7 @@
  
    # PHP FPM container. All web requests are going through this container.
    php:
-@@ -122,6 +132,11 @@
+@@ -126,6 +136,11 @@
        <<: *default-environment
      depends_on:
        - cli
@@ -41,7 +41,7 @@
  
    database:
      build:
-@@ -134,9 +149,13 @@
+@@ -138,9 +153,13 @@
        <<: *default-environment
      ports:
        - "3306" # Database port in a container. Find port on host with `ahoy info` or `docker compose port database 3306`.
@@ -55,7 +55,7 @@
  
    solr:
      build:
-@@ -152,6 +171,8 @@
+@@ -158,6 +177,8 @@
        - "8983" # Solr port in a container. Find port on host with `ahoy info` or `docker compose port solr 8983`.
      volumes:
        - solr:/var/solr
@@ -64,7 +64,7 @@
  
    clamav:
      build:
-@@ -164,6 +185,10 @@
+@@ -170,6 +191,10 @@
        << : *default-environment
      networks:
        - default
@@ -75,7 +75,7 @@
  
    # Chrome container, used for browser testing.
    chrome:
-@@ -176,6 +201,8 @@
+@@ -182,6 +207,8 @@
        <<: *default-environment
      depends_on:
        - cli
@@ -84,7 +84,7 @@
  
    # Helper container to wait for services to become available.
    wait_dependencies:
-@@ -185,6 +212,8 @@
+@@ -191,6 +218,8 @@
        - database
        - clamav
      command: database:3306 clamav:3310

--- a/.vortex/installer/tests/Fixtures/install/services_no_clamav/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_no_clamav/docker-compose.yml
@@ -1,4 +1,4 @@
-@@ -153,18 +153,6 @@
+@@ -159,18 +159,6 @@
      volumes:
        - solr:/var/solr
  
@@ -17,7 +17,7 @@
    # Chrome container, used for browser testing.
    chrome:
      image: selenium/standalone-chromium:__VERSION__
-@@ -183,8 +171,7 @@
+@@ -189,8 +177,7 @@
      depends_on:
        - cli
        - database

--- a/.vortex/installer/tests/Fixtures/install/services_no_solr/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_no_solr/docker-compose.yml
@@ -1,4 +1,4 @@
-@@ -138,21 +138,6 @@
+@@ -142,23 +142,6 @@
    valkey:
      image: uselagoon/valkey-8:__VERSION__
  
@@ -8,6 +8,8 @@
 -      dockerfile: .docker/solr.dockerfile
 -      args:
 -        CLI_IMAGE: *cli-image
+-      additional_contexts:
+-        cli: "service:cli"
 -    environment:
 -      <<: *default-environment
 -    depends_on:
@@ -20,7 +22,7 @@
    clamav:
      build:
        context: .
-@@ -193,4 +178,3 @@
+@@ -199,4 +182,3 @@
  volumes:
    app: {}
    files: {}

--- a/.vortex/installer/tests/Fixtures/install/services_no_valkey/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_no_valkey/docker-compose.yml
@@ -7,7 +7,7 @@
  
  # ------------------------------------------------------------------------------
  # Services.
-@@ -134,9 +132,6 @@
+@@ -138,9 +136,6 @@
        <<: *default-environment
      ports:
        - "3306" # Database port in a container. Find port on host with `ahoy info` or `docker compose port database 3306`.

--- a/.vortex/installer/tests/Fixtures/install/services_none/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_none/docker-compose.yml
@@ -7,7 +7,7 @@
  
  # ------------------------------------------------------------------------------
  # Services.
-@@ -135,36 +133,6 @@
+@@ -139,38 +137,6 @@
      ports:
        - "3306" # Database port in a container. Find port on host with `ahoy info` or `docker compose port database 3306`.
  
@@ -20,6 +20,8 @@
 -      dockerfile: .docker/solr.dockerfile
 -      args:
 -        CLI_IMAGE: *cli-image
+-      additional_contexts:
+-        cli: "service:cli"
 -    environment:
 -      <<: *default-environment
 -    depends_on:
@@ -44,7 +46,7 @@
    # Chrome container, used for browser testing.
    chrome:
      image: selenium/standalone-chromium:__VERSION__
-@@ -183,8 +151,7 @@
+@@ -189,8 +155,7 @@
      depends_on:
        - cli
        - database
@@ -54,7 +56,7 @@
  
  networks:           ### Use external networks locally. Automatically removed in CI.
    amazeeio-network: ### Automatically removed in CI.
-@@ -193,4 +160,3 @@
+@@ -199,4 +164,3 @@
  volumes:
    app: {}
    files: {}

--- a/.vortex/tests/bats/fixtures/docker-compose.env.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.env.json
@@ -224,6 +224,9 @@
         },
         "nginx": {
             "build": {
+                "additional_contexts": {
+                    "cli": "service:cli"
+                },
                 "args": {
                     "CLI_IMAGE": "star_wars",
                     "WEBROOT": "web"
@@ -288,6 +291,9 @@
         },
         "php": {
             "build": {
+                "additional_contexts": {
+                    "cli": "service:cli"
+                },
                 "args": {
                     "CLI_IMAGE": "star_wars"
                 },
@@ -351,6 +357,9 @@
         },
         "solr": {
             "build": {
+                "additional_contexts": {
+                    "cli": "service:cli"
+                },
                 "args": {
                     "CLI_IMAGE": "star_wars"
                 },

--- a/.vortex/tests/bats/fixtures/docker-compose.env_local.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.env_local.json
@@ -224,6 +224,9 @@
         },
         "nginx": {
             "build": {
+                "additional_contexts": {
+                    "cli": "service:cli"
+                },
                 "args": {
                     "CLI_IMAGE": "star_wars",
                     "WEBROOT": "web"
@@ -288,6 +291,9 @@
         },
         "php": {
             "build": {
+                "additional_contexts": {
+                    "cli": "service:cli"
+                },
                 "args": {
                     "CLI_IMAGE": "star_wars"
                 },
@@ -351,6 +357,9 @@
         },
         "solr": {
             "build": {
+                "additional_contexts": {
+                    "cli": "service:cli"
+                },
                 "args": {
                     "CLI_IMAGE": "star_wars"
                 },

--- a/.vortex/tests/bats/fixtures/docker-compose.env_mod.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.env_mod.json
@@ -224,6 +224,9 @@
         },
         "nginx": {
             "build": {
+                "additional_contexts": {
+                    "cli": "service:cli"
+                },
                 "args": {
                     "CLI_IMAGE": "the_matrix",
                     "WEBROOT": "docroot"
@@ -288,6 +291,9 @@
         },
         "php": {
             "build": {
+                "additional_contexts": {
+                    "cli": "service:cli"
+                },
                 "args": {
                     "CLI_IMAGE": "the_matrix"
                 },
@@ -351,6 +357,9 @@
         },
         "solr": {
             "build": {
+                "additional_contexts": {
+                    "cli": "service:cli"
+                },
                 "args": {
                     "CLI_IMAGE": "the_matrix"
                 },

--- a/.vortex/tests/bats/fixtures/docker-compose.noenv.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.noenv.json
@@ -224,6 +224,9 @@
         },
         "nginx": {
             "build": {
+                "additional_contexts": {
+                    "cli": "service:cli"
+                },
                 "args": {
                     "CLI_IMAGE": "star_wars",
                     "WEBROOT": "web"
@@ -288,6 +291,9 @@
         },
         "php": {
             "build": {
+                "additional_contexts": {
+                    "cli": "service:cli"
+                },
                 "args": {
                     "CLI_IMAGE": "star_wars"
                 },
@@ -351,6 +357,9 @@
         },
         "solr": {
             "build": {
+                "additional_contexts": {
+                    "cli": "service:cli"
+                },
                 "args": {
                     "CLI_IMAGE": "star_wars"
                 },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,8 @@ services:
       args:
         CLI_IMAGE: *cli-image
         WEBROOT: "${WEBROOT:-web}"
+      additional_contexts:
+        cli: "service:cli"
     <<: [*default-volumes, *default-user]
     environment:
       <<: *default-environment
@@ -142,6 +144,8 @@ services:
       dockerfile: .docker/php.dockerfile
       args:
         CLI_IMAGE: *cli-image
+      additional_contexts:
+        cli: "service:cli"
     <<: [*default-volumes, *default-user]
     environment:
       <<: *default-environment
@@ -187,6 +191,8 @@ services:
       dockerfile: .docker/solr.dockerfile
       args:
         CLI_IMAGE: *cli-image
+      additional_contexts:
+        cli: "service:cli"
     environment:
       <<: *default-environment
     depends_on:


### PR DESCRIPTION
Closes #1779

Based on https://docs.docker.com/compose/how-tos/dependent-images/#use-another-services-image-as-the-base-image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker Compose configurations and related fixtures by adding an additional context for the CLI service in the build setup of nginx, php, and solr services, maintaining existing build arguments and service behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->