### PR TITLE
Switched ClamAV to use `clamav/clamav-debian` image for multi-platform support.

### DIFF
--- a/.docker/clamav.dockerfile
+++ b/.docker/clamav.dockerfile
@@ -5,19 +5,21 @@
 # Allow running ClamAV in rootless mode.
 # @see https://github.com/Cisco-Talos/clamav/issues/478
 #
-# hadolint global ignore=DL3018
+# hadolint global ignore=DL3008,DL3018
 #
 # @see https://hub.docker.com/r/uselagoon/commons/tags
 # @see https://github.com/uselagoon/lagoon-images/tree/main/images/commons
 
 FROM uselagoon/commons:25.6.0 AS commons
 
-FROM clamav/clamav:1.4.3
+FROM clamav/clamav-debian:1.0.9
 
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
 
-RUN apk add --no-cache tzdata
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY .docker/config/clamav/clamav.conf /tmp/clamav.conf
 

--- a/.vortex/installer/tests/Fixtures/install/_baseline/.docker/clamav.dockerfile
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/.docker/clamav.dockerfile
@@ -5,19 +5,21 @@
 # Allow running ClamAV in rootless mode.
 # @see https://github.com/Cisco-Talos/clamav/issues/478
 #
-# hadolint global ignore=DL3018
+# hadolint global ignore=DL3008,DL3018
 #
 # @see https://hub.docker.com/r/uselagoon/commons/tags
 # @see https://github.com/uselagoon/lagoon-images/tree/main/images/commons
 
 FROM uselagoon/commons:__VERSION__ AS commons
 
-FROM clamav/clamav:__VERSION__
+FROM clamav/clamav-debian:__VERSION__
 
 COPY --from=commons /lagoon /lagoon
 COPY --from=commons /bin/fix-permissions /bin/ep /bin/docker-sleep /bin/wait-for /bin/
 
-RUN apk add --no-cache tzdata
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY .docker/config/clamav/clamav.conf /tmp/clamav.conf
 

--- a/.vortex/installer/tests/Fixtures/install/_baseline/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/docker-compose.yml
@@ -164,7 +164,6 @@ services:
     build:
       context: .
       dockerfile: .docker/clamav.dockerfile
-    platform: linux/amd64
     ports:
       - "3310" # Find port on host with `docker compose port clamav 3310`.
     environment:

--- a/.vortex/installer/tests/Fixtures/install/hosting_lagoon/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/hosting_lagoon/docker-compose.yml
@@ -64,7 +64,7 @@
  
    clamav:
      build:
-@@ -171,6 +192,10 @@
+@@ -170,6 +191,10 @@
        << : *default-environment
      networks:
        - default
@@ -75,7 +75,7 @@
  
    # Chrome container, used for browser testing.
    chrome:
-@@ -183,6 +208,8 @@
+@@ -182,6 +207,8 @@
        <<: *default-environment
      depends_on:
        - cli
@@ -84,7 +84,7 @@
  
    # Helper container to wait for services to become available.
    wait_dependencies:
-@@ -192,6 +219,8 @@
+@@ -191,6 +218,8 @@
        - database
        - clamav
      command: database:3306 clamav:3310

--- a/.vortex/installer/tests/Fixtures/install/provision_database_lagoon/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/provision_database_lagoon/docker-compose.yml
@@ -64,7 +64,7 @@
  
    clamav:
      build:
-@@ -171,6 +192,10 @@
+@@ -170,6 +191,10 @@
        << : *default-environment
      networks:
        - default
@@ -75,7 +75,7 @@
  
    # Chrome container, used for browser testing.
    chrome:
-@@ -183,6 +208,8 @@
+@@ -182,6 +207,8 @@
        <<: *default-environment
      depends_on:
        - cli
@@ -84,7 +84,7 @@
  
    # Helper container to wait for services to become available.
    wait_dependencies:
-@@ -192,6 +219,8 @@
+@@ -191,6 +218,8 @@
        - database
        - clamav
      command: database:3306 clamav:3310

--- a/.vortex/installer/tests/Fixtures/install/services_no_clamav/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_no_clamav/docker-compose.yml
@@ -1,4 +1,4 @@
-@@ -160,18 +160,6 @@
+@@ -160,17 +160,6 @@
      volumes:
        - solr:/var/solr
  
@@ -6,7 +6,6 @@
 -    build:
 -      context: .
 -      dockerfile: .docker/clamav.dockerfile
--    platform: linux/amd64
 -    ports:
 -      - "3310" # Find port on host with `docker compose port clamav 3310`.
 -    environment:
@@ -17,7 +16,7 @@
    # Chrome container, used for browser testing.
    chrome:
      image: selenium/standalone-chromium:__VERSION__
-@@ -190,8 +178,7 @@
+@@ -189,8 +178,7 @@
      depends_on:
        - cli
        - database

--- a/.vortex/installer/tests/Fixtures/install/services_no_solr/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_no_solr/docker-compose.yml
@@ -22,7 +22,7 @@
    clamav:
      build:
        context: .
-@@ -200,4 +183,3 @@
+@@ -199,4 +182,3 @@
  volumes:
    app: {}
    files: {}

--- a/.vortex/installer/tests/Fixtures/install/services_none/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_none/docker-compose.yml
@@ -7,7 +7,7 @@
  
  # ------------------------------------------------------------------------------
  # Services.
-@@ -140,38 +138,6 @@
+@@ -140,37 +138,6 @@
      ports:
        - "3306" # Database port in a container. Find port on host with `ahoy info` or `docker compose port database 3306`.
  
@@ -35,7 +35,6 @@
 -    build:
 -      context: .
 -      dockerfile: .docker/clamav.dockerfile
--    platform: linux/amd64
 -    ports:
 -      - "3310" # Find port on host with `docker compose port clamav 3310`.
 -    environment:
@@ -46,7 +45,7 @@
    # Chrome container, used for browser testing.
    chrome:
      image: selenium/standalone-chromium:__VERSION__
-@@ -190,8 +156,7 @@
+@@ -189,8 +156,7 @@
      depends_on:
        - cli
        - database
@@ -56,7 +55,7 @@
  
  networks:           ### Use external networks locally. Automatically removed in CI.
    amazeeio-network: ### Automatically removed in CI.
-@@ -200,4 +165,3 @@
+@@ -199,4 +165,3 @@
  volumes:
    app: {}
    files: {}

--- a/.vortex/tests/bats/fixtures/docker-compose.env.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.env.json
@@ -105,7 +105,6 @@
             "networks": {
                 "default": null
             },
-            "platform": "linux/amd64",
             "ports": [
                 {
                     "mode": "ingress",

--- a/.vortex/tests/bats/fixtures/docker-compose.env_local.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.env_local.json
@@ -105,7 +105,6 @@
             "networks": {
                 "default": null
             },
-            "platform": "linux/amd64",
             "ports": [
                 {
                     "mode": "ingress",

--- a/.vortex/tests/bats/fixtures/docker-compose.env_mod.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.env_mod.json
@@ -105,7 +105,6 @@
             "networks": {
                 "default": null
             },
-            "platform": "linux/amd64",
             "ports": [
                 {
                     "mode": "ingress",

--- a/.vortex/tests/bats/fixtures/docker-compose.noenv.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.noenv.json
@@ -105,7 +105,6 @@
             "networks": {
                 "default": null
             },
-            "platform": "linux/amd64",
             "ports": [
                 {
                     "mode": "ingress",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,7 +213,6 @@ services:
     build:
       context: .
       dockerfile: .docker/clamav.dockerfile
-    platform: linux/amd64
     ports:
       - "3310" # Find port on host with `docker compose port clamav 3310`.
     environment:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ClamAV container to use a Debian-based image and adjusted package installation steps for compatibility.
  * Removed explicit platform specification for the ClamAV service in Docker Compose files and related test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->