### PR TITLE
Removed generic private package used for testing from the root `composer.json`.

### DIFF
--- a/.vortex/tests/phpunit/Functional/WorkflowTest.php
+++ b/.vortex/tests/phpunit/Functional/WorkflowTest.php
@@ -51,12 +51,12 @@ class WorkflowTest extends FunctionalTestCase {
   }
 
   /**
-   * Test GitHub token handling during build.
+   * Test Package token handling during build.
    *
    * Make sure to run with TEST_PACKAGE_TOKEN=working_test_token or this test
    * will fail.
    */
-  public function testGitHubToken(): void {
+  public function testPackageToken(): void {
     $package_token = getenv('TEST_PACKAGE_TOKEN');
     $this->assertNotEmpty($package_token, 'TEST_PACKAGE_TOKEN environment variable must be set');
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "php": ">=8.3",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^1.7",
-        "drevops/generic-private-package": "^1.0",
         "drupal/admin_toolbar": "^3.6",
         "drupal/clamav": "^2.1",
         "drupal/coffee": "^2",
@@ -60,10 +59,6 @@
         {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/drevops/generic-private-package"
         }
     ],
     "minimum-stability": "beta",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test names and documentation to focus on "Package token" handling during the build process.
* **Chores**
  * Removed the "drevops/generic-private-package" dependency and its related repository entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->