### PR TITLE
Fixed Lagoon CLI download in scripts.

### DIFF
--- a/.vortex/docs/content/workflows/variables.mdx
+++ b/.vortex/docs/content/workflows/variables.mdx
@@ -1193,7 +1193,7 @@ Defined in: `scripts/vortex/deploy-lagoon.sh`, `scripts/vortex/task-custom-lagoo
 
 Lagoon CLI version to use.
 
-Default value: `latest`
+Default value: `v0.32.0`
 
 Defined in: `scripts/vortex/deploy-lagoon.sh`, `scripts/vortex/task-custom-lagoon.sh`
 

--- a/scripts/vortex/deploy-lagoon.sh
+++ b/scripts/vortex/deploy-lagoon.sh
@@ -66,7 +66,7 @@ VORTEX_LAGOONCLI_PATH="${VORTEX_LAGOONCLI_PATH:-/tmp}"
 VORTEX_LAGOONCLI_FORCE_INSTALL="${VORTEX_LAGOONCLI_FORCE_INSTALL:-}"
 
 # Lagoon CLI version to use.
-VORTEX_LAGOONCLI_VERSION="${VORTEX_LAGOONCLI_VERSION:-latest}"
+VORTEX_LAGOONCLI_VERSION="${VORTEX_LAGOONCLI_VERSION:-v0.32.0}"
 
 # Flag to control failure behavior when Lagoon environment limits are exceeded.
 # When set to 0, the deployment will exit with success instead of failure.
@@ -106,14 +106,10 @@ if ! command -v lagoon >/dev/null || [ -n "${VORTEX_LAGOONCLI_FORCE_INSTALL}" ];
 
   platform=$(uname -s | tr '[:upper:]' '[:lower:]')
   arch_suffix=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-
-  download_url="https://github.com/uselagoon/lagoon-cli/releases/latest/download/lagoon-cli-${platform}-${arch_suffix}"
-  if [ "${VORTEX_LAGOONCLI_VERSION}" != "latest" ]; then
-    download_url="https://github.com/uselagoon/lagoon-cli/releases/download/${VORTEX_LAGOONCLI_VERSION}/lagoon-cli-${platform}-${arch_suffix}"
-  fi
+  download_url="https://github.com/uselagoon/lagoon-cli/releases/download/${VORTEX_LAGOONCLI_VERSION}/lagoon-cli-${VORTEX_LAGOONCLI_VERSION}-${platform}-${arch_suffix}"
 
   note "Downloading Lagoon CLI from ${download_url}."
-  curl -L -o "${VORTEX_LAGOONCLI_PATH}/lagoon" "${download_url}"
+  curl -fSLs -o "${VORTEX_LAGOONCLI_PATH}/lagoon" "${download_url}"
 
   note "Installing Lagoon CLI to ${VORTEX_LAGOONCLI_PATH}/lagoon."
   chmod +x "${VORTEX_LAGOONCLI_PATH}/lagoon"

--- a/scripts/vortex/task-custom-lagoon.sh
+++ b/scripts/vortex/task-custom-lagoon.sh
@@ -48,7 +48,7 @@ VORTEX_LAGOONCLI_PATH="${VORTEX_LAGOONCLI_PATH:-/tmp}"
 VORTEX_LAGOONCLI_FORCE_INSTALL="${VORTEX_LAGOONCLI_FORCE_INSTALL:-}"
 
 # Lagoon CLI version to use.
-VORTEX_LAGOONCLI_VERSION="${VORTEX_LAGOONCLI_VERSION:-latest}"
+VORTEX_LAGOONCLI_VERSION="${VORTEX_LAGOONCLI_VERSION:-v0.32.0}"
 
 # ------------------------------------------------------------------------------
 
@@ -73,16 +73,14 @@ export VORTEX_SSH_PREFIX="TASK" && . ./scripts/vortex/setup-ssh.sh
 if ! command -v lagoon >/dev/null || [ -n "${VORTEX_LAGOONCLI_FORCE_INSTALL}" ]; then
   task "Installing Lagoon CLI."
 
-  lagooncli_download_url="https://api.github.com/repos/uselagoon/lagoon-cli/releases/latest"
-  if [ "${VORTEX_LAGOONCLI_VERSION}" != "latest" ]; then
-    lagooncli_download_url="https://api.github.com/repos/uselagoon/lagoon-cli/releases/tags/${VORTEX_LAGOONCLI_VERSION}"
-  fi
+  platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+  arch_suffix=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+  download_url="https://github.com/uselagoon/lagoon-cli/releases/download/${VORTEX_LAGOONCLI_VERSION}/lagoon-cli-${VORTEX_LAGOONCLI_VERSION}-${platform}-${arch_suffix}"
 
-  curl -sL "${lagooncli_download_url}" |
-    grep "browser_download_url" |
-    grep -i "$(uname -s)-amd64\"$" |
-    cut -d '"' -f 4 |
-    xargs curl -L -o "${VORTEX_LAGOONCLI_PATH}/lagoon"
+  note "Downloading Lagoon CLI from ${download_url}."
+  curl -fSLs -o "${VORTEX_LAGOONCLI_PATH}/lagoon" "${download_url}"
+
+  note "Installing Lagoon CLI to ${VORTEX_LAGOONCLI_PATH}/lagoon."
   chmod +x "${VORTEX_LAGOONCLI_PATH}/lagoon"
   export PATH="${PATH}:${VORTEX_LAGOONCLI_PATH}"
 fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default Lagoon CLI version used in deployment and task scripts from "latest" to "v0.32.0" for improved stability and consistency.
  * Simplified and improved the reliability of the Lagoon CLI download process during deployments and custom tasks.
* **Documentation**
  * Updated documentation to reflect the new default Lagoon CLI version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->