### PR TITLE
Removed `ahoy pull` command.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -80,10 +80,6 @@ commands:
     usage: Show container logs for services.
     cmd: docker compose logs "$@"
 
-  pull:
-    usage: Pull latest container images.
-    cmd: if [ ! -z "$(docker image ls -q)" ]; then docker image ls --format \"{{.Repository}}:{{.Tag}}\" | grep uselagoon/ | grep -v none | xargs -n1 docker pull -q | cat; fi
-
   cli:
     usage: Start a shell or run a command inside the CLI service container.
     # Drop into a shell if no arguments are supplied, otherwise run the command.

--- a/.vortex/installer/tests/Fixtures/install/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/.ahoy.yml
@@ -75,10 +75,6 @@ commands:
     usage: Show container logs for services.
     cmd: docker compose logs "$@"
 
-  pull:
-    usage: Pull latest container images.
-    cmd: if [ ! -z "$(docker image ls -q)" ]; then docker image ls --format \"{{.Repository}}:{{.Tag}}\" | grep uselagoon/ | grep -v none | xargs -n1 docker pull -q | cat; fi
-
   cli:
     usage: Start a shell or run a command inside the CLI service container.
     # Drop into a shell if no arguments are supplied, otherwise run the command.

--- a/.vortex/installer/tests/Fixtures/install/provision_profile/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/provision_profile/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -115,11 +115,6 @@
+@@ -111,11 +111,6 @@
      usage: Unblock user 1 and generate a one time login link.
      cmd: ahoy cli ./scripts/vortex/login.sh
  

--- a/.vortex/installer/tests/Fixtures/install/services_no_valkey/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_no_valkey/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -103,10 +103,6 @@
+@@ -99,10 +99,6 @@
      usage: Run Drush commands in the CLI service container.
      cmd: ahoy cli "vendor/bin/drush -l \${VORTEX_LOCALDEV_URL} $*"
  

--- a/.vortex/installer/tests/Fixtures/install/services_none/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_none/.ahoy.yml
@@ -6,7 +6,7 @@
        VORTEX_HOST_SELENIUM_VNC_PORT=$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2) \
        VORTEX_HOST_HAS_SEQUELACE=$(uname -a | grep -i -q darwin && mdfind -name 'Sequel Ace' 2>/dev/null | grep -q "Ace" && echo 1 || true) \
        ahoy cli ./scripts/vortex/info.sh "$@"
-@@ -102,10 +101,6 @@
+@@ -98,10 +97,6 @@
    drush:
      usage: Run Drush commands in the CLI service container.
      cmd: ahoy cli "vendor/bin/drush -l \${VORTEX_LOCALDEV_URL} $*"

--- a/.vortex/installer/tests/Fixtures/install/theme_absent/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/theme_absent/.ahoy.yml
@@ -6,7 +6,7 @@
        ahoy provision                      # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -160,25 +159,10 @@
+@@ -156,25 +155,10 @@
      usage: Install front-end assets.
      cmd: |
        ahoy cli "yarn install --frozen-lockfile"
@@ -33,7 +33,7 @@
  
    lint-be:
      usage: Lint back-end code.
-@@ -193,7 +177,6 @@
+@@ -189,7 +173,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
        ahoy cli "yarn run lint"
@@ -41,7 +41,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -201,7 +184,7 @@
+@@ -197,7 +180,7 @@
  
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
@@ -50,7 +50,7 @@
  
    lint-be-fix:
      usage: Fix lint issues of back-end code.
-@@ -214,7 +197,6 @@
+@@ -210,7 +193,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/scripts/vortex/doctor.sh
+++ b/scripts/vortex/doctor.sh
@@ -203,7 +203,7 @@ main() {
 
       if [ "${VORTEX_DOCTOR_CHECK_BOOTSTRAP}" = "1" ]; then
         if ! curl -L -s -N "${local_dev_url}" | grep -q -i "charset="; then
-          fail "Website is running, but cannot be bootstrapped. Try pulling latest container images with 'ahoy pull'."
+          fail "Website is running, but cannot be bootstrapped. Check web-server configuration."
           exit 1
         fi
         pass "Bootstrapped website at http://${local_dev_url}."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the "pull" command from available commands.
* **Documentation**
  * Updated error messaging to suggest checking web-server configuration instead of pulling container images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->