### PR TITLE
Added timing to the provision command.

### DIFF
--- a/.vortex/tests/bats/unit/provision.bats
+++ b/.vortex/tests/bats/unit/provision.bats
@@ -164,7 +164,7 @@ assert_provision_info() {
     "Disabled maintenance mode."
 
     # Installation completion.
-    "Finished site provisioning."
+    "Finished site provisioning"
   )
 
   mocks="$(run_steps "setup")"
@@ -295,7 +295,7 @@ assert_provision_info() {
     "Disabled maintenance mode."
 
     # Installation completion.
-    "Finished site provisioning."
+    "Finished site provisioning"
   )
 
   mocks="$(run_steps "setup")"
@@ -435,7 +435,7 @@ assert_provision_info() {
     "Disabled maintenance mode."
 
     # Installation completion.
-    "Finished site provisioning."
+    "Finished site provisioning"
   )
 
   mocks="$(run_steps "setup")"
@@ -580,7 +580,7 @@ assert_provision_info() {
     "Disabled maintenance mode."
 
     # Installation completion.
-    "Finished site provisioning."
+    "Finished site provisioning"
   )
 
   mocks="$(run_steps "setup")"
@@ -720,7 +720,7 @@ assert_provision_info() {
     "Disabled maintenance mode."
 
     # Installation completion.
-    "Finished site provisioning."
+    "Finished site provisioning"
   )
 
   mocks="$(run_steps "setup")"
@@ -854,7 +854,7 @@ assert_provision_info() {
     "Disabled maintenance mode."
 
     # Installation completion.
-    "Finished site provisioning."
+    "Finished site provisioning"
   )
 
   mocks="$(run_steps "setup")"
@@ -995,7 +995,7 @@ assert_provision_info() {
     "Disabled maintenance mode."
 
     # Installation completion.
-    "Finished site provisioning."
+    "Finished site provisioning"
   )
 
   mocks="$(run_steps "setup")"
@@ -1114,7 +1114,7 @@ assert_provision_info() {
     "Disabled maintenance mode."
 
     # Installation completion.
-    "Finished site provisioning."
+    "Finished site provisioning"
   )
 
   export VORTEX_PROVISION_SANITIZE_DB_PASSWORD="MOCK_DB_SANITIZE_PASSWORD"

--- a/scripts/vortex/provision.sh
+++ b/scripts/vortex/provision.sh
@@ -78,6 +78,8 @@ yesno() { [ "${1}" = "1" ] && echo "Yes" || echo "No"; }
 
 info "Started site provisioning."
 
+start_time=$(date +%s)
+
 if [ "${VORTEX_PROVISION_SKIP}" = "1" ]; then
   pass "Skipped site provisioning as VORTEX_PROVISION_SKIP is set to 1."
   info "Finished site provisioning."
@@ -240,7 +242,8 @@ echo
 if [ "${VORTEX_PROVISION_POST_OPERATIONS_SKIP}" = "1" ]; then
   info "Skipped running of post-provision operations as VORTEX_PROVISION_POST_OPERATIONS_SKIP is set to 1."
   echo
-  info "Finished site provisioning."
+  duration=$(($(date +%s) - start_time))
+  info "Finished site provisioning ($((duration / 60))m $((duration % 60))s)."
   exit 0
 fi
 
@@ -324,4 +327,5 @@ if [ "${VORTEX_PROVISION_USE_MAINTENANCE_MODE}" = "1" ]; then
   echo
 fi
 
-info "Finished site provisioning."
+duration=$(($(date +%s) - start_time))
+info "Finished site provisioning ($((duration / 60))m $((duration % 60))s)."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The site provisioning process now displays the total duration taken, showing minutes and seconds upon completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->