### PR TITLE
[#1859] Fixed `TZ` replacement in the installer.

### DIFF
--- a/.vortex/installer/src/Prompts/Handlers/Timezone.php
+++ b/.vortex/installer/src/Prompts/Handlers/Timezone.php
@@ -656,10 +656,11 @@ class Timezone extends AbstractHandler {
    * {@inheritdoc}
    */
   public function process(): void {
-    $timezone = $this->getResponseAsString();
+    $v = $this->getResponseAsString();
+    $t = $this->tmpDir;
 
-    File::replaceContentAsync('/TZ=[A-Za-z0-9\/_\-+]+/', 'TZ=' . $timezone);
-    File::replaceContentAsync('/"timezone": "[A-Za-z0-9\/_\-+]+",/', sprintf('"timezone": "%s",', $timezone));
+    File::replaceContentInFile($t . '/.env', '/TZ=[A-Za-z0-9\/_\-+]+/', 'TZ=' . $v);
+    File::replaceContentInFile($t . '/renovate.json', '/"timezone": "[A-Za-z0-9\/_\-+]+",/', sprintf('"timezone": "%s",', $v));
   }
 
 }

--- a/.vortex/installer/tests/Functional/InstallTest.php
+++ b/.vortex/installer/tests/Functional/InstallTest.php
@@ -211,9 +211,11 @@ class InstallTest extends FunctionalTestCase {
           // Timezone should not be replaced in GHA config in code as it should
           // be overridden via UI.
           $test->assertFileNotContainsString('America/New_York', static::$sut . '/.github/workflows/build-test-deploy.yml');
+          $test->assertFileContainsString('UTC', static::$sut . '/.github/workflows/build-test-deploy.yml');
 
           // Timezone should not be replaced in Docker Compose config.
           $test->assertFileNotContainsString('America/New_York', static::$sut . '/docker-compose.yml');
+          $test->assertFileContainsString('UTC', static::$sut . '/docker-compose.yml');
         }),
       ],
       'timezone, circleci' => [
@@ -224,8 +226,8 @@ class InstallTest extends FunctionalTestCase {
         static::cw(function (FunctionalTestCase $test): void {
           // Timezone should not be replaced in CircleCI config in code as it
           // should be overridden via UI.
-          $test->assertFileContainsString('TZ: UTC', static::$sut . '/.circleci/config.yml');
           $test->assertFileNotContainsString('TZ: America/New_York', static::$sut . '/.circleci/config.yml');
+          $test->assertFileContainsString('TZ: UTC', static::$sut . '/.circleci/config.yml');
         }),
       ],
 


### PR DESCRIPTION
Closes #1859


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone handling to ensure correct timezone values are applied to configuration files during installation.

* **Tests**
  * Enhanced tests to confirm that the default "UTC" timezone is correctly set in CI/CD configuration files and that "America/New_York" is not incorrectly present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->