### PR TITLE
[#1894] Allow to download a fresh DB using `ahoy download-db --no-cache`.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -120,9 +120,11 @@ commands:
 
   #;< !PROVISION_TYPE_PROFILE
   download-db:
-    usage: Download database.
+    usage: Download database. Run with "--no-cache" option to force fresh database backup.
     aliases: ['fetch-db']
-    cmd: ./scripts/vortex/download-db.sh
+    cmd: |
+      case " $* " in *" --no-cache "*) export VORTEX_DB_DOWNLOAD_NO_CACHE=1;; esac
+      ./scripts/vortex/download-db.sh
   #;> !PROVISION_TYPE_PROFILE
 
   reload-db:

--- a/.vortex/docs/content/workflows/development.mdx
+++ b/.vortex/docs/content/workflows/development.mdx
@@ -45,7 +45,10 @@ ahoy provision
 
 To fetch the database with the latest data from the production environment,
 use the `ahoy fetch-db` command, which will download the latest database
-dump from the production environment into a `.data` directory.
+dump from the production environment into a `.data` directory. If there was a
+download attempt on the same day (locally or from CI), it will download the
+cached database dump. Use `ahoy fetch-db --no-cache` to create a new database
+dump regardless of the cache.
 
 :::note
 

--- a/.vortex/docs/content/workflows/variables.mdx
+++ b/.vortex/docs/content/workflows/variables.mdx
@@ -666,6 +666,14 @@ Default value: `${LAGOON_PROJECT}-${VORTEX_DB_DOWNLOAD_ENVIRONMENT}`
 
 Defined in: `scripts/vortex/download-db-lagoon.sh`
 
+### `VORTEX_DB_DOWNLOAD_NO_CACHE`
+
+Flag to download a fresh copy of the database.
+
+Default value: `UNDEFINED`
+
+Defined in: `scripts/vortex/download-db-lagoon.sh`
+
 ### `VORTEX_DB_DOWNLOAD_PROCEED`
 
 Proceed with download.
@@ -673,14 +681,6 @@ Proceed with download.
 Default value: `1`
 
 Defined in: `scripts/vortex/download-db.sh`
-
-### `VORTEX_DB_DOWNLOAD_REFRESH`
-
-Flag to download a fresh copy of the database.
-
-Default value: `UNDEFINED`
-
-Defined in: `scripts/vortex/download-db-lagoon.sh`
 
 ### `VORTEX_DB_DOWNLOAD_SOURCE`
 

--- a/.vortex/installer/tests/Fixtures/install/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/.ahoy.yml
@@ -112,9 +112,11 @@ commands:
     cmd: ahoy cli ./scripts/vortex/login.sh
 
   download-db:
-    usage: Download database.
+    usage: Download database. Run with "--no-cache" option to force fresh database backup.
     aliases: ['fetch-db']
-    cmd: ./scripts/vortex/download-db.sh
+    cmd: |
+      case " $* " in *" --no-cache "*) export VORTEX_DB_DOWNLOAD_NO_CACHE=1;; esac
+      ./scripts/vortex/download-db.sh
 
   reload-db:
     usage: Reload the database container using local database image.

--- a/.vortex/installer/tests/Fixtures/install/provision_profile/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/provision_profile/.ahoy.yml
@@ -1,11 +1,13 @@
-@@ -111,11 +111,6 @@
+@@ -111,13 +111,6 @@
      usage: Unblock user 1 and generate a one time login link.
      cmd: ahoy cli ./scripts/vortex/login.sh
  
 -  download-db:
--    usage: Download database.
+-    usage: Download database. Run with "--no-cache" option to force fresh database backup.
 -    aliases: ['fetch-db']
--    cmd: ./scripts/vortex/download-db.sh
+-    cmd: |
+-      case " $* " in *" --no-cache "*) export VORTEX_DB_DOWNLOAD_NO_CACHE=1;; esac
+-      ./scripts/vortex/download-db.sh
 -
    reload-db:
      usage: Reload the database container using local database image.

--- a/.vortex/installer/tests/Fixtures/install/theme_absent/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/theme_absent/.ahoy.yml
@@ -6,7 +6,7 @@
        ahoy provision                      # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -156,25 +155,10 @@
+@@ -158,25 +157,10 @@
      usage: Install front-end assets.
      cmd: |
        ahoy cli "yarn install --frozen-lockfile"
@@ -33,7 +33,7 @@
  
    lint-be:
      usage: Lint back-end code.
-@@ -189,7 +173,6 @@
+@@ -191,7 +175,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
        ahoy cli "yarn run lint"
@@ -41,7 +41,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -197,7 +180,7 @@
+@@ -199,7 +182,7 @@
  
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
@@ -50,7 +50,7 @@
  
    lint-be-fix:
      usage: Fix lint issues of back-end code.
-@@ -210,7 +193,6 @@
+@@ -212,7 +195,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/tests/bats/unit/download-db-lagoon.bats
+++ b/.vortex/tests/bats/unit/download-db-lagoon.bats
@@ -21,6 +21,8 @@ load ../_helper.bash
     "[INFO] Started SSH setup."
     "Found variable VORTEX_DB_DOWNLOAD_SSH_FILE with value false."
 
+    "- Database dump refresh requested. Will create a new dump."
+
     # Mock SSH command to create/check database dump on remote
     "@ssh * # 0 # > Creating a database dump /tmp/db_$(date +%Y%m%d).sql."
 
@@ -73,6 +75,8 @@ load ../_helper.bash
     "[INFO] Started SSH setup."
     "Found variable VORTEX_DB_DOWNLOAD_SSH_FILE with value false."
 
+    "- Database dump refresh requested. Will create a new dump."
+
     # Mock SSH command that finds existing dump
     "@ssh * # 0 # > Using existing dump /tmp/db_$(date +%Y%m%d).sql."
 
@@ -124,6 +128,8 @@ load ../_helper.bash
     "[INFO] Started SSH setup."
     "Found variable VORTEX_DB_DOWNLOAD_SSH_FILE with value false."
 
+    "Database dump refresh requested. Will create a new dump."
+
     # Mock SSH command that refreshes dump (removes old, creates new)
     "@ssh * # 0 # Removed previously created DB dumps.\\n      > Creating a database dump /tmp/db_$(date +%Y%m%d).sql."
 
@@ -137,7 +143,7 @@ load ../_helper.bash
 
   export LAGOON_PROJECT="testproject"
   export VORTEX_DB_DOWNLOAD_ENVIRONMENT="main"
-  export VORTEX_DB_DOWNLOAD_REFRESH="1"
+  export VORTEX_DB_DOWNLOAD_NO_CACHE="1"
   export VORTEX_DB_DIR=".data"
   export VORTEX_DB_FILE="db.sql"
 


### PR DESCRIPTION
Closes #1894


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--no-cache` option to the database download command, allowing users to force a fresh database backup.

* **Documentation**
  * Updated documentation to clarify database caching behavior and explain the new `--no-cache` option.
  * Revised environment variable documentation to reflect new variable names and descriptions related to database download workflows.

* **Bug Fixes**
  * Improved log messages and variable handling in database download scripts for clearer feedback and consistency.

* **Tests**
  * Updated test cases to align with the new environment variable and improved log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->