### PR TITLE
[#1918] Updated CI config to export and restore exported codebase only for artifact deployment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,6 @@ aliases:
     # Change to 'large' for faster builds.
     resource_class: medium
 
-  # Set up remote Docker.
   - &step_setup_remote_docker
     setup_remote_docker:
       # Docker Layer Caching allows to significantly speed up builds by caching
@@ -91,7 +90,6 @@ aliases:
       docker_layer_caching: false
       version: default
 
-  # Process the codebase to be run in CI environment.
   - &step_process_codebase_for_ci
     run:
       name: Process codebase to run in CI
@@ -99,6 +97,11 @@ aliases:
         find . -name "docker-compose.yml" -print0 | xargs -0 -I {} sh -c "sed -i -e ''/###/d'' {} && sed -i -e ''s/##//'' {}"
         mkdir -p /tmp/workspace/code
 
+  - &load_variables_from_dotenv
+    run:
+      name: Load environment variables from .env file
+      # Load variables from .env file, respecting existing values, and make them available for the next steps.
+      command: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && export -p >> "$BASH_ENV"
 
 ################################################################################
 # PARAMETERS
@@ -133,6 +136,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
       - *step_setup_remote_docker
 
       - run:
@@ -214,6 +218,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Validate Composer configuration
@@ -262,6 +267,7 @@ jobs:
       - run:
           name: Export built codebase
           command: |
+            echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
             docker compose cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
@@ -398,6 +404,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Deploy
@@ -424,6 +431,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Deploy
@@ -495,6 +503,7 @@ jobs:
     steps:
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
       - *step_setup_remote_docker
 
       - run:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -199,6 +199,9 @@ jobs:
       - name: Process the codebase to run in CI
         run: find . -name "docker-compose.yml" -print0 | xargs -0 -I {} sh -c "sed -i -e '/###/d' {} && sed -i -e 's/##//' {}"
 
+      - name: Load environment variables from .env
+        run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"
+
       - name: Validate Composer configuration
         run: composer validate --strict
         continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE == '1' }}
@@ -248,7 +251,7 @@ jobs:
         run: docker compose up -d
 
       - name: Export built codebase
-        if: matrix.instance == 0
+        if: matrix.instance == 0 && contains(env.VORTEX_DEPLOY_TYPES, 'artifact')
         run: |
           mkdir -p "/tmp/workspace/code"
           docker compose cp -L cli:"/app/." "/tmp/workspace/code"
@@ -362,7 +365,7 @@ jobs:
 
       - name: Upload exported codebase as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.instance == 0 && !startsWith(github.head_ref || github.ref_name, 'deps/') }}
+        if: ${{ matrix.instance == 0 && !startsWith(github.head_ref || github.ref_name, 'deps/') && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
         with:
           name: code-artifact
           path: "/tmp/workspace/code"
@@ -407,8 +410,12 @@ jobs:
           persist-credentials: false
           ref: ${{ github.head_ref || github.ref_name }}
 
+      - name: Load environment variables from .env
+        run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"
+
       - name: Download exported codebase as an artifact
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        if: ${{ contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
         with:
           name: code-artifact
           path: "/tmp/workspace/code"

--- a/.github/workflows/vortex-test-common.yml
+++ b/.github/workflows/vortex-test-common.yml
@@ -273,5 +273,5 @@ jobs:
         continue-on-error: ${{ vars.VORTEX_CI_YAMLLINT_IGNORE_FAILURE == '1' }}
 
       - name: Check coding standards with actionlint
-        run: docker run --rm -v "${GITHUB_WORKSPACE:-.}":/app --workdir /app rhysd/actionlint:1.7.2 -ignore 'SC2002:' -ignore 'SC2155:' -ignore 'SC2015:' -ignore 'SC2046:'
+        run: docker run --rm -v "${GITHUB_WORKSPACE:-.}":/app --workdir /app rhysd/actionlint:1.7.2 -ignore 'SC2002:' -ignore 'SC2155:' -ignore 'SC2015:' -ignore 'SC2046:' -ignore 'SC1090:'
         continue-on-error: ${{ vars.VORTEX_CI_ACTIONLINT_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/install/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/.github/workflows/build-test-deploy.yml
@@ -188,6 +188,9 @@ jobs:
       - name: Process the codebase to run in CI
         run: find . -name "docker-compose.yml" -print0 | xargs -0 -I {} sh -c "sed -i -e '/###/d' {} && sed -i -e 's/##//' {}"
 
+      - name: Load environment variables from .env
+        run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"
+
       - name: Validate Composer configuration
         run: composer validate --strict
         continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE == '1' }}
@@ -235,7 +238,7 @@ jobs:
         run: docker compose up -d
 
       - name: Export built codebase
-        if: matrix.instance == 0
+        if: matrix.instance == 0 && contains(env.VORTEX_DEPLOY_TYPES, 'artifact')
         run: |
           mkdir -p "/tmp/workspace/code"
           docker compose cp -L cli:"/app/." "/tmp/workspace/code"
@@ -347,7 +350,7 @@ jobs:
 
       - name: Upload exported codebase as artifact
         uses: actions/upload-artifact@__HASH__ # __VERSION__
-        if: ${{ matrix.instance == 0 && !startsWith(github.head_ref || github.ref_name, 'deps/') }}
+        if: ${{ matrix.instance == 0 && !startsWith(github.head_ref || github.ref_name, 'deps/') && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
         with:
           name: code-artifact
           path: "/tmp/workspace/code"
@@ -389,8 +392,12 @@ jobs:
           persist-credentials: false
           ref: ${{ github.head_ref || github.ref_name }}
 
+      - name: Load environment variables from .env
+        run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"
+
       - name: Download exported codebase as an artifact
         uses: actions/download-artifact@__HASH__ # __VERSION__
+        if: ${{ contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
         with:
           name: code-artifact
           path: "/tmp/workspace/code"

--- a/.vortex/installer/tests/Fixtures/install/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/ciprovider_circleci/.circleci/config.yml
@@ -71,7 +71,6 @@ aliases:
     # Change to 'large' for faster builds.
     resource_class: medium
 
-  # Set up remote Docker.
   - &step_setup_remote_docker
     setup_remote_docker:
       # Docker Layer Caching allows to significantly speed up builds by caching
@@ -80,13 +79,18 @@ aliases:
       docker_layer_caching: false
       version: default
 
-  # Process the codebase to be run in CI environment.
   - &step_process_codebase_for_ci
     run:
       name: Process codebase to run in CI
       command: |
         find . -name "docker-compose.yml" -print0 | xargs -0 -I {} sh -c "sed -i -e ''/###/d'' {} && sed -i -e ''s/##//'' {}"
         mkdir -p /tmp/workspace/code
+
+  - &load_variables_from_dotenv
+    run:
+      name: Load environment variables from .env file
+      # Load variables from .env file, respecting existing values, and make them available for the next steps.
+      command: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && export -p >> "$BASH_ENV"
 
 ################################################################################
 # PARAMETERS
@@ -120,6 +124,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
       - *step_setup_remote_docker
 
       - run:
@@ -200,6 +205,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Validate Composer configuration
@@ -246,6 +252,7 @@ jobs:
       - run:
           name: Export built codebase
           command: |
+            echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
             docker compose cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
@@ -379,6 +386,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Deploy
@@ -405,6 +413,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Deploy

--- a/.vortex/installer/tests/Fixtures/install/deploy_type_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/deploy_type_all_circleci/.circleci/config.yml
@@ -71,7 +71,6 @@ aliases:
     # Change to 'large' for faster builds.
     resource_class: medium
 
-  # Set up remote Docker.
   - &step_setup_remote_docker
     setup_remote_docker:
       # Docker Layer Caching allows to significantly speed up builds by caching
@@ -80,13 +79,18 @@ aliases:
       docker_layer_caching: false
       version: default
 
-  # Process the codebase to be run in CI environment.
   - &step_process_codebase_for_ci
     run:
       name: Process codebase to run in CI
       command: |
         find . -name "docker-compose.yml" -print0 | xargs -0 -I {} sh -c "sed -i -e ''/###/d'' {} && sed -i -e ''s/##//'' {}"
         mkdir -p /tmp/workspace/code
+
+  - &load_variables_from_dotenv
+    run:
+      name: Load environment variables from .env file
+      # Load variables from .env file, respecting existing values, and make them available for the next steps.
+      command: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && export -p >> "$BASH_ENV"
 
 ################################################################################
 # PARAMETERS
@@ -120,6 +124,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
       - *step_setup_remote_docker
 
       - run:
@@ -200,6 +205,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Validate Composer configuration
@@ -246,6 +252,7 @@ jobs:
       - run:
           name: Export built codebase
           command: |
+            echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
             docker compose cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
@@ -379,6 +386,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Deploy
@@ -405,6 +413,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Deploy

--- a/.vortex/installer/tests/Fixtures/install/deploy_type_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/deploy_type_none_circleci/.circleci/config.yml
@@ -71,7 +71,6 @@ aliases:
     # Change to 'large' for faster builds.
     resource_class: medium
 
-  # Set up remote Docker.
   - &step_setup_remote_docker
     setup_remote_docker:
       # Docker Layer Caching allows to significantly speed up builds by caching
@@ -80,13 +79,18 @@ aliases:
       docker_layer_caching: false
       version: default
 
-  # Process the codebase to be run in CI environment.
   - &step_process_codebase_for_ci
     run:
       name: Process codebase to run in CI
       command: |
         find . -name "docker-compose.yml" -print0 | xargs -0 -I {} sh -c "sed -i -e ''/###/d'' {} && sed -i -e ''s/##//'' {}"
         mkdir -p /tmp/workspace/code
+
+  - &load_variables_from_dotenv
+    run:
+      name: Load environment variables from .env file
+      # Load variables from .env file, respecting existing values, and make them available for the next steps.
+      command: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && export -p >> "$BASH_ENV"
 
 ################################################################################
 # PARAMETERS
@@ -120,6 +124,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
       - *step_setup_remote_docker
 
       - run:
@@ -200,6 +205,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Validate Composer configuration
@@ -246,6 +252,7 @@ jobs:
       - run:
           name: Export built codebase
           command: |
+            echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
             docker compose cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"

--- a/.vortex/installer/tests/Fixtures/install/deploy_type_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/deploy_type_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -361,61 +361,3 @@
+@@ -364,65 +364,3 @@
          timeout-minutes: 120 # Cancel the action after 15 minutes, regardless of whether a connection has been established.
          with:
            detached: true
@@ -30,8 +30,12 @@
 -          persist-credentials: false
 -          ref: ${{ github.head_ref || github.ref_name }}
 -
+-      - name: Load environment variables from .env
+-        run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"
+-
 -      - name: Download exported codebase as an artifact
 -        uses: actions/download-artifact@__HASH__ # __VERSION__
+-        if: ${{ contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
 -        with:
 -          name: code-artifact
 -          path: "/tmp/workspace/code"

--- a/.vortex/installer/tests/Fixtures/install/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -71,7 +71,6 @@ aliases:
     # Change to 'large' for faster builds.
     resource_class: medium
 
-  # Set up remote Docker.
   - &step_setup_remote_docker
     setup_remote_docker:
       # Docker Layer Caching allows to significantly speed up builds by caching
@@ -80,13 +79,18 @@ aliases:
       docker_layer_caching: false
       version: default
 
-  # Process the codebase to be run in CI environment.
   - &step_process_codebase_for_ci
     run:
       name: Process codebase to run in CI
       command: |
         find . -name "docker-compose.yml" -print0 | xargs -0 -I {} sh -c "sed -i -e ''/###/d'' {} && sed -i -e ''s/##//'' {}"
         mkdir -p /tmp/workspace/code
+
+  - &load_variables_from_dotenv
+    run:
+      name: Load environment variables from .env file
+      # Load variables from .env file, respecting existing values, and make them available for the next steps.
+      command: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && export -p >> "$BASH_ENV"
 
 ################################################################################
 # PARAMETERS
@@ -120,6 +124,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
       - *step_setup_remote_docker
 
       - run:
@@ -200,6 +205,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Validate Composer configuration
@@ -246,6 +252,7 @@ jobs:
       - run:
           name: Export built codebase
           command: |
+            echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
             docker compose cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
@@ -379,6 +386,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Deploy
@@ -405,6 +413,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Deploy

--- a/.vortex/installer/tests/Fixtures/install/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/provision_profile/.github/workflows/build-test-deploy.yml
@@ -133,7 +133,7 @@
  
      steps:
        - name: Preserve $HOME set in the container
-@@ -192,29 +82,6 @@
+@@ -195,29 +85,6 @@
          run: composer validate --strict
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE == '1' }}
  
@@ -163,7 +163,7 @@
        - name: Login to container registry
          run: ./scripts/vortex/login-container-registry.sh
  
-@@ -365,7 +232,6 @@
+@@ -368,7 +235,6 @@
    deploy:
      runs-on: ubuntu-latest
      needs: build

--- a/.vortex/installer/tests/Fixtures/install/theme_absent/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/theme_absent/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -288,11 +288,6 @@
+@@ -291,11 +291,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/install/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/timezone_circleci/.circleci/config.yml
@@ -71,7 +71,6 @@ aliases:
     # Change to 'large' for faster builds.
     resource_class: medium
 
-  # Set up remote Docker.
   - &step_setup_remote_docker
     setup_remote_docker:
       # Docker Layer Caching allows to significantly speed up builds by caching
@@ -80,13 +79,18 @@ aliases:
       docker_layer_caching: false
       version: default
 
-  # Process the codebase to be run in CI environment.
   - &step_process_codebase_for_ci
     run:
       name: Process codebase to run in CI
       command: |
         find . -name "docker-compose.yml" -print0 | xargs -0 -I {} sh -c "sed -i -e ''/###/d'' {} && sed -i -e ''s/##//'' {}"
         mkdir -p /tmp/workspace/code
+
+  - &load_variables_from_dotenv
+    run:
+      name: Load environment variables from .env file
+      # Load variables from .env file, respecting existing values, and make them available for the next steps.
+      command: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && export -p >> "$BASH_ENV"
 
 ################################################################################
 # PARAMETERS
@@ -120,6 +124,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
       - *step_setup_remote_docker
 
       - run:
@@ -200,6 +205,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Validate Composer configuration
@@ -246,6 +252,7 @@ jobs:
       - run:
           name: Export built codebase
           command: |
+            echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
             docker compose cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
@@ -379,6 +386,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Deploy
@@ -405,6 +413,7 @@ jobs:
 
       - checkout
       - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
 
       - run:
           name: Deploy


### PR DESCRIPTION
Closes #1918

Also variables from `.env` to be available in the build steps, respecting existing values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - CI pipelines now load environment variables from a .env file, making them available across jobs.
- Chores
  - Artifact-related steps (export, upload, download) run only for artifact deployments, reducing unnecessary work on other runs.
  - Updated workflow gating to conditionally execute build/deploy steps based on deployment type.
- Tests
  - Relaxed action linting by ignoring an additional rule to reduce false positives during CI checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->