### PR TITLE
[#1917] Updated Redis config and enabled by default.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -106,6 +106,7 @@ commands:
 
   #;< SERVICE_VALKEY
   flush-valkey:
+    aliases: [flush-redis]
     usage: Flush Valkey cache.
     cmd: docker compose exec valkey valkey-cli flushall
   #;> SERVICE_VALKEY

--- a/.env
+++ b/.env
@@ -75,7 +75,7 @@ DRUPAL_SHIELD_PRINT="Restricted access."
 #;< SERVICE_VALKEY
 # Enable Redis/Valkey integration.
 # See settings.redis.php for details.
-DRUPAL_REDIS_ENABLED=0
+DRUPAL_REDIS_ENABLED=1
 #;> SERVICE_VALKEY
 
 #;< SERVICE_CLAMAV

--- a/.vortex/docs/content/workflows/variables.mdx
+++ b/.vortex/docs/content/workflows/variables.mdx
@@ -226,7 +226,7 @@ Defined in: `docker-compose.yml`
 
 Enable Redis/Valkey integration.<br/>See settings.redis.php for details.
 
-Default value: `UNDEFINED`
+Default value: `1`
 
 Defined in: `.env`
 

--- a/.vortex/installer/src/Prompts/Handlers/Services.php
+++ b/.vortex/installer/src/Prompts/Handlers/Services.php
@@ -115,7 +115,7 @@ class Services extends AbstractHandler {
       @unlink($t . DIRECTORY_SEPARATOR . '.docker/clamav.dockerfile');
       @unlink($t . DIRECTORY_SEPARATOR . $w . DIRECTORY_SEPARATOR . 'sites/default/includes/modules/settings.clamav.php');
       @unlink($t . DIRECTORY_SEPARATOR . 'tests/behat/features/clamav.feature');
-      File::replaceContentInFile($t . DIRECTORY_SEPARATOR . 'docker-compose.yml', 'command: database:3306 clamav:3310', 'command: database:3306');
+      File::replaceContentInFile($t . DIRECTORY_SEPARATOR . 'docker-compose.yml', 'clamav:3310', '');
       File::replaceContentInFile($t . DIRECTORY_SEPARATOR . 'composer.json', '/\s*"drupal\/clamav":\s*"[^\"]+",?\n/', "\n");
     }
 
@@ -149,7 +149,9 @@ class Services extends AbstractHandler {
       File::rmdir($t . DIRECTORY_SEPARATOR . '.docker/config/valkey');
       @unlink($t . DIRECTORY_SEPARATOR . '.docker/valkey.dockerfile');
       @unlink($t . DIRECTORY_SEPARATOR . $w . DIRECTORY_SEPARATOR . 'sites/default/includes/modules/settings.redis.php');
+      File::replaceContentInFile($t . DIRECTORY_SEPARATOR . 'docker-compose.yml', 'valkey:6379', '');
       File::replaceContentInFile($t . DIRECTORY_SEPARATOR . 'composer.json', '/\s*"drupal\/redis":\s*"[^\"]+",?\n/', "\n");
+      @unlink($t . DIRECTORY_SEPARATOR . 'tests/behat/features/redis.feature');
     }
   }
 

--- a/.vortex/installer/tests/Fixtures/install/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/.ahoy.yml
@@ -100,6 +100,7 @@ commands:
     cmd: ahoy cli "vendor/bin/drush -l \${VORTEX_LOCALDEV_URL} $*"
 
   flush-valkey:
+    aliases: [flush-redis]
     usage: Flush Valkey cache.
     cmd: docker compose exec valkey valkey-cli flushall
 

--- a/.vortex/installer/tests/Fixtures/install/_baseline/.env
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/.env
@@ -72,7 +72,7 @@ DRUPAL_SHIELD_PRINT="Restricted access."
 
 # Enable Redis/Valkey integration.
 # See settings.redis.php for details.
-DRUPAL_REDIS_ENABLED=0
+DRUPAL_REDIS_ENABLED=1
 
 # Enable ClamAV integration.
 DRUPAL_CLAMAV_ENABLED=1

--- a/.vortex/installer/tests/Fixtures/install/_baseline/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/docker-compose.yml
@@ -196,7 +196,8 @@ services:
       - clamav
       - cli
       - database
-    command: database:3306 clamav:3310
+      - valkey
+    command: database:3306 clamav:3310 valkey:6379
 
 networks:           ### Use external networks locally. Automatically removed in CI.
   amazeeio-network: ### Automatically removed in CI.

--- a/.vortex/installer/tests/Fixtures/install/_baseline/rector.php
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/rector.php
@@ -23,6 +23,7 @@ use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Php81\Rector\Array_\FirstClassCallableRector;
 use Rector\Set\ValueObject\SetList;
@@ -77,6 +78,9 @@ return static function (RectorConfig $rectorConfig): void {
     NewlineBeforeNewAssignSetRector::class,
     RemoveAlwaysTrueIfConditionRector::class,
     SimplifyEmptyCheckOnEmptyArrayRector::class,
+    StringClassNameToClassConstantRector::class => [
+      $drupalRoot . '/sites/default/includes/*',
+    ],
     // Dependencies.
     '*/vendor/*',
     '*/node_modules/*',

--- a/.vortex/installer/tests/Fixtures/install/_baseline/tests/behat/features/redis.feature
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/tests/behat/features/redis.feature
@@ -1,0 +1,15 @@
+@redis
+Feature: Redis cache functionality
+
+  As a site administrator
+  I want to verify that Redis caching is working properly
+  So that I can ensure optimal site performance and caching functionality
+
+  @api
+  Scenario: Redis is working properly
+    Given I am logged in as a user with the "administrator" role
+    When I go to "/admin/reports/redis"
+    Then the response status code should be 200
+    And I should see "Connected, using the PhpRedis client"
+    And I should not see "0 tags with 0 invalidations"
+    And I save screenshot

--- a/.vortex/installer/tests/Fixtures/install/_baseline/web/sites/default/includes/modules/settings.redis.php
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/web/sites/default/includes/modules/settings.redis.php
@@ -7,15 +7,13 @@
  * Redis module can work with Redis or Valkey services as they are
  * interchangeable. We use `DRUPAL_REDIS_` environment variables as the Drupal
  * module name is `redis`.
+ *
+ * @phpcs:disable DrupalPractice.Commenting.CommentEmptyLine.SpacingAfter
+ * @phpcs:disable Drupal.Commenting.InlineComment.SpacingAfter
+ * @phpcs:disable Drupal.Commenting.InlineComment.InvalidEndChar
  */
 
 declare(strict_types=1);
-
-use Drupal\Component\Serialization\PhpSerialize;
-use Drupal\redis\Cache\CacheBackendFactory;
-use Drupal\redis\Cache\PhpRedis;
-use Drupal\redis\Cache\RedisCacheTagsChecksum;
-use Drupal\redis\ClientFactory;
 
 // Using 'DRUPAL_REDIS_ENABLED' variable to resolve deployment concurrency:
 // Redis module needs to be enabled without the configuration below applied
@@ -29,16 +27,53 @@ use Drupal\redis\ClientFactory;
 // project-wide env variable (and since it has the same value '1' as removed
 // per-env variable - there will be no change in how code works).
 if (file_exists($contrib_path . '/redis') && !empty(getenv('DRUPAL_REDIS_ENABLED'))) {
-  $settings['redis.connection']['interface'] = 'PhpRedis';
   // Some providers use `REDIS_`-prefixed environment variables.
   $settings['redis.connection']['host'] = getenv('VALKEY_HOST') ?: getenv('REDIS_HOST') ?: 'valkey';
   $settings['redis.connection']['port'] = getenv('VALKEY_SERVICE_PORT') ?: getenv('REDIS_SERVICE_PORT') ?: '6379';
+
+  // Customize used interface.
+  $settings['redis.connection']['interface'] = 'PhpRedis';
 
   // Do not set the cache backend during installations of Drupal, but allow
   // to override this by setting VORTEX_REDIS_EXTENSION_LOADED to non-zero.
   // Note that Valkey uses `redis` PHP extension.
   if ((extension_loaded('redis') && getenv('VORTEX_REDIS_EXTENSION_LOADED') === FALSE) || !empty(getenv('VORTEX_REDIS_EXTENSION_LOADED'))) {
+
+    // Set Redis as the default backend for any cache bin not otherwise
+    // specified.
     $settings['cache']['default'] = 'cache.backend.redis';
+
+    // Per-bin configuration examples, bypass the default ChainedFastBackend.
+    // *Only* use this when using Relay (see README.Relay.md) or when APCu is
+    // not available.
+    // $settings['cache']['bins']['config'] = 'cache.backend.redis';
+    // $settings['cache']['bins']['discovery'] = 'cache.backend.redis';
+    // $settings['cache']['bins']['bootstrap'] = 'cache.backend.redis';
+
+    // Use compression for cache entries longer than the specified limit.
+    $settings['redis_compress_length'] = 100;
+
+    // Customize the prefix, a reliable but long fallback is used if not
+    // defined.
+    // $settings['cache_prefix'] = 'prefix';
+
+    // Respect specific TTL with an offset see README.md for more information.
+    $settings['redis_ttl_offset'] = 3600;
+
+    // Additional optimizations, see README.md.
+    $settings['redis_invalidate_all_as_delete'] = TRUE;
+
+    $settings['flush_redis_on_drupal_flush_cache'] = TRUE;
+
+    // Apply changes to the container configuration to better leverage Redis.
+    // This includes using Redis for the lock and flood control systems, as well
+    // as the cache tag checksum. Alternatively, copy the contents of that file
+    // to your project-specific services.yml file, modify as appropriate, and
+    // remove this line.
+    $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
+
+    // Allow the services to work before the Redis module itself is enabled.
+    $settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
 
     if (!isset($class_loader)) {
       // Initialize the autoloader.
@@ -48,33 +83,37 @@ if (file_exists($contrib_path . '/redis') && !empty(getenv('DRUPAL_REDIS_ENABLED
       }
     }
 
-    $class_loader->addPsr4('Drupal\\redis\\', $contrib_path . '/redis/src');
+    // Manually add the classloader path, this is required for the container
+    // cache bin definition below and allows to use it without the redis module
+    // being enabled.
+    $class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src');
 
+    // Use redis for container cache.
+    // The container cache is used to load the container definition itself, and
+    // thus any configuration stored in the container itself is not available
+    // yet. These lines force the container cache to use Redis rather than the
+    // default SQL cache.
     $settings['bootstrap_container_definition'] = [
       'parameters' => [],
       'services' => [
         'redis.factory' => [
-          'class' => ClientFactory::class,
+          'class' => 'Drupal\redis\ClientFactory',
         ],
         'cache.backend.redis' => [
-          'class' => CacheBackendFactory::class,
-          'arguments' => [
-            '@redis.factory',
-            '@cache_tags_provider.container',
-            '@serialization.phpserialize',
-          ],
+          'class' => 'Drupal\redis\Cache\CacheBackendFactory',
+          'arguments' => ['@redis.factory', '@cache_tags_provider.container', '@serialization.phpserialize'],
         ],
         'cache.container' => [
-          'class' => PhpRedis::class,
+          'class' => '\Drupal\redis\Cache\PhpRedis',
           'factory' => ['@cache.backend.redis', 'get'],
           'arguments' => ['container'],
         ],
         'cache_tags_provider.container' => [
-          'class' => RedisCacheTagsChecksum::class,
+          'class' => 'Drupal\redis\Cache\RedisCacheTagsChecksum',
           'arguments' => ['@redis.factory'],
         ],
         'serialization.phpserialize' => [
-          'class' => PhpSerialize::class,
+          'class' => 'Drupal\Component\Serialization\PhpSerialize',
         ],
       ],
     ];

--- a/.vortex/installer/tests/Fixtures/install/hosting_acquia/docroot/sites/default/includes/modules/settings.redis.php
+++ b/.vortex/installer/tests/Fixtures/install/hosting_acquia/docroot/sites/default/includes/modules/settings.redis.php
@@ -7,15 +7,13 @@
  * Redis module can work with Redis or Valkey services as they are
  * interchangeable. We use `DRUPAL_REDIS_` environment variables as the Drupal
  * module name is `redis`.
+ *
+ * @phpcs:disable DrupalPractice.Commenting.CommentEmptyLine.SpacingAfter
+ * @phpcs:disable Drupal.Commenting.InlineComment.SpacingAfter
+ * @phpcs:disable Drupal.Commenting.InlineComment.InvalidEndChar
  */
 
 declare(strict_types=1);
-
-use Drupal\Component\Serialization\PhpSerialize;
-use Drupal\redis\Cache\CacheBackendFactory;
-use Drupal\redis\Cache\PhpRedis;
-use Drupal\redis\Cache\RedisCacheTagsChecksum;
-use Drupal\redis\ClientFactory;
 
 // Using 'DRUPAL_REDIS_ENABLED' variable to resolve deployment concurrency:
 // Redis module needs to be enabled without the configuration below applied
@@ -29,16 +27,53 @@ use Drupal\redis\ClientFactory;
 // project-wide env variable (and since it has the same value '1' as removed
 // per-env variable - there will be no change in how code works).
 if (file_exists($contrib_path . '/redis') && !empty(getenv('DRUPAL_REDIS_ENABLED'))) {
-  $settings['redis.connection']['interface'] = 'PhpRedis';
   // Some providers use `REDIS_`-prefixed environment variables.
   $settings['redis.connection']['host'] = getenv('VALKEY_HOST') ?: getenv('REDIS_HOST') ?: 'valkey';
   $settings['redis.connection']['port'] = getenv('VALKEY_SERVICE_PORT') ?: getenv('REDIS_SERVICE_PORT') ?: '6379';
+
+  // Customize used interface.
+  $settings['redis.connection']['interface'] = 'PhpRedis';
 
   // Do not set the cache backend during installations of Drupal, but allow
   // to override this by setting VORTEX_REDIS_EXTENSION_LOADED to non-zero.
   // Note that Valkey uses `redis` PHP extension.
   if ((extension_loaded('redis') && getenv('VORTEX_REDIS_EXTENSION_LOADED') === FALSE) || !empty(getenv('VORTEX_REDIS_EXTENSION_LOADED'))) {
+
+    // Set Redis as the default backend for any cache bin not otherwise
+    // specified.
     $settings['cache']['default'] = 'cache.backend.redis';
+
+    // Per-bin configuration examples, bypass the default ChainedFastBackend.
+    // *Only* use this when using Relay (see README.Relay.md) or when APCu is
+    // not available.
+    // $settings['cache']['bins']['config'] = 'cache.backend.redis';
+    // $settings['cache']['bins']['discovery'] = 'cache.backend.redis';
+    // $settings['cache']['bins']['bootstrap'] = 'cache.backend.redis';
+
+    // Use compression for cache entries longer than the specified limit.
+    $settings['redis_compress_length'] = 100;
+
+    // Customize the prefix, a reliable but long fallback is used if not
+    // defined.
+    // $settings['cache_prefix'] = 'prefix';
+
+    // Respect specific TTL with an offset see README.md for more information.
+    $settings['redis_ttl_offset'] = 3600;
+
+    // Additional optimizations, see README.md.
+    $settings['redis_invalidate_all_as_delete'] = TRUE;
+
+    $settings['flush_redis_on_drupal_flush_cache'] = TRUE;
+
+    // Apply changes to the container configuration to better leverage Redis.
+    // This includes using Redis for the lock and flood control systems, as well
+    // as the cache tag checksum. Alternatively, copy the contents of that file
+    // to your project-specific services.yml file, modify as appropriate, and
+    // remove this line.
+    $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
+
+    // Allow the services to work before the Redis module itself is enabled.
+    $settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
 
     if (!isset($class_loader)) {
       // Initialize the autoloader.
@@ -48,33 +83,37 @@ if (file_exists($contrib_path . '/redis') && !empty(getenv('DRUPAL_REDIS_ENABLED
       }
     }
 
-    $class_loader->addPsr4('Drupal\\redis\\', $contrib_path . '/redis/src');
+    // Manually add the classloader path, this is required for the container
+    // cache bin definition below and allows to use it without the redis module
+    // being enabled.
+    $class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src');
 
+    // Use redis for container cache.
+    // The container cache is used to load the container definition itself, and
+    // thus any configuration stored in the container itself is not available
+    // yet. These lines force the container cache to use Redis rather than the
+    // default SQL cache.
     $settings['bootstrap_container_definition'] = [
       'parameters' => [],
       'services' => [
         'redis.factory' => [
-          'class' => ClientFactory::class,
+          'class' => 'Drupal\redis\ClientFactory',
         ],
         'cache.backend.redis' => [
-          'class' => CacheBackendFactory::class,
-          'arguments' => [
-            '@redis.factory',
-            '@cache_tags_provider.container',
-            '@serialization.phpserialize',
-          ],
+          'class' => 'Drupal\redis\Cache\CacheBackendFactory',
+          'arguments' => ['@redis.factory', '@cache_tags_provider.container', '@serialization.phpserialize'],
         ],
         'cache.container' => [
-          'class' => PhpRedis::class,
+          'class' => '\Drupal\redis\Cache\PhpRedis',
           'factory' => ['@cache.backend.redis', 'get'],
           'arguments' => ['container'],
         ],
         'cache_tags_provider.container' => [
-          'class' => RedisCacheTagsChecksum::class,
+          'class' => 'Drupal\redis\Cache\RedisCacheTagsChecksum',
           'arguments' => ['@redis.factory'],
         ],
         'serialization.phpserialize' => [
-          'class' => PhpSerialize::class,
+          'class' => 'Drupal\Component\Serialization\PhpSerialize',
         ],
       ],
     ];

--- a/.vortex/installer/tests/Fixtures/install/hosting_lagoon/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/hosting_lagoon/docker-compose.yml
@@ -84,10 +84,10 @@
  
    # Helper container to wait for services to become available.
    wait_dependencies:
-@@ -197,6 +224,8 @@
-       - cli
+@@ -198,6 +225,8 @@
        - database
-     command: database:3306 clamav:3310
+       - valkey
+     command: database:3306 clamav:3310 valkey:6379
 +    labels:
 +      lagoon.type: none # Do not deploy in Lagoon.
  

--- a/.vortex/installer/tests/Fixtures/install/provision_database_lagoon/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/provision_database_lagoon/docker-compose.yml
@@ -84,10 +84,10 @@
  
    # Helper container to wait for services to become available.
    wait_dependencies:
-@@ -197,6 +224,8 @@
-       - cli
+@@ -198,6 +225,8 @@
        - database
-     command: database:3306 clamav:3310
+       - valkey
+     command: database:3306 clamav:3310 valkey:6379
 +    labels:
 +      lagoon.type: none # Do not deploy in Lagoon.
  

--- a/.vortex/installer/tests/Fixtures/install/provision_profile/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/provision_profile/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -111,13 +111,6 @@
+@@ -112,13 +112,6 @@
      usage: Unblock user 1 and generate a one time login link.
      cmd: ahoy cli ./scripts/vortex/login.sh
  

--- a/.vortex/installer/tests/Fixtures/install/services_no_clamav/.env
+++ b/.vortex/installer/tests/Fixtures/install/services_no_clamav/.env
@@ -1,6 +1,6 @@
 @@ -74,15 +74,6 @@
  # See settings.redis.php for details.
- DRUPAL_REDIS_ENABLED=0
+ DRUPAL_REDIS_ENABLED=1
  
 -# Enable ClamAV integration.
 -DRUPAL_CLAMAV_ENABLED=1

--- a/.vortex/installer/tests/Fixtures/install/services_no_clamav/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_no_clamav/docker-compose.yml
@@ -16,15 +16,16 @@
    # Chrome container, used for browser testing.
    chrome:
      image: selenium/standalone-chromium:__VERSION__
-@@ -193,10 +182,9 @@
+@@ -193,11 +182,10 @@
    wait_dependencies:
      image: drevops/docker-wait-for-dependencies:__VERSION__
      depends_on:
 -      - clamav
        - cli
        - database
--    command: database:3306 clamav:3310
-+    command: database:3306
+       - valkey
+-    command: database:3306 clamav:3310 valkey:6379
++    command: database:3306  valkey:6379
  
  networks:           ### Use external networks locally. Automatically removed in CI.
    amazeeio-network: ### Automatically removed in CI.

--- a/.vortex/installer/tests/Fixtures/install/services_no_solr/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_no_solr/docker-compose.yml
@@ -22,7 +22,7 @@
    clamav:
      build:
        context: .
-@@ -205,7 +188,6 @@
+@@ -206,7 +189,6 @@
  volumes:
    app: {}
    files: {}

--- a/.vortex/installer/tests/Fixtures/install/services_no_valkey/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_no_valkey/.ahoy.yml
@@ -1,8 +1,9 @@
-@@ -99,10 +99,6 @@
+@@ -99,11 +99,6 @@
      usage: Run Drush commands in the CLI service container.
      cmd: ahoy cli "vendor/bin/drush -l \${VORTEX_LOCALDEV_URL} $*"
  
 -  flush-valkey:
+-    aliases: [flush-redis]
 -    usage: Flush Valkey cache.
 -    cmd: docker compose exec valkey valkey-cli flushall
 -

--- a/.vortex/installer/tests/Fixtures/install/services_no_valkey/.env
+++ b/.vortex/installer/tests/Fixtures/install/services_no_valkey/.env
@@ -4,7 +4,7 @@
  
 -# Enable Redis/Valkey integration.
 -# See settings.redis.php for details.
--DRUPAL_REDIS_ENABLED=0
+-DRUPAL_REDIS_ENABLED=1
 -
  # Enable ClamAV integration.
  DRUPAL_CLAMAV_ENABLED=1

--- a/.vortex/installer/tests/Fixtures/install/services_no_valkey/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_no_valkey/docker-compose.yml
@@ -7,13 +7,23 @@
  
  # The default user under which the containers should run.
  x-user: &default-user
-@@ -145,9 +143,6 @@
-     <<: *default-user
+@@ -146,9 +144,6 @@
      ports:
        - '3306' # Database port in a container. Find port on host with `ahoy info` or `docker compose port database 3306`.
--
+ 
 -  valkey:
 -    image: uselagoon/valkey-8:__VERSION__
- 
+-
    solr:
      build:
+       context: .
+@@ -196,8 +191,7 @@
+       - clamav
+       - cli
+       - database
+-      - valkey
+-    command: database:3306 clamav:3310 valkey:6379
++    command: database:3306 clamav:3310 
+ 
+ networks:           ### Use external networks locally. Automatically removed in CI.
+   amazeeio-network: ### Automatically removed in CI.

--- a/.vortex/installer/tests/Fixtures/install/services_none/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_none/.ahoy.yml
@@ -6,12 +6,13 @@
        VORTEX_HOST_SELENIUM_VNC_PORT=$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2) \
        VORTEX_HOST_HAS_SEQUELACE=$(uname -a | grep -i -q darwin && mdfind -name 'Sequel Ace' 2>/dev/null | grep -q "Ace" && echo 1 || true) \
        ahoy cli ./scripts/vortex/info.sh "$@"
-@@ -98,10 +97,6 @@
+@@ -98,11 +97,6 @@
    drush:
      usage: Run Drush commands in the CLI service container.
      cmd: ahoy cli "vendor/bin/drush -l \${VORTEX_LOCALDEV_URL} $*"
 -
 -  flush-valkey:
+-    aliases: [flush-redis]
 -    usage: Flush Valkey cache.
 -    cmd: docker compose exec valkey valkey-cli flushall
  

--- a/.vortex/installer/tests/Fixtures/install/services_none/.env
+++ b/.vortex/installer/tests/Fixtures/install/services_none/.env
@@ -4,7 +4,7 @@
  
 -# Enable Redis/Valkey integration.
 -# See settings.redis.php for details.
--DRUPAL_REDIS_ENABLED=0
+-DRUPAL_REDIS_ENABLED=1
 -
 -# Enable ClamAV integration.
 -DRUPAL_CLAMAV_ENABLED=1

--- a/.vortex/installer/tests/Fixtures/install/services_none/docker-compose.yml
+++ b/.vortex/installer/tests/Fixtures/install/services_none/docker-compose.yml
@@ -45,19 +45,20 @@
    # Chrome container, used for browser testing.
    chrome:
      image: selenium/standalone-chromium:__VERSION__
-@@ -193,10 +160,9 @@
+@@ -193,11 +160,9 @@
    wait_dependencies:
      image: drevops/docker-wait-for-dependencies:__VERSION__
      depends_on:
 -      - clamav
        - cli
        - database
--    command: database:3306 clamav:3310
-+    command: database:3306
+-      - valkey
+-    command: database:3306 clamav:3310 valkey:6379
++    command: database:3306  
  
  networks:           ### Use external networks locally. Automatically removed in CI.
    amazeeio-network: ### Automatically removed in CI.
-@@ -205,7 +171,6 @@
+@@ -206,7 +171,6 @@
  volumes:
    app: {}
    files: {}

--- a/.vortex/installer/tests/Fixtures/install/theme_absent/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/theme_absent/.ahoy.yml
@@ -6,7 +6,7 @@
        ahoy provision                      # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -158,25 +157,10 @@
+@@ -159,25 +158,10 @@
      usage: Install front-end assets.
      cmd: |
        ahoy cli "yarn install --frozen-lockfile"
@@ -33,7 +33,7 @@
  
    lint-be:
      usage: Lint back-end code.
-@@ -191,7 +175,6 @@
+@@ -192,7 +176,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
        ahoy cli "yarn run lint"
@@ -41,7 +41,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -199,7 +182,7 @@
+@@ -200,7 +183,7 @@
  
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
@@ -50,7 +50,7 @@
  
    lint-be-fix:
      usage: Fix lint issues of back-end code.
-@@ -212,7 +195,6 @@
+@@ -213,7 +196,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/install/theme_absent/rector.php
+++ b/.vortex/installer/tests/Fixtures/install/theme_absent/rector.php
@@ -1,4 +1,4 @@
-@@ -42,7 +42,6 @@
+@@ -43,7 +43,6 @@
  
    $rectorConfig->paths([
      $drupalRoot . '/modules/custom',

--- a/.vortex/tests/bats/fixtures/docker-compose.env.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.env.json
@@ -34,7 +34,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -94,7 +94,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -154,7 +154,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -212,7 +212,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -270,7 +270,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -337,7 +337,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -404,7 +404,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -451,7 +451,8 @@
         "wait_dependencies": {
             "command": [
                 "database:3306",
-                "clamav:3310"
+                "clamav:3310",
+                "valkey:6379"
             ],
             "depends_on": {
                 "clamav": {
@@ -463,6 +464,10 @@
                     "required": true
                 },
                 "database": {
+                    "condition": "service_started",
+                    "required": true
+                },
+                "valkey": {
                     "condition": "service_started",
                     "required": true
                 }

--- a/.vortex/tests/bats/fixtures/docker-compose.env_local.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.env_local.json
@@ -34,7 +34,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -94,7 +94,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -154,7 +154,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -212,7 +212,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -270,7 +270,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -337,7 +337,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -404,7 +404,7 @@
                 "DRUPAL_CONFIG_PATH": "../config/default",
                 "DRUPAL_PRIVATE_FILES": "sites/default/files/private",
                 "DRUPAL_PUBLIC_FILES": "sites/default/files",
-                "DRUPAL_REDIS_ENABLED": "0",
+                "DRUPAL_REDIS_ENABLED": "1",
                 "DRUPAL_SHIELD_PASS": "",
                 "DRUPAL_SHIELD_USER": "",
                 "DRUPAL_TEMPORARY_FILES": "/tmp",
@@ -451,7 +451,8 @@
         "wait_dependencies": {
             "command": [
                 "database:3306",
-                "clamav:3310"
+                "clamav:3310",
+                "valkey:6379"
             ],
             "depends_on": {
                 "clamav": {
@@ -463,6 +464,10 @@
                     "required": true
                 },
                 "database": {
+                    "condition": "service_started",
+                    "required": true
+                },
+                "valkey": {
                     "condition": "service_started",
                     "required": true
                 }

--- a/.vortex/tests/bats/fixtures/docker-compose.env_mod.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.env_mod.json
@@ -451,7 +451,8 @@
         "wait_dependencies": {
             "command": [
                 "database:3306",
-                "clamav:3310"
+                "clamav:3310",
+                "valkey:6379"
             ],
             "depends_on": {
                 "clamav": {
@@ -463,6 +464,10 @@
                     "required": true
                 },
                 "database": {
+                    "condition": "service_started",
+                    "required": true
+                },
+                "valkey": {
                     "condition": "service_started",
                     "required": true
                 }

--- a/.vortex/tests/bats/fixtures/docker-compose.noenv.json
+++ b/.vortex/tests/bats/fixtures/docker-compose.noenv.json
@@ -451,7 +451,8 @@
         "wait_dependencies": {
             "command": [
                 "database:3306",
-                "clamav:3310"
+                "clamav:3310",
+                "valkey:6379"
             ],
             "depends_on": {
                 "clamav": {
@@ -463,6 +464,10 @@
                     "required": true
                 },
                 "database": {
+                    "condition": "service_started",
+                    "required": true
+                },
+                "valkey": {
                     "condition": "service_started",
                     "required": true
                 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,7 +258,10 @@ services:
       #;> SERVICE_CLAMAV
       - cli
       - database
-    command: database:3306 clamav:3310
+      #;< SERVICE_VALKEY
+      - valkey
+      #;> SERVICE_VALKEY
+    command: database:3306 clamav:3310 valkey:6379
     #;< HOSTING_LAGOON
     labels:
       lagoon.type: none # Do not deploy in Lagoon.

--- a/rector.php
+++ b/rector.php
@@ -23,6 +23,7 @@ use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Php81\Rector\Array_\FirstClassCallableRector;
 use Rector\Set\ValueObject\SetList;
@@ -77,6 +78,9 @@ return static function (RectorConfig $rectorConfig): void {
     NewlineBeforeNewAssignSetRector::class,
     RemoveAlwaysTrueIfConditionRector::class,
     SimplifyEmptyCheckOnEmptyArrayRector::class,
+    StringClassNameToClassConstantRector::class => [
+      $drupalRoot . '/sites/default/includes/*',
+    ],
     // Dependencies.
     '*/vendor/*',
     '*/node_modules/*',

--- a/tests/behat/features/redis.feature
+++ b/tests/behat/features/redis.feature
@@ -1,0 +1,15 @@
+@redis
+Feature: Redis cache functionality
+
+  As a site administrator
+  I want to verify that Redis caching is working properly
+  So that I can ensure optimal site performance and caching functionality
+
+  @api
+  Scenario: Redis is working properly
+    Given I am logged in as a user with the "administrator" role
+    When I go to "/admin/reports/redis"
+    Then the response status code should be 200
+    And I should see "Connected, using the PhpRedis client"
+    And I should not see "0 tags with 0 invalidations"
+    And I save screenshot

--- a/web/sites/default/includes/modules/settings.redis.php
+++ b/web/sites/default/includes/modules/settings.redis.php
@@ -7,15 +7,13 @@
  * Redis module can work with Redis or Valkey services as they are
  * interchangeable. We use `DRUPAL_REDIS_` environment variables as the Drupal
  * module name is `redis`.
+ *
+ * @phpcs:disable DrupalPractice.Commenting.CommentEmptyLine.SpacingAfter
+ * @phpcs:disable Drupal.Commenting.InlineComment.SpacingAfter
+ * @phpcs:disable Drupal.Commenting.InlineComment.InvalidEndChar
  */
 
 declare(strict_types=1);
-
-use Drupal\Component\Serialization\PhpSerialize;
-use Drupal\redis\Cache\CacheBackendFactory;
-use Drupal\redis\Cache\PhpRedis;
-use Drupal\redis\Cache\RedisCacheTagsChecksum;
-use Drupal\redis\ClientFactory;
 
 // Using 'DRUPAL_REDIS_ENABLED' variable to resolve deployment concurrency:
 // Redis module needs to be enabled without the configuration below applied
@@ -29,16 +27,53 @@ use Drupal\redis\ClientFactory;
 // project-wide env variable (and since it has the same value '1' as removed
 // per-env variable - there will be no change in how code works).
 if (file_exists($contrib_path . '/redis') && !empty(getenv('DRUPAL_REDIS_ENABLED'))) {
-  $settings['redis.connection']['interface'] = 'PhpRedis';
   // Some providers use `REDIS_`-prefixed environment variables.
   $settings['redis.connection']['host'] = getenv('VALKEY_HOST') ?: getenv('REDIS_HOST') ?: 'valkey';
   $settings['redis.connection']['port'] = getenv('VALKEY_SERVICE_PORT') ?: getenv('REDIS_SERVICE_PORT') ?: '6379';
+
+  // Customize used interface.
+  $settings['redis.connection']['interface'] = 'PhpRedis';
 
   // Do not set the cache backend during installations of Drupal, but allow
   // to override this by setting VORTEX_REDIS_EXTENSION_LOADED to non-zero.
   // Note that Valkey uses `redis` PHP extension.
   if ((extension_loaded('redis') && getenv('VORTEX_REDIS_EXTENSION_LOADED') === FALSE) || !empty(getenv('VORTEX_REDIS_EXTENSION_LOADED'))) {
+
+    // Set Redis as the default backend for any cache bin not otherwise
+    // specified.
     $settings['cache']['default'] = 'cache.backend.redis';
+
+    // Per-bin configuration examples, bypass the default ChainedFastBackend.
+    // *Only* use this when using Relay (see README.Relay.md) or when APCu is
+    // not available.
+    // $settings['cache']['bins']['config'] = 'cache.backend.redis';
+    // $settings['cache']['bins']['discovery'] = 'cache.backend.redis';
+    // $settings['cache']['bins']['bootstrap'] = 'cache.backend.redis';
+
+    // Use compression for cache entries longer than the specified limit.
+    $settings['redis_compress_length'] = 100;
+
+    // Customize the prefix, a reliable but long fallback is used if not
+    // defined.
+    // $settings['cache_prefix'] = 'prefix';
+
+    // Respect specific TTL with an offset see README.md for more information.
+    $settings['redis_ttl_offset'] = 3600;
+
+    // Additional optimizations, see README.md.
+    $settings['redis_invalidate_all_as_delete'] = TRUE;
+
+    $settings['flush_redis_on_drupal_flush_cache'] = TRUE;
+
+    // Apply changes to the container configuration to better leverage Redis.
+    // This includes using Redis for the lock and flood control systems, as well
+    // as the cache tag checksum. Alternatively, copy the contents of that file
+    // to your project-specific services.yml file, modify as appropriate, and
+    // remove this line.
+    $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
+
+    // Allow the services to work before the Redis module itself is enabled.
+    $settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
 
     if (!isset($class_loader)) {
       // Initialize the autoloader.
@@ -48,33 +83,37 @@ if (file_exists($contrib_path . '/redis') && !empty(getenv('DRUPAL_REDIS_ENABLED
       }
     }
 
-    $class_loader->addPsr4('Drupal\\redis\\', $contrib_path . '/redis/src');
+    // Manually add the classloader path, this is required for the container
+    // cache bin definition below and allows to use it without the redis module
+    // being enabled.
+    $class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src');
 
+    // Use redis for container cache.
+    // The container cache is used to load the container definition itself, and
+    // thus any configuration stored in the container itself is not available
+    // yet. These lines force the container cache to use Redis rather than the
+    // default SQL cache.
     $settings['bootstrap_container_definition'] = [
       'parameters' => [],
       'services' => [
         'redis.factory' => [
-          'class' => ClientFactory::class,
+          'class' => 'Drupal\redis\ClientFactory',
         ],
         'cache.backend.redis' => [
-          'class' => CacheBackendFactory::class,
-          'arguments' => [
-            '@redis.factory',
-            '@cache_tags_provider.container',
-            '@serialization.phpserialize',
-          ],
+          'class' => 'Drupal\redis\Cache\CacheBackendFactory',
+          'arguments' => ['@redis.factory', '@cache_tags_provider.container', '@serialization.phpserialize'],
         ],
         'cache.container' => [
-          'class' => PhpRedis::class,
+          'class' => '\Drupal\redis\Cache\PhpRedis',
           'factory' => ['@cache.backend.redis', 'get'],
           'arguments' => ['container'],
         ],
         'cache_tags_provider.container' => [
-          'class' => RedisCacheTagsChecksum::class,
+          'class' => 'Drupal\redis\Cache\RedisCacheTagsChecksum',
           'arguments' => ['@redis.factory'],
         ],
         'serialization.phpserialize' => [
-          'class' => PhpSerialize::class,
+          'class' => 'Drupal\Component\Serialization\PhpSerialize',
         ],
       ],
     ];


### PR DESCRIPTION
Closes #1917


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redis/Valkey caching enabled by default across environments; added CLI alias "flush-redis".
  - New Redis cache options: compression threshold, TTL offset, tag invalidation behavior, and automatic flush on Drupal cache clear.

- **Documentation**
  - Variables docs updated to show Redis enabled by default.

- **Tests**
  - Added end-to-end Redis connectivity test; test workflows updated to use the new CLI flow and ValKey waits.

- **Chores**
  - Installer/tooling updated to add/remove Redis-related artifacts and coordinate startup dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->