### PR TITLE
[#1423] Fixed double CI runs and deployments when pushing `project/*` branches.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,6 +421,14 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Check if deployment should be skipped
+          command: |
+            if [ "${CIRCLE_PULL_REQUEST}" != "" ] && echo "${CIRCLE_BRANCH}" | grep -q "^project/"; then
+              echo "Skipping deployment - PR from project/* branch"
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Deploy
           command: |
             VORTEX_DEPLOY_BRANCH="${CIRCLE_BRANCH}" \

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -54,6 +54,7 @@ jobs:
   #;< !PROVISION_TYPE_PROFILE
   database:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || !startsWith(github.head_ref, 'project/') }}
 
     container:
       image: drevops/ci-runner:25.8.0@sha256:d6ba40fc4248ce291302a2cf212de9b80da5433f2fdf29be09ed59659df9e18d
@@ -157,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: database
     #;< !PROVISION_TYPE_PROFILE
-    if: github.event_name != 'schedule'
+    if: ${{ github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
     #;> !PROVISION_TYPE_PROFILE
 
     strategy:
@@ -399,7 +400,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     #;< !PROVISION_TYPE_PROFILE
-    if: ${{ github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') }}
+    if: ${{ github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
     #;> !PROVISION_TYPE_PROFILE
 
     container:

--- a/.vortex/CLAUDE.md
+++ b/.vortex/CLAUDE.md
@@ -620,6 +620,10 @@ The installer tests have been refactored to use a modular, handler-focused archi
 - **BATS Documentation**: https://github.com/bats-core/bats-core
 - **Issue Tracking**: https://github.com/drevops/vortex/issues
 
+## Important AI Assistant Guidelines
+
+**CRITICAL**: NEVER directly modify files under `.vortex/installer/tests/Fixtures/`. These are test fixtures that must be updated by the user **MANUALLY**.
+
 ---
 
 *This knowledge base should be updated whenever significant changes are made to the Vortex testing or maintenance procedures.*

--- a/.vortex/docs/content/workflows/deployment.mdx
+++ b/.vortex/docs/content/workflows/deployment.mdx
@@ -22,6 +22,42 @@ variable as a comma-separated list of one or multiple supported deployment types
 
 ## Using deployments
 
+## Deployment targets
+
+Deployment targets can be branches and pull requests. These targets are defined
+in the CI configuration files and the hosting platform.
+
+By default, deployments are triggered when commits are pushed into the following
+branches:
+- `production`
+- `main`
+- `master`
+- `develop`
+- `release/**`
+- `hotfix/**`
+- `project/**`
+
+This will run the deployment script to forward the code to the remote hosting
+platform and tell it to use the current branch's code for the deployment.
+
+When a pull request is raised against one of the branches above, a deployment
+will run for the pull request's branch. Depending on the hosting platform, this
+may create a temporary environment for the pull request with the name of the
+pull request.
+
+Note that `feature/*` or `bugfix/*` (or any other branches) branches are not
+included in the default list of deployment targets. This is to prevent
+deployments from branches that are typically short-lived and have a pull
+request raised, which will trigger a deployment. Adding these branches to the
+list of deployment targets will lead to duplicated CI runs and deployments.
+
+`project/*` branches are long-lived branches that are typically used for
+larger features or projects that may span multiple pull requests. Such branches
+would be manually synced with the `develop` branch and deployed to a remote
+environment for testing. An example of this would be a migration branch that
+has migration code and configuration that is not yet ready to be merged into
+`develop` but needs to be deployed to a remote environment for testing.
+
 ### Deployment action
 
 By default, an existing database will be retained during a deployment.

--- a/.vortex/installer/tests/Fixtures/install/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/.github/workflows/build-test-deploy.yml
@@ -48,6 +48,7 @@ defaults:
 jobs:
   database:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || !startsWith(github.head_ref, 'project/') }}
 
     container:
       image: drevops/ci-runner:__VERSION__
@@ -149,7 +150,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: database
-    if: github.event_name != 'schedule'
+    if: ${{ github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 
     strategy:
       matrix:
@@ -368,7 +369,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') }}
+    if: ${{ github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 
     container:
       image: drevops/ci-runner:__VERSION__

--- a/.vortex/installer/tests/Fixtures/install/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/ciprovider_circleci/.circleci/config.yml
@@ -389,6 +389,14 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Check if deployment should be skipped
+          command: |
+            if [ "${CIRCLE_PULL_REQUEST}" != "" ] && echo "${CIRCLE_BRANCH}" | grep -q "^project/"; then
+              echo "Skipping deployment - PR from project/* branch"
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Deploy
           command: |
             VORTEX_DEPLOY_BRANCH="${CIRCLE_BRANCH}" \

--- a/.vortex/installer/tests/Fixtures/install/deploy_type_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/deploy_type_all_circleci/.circleci/config.yml
@@ -389,6 +389,14 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Check if deployment should be skipped
+          command: |
+            if [ "${CIRCLE_PULL_REQUEST}" != "" ] && echo "${CIRCLE_BRANCH}" | grep -q "^project/"; then
+              echo "Skipping deployment - PR from project/* branch"
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Deploy
           command: |
             VORTEX_DEPLOY_BRANCH="${CIRCLE_BRANCH}" \

--- a/.vortex/installer/tests/Fixtures/install/deploy_type_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/deploy_type_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -364,65 +364,3 @@
+@@ -365,65 +365,3 @@
          timeout-minutes: 120 # Cancel the action after 15 minutes, regardless of whether a connection has been established.
          with:
            detached: true
@@ -6,7 +6,7 @@
 -  deploy:
 -    runs-on: ubuntu-latest
 -    needs: build
--    if: ${{ github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') }}
+-    if: ${{ github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 -
 -    container:
 -      image: drevops/ci-runner:__VERSION__

--- a/.vortex/installer/tests/Fixtures/install/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -389,6 +389,14 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Check if deployment should be skipped
+          command: |
+            if [ "${CIRCLE_PULL_REQUEST}" != "" ] && echo "${CIRCLE_BRANCH}" | grep -q "^project/"; then
+              echo "Skipping deployment - PR from project/* branch"
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Deploy
           command: |
             VORTEX_DEPLOY_BRANCH="${CIRCLE_BRANCH}" \

--- a/.vortex/installer/tests/Fixtures/install/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/provision_profile/.github/workflows/build-test-deploy.yml
@@ -7,12 +7,13 @@
  
  defaults:
    run:
-@@ -46,110 +44,10 @@
+@@ -46,111 +44,10 @@
      shell: bash
  
  jobs:
 -  database:
 -    runs-on: ubuntu-latest
+-    if: ${{ github.event_name == 'push' || !startsWith(github.head_ref, 'project/') }}
  
 -    container:
 -      image: drevops/ci-runner:__VERSION__
@@ -114,11 +115,11 @@
    build:
      runs-on: ubuntu-latest
      needs: database
--    if: github.event_name != 'schedule'
+-    if: ${{ github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
  
      strategy:
        matrix:
-@@ -169,14 +67,6 @@
+@@ -170,14 +67,6 @@
          VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"
          VORTEX_SSH_REMOVE_ALL_KEYS: "1"
          VORTEX_DEBUG: ${{ vars.VORTEX_DEBUG }}
@@ -133,7 +134,7 @@
  
      steps:
        - name: Preserve $HOME set in the container
-@@ -195,29 +85,6 @@
+@@ -196,29 +85,6 @@
          run: composer validate --strict
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE == '1' }}
  
@@ -163,11 +164,11 @@
        - name: Login to container registry
          run: ./scripts/vortex/login-container-registry.sh
  
-@@ -368,7 +235,6 @@
+@@ -369,7 +235,6 @@
    deploy:
      runs-on: ubuntu-latest
      needs: build
--    if: ${{ github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') }}
+-    if: ${{ github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
  
      container:
        image: drevops/ci-runner:__VERSION__

--- a/.vortex/installer/tests/Fixtures/install/theme_absent/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/theme_absent/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -291,11 +291,6 @@
+@@ -292,11 +292,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/install/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/timezone_circleci/.circleci/config.yml
@@ -389,6 +389,14 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Check if deployment should be skipped
+          command: |
+            if [ "${CIRCLE_PULL_REQUEST}" != "" ] && echo "${CIRCLE_BRANCH}" | grep -q "^project/"; then
+              echo "Skipping deployment - PR from project/* branch"
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Deploy
           command: |
             VORTEX_DEPLOY_BRANCH="${CIRCLE_BRANCH}" \

--- a/.vortex/installer/tests/Fixtures/install/tools_groups_no_be_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_groups_no_be_lint/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -256,26 +256,6 @@
+@@ -257,26 +257,6 @@
          run: docker compose exec -T cli composer normalize --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_NORMALIZE_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/install/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -365,6 +365,14 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Check if deployment should be skipped
+          command: |
+            if [ "${CIRCLE_PULL_REQUEST}" != "" ] && echo "${CIRCLE_BRANCH}" | grep -q "^project/"; then
+              echo "Skipping deployment - PR from project/* branch"
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Deploy
           command: |
             VORTEX_DEPLOY_BRANCH="${CIRCLE_BRANCH}" \

--- a/.vortex/installer/tests/Fixtures/install/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -281,11 +281,6 @@
+@@ -282,11 +282,6 @@
          run: docker compose exec -T cli vendor/bin/twig-cs-fixer
          continue-on-error: ${{ vars.VORTEX_CI_TWIG_CS_FIXER_IGNORE_FAILURE == '1' }}
  
@@ -10,7 +10,7 @@
        - name: Lint module code with NodeJS linters
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: docker compose exec -T cli bash -c "yarn run lint"
-@@ -303,22 +298,6 @@
+@@ -304,22 +299,6 @@
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./scripts/vortex/provision.sh

--- a/.vortex/installer/tests/Fixtures/install/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -369,6 +369,14 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Check if deployment should be skipped
+          command: |
+            if [ "${CIRCLE_PULL_REQUEST}" != "" ] && echo "${CIRCLE_BRANCH}" | grep -q "^project/"; then
+              echo "Skipping deployment - PR from project/* branch"
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Deploy
           command: |
             VORTEX_DEPLOY_BRANCH="${CIRCLE_BRANCH}" \

--- a/.vortex/installer/tests/Fixtures/install/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -281,11 +281,6 @@
+@@ -282,11 +282,6 @@
          run: docker compose exec -T cli vendor/bin/twig-cs-fixer
          continue-on-error: ${{ vars.VORTEX_CI_TWIG_CS_FIXER_IGNORE_FAILURE == '1' }}
  
@@ -10,7 +10,7 @@
        - name: Lint module code with NodeJS linters
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: docker compose exec -T cli bash -c "yarn run lint"
-@@ -308,18 +303,6 @@
+@@ -309,18 +304,6 @@
        - name: Test with PHPUnit
          run: docker compose exec -T cli vendor/bin/phpunit
          continue-on-error: ${{ vars.VORTEX_CI_PHPUNIT_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/install/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_no_behat_circleci/.circleci/config.yml
@@ -373,6 +373,14 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Check if deployment should be skipped
+          command: |
+            if [ "${CIRCLE_PULL_REQUEST}" != "" ] && echo "${CIRCLE_BRANCH}" | grep -q "^project/"; then
+              echo "Skipping deployment - PR from project/* branch"
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Deploy
           command: |
             VORTEX_DEPLOY_BRANCH="${CIRCLE_BRANCH}" \

--- a/.vortex/installer/tests/Fixtures/install/tools_no_phpcs/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_no_phpcs/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -256,11 +256,6 @@
+@@ -257,11 +257,6 @@
          run: docker compose exec -T cli composer normalize --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_NORMALIZE_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/install/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_no_phpcs_circleci/.circleci/config.yml
@@ -383,6 +383,14 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Check if deployment should be skipped
+          command: |
+            if [ "${CIRCLE_PULL_REQUEST}" != "" ] && echo "${CIRCLE_BRANCH}" | grep -q "^project/"; then
+              echo "Skipping deployment - PR from project/* branch"
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Deploy
           command: |
             VORTEX_DEPLOY_BRANCH="${CIRCLE_BRANCH}" \

--- a/.vortex/installer/tests/Fixtures/install/tools_no_phpmd/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_no_phpmd/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -271,11 +271,6 @@
+@@ -272,11 +272,6 @@
          run: docker compose exec -T cli vendor/bin/rector --clear-cache --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_RECTOR_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/install/tools_no_phpmd_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_no_phpmd_circleci/.circleci/config.yml
@@ -383,6 +383,14 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Check if deployment should be skipped
+          command: |
+            if [ "${CIRCLE_PULL_REQUEST}" != "" ] && echo "${CIRCLE_BRANCH}" | grep -q "^project/"; then
+              echo "Skipping deployment - PR from project/* branch"
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Deploy
           command: |
             VORTEX_DEPLOY_BRANCH="${CIRCLE_BRANCH}" \

--- a/.vortex/installer/tests/Fixtures/install/tools_no_phpstan/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_no_phpstan/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -261,11 +261,6 @@
+@@ -262,11 +262,6 @@
          run: docker compose exec -T cli vendor/bin/phpcs
          continue-on-error: ${{ vars.VORTEX_CI_PHPCS_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/install/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_no_phpstan_circleci/.circleci/config.yml
@@ -383,6 +383,14 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Check if deployment should be skipped
+          command: |
+            if [ "${CIRCLE_PULL_REQUEST}" != "" ] && echo "${CIRCLE_BRANCH}" | grep -q "^project/"; then
+              echo "Skipping deployment - PR from project/* branch"
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Deploy
           command: |
             VORTEX_DEPLOY_BRANCH="${CIRCLE_BRANCH}" \

--- a/.vortex/installer/tests/Fixtures/install/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -305,10 +305,6 @@
+@@ -306,10 +306,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./scripts/vortex/provision.sh
          timeout-minutes: 30
  

--- a/.vortex/installer/tests/Fixtures/install/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_no_phpunit_circleci/.circleci/config.yml
@@ -385,6 +385,14 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Check if deployment should be skipped
+          command: |
+            if [ "${CIRCLE_PULL_REQUEST}" != "" ] && echo "${CIRCLE_BRANCH}" | grep -q "^project/"; then
+              echo "Skipping deployment - PR from project/* branch"
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Deploy
           command: |
             VORTEX_DEPLOY_BRANCH="${CIRCLE_BRANCH}" \

--- a/.vortex/installer/tests/Fixtures/install/tools_no_rector/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_no_rector/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -266,11 +266,6 @@
+@@ -267,11 +267,6 @@
          run: docker compose exec -T cli vendor/bin/phpstan
          continue-on-error: ${{ vars.VORTEX_CI_PHPSTAN_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/install/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_no_rector_circleci/.circleci/config.yml
@@ -383,6 +383,14 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Check if deployment should be skipped
+          command: |
+            if [ "${CIRCLE_PULL_REQUEST}" != "" ] && echo "${CIRCLE_BRANCH}" | grep -q "^project/"; then
+              echo "Skipping deployment - PR from project/* branch"
+              circleci-agent step halt
+            fi
+
+      - run:
           name: Deploy
           command: |
             VORTEX_DEPLOY_BRANCH="${CIRCLE_BRANCH}" \

--- a/.vortex/installer/tests/Fixtures/install/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/install/tools_none/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -256,36 +256,11 @@
+@@ -257,36 +257,11 @@
          run: docker compose exec -T cli composer normalize --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_NORMALIZE_IGNORE_FAILURE == '1' }}
  
@@ -35,7 +35,7 @@
        - name: Lint module code with NodeJS linters
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: docker compose exec -T cli bash -c "yarn run lint"
-@@ -303,22 +278,6 @@
+@@ -304,22 +279,6 @@
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./scripts/vortex/provision.sh


### PR DESCRIPTION
Closes #1423


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added “Deployment targets” guidance outlining which branches/PRs trigger deployments, temporary environments, and treatment of long‑lived project/* branches.
  * Added contributor guidelines clarifying restrictions on modifying installer test fixtures.

* **Chores**
  * Updated CI to conditionally run database, build, and deploy jobs: skip PRs from project/* branches, continue on pushes, and exclude scheduled runs and deps/* where applicable.
  * Introduced a pre-deploy check that halts deployments when skip conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->