### PR TITLE
Updated more docs to use tabs.

### DIFF
--- a/.vortex/docs/content/tools/behat.mdx
+++ b/.vortex/docs/content/tools/behat.mdx
@@ -22,7 +22,7 @@ import TabItem from '@theme/TabItem';
     ahoy test-bdd
     ```
   </TabItem>
-  <TabItem value="direct" label="Docker Compose">
+  <TabItem value="docker-compose" label="Docker Compose">
     ```shell
     docker compose exec cli php -d memory_limit=-1 vendor/bin/behat
     ```
@@ -37,7 +37,7 @@ import TabItem from '@theme/TabItem';
     ahoy test-bdd tests/behat/features/my.feature
     ```
   </TabItem>
-  <TabItem value="direct" label="Docker Compose">
+  <TabItem value="docker-compose" label="Docker Compose">
     ```shell
     docker compose exec cli vendor/bin/behat tests/behat/features/my.feature
     ```
@@ -52,7 +52,7 @@ import TabItem from '@theme/TabItem';
     ahoy test-bdd --tags=group_name
     ```
   </TabItem>
-  <TabItem value="direct" label="Docker Compose">
+  <TabItem value="docker-compose" label="Docker Compose">
     ```shell
     docker compose exec cli vendor/bin/behat --tags=group_name
     ```
@@ -200,7 +200,7 @@ using a browser thanks to the VNC server running in the container and [noVNC](ht
     ```
     2. Click on the link next to `Selenium VNC URL on host` to open the browser.
   </TabItem>
-  <TabItem value="direct" label="Docker Compose">
+  <TabItem value="docker-compose" label="Docker Compose">
     1. Get the port number:
     ```shell
     docker compose port chrome 7900

--- a/.vortex/docs/content/tools/gherkin-lint.mdx
+++ b/.vortex/docs/content/tools/gherkin-lint.mdx
@@ -8,15 +8,21 @@ https://github.com/dantleech/gherkin-lint-php
 
 ## Usage
 
-```shell
-vendor/bin/gherkinlint lint tests/behat/features
-```
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-or
-
-```shell
-ahoy lint-tests
-```
+<Tabs>
+  <TabItem value="ahoy" label="Ahoy" default>
+    ```shell
+    ahoy lint-tests
+    ```
+  </TabItem>
+  <TabItem value="docker-compose" label="Docker Compose">
+    ```shell
+    docker compose exec cli vendor/bin/gherkinlint lint tests/behat/features
+    ```
+  </TabItem>
+</Tabs>
 
 ## Configuration
 

--- a/.vortex/docs/content/tools/phpmd.mdx
+++ b/.vortex/docs/content/tools/phpmd.mdx
@@ -19,15 +19,21 @@ for Drupal projects.
 
 ## Usage
 
-```shell
-vendor/bin/phpmd . text phpmd.xml
-```
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-or
-
-```shell
-ahoy lint-be
-```
+<Tabs>
+  <TabItem value="ahoy" label="Ahoy" default>
+    ```shell
+    ahoy lint-be
+    ```
+  </TabItem>
+  <TabItem value="docker-compose" label="Docker Compose">
+    ```shell
+    docker compose exec cli vendor/bin/phpmd . text phpmd.xml
+    ```
+  </TabItem>
+</Tabs>
 
 ## Configuration
 

--- a/.vortex/docs/content/tools/phpstan.mdx
+++ b/.vortex/docs/content/tools/phpstan.mdx
@@ -19,15 +19,21 @@ Drupal projects.
 
 ## Usage
 
-```shell
-vendor/bin/phpstan
-```
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-or
-
-```shell
-ahoy lint-be
-```
+<Tabs>
+  <TabItem value="ahoy" label="Ahoy" default>
+    ```shell
+    ahoy lint-be
+    ```
+  </TabItem>
+  <TabItem value="docker-compose" label="Docker Compose">
+    ```shell
+    docker compose exec cli vendor/bin/phpstan
+    ```
+  </TabItem>
+</Tabs>
 
 :::note
 

--- a/.vortex/docs/content/tools/twig-cs-fixer.mdx
+++ b/.vortex/docs/content/tools/twig-cs-fixer.mdx
@@ -10,15 +10,21 @@ https://github.com/VincentLanglet/Twig-CS-Fixer
 
 ## Usage
 
-```shell
-vendor/bin/twig-cs-fixer
-```
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-or
-
-```shell
-ahoy lint-fe
-```
+<Tabs>
+  <TabItem value="ahoy" label="Ahoy" default>
+    ```shell
+    ahoy lint-fe
+    ```
+  </TabItem>
+  <TabItem value="docker-compose" label="Docker Compose">
+    ```shell
+    docker compose exec cli vendor/bin/twig-cs-fixer
+    ```
+  </TabItem>
+</Tabs>
 
 ## Configuration
 

--- a/.vortex/docs/content/workflows/testing.mdx
+++ b/.vortex/docs/content/workflows/testing.mdx
@@ -14,36 +14,22 @@ import TabItem from '@theme/TabItem';
 
 <Tabs>
   <TabItem value="ahoy" label="Ahoy" default>
-
-```shell
-ahoy test               # Run Unit, Kernel and Functional tests
-
-ahoy test-unit          # Run Unit tests
-
-ahoy test-kernel        # Run Kernel tests
-
-ahoy test-functional    # Run Functional tests
-
-ahoy test-bdd           # Run BDD tests
-```
-
+    ```shell
+    ahoy test               # Run Unit, Kernel and Functional tests
+    ahoy test-unit          # Run Unit tests
+    ahoy test-kernel        # Run Kernel tests
+    ahoy test-functional    # Run Functional tests
+    ahoy test-bdd           # Run BDD tests
+    ```
   </TabItem>
-  <TabItem value="direct" label="Direct">
-
-These commands can be run directly from within the container:
-
-```shell
-vendor/bin/phpunit                           # Run Unit, Kernel and Functional tests
-
-vendor/bin/phpunit --testsuite=unit          # Run Unit tests
-
-vendor/bin/phpunit --testsuite=kernel        # Run Kernel tests
-
-vendor/bin/phpunit --testsuite=functional    # Run Functional tests
-
-vendor/bin/behat                             # Run BDD tests
-```
-
+  <TabItem value="docker-compose" label="Docker Compose">
+    ```shell
+    docker compose exec cli vendor/bin/phpunit                           # Run Unit, Kernel and Functional tests
+    docker compose exec cli vendor/bin/phpunit --testsuite=unit          # Run Unit tests
+    docker compose exec cli vendor/bin/phpunit --testsuite=kernel        # Run Kernel tests
+    docker compose exec cli vendor/bin/phpunit --testsuite=functional    # Run Functional tests
+    docker compose exec cli vendor/bin/behat                             # Run BDD tests
+    ```
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized “Usage” sections across tools with tabbed UI: Ahoy (default) and Docker Compose.
  * Updated Behat docs to use Docker Compose tab values consistently.
  * Converted gherkin-lint, phpmd, phpstan, and twig-cs-fixer examples from standalone code blocks to tabs; removed redundant snippets.
  * Revised Testing workflow: replaced “Direct” with “Docker Compose” commands for PHPUnit and Behat; refined formatting/indentation for clarity.
  * Overall, docs now emphasize running commands via Docker Compose alongside existing Ahoy guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->