### PR TITLE
Fixed installer not correctly discovers relative web root.

### DIFF
--- a/.vortex/installer/src/Prompts/Handlers/Webroot.php
+++ b/.vortex/installer/src/Prompts/Handlers/Webroot.php
@@ -70,6 +70,14 @@ class Webroot extends AbstractHandler {
     }
 
     $v = JsonManipulator::fromFile($this->dstDir . '/composer.json')?->getProperty('extra.drupal-scaffold.locations.web-root');
+    if (!empty($v)) {
+      try {
+        $v = File::toRelative($v, $this->dstDir);
+      }
+      catch (\Exception) {
+        $v = NULL;
+      }
+    }
 
     if (!empty($v)) {
       return $v;

--- a/.vortex/installer/src/Utils/File.php
+++ b/.vortex/installer/src/Utils/File.php
@@ -99,4 +99,23 @@ class File extends UpstreamFile {
     });
   }
 
+  /**
+   * Convert a path to a relative path.
+   *
+   * @param string $path
+   *   The path to convert.
+   * @param string|null $base
+   *   The base path to resolve relative paths against. If NULL, the current
+   *   working directory is used.
+   *
+   * @return string
+   *   The relative path.
+   */
+  public static function toRelative(string $path, ?string $base = NULL): string {
+    $base = $base ?? (string) getcwd();
+    $absolute = static::absolute($path, $base);
+
+    return str_replace($base . DIRECTORY_SEPARATOR, '', $absolute);
+  }
+
 }

--- a/.vortex/installer/tests/Unit/FileTest.php
+++ b/.vortex/installer/tests/Unit/FileTest.php
@@ -32,4 +32,118 @@ class FileTest extends UnitTestCase {
     ];
   }
 
+  #[DataProvider('dataProviderToRelative')]
+  public function testToRelative(string $path, ?string $base, string $expected): void {
+    $result = File::toRelative($path, $base);
+    $this->assertSame($expected, $result);
+  }
+
+  public static function dataProviderToRelative(): array {
+    // Get the current working directory for test cases.
+    $cwd = getcwd();
+
+    return [
+      // Test cases with explicit base path.
+      'absolute path with base' => [
+        '/var/www/project/file.txt',
+        '/var/www',
+        'project/file.txt',
+      ],
+      'absolute path same as base' => [
+        '/var/www',
+        '/var/www',
+        '/var/www',
+      ],
+      'nested absolute path' => [
+        '/var/www/project/src/utils/file.php',
+        '/var/www/project',
+        'src/utils/file.php',
+      ],
+      'relative path with base' => [
+        'src/file.php',
+        '/var/www/project',
+        'src/file.php',
+      ],
+      'dot relative path with base' => [
+        './src/file.php',
+        '/var/www/project',
+        'src/file.php',
+      ],
+      'parent directory path with base' => [
+        '../other/file.php',
+        '/var/www/project',
+        '/var/www/other/file.php',
+      ],
+
+      // Test cases with NULL base (should use current working directory).
+      'absolute path with null base' => [
+        $cwd . '/test/file.txt',
+        NULL,
+        'test/file.txt',
+      ],
+      'current directory with null base' => [
+        $cwd,
+        NULL,
+        $cwd,
+      ],
+      'relative path with null base' => [
+        'test/file.txt',
+        NULL,
+        'test/file.txt',
+      ],
+      'dot path with null base' => [
+        './test/file.txt',
+        NULL,
+        'test/file.txt',
+      ],
+
+      // Edge cases.
+      'empty path with base - resolves to base' => [
+        '',
+        '/var/www',
+        '/var/www',
+      ],
+      'root path - no base match' => [
+        '/',
+        '/var',
+        '/',
+      ],
+      'base is child of path - no match' => [
+        '/var/www',
+        '/var/www/project',
+        '/var/www',
+      ],
+      'windows-style path on unix' => [
+        '/c/Users/project/file.txt',
+        '/c/Users',
+        'project/file.txt',
+      ],
+      'path with special characters' => [
+        '/var/www/project with spaces/file-name_test.php',
+        '/var/www',
+        'project with spaces/file-name_test.php',
+      ],
+      'path with dots in filename' => [
+        '/var/www/project/.env.local',
+        '/var/www',
+        'project/.env.local',
+      ],
+      'complex nested structure' => [
+        '/var/www/html/project/src/Utils/File.php',
+        '/var/www/html',
+        'project/src/Utils/File.php',
+      ],
+      'same directory level' => [
+        '/var/www/project1/file.txt',
+        '/var/www/project2',
+        '/var/www/project1/file.txt',
+      ],
+      'deep nesting from base' => [
+        '/var/www/a/b/c/d/e/file.txt',
+        '/var/www',
+        'a/b/c/d/e/file.txt',
+      ],
+    ];
+  }
+
 }

--- a/.vortex/installer/tests/Unit/Handlers/WebrootPromptManagerTest.php
+++ b/.vortex/installer/tests/Unit/Handlers/WebrootPromptManagerTest.php
@@ -63,6 +63,14 @@ class WebrootPromptManagerTest extends AbstractPromptManagerTestCase {
         },
       ],
 
+      'webroot - discovery - composer, relative' => [
+        [],
+        [Webroot::id() => 'discovered_webroot'] + $expected_defaults,
+        function (AbstractPromptManagerTestCase $test, Config $config): void {
+          $test->stubComposerJsonValue('extra', ['drupal-scaffold' => ['locations' => ['web-root' => './discovered_webroot']]]);
+        },
+      ],
+
       'webroot - discovery - invalid' => [
         [],
         $expected_defaults,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better handling of relative webroot paths during setup; paths are normalized against the destination directory.

* **Bug Fixes**
  * Robust webroot discovery: unresolvable or invalid paths no longer break setup and now fall back gracefully when normalization fails.

* **Tests**
  * Added comprehensive tests covering relative path scenarios and edge cases to ensure consistent behavior across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->