### PR TITLE
Fixed installer to correctly update `composer.json` for Drupal CMS starter.

### DIFF
--- a/.vortex/installer/src/Prompts/Handlers/Starter.php
+++ b/.vortex/installer/src/Prompts/Handlers/Starter.php
@@ -93,12 +93,19 @@ DOC;
     if ($this->response == self::INSTALL_PROFILE_DRUPALCMS) {
       $cj = JsonManipulator::fromFile($this->tmpDir . '/composer.json');
 
-      $cj->addLink('require', 'drupal/cms', '^1.0', TRUE);
+      $cj->addLink('require', 'drupal/cms', '^1.2', TRUE);
       $cj->addLink('require', 'wikimedia/composer-merge-plugin', '^2.1', TRUE);
       $cj->addLink('require', 'symfony/http-client', '^6.4 || ^7.0', TRUE);
 
+      $cj->addConfigSetting('allow-plugins.composer/installers', TRUE);
+      $cj->addConfigSetting('allow-plugins.drupal/core-composer-scaffold', TRUE);
       $cj->addConfigSetting('allow-plugins.drupal/core-project-message', TRUE);
+      $cj->addConfigSetting('allow-plugins.drupal/core-recipe-unpack', TRUE);
+      $cj->addConfigSetting('allow-plugins.drupal/core-vendor-hardening', TRUE);
+      $cj->addConfigSetting('allow-plugins.php-http/discovery', TRUE);
       $cj->addConfigSetting('allow-plugins.wikimedia/composer-merge-plugin', TRUE);
+
+      $cj->addProperty('minimum-stability', 'alpha');
 
       $cj->addProperty('extra.merge-plugin.ignore-duplicates', FALSE);
       $cj->addProperty('extra.merge-plugin.merge-false', TRUE);

--- a/.vortex/installer/tests/Fixtures/install/starter_drupal_cms_profile/composer.json
+++ b/.vortex/installer/tests/Fixtures/install/starter_drupal_cms_profile/composer.json
@@ -17,18 +17,29 @@
      },
      "require-dev": {
          "behat/behat": "__VERSION__",
-@@ -81,7 +84,9 @@
+@@ -58,7 +61,7 @@
+             "url": "https://packages.drupal.org/8"
+         }
+     ],
+-    "minimum-stability": "beta",
++    "minimum-stability": "alpha",
+     "prefer-stable": true,
+     "autoload": {
+         "classmap": [
+@@ -81,7 +84,11 @@
              "php-http/discovery": true,
              "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,
 -            "tbachert/spi": true
 +            "tbachert/spi": true,
 +            "drupal/core-project-message": true,
++            "drupal/core-recipe-unpack": true,
++            "drupal/core-vendor-hardening": true,
 +            "wikimedia/composer-merge-plugin": true
          },
          "discard-changes": true,
          "platform": {
-@@ -158,7 +163,20 @@
+@@ -158,7 +165,20 @@
          "patchLevel": {
              "drupal/core": "-p2"
          },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded CMS dependency to 1.2 for improved compatibility and stability.
  * Enabled additional Composer plugins (installers, core scaffold, recipe unpack, vendor hardening, HTTP discovery) while retaining existing merge-plugin behavior.
  * Set minimum stability to alpha to allow early-release packages during installation.
  * Improved installer configuration for more reliable project setup; no direct UI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->