### PR TITLE
Simplified Redis extension loaded condition.

### DIFF
--- a/.vortex/installer/tests/Fixtures/install/_baseline/tests/phpunit/Drupal/SwitchableSettingsTest.php
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/tests/phpunit/Drupal/SwitchableSettingsTest.php
@@ -252,30 +252,6 @@ class SwitchableSettingsTest extends SettingsTestCase {
   }
 
   /**
-   * Test Redis partial settings.
-   */
-  public function testRedisPartial(): void {
-    $this->setEnvVars([
-      'DRUPAL_REDIS_ENABLED' => 1,
-      'REDIS_HOST' => 'redis_host',
-      'REDIS_SERVICE_PORT' => 1234,
-      'VORTEX_REDIS_EXTENSION_LOADED' => 0,
-    ]);
-
-    $this->requireSettingsFile();
-
-    $settings['redis.connection']['interface'] = 'PhpRedis';
-    $settings['redis.connection']['host'] = 'redis_host';
-    $settings['redis.connection']['port'] = 1234;
-    $no_settings['cache']['default'] = 'cache.backend.redis';
-
-    $this->assertArrayNotHasKey('bootstrap_container_definition', $this->settings);
-
-    $this->assertSettingsContains($settings);
-    $this->assertSettingsNotContains($no_settings);
-  }
-
-  /**
    * Test Redis settings with REDIS_* environment variables.
    */
   public function testRedisVariables(): void {

--- a/.vortex/installer/tests/Fixtures/install/_baseline/web/sites/default/includes/modules/settings.redis.php
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/web/sites/default/includes/modules/settings.redis.php
@@ -35,9 +35,9 @@ if (file_exists($contrib_path . '/redis') && !empty(getenv('DRUPAL_REDIS_ENABLED
   $settings['redis.connection']['interface'] = 'PhpRedis';
 
   // Do not set the cache backend during installations of Drupal, but allow
-  // to override this by setting VORTEX_REDIS_EXTENSION_LOADED to non-zero.
+  // to override this by setting VORTEX_REDIS_EXTENSION_LOADED = '1'.
   // Redis uses `redis` PHP extension.
-  if ((extension_loaded('redis') && getenv('VORTEX_REDIS_EXTENSION_LOADED') === FALSE) || !empty(getenv('VORTEX_REDIS_EXTENSION_LOADED'))) {
+  if (extension_loaded('redis') || getenv('VORTEX_REDIS_EXTENSION_LOADED') === '1') {
 
     // Set Redis as the default backend for any cache bin not otherwise
     // specified.

--- a/.vortex/installer/tests/Fixtures/install/hosting_acquia/docroot/sites/default/includes/modules/settings.redis.php
+++ b/.vortex/installer/tests/Fixtures/install/hosting_acquia/docroot/sites/default/includes/modules/settings.redis.php
@@ -35,9 +35,9 @@ if (file_exists($contrib_path . '/redis') && !empty(getenv('DRUPAL_REDIS_ENABLED
   $settings['redis.connection']['interface'] = 'PhpRedis';
 
   // Do not set the cache backend during installations of Drupal, but allow
-  // to override this by setting VORTEX_REDIS_EXTENSION_LOADED to non-zero.
+  // to override this by setting VORTEX_REDIS_EXTENSION_LOADED = '1'.
   // Redis uses `redis` PHP extension.
-  if ((extension_loaded('redis') && getenv('VORTEX_REDIS_EXTENSION_LOADED') === FALSE) || !empty(getenv('VORTEX_REDIS_EXTENSION_LOADED'))) {
+  if (extension_loaded('redis') || getenv('VORTEX_REDIS_EXTENSION_LOADED') === '1') {
 
     // Set Redis as the default backend for any cache bin not otherwise
     // specified.

--- a/.vortex/installer/tests/Fixtures/install/hosting_project_name___acquia/docroot/sites/default/includes/modules/settings.redis.php
+++ b/.vortex/installer/tests/Fixtures/install/hosting_project_name___acquia/docroot/sites/default/includes/modules/settings.redis.php
@@ -35,9 +35,9 @@ if (file_exists($contrib_path . '/redis') && !empty(getenv('DRUPAL_REDIS_ENABLED
   $settings['redis.connection']['interface'] = 'PhpRedis';
 
   // Do not set the cache backend during installations of Drupal, but allow
-  // to override this by setting VORTEX_REDIS_EXTENSION_LOADED to non-zero.
+  // to override this by setting VORTEX_REDIS_EXTENSION_LOADED = '1'.
   // Redis uses `redis` PHP extension.
-  if ((extension_loaded('redis') && getenv('VORTEX_REDIS_EXTENSION_LOADED') === FALSE) || !empty(getenv('VORTEX_REDIS_EXTENSION_LOADED'))) {
+  if (extension_loaded('redis') || getenv('VORTEX_REDIS_EXTENSION_LOADED') === '1') {
 
     // Set Redis as the default backend for any cache bin not otherwise
     // specified.

--- a/.vortex/installer/tests/Fixtures/install/non_interactive_config_file/tests/phpunit/Drupal/SwitchableSettingsTest.php
+++ b/.vortex/installer/tests/Fixtures/install/non_interactive_config_file/tests/phpunit/Drupal/SwitchableSettingsTest.php
@@ -1,4 +1,4 @@
-@@ -228,103 +228,6 @@
+@@ -228,79 +228,6 @@
    }
  
    /**
@@ -23,30 +23,6 @@
 -    unset($this->settings['bootstrap_container_definition']);
 -
 -    $this->assertSettingsContains($settings);
--  }
--
--  /**
--   * Test Redis partial settings.
--   */
--  public function testRedisPartial(): void {
--    $this->setEnvVars([
--      'DRUPAL_REDIS_ENABLED' => 1,
--      'REDIS_HOST' => 'redis_host',
--      'REDIS_SERVICE_PORT' => 1234,
--      'VORTEX_REDIS_EXTENSION_LOADED' => 0,
--    ]);
--
--    $this->requireSettingsFile();
--
--    $settings['redis.connection']['interface'] = 'PhpRedis';
--    $settings['redis.connection']['host'] = 'redis_host';
--    $settings['redis.connection']['port'] = 1234;
--    $no_settings['cache']['default'] = 'cache.backend.redis';
--
--    $this->assertArrayNotHasKey('bootstrap_container_definition', $this->settings);
--
--    $this->assertSettingsContains($settings);
--    $this->assertSettingsNotContains($no_settings);
 -  }
 -
 -  /**

--- a/.vortex/installer/tests/Fixtures/install/services_no_redis/tests/phpunit/Drupal/SwitchableSettingsTest.php
+++ b/.vortex/installer/tests/Fixtures/install/services_no_redis/tests/phpunit/Drupal/SwitchableSettingsTest.php
@@ -1,4 +1,4 @@
-@@ -228,103 +228,6 @@
+@@ -228,79 +228,6 @@
    }
  
    /**
@@ -23,30 +23,6 @@
 -    unset($this->settings['bootstrap_container_definition']);
 -
 -    $this->assertSettingsContains($settings);
--  }
--
--  /**
--   * Test Redis partial settings.
--   */
--  public function testRedisPartial(): void {
--    $this->setEnvVars([
--      'DRUPAL_REDIS_ENABLED' => 1,
--      'REDIS_HOST' => 'redis_host',
--      'REDIS_SERVICE_PORT' => 1234,
--      'VORTEX_REDIS_EXTENSION_LOADED' => 0,
--    ]);
--
--    $this->requireSettingsFile();
--
--    $settings['redis.connection']['interface'] = 'PhpRedis';
--    $settings['redis.connection']['host'] = 'redis_host';
--    $settings['redis.connection']['port'] = 1234;
--    $no_settings['cache']['default'] = 'cache.backend.redis';
--
--    $this->assertArrayNotHasKey('bootstrap_container_definition', $this->settings);
--
--    $this->assertSettingsContains($settings);
--    $this->assertSettingsNotContains($no_settings);
 -  }
 -
 -  /**

--- a/.vortex/installer/tests/Fixtures/install/services_none/tests/phpunit/Drupal/SwitchableSettingsTest.php
+++ b/.vortex/installer/tests/Fixtures/install/services_none/tests/phpunit/Drupal/SwitchableSettingsTest.php
@@ -61,7 +61,7 @@
     * Test Config Split config.
     */
    #[DataProvider('dataProviderConfigSplit')]
-@@ -225,103 +169,6 @@
+@@ -225,79 +169,6 @@
          ],
        ],
      ];
@@ -89,30 +89,6 @@
 -    unset($this->settings['bootstrap_container_definition']);
 -
 -    $this->assertSettingsContains($settings);
--  }
--
--  /**
--   * Test Redis partial settings.
--   */
--  public function testRedisPartial(): void {
--    $this->setEnvVars([
--      'DRUPAL_REDIS_ENABLED' => 1,
--      'REDIS_HOST' => 'redis_host',
--      'REDIS_SERVICE_PORT' => 1234,
--      'VORTEX_REDIS_EXTENSION_LOADED' => 0,
--    ]);
--
--    $this->requireSettingsFile();
--
--    $settings['redis.connection']['interface'] = 'PhpRedis';
--    $settings['redis.connection']['host'] = 'redis_host';
--    $settings['redis.connection']['port'] = 1234;
--    $no_settings['cache']['default'] = 'cache.backend.redis';
--
--    $this->assertArrayNotHasKey('bootstrap_container_definition', $this->settings);
--
--    $this->assertSettingsContains($settings);
--    $this->assertSettingsNotContains($no_settings);
 -  }
 -
 -  /**

--- a/tests/phpunit/Drupal/SwitchableSettingsTest.php
+++ b/tests/phpunit/Drupal/SwitchableSettingsTest.php
@@ -258,30 +258,6 @@ class SwitchableSettingsTest extends SettingsTestCase {
   }
 
   /**
-   * Test Redis partial settings.
-   */
-  public function testRedisPartial(): void {
-    $this->setEnvVars([
-      'DRUPAL_REDIS_ENABLED' => 1,
-      'REDIS_HOST' => 'redis_host',
-      'REDIS_SERVICE_PORT' => 1234,
-      'VORTEX_REDIS_EXTENSION_LOADED' => 0,
-    ]);
-
-    $this->requireSettingsFile();
-
-    $settings['redis.connection']['interface'] = 'PhpRedis';
-    $settings['redis.connection']['host'] = 'redis_host';
-    $settings['redis.connection']['port'] = 1234;
-    $no_settings['cache']['default'] = 'cache.backend.redis';
-
-    $this->assertArrayNotHasKey('bootstrap_container_definition', $this->settings);
-
-    $this->assertSettingsContains($settings);
-    $this->assertSettingsNotContains($no_settings);
-  }
-
-  /**
    * Test Redis settings with REDIS_* environment variables.
    */
   public function testRedisVariables(): void {

--- a/web/sites/default/includes/modules/settings.redis.php
+++ b/web/sites/default/includes/modules/settings.redis.php
@@ -35,9 +35,9 @@ if (file_exists($contrib_path . '/redis') && !empty(getenv('DRUPAL_REDIS_ENABLED
   $settings['redis.connection']['interface'] = 'PhpRedis';
 
   // Do not set the cache backend during installations of Drupal, but allow
-  // to override this by setting VORTEX_REDIS_EXTENSION_LOADED to non-zero.
+  // to override this by setting VORTEX_REDIS_EXTENSION_LOADED = '1'.
   // Redis uses `redis` PHP extension.
-  if ((extension_loaded('redis') && getenv('VORTEX_REDIS_EXTENSION_LOADED') === FALSE) || !empty(getenv('VORTEX_REDIS_EXTENSION_LOADED'))) {
+  if (extension_loaded('redis') || getenv('VORTEX_REDIS_EXTENSION_LOADED') === '1') {
 
     // Set Redis as the default backend for any cache bin not otherwise
     // specified.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Redis now enables only when the Redis extension is loaded or when an environment variable is explicitly set to '1', preventing unintended activation from ambiguous values and making configuration more predictable.
- Tests
  - Removed an obsolete unit test that validated partial Redis settings when the Redis extension was disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->