### PR TITLE
[#2086] Added support for `--interactive` flag when running `ahoy update-vortex`.

### DIFF
--- a/.vortex/.ahoy.yml
+++ b/.vortex/.ahoy.yml
@@ -46,6 +46,7 @@ commands:
       ahoy lint-scripts
       ahoy lint-dockerfiles
       ahoy lint-docs
+      ahoy lint-markdown
 
   lint-installer:
     cmd: composer --working-dir installer lint

--- a/.vortex/docs/content/workflows/variables.mdx
+++ b/.vortex/docs/content/workflows/variables.mdx
@@ -1182,6 +1182,14 @@ Default value: `UNDEFINED`
 
 Defined or used in: `.env`
 
+### `VORTEX_INSTALLER_INTERACTIVE`
+
+Run installer in interactive mode.
+
+Default value: `0`
+
+Defined or used in: `scripts/vortex/update-vortex.sh`
+
 ### `VORTEX_INSTALLER_PATH`
 
 The path to the installer script.<br/>If set, this will override the VORTEX_INSTALLER_URL.

--- a/.vortex/tests/bats/unit/update-vortex.bats
+++ b/.vortex/tests/bats/unit/update-vortex.bats
@@ -203,3 +203,51 @@ load ../_helper.bash
 
   popd >/dev/null || exit 1
 }
+
+@test "Script runs in interactive mode when --interactive flag is provided" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  create_global_command_wrapper "curl"
+  create_global_command_wrapper "php"
+
+  export VORTEX_INSTALLER_URL_CACHE_BUST="1234567890"
+
+  declare -a STEPS=(
+    "@curl -fsSL https://www.vortextemplate.com/install?1234567890 -o installer.php # 0"
+    "@php installer.php --uri=https://github.com/drevops/vortex.git@stable # 0"
+    "Using installer script from URL: https://www.vortextemplate.com/install"
+    "Downloading installer to installer.php"
+  )
+
+  mocks="$(run_steps "setup")"
+  run "${ROOT_DIR}/scripts/vortex/update-vortex.sh" --interactive
+  run_steps "assert" "${mocks[@]}"
+
+  assert_success
+
+  popd >/dev/null || exit 1
+}
+
+@test "Script runs in interactive mode with custom template repository" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  create_global_command_wrapper "curl"
+  create_global_command_wrapper "php"
+
+  export VORTEX_INSTALLER_URL_CACHE_BUST="1234567890"
+
+  declare -a STEPS=(
+    "@curl -fsSL https://www.vortextemplate.com/install?1234567890 -o installer.php # 0"
+    "@php installer.php --uri=https://github.com/custom/repo.git@main # 0"
+    "Using installer script from URL: https://www.vortextemplate.com/install"
+    "Downloading installer to installer.php"
+  )
+
+  mocks="$(run_steps "setup")"
+  run "${ROOT_DIR}/scripts/vortex/update-vortex.sh" --interactive https://github.com/custom/repo.git@main
+  run_steps "assert" "${mocks[@]}"
+
+  assert_success
+
+  popd >/dev/null || exit 1
+}

--- a/scripts/vortex/update-vortex.sh
+++ b/scripts/vortex/update-vortex.sh
@@ -26,7 +26,7 @@ set -eu
 # /local/path/to/vortex.git@stable               # Will auto-discover the latest stable tag from local repo.
 # /local/path/to/vortex.git@1.2.3                # Will use specific release from local repo.
 # /local/path/to/vortex.git@abcd123              # Will use specific commit from local repo.
-VORTEX_INSTALLER_TEMPLATE_REPO="${VORTEX_INSTALLER_TEMPLATE_REPO:-${1:-https://github.com/drevops/vortex.git@stable}}"
+VORTEX_INSTALLER_TEMPLATE_REPO="${VORTEX_INSTALLER_TEMPLATE_REPO:-https://github.com/drevops/vortex.git@stable}"
 
 # The URL of the installer script.
 VORTEX_INSTALLER_URL="${VORTEX_INSTALLER_URL:-https://www.vortextemplate.com/install}"
@@ -37,6 +37,9 @@ VORTEX_INSTALLER_URL_CACHE_BUST="${VORTEX_INSTALLER_URL_CACHE_BUST:-"$(date +%s)
 # The path to the installer script.
 # If set, this will override the VORTEX_INSTALLER_URL.
 VORTEX_INSTALLER_PATH="${VORTEX_INSTALLER_PATH:-}"
+
+# Run installer in interactive mode.
+VORTEX_INSTALLER_INTERACTIVE="${VORTEX_INSTALLER_INTERACTIVE:-0}"
 
 # ------------------------------------------------------------------------------
 
@@ -54,6 +57,14 @@ for cmd in php curl; do command -v "${cmd}" >/dev/null || {
   exit 1
 }; done
 
+for arg in "$@"; do
+  if [ "${arg}" = "--interactive" ]; then
+    VORTEX_INSTALLER_INTERACTIVE=1
+  else
+    VORTEX_INSTALLER_TEMPLATE_REPO="${arg}"
+  fi
+done
+
 if [ -n "${VORTEX_INSTALLER_PATH}" ]; then
   note "Using installer script from local path: ${VORTEX_INSTALLER_PATH}"
   if [ ! -f "${VORTEX_INSTALLER_PATH}" ]; then
@@ -70,4 +81,8 @@ else
   fi
 fi
 
-php "${VORTEX_INSTALLER_PATH}" --no-interaction --uri="${VORTEX_INSTALLER_TEMPLATE_REPO}"
+if [ "${VORTEX_INSTALLER_INTERACTIVE}" = "0" ]; then
+  php "${VORTEX_INSTALLER_PATH}" --no-interaction --uri="${VORTEX_INSTALLER_TEMPLATE_REPO}"
+else
+  php "${VORTEX_INSTALLER_PATH}" --uri="${VORTEX_INSTALLER_TEMPLATE_REPO}"
+fi


### PR DESCRIPTION
Closes #2086


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive installer mode configurable via a new flag; installer now runs in interactive or non-interactive mode depending on the setting.
  * Adjusted how the installer determines the template repository when arguments are omitted.

* **Documentation**
  * Added extensive shell script and installer development patterns, testing guidance, performance notes, and common pitfalls.
  * Note: a section was unintentionally duplicated in the docs.

* **Tests**
  * Added unit tests covering interactive installer scenarios, including custom repository use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->