### PR TITLE
Reconciled notification variables in scripts.

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -26,12 +26,10 @@ tasks:
         name: Notify about pre-deployment.
         command: |
           if [ -n "$LAGOON_PR_NUMBER" ]; then
-            export VORTEX_NOTIFY_REF=$LAGOON_PR_NUMBER
             export VORTEX_NOTIFY_SHA=${LAGOON_PR_HEAD_SHA#origin/}
             export VORTEX_NOTIFY_BRANCH=$LAGOON_PR_HEAD_BRANCH
             export VORTEX_NOTIFY_PR_NUMBER="${LAGOON_PR_NUMBER:-}"
           else
-            export VORTEX_NOTIFY_REF=$LAGOON_GIT_BRANCH
             export VORTEX_NOTIFY_SHA=$LAGOON_GIT_SHA
             export VORTEX_NOTIFY_BRANCH=$LAGOON_GIT_BRANCH
           fi
@@ -98,12 +96,10 @@ tasks:
         name: Send deployment notifications
         command: |
           if [ -n "$LAGOON_PR_NUMBER" ]; then
-            export VORTEX_NOTIFY_REF=$LAGOON_PR_NUMBER
             export VORTEX_NOTIFY_SHA=${LAGOON_PR_HEAD_SHA#origin/}
             export VORTEX_NOTIFY_BRANCH=$LAGOON_PR_HEAD_BRANCH
             export VORTEX_NOTIFY_PR_NUMBER="${LAGOON_PR_NUMBER:-}"
           else
-            export VORTEX_NOTIFY_REF=$LAGOON_GIT_BRANCH
             export VORTEX_NOTIFY_SHA=$LAGOON_GIT_SHA
             export VORTEX_NOTIFY_BRANCH=$LAGOON_GIT_BRANCH
           fi

--- a/.vortex/docs/content/workflows/notifications.mdx
+++ b/.vortex/docs/content/workflows/notifications.mdx
@@ -30,10 +30,17 @@ Available channels: [`email`](#email), [`github`](#github),
 These variables apply to all notification channels unless overridden by
 channel-specific settings.
 
-| Variable                | Required | Default          | Location | Description                        |
-|-------------------------|----------|------------------|----------|------------------------------------|
-| `VORTEX_NOTIFY_PROJECT` | No       | `VORTEX_PROJECT` | `.env`   | Project name used in notifications |
-| `VORTEX_NOTIFY_SKIP`    | No       |                  | Hosting  | Set to `1` to skip notifications   |
+| Variable                         | Required | Default           | Location | Description                                                                       |
+|----------------------------------|----------|-------------------|----------|-----------------------------------------------------------------------------------|
+| `VORTEX_NOTIFY_CHANNELS`         | No       | `email`           | `.env`   | Notification channels (comma-separated: email,slack,newrelic,github,jira,webhook) |
+| `VORTEX_NOTIFY_PROJECT`          | No       | `VORTEX_PROJECT`  | `.env`   | Notification project name                                                         |
+| `VORTEX_NOTIFY_BRANCH`           | No       |                   | Hosting  | Notification git branch name                                                      |
+| `VORTEX_NOTIFY_PR_NUMBER`        | No       |                   | Hosting  | Notification pull request number (if applicable)                                  |
+| `VORTEX_NOTIFY_SHA`              | No       |                   | Hosting  | Notification git commit SHA                                                       |
+| `VORTEX_NOTIFY_ENVIRONMENT_URL`  | No       |                   | Hosting  | Notification deployment environment URL                                           |
+| `VORTEX_NOTIFY_ENVIRONMENT_TYPE` | No       |                   | Hosting  | Notification environment type (production, uat, dev, pr)                          |
+| `VORTEX_NOTIFY_EVENT`            | No       | `post_deployment` | Hosting  | Notification event type (pre_deployment or post_deployment)                       |
+| `VORTEX_NOTIFY_SKIP`             | No       |                   | Hosting  | Notification skip flag (set to `1` to skip notifications)                         |
 
 ## Email
 
@@ -51,10 +58,10 @@ Send deployment notification via email.
 
 ### Environment variables
 
-| Variable                         | Required | Default | Location | Description                             |
-|----------------------------------|----------|---------|----------|-----------------------------------------|
-| `VORTEX_NOTIFY_EMAIL_FROM`       | **Yes**  |         | `.env`   | Email address to send notifications from|
-| `VORTEX_NOTIFY_EMAIL_RECIPIENTS` | **Yes**  |         | `.env`   | Recipients (format: `email\|name`)      |
+| Variable                         | Required | Default | Location | Description                                           |
+|----------------------------------|----------|---------|----------|-------------------------------------------------------|
+| `VORTEX_NOTIFY_EMAIL_FROM`       | **Yes**  |         | `.env`   | Email notification sender address                     |
+| `VORTEX_NOTIFY_EMAIL_RECIPIENTS` | **Yes**  |         | `.env`   | Email notification recipients (format: `email\|name`) |
 
 ### Example
 
@@ -92,8 +99,8 @@ automatically post deployment status to GitHub pull requests.
 
 | Variable                          | Required | Default | Location | Description                       |
 |-----------------------------------|----------|---------|----------|-----------------------------------|
-| `VORTEX_NOTIFY_GITHUB_TOKEN`      | **Yes**  |         | Hosting  | GitHub personal access token      |
-| `VORTEX_NOTIFY_GITHUB_REPOSITORY` | **Yes**  |         | Hosting  | Repository in `owner/repo` format |
+| `VORTEX_NOTIFY_GITHUB_TOKEN`      | **Yes**  |         | Hosting  | GitHub notification personal access token |
+| `VORTEX_NOTIFY_GITHUB_REPOSITORY` | **Yes**  |         | Hosting  | GitHub notification repository in `owner/repo` format |
 
 ### Example
 
@@ -129,14 +136,14 @@ assignee in JIRA.
 
 ### Environment variables
 
-| Variable                            | Required | Default                      | Location | Description                |
-|-------------------------------------|----------|------------------------------|----------|----------------------------|
-| `VORTEX_NOTIFY_JIRA_TOKEN`          | **Yes**  |                              | Hosting  | JIRA API token             |
-| `VORTEX_NOTIFY_JIRA_USER`           | **Yes**  |                              | `.env`   | JIRA user email address    |
-| `VORTEX_NOTIFY_JIRA_ASSIGNEE`       | No       |                              | `.env`   | User email to assign to    |
-| `VORTEX_NOTIFY_JIRA_TRANSITION`     | No       |                              | `.env`   | State to transition to     |
-| `VORTEX_NOTIFY_JIRA_ENDPOINT`       | No       | `https://jira.atlassian.com` | `.env`   | JIRA API endpoint          |
-| `VORTEX_NOTIFY_JIRA_COMMENT_PREFIX` | No       | `"Deployed to "`             | `.env`   | Comment prefix             |
+| Variable                            | Required | Default                      | Location | Description                              |
+|-------------------------------------|----------|------------------------------|----------|------------------------------------------|
+| `VORTEX_NOTIFY_JIRA_TOKEN`          | **Yes**  |                              | Hosting  | JIRA notification API token              |
+| `VORTEX_NOTIFY_JIRA_USER`           | **Yes**  |                              | `.env`   | JIRA notification user email address     |
+| `VORTEX_NOTIFY_JIRA_ASSIGNEE`       | No       |                              | `.env`   | JIRA notification assignee email         |
+| `VORTEX_NOTIFY_JIRA_TRANSITION`     | No       |                              | `.env`   | JIRA notification state to transition to |
+| `VORTEX_NOTIFY_JIRA_ENDPOINT`       | No       | `https://jira.atlassian.com` | `.env`   | JIRA notification API endpoint           |
+| `VORTEX_NOTIFY_JIRA_COMMENT_PREFIX` | No       | `"Deployed to "`             | `.env`   | JIRA notification comment prefix         |
 
 ### Example
 
@@ -165,16 +172,16 @@ markers in New Relic APM when a deployment is performed.
 
 ### Environment variables
 
-| Variable                             | Required | Default                              | Location | Description                |
-|--------------------------------------|----------|--------------------------------------|----------|----------------------------|
-| `VORTEX_NOTIFY_NEWRELIC_APIKEY`      | **Yes**  |                                      | Hosting  | New Relic API key          |
-| `VORTEX_NOTIFY_NEWRELIC_PROJECT`     | No       | `VORTEX_NOTIFY_PROJECT`              | `.env`   | Project name               |
-| `VORTEX_NOTIFY_NEWRELIC_APP_NAME`    | No       | `{PROJECT}-{REF}`                    | `.env`   | Application name           |
-| `VORTEX_NOTIFY_NEWRELIC_APPID`       | No       |                                      | `.env`   | Application ID (auto)      |
-| `VORTEX_NOTIFY_NEWRELIC_DESCRIPTION` | No       | `"{ref} deployed"`                   | `.env`   | Deployment description     |
-| `VORTEX_NOTIFY_NEWRELIC_CHANGELOG`   | No       | `VORTEX_NOTIFY_NEWRELIC_DESCRIPTION` | `.env`   | Deployment changelog       |
-| `VORTEX_NOTIFY_NEWRELIC_USER`        | No       | `Deployment robot`                   | `.env`   | User performing deployment |
-| `VORTEX_NOTIFY_NEWRELIC_ENDPOINT`    | No       | `https://api.newrelic.com/v2`        | `.env`   | API endpoint               |
+| Variable                             | Required | Default                              | Location | Description                                             |
+|--------------------------------------|----------|--------------------------------------|----------|---------------------------------------------------------|
+| `VORTEX_NOTIFY_NEWRELIC_APIKEY`      | **Yes**  |                                      | Hosting  | New Relic notification API key                          |
+| `VORTEX_NOTIFY_NEWRELIC_PROJECT`     | No       | `VORTEX_NOTIFY_PROJECT`              | `.env`   | New Relic notification project name                     |
+| `VORTEX_NOTIFY_NEWRELIC_APP_NAME`    | No       | `{PROJECT}-{BRANCH}`                 | `.env`   | New Relic notification application name                 |
+| `VORTEX_NOTIFY_NEWRELIC_APPID`       | No       |                                      | `.env`   | New Relic notification application ID (auto-discovered) |
+| `VORTEX_NOTIFY_NEWRELIC_DESCRIPTION` | No       | `"{branch} deployed"`                | `.env`   | New Relic notification deployment description           |
+| `VORTEX_NOTIFY_NEWRELIC_CHANGELOG`   | No       | `VORTEX_NOTIFY_NEWRELIC_DESCRIPTION` | `.env`   | New Relic notification deployment changelog             |
+| `VORTEX_NOTIFY_NEWRELIC_USER`        | No       | `Deployment robot`                   | `.env`   | New Relic notification user performing deployment       |
+| `VORTEX_NOTIFY_NEWRELIC_ENDPOINT`    | No       | `https://api.newrelic.com/v2`        | `.env`   | New Relic notification API endpoint                     |
 
 ### Example
 
@@ -196,13 +203,13 @@ Post deployment notification to Slack a channel.
 
 ### Environment variables
 
-| Variable                         | Required | Default                 | Location | Description                 |
-|----------------------------------|----------|-------------------------|----------|-----------------------------|
-| `VORTEX_NOTIFY_SLACK_WEBHOOK`    | **Yes**  |                         | Hosting  | Slack Incoming Webhook URL  |
-| `VORTEX_NOTIFY_SLACK_PROJECT`    | No       | `VORTEX_NOTIFY_PROJECT` | `.env`   | Project name                |
-| `VORTEX_NOTIFY_SLACK_CHANNEL`    | No       |                         | `.env`   | Target channel (overrides)  |
-| `VORTEX_NOTIFY_SLACK_USERNAME`   | No       | `Deployment Bot`        | `.env`   | Bot display name            |
-| `VORTEX_NOTIFY_SLACK_ICON_EMOJI` | No       | `:rocket:`              | `.env`   | Bot icon emoji              |
+| Variable                         | Required | Default                 | Location | Description                                                   |
+|----------------------------------|----------|-------------------------|----------|---------------------------------------------------------------|
+| `VORTEX_NOTIFY_SLACK_WEBHOOK`    | **Yes**  |                         | Hosting  | Slack notification webhook URL                                |
+| `VORTEX_NOTIFY_SLACK_PROJECT`    | No       | `VORTEX_NOTIFY_PROJECT` | `.env`   | Slack notification project name                               |
+| `VORTEX_NOTIFY_SLACK_CHANNEL`    | No       |                         | `.env`   | Slack notification target channel (overrides webhook default) |
+| `VORTEX_NOTIFY_SLACK_USERNAME`   | No       | `Deployment Bot`        | `.env`   | Slack notification bot display name                           |
+| `VORTEX_NOTIFY_SLACK_ICON_EMOJI` | No       | `:rocket:`              | `.env`   | Slack notification bot icon emoji                             |
 
 ### Example
 
@@ -223,11 +230,11 @@ Send HTTP request to an arbitrary webhook URL.
 
 ### Environment variables
 
-| Variable                                | Required | Default                          | Location          | Description             |
-|-----------------------------------------|----------|----------------------------------|-------------------|-------------------------|
-| `VORTEX_NOTIFY_WEBHOOK_URL`             | **Yes**  |                                  | `.env` or Hosting | Webhook endpoint URL    |
-| `VORTEX_NOTIFY_WEBHOOK_PROJECT`         | No       | `VORTEX_NOTIFY_PROJECT`          | Hosting           | Project name            |
-| `VORTEX_NOTIFY_WEBHOOK_METHOD`          | No       | `POST`                           | `.env`            | HTTP method             |
-| `VORTEX_NOTIFY_WEBHOOK_HEADERS`         | No       | `Content-Type: application/json` | `.env`            | Pipe-separated headers  |
-| `VORTEX_NOTIFY_WEBHOOK_PAYLOAD`         | No       | JSON with substitution variables | `.env`            | JSON payload            |
-| `VORTEX_NOTIFY_WEBHOOK_RESPONSE_STATUS` | No       | `200`                            | `.env`            | Expected HTTP status    |
+| Variable                                | Required | Default                          | Location          | Description                                 |
+|-----------------------------------------|----------|----------------------------------|-------------------|---------------------------------------------|
+| `VORTEX_NOTIFY_WEBHOOK_URL`             | **Yes**  |                                  | `.env` or Hosting | Webhook notification endpoint URL           |
+| `VORTEX_NOTIFY_WEBHOOK_PROJECT`         | No       | `VORTEX_NOTIFY_PROJECT`          | Hosting           | Webhook notification project name           |
+| `VORTEX_NOTIFY_WEBHOOK_METHOD`          | No       | `POST`                           | `.env`            | Webhook notification HTTP method            |
+| `VORTEX_NOTIFY_WEBHOOK_HEADERS`         | No       | `Content-Type: application/json` | `.env`            | Webhook notification pipe-separated headers |
+| `VORTEX_NOTIFY_WEBHOOK_PAYLOAD`         | No       | JSON with substitution variables | `.env`            | Webhook notification JSON payload           |
+| `VORTEX_NOTIFY_WEBHOOK_RESPONSE_STATUS` | No       | `200`                            | `.env`            | Webhook notification expected HTTP status   |

--- a/.vortex/docs/content/workflows/variables.mdx
+++ b/.vortex/docs/content/workflows/variables.mdx
@@ -1299,11 +1299,11 @@ Defined or used in: `.env.local.example`, `scripts/vortex/info.sh`
 
 ### `VORTEX_NOTIFY_BRANCH`
 
-Deployment reference branch.
+Notification git branch name.
 
 Default value: `UNDEFINED`
 
-Defined or used in: `scripts/vortex/notify-github.sh`, `scripts/vortex/notify-jira.sh`
+Defined or used in: `scripts/vortex/notify.sh`
 
 ### `VORTEX_NOTIFY_CHANNELS`
 
@@ -1315,11 +1315,27 @@ Default value: `email`
 
 Defined or used in: `.env`, `scripts/vortex/notify.sh`
 
+### `VORTEX_NOTIFY_EMAIL_BRANCH`
+
+Email notification git branch name.
+
+Default value: `${VORTEX_NOTIFY_BRANCH}`
+
+Defined or used in: `scripts/vortex/notify-email.sh`
+
 ### `VORTEX_NOTIFY_EMAIL_ENVIRONMENT_URL`
 
-Environment URL to notify about.
+Email notification deployment environment URL.
 
 Default value: `${VORTEX_NOTIFY_ENVIRONMENT_URL}`
+
+Defined or used in: `scripts/vortex/notify-email.sh`
+
+### `VORTEX_NOTIFY_EMAIL_EVENT`
+
+Email notification event type. Can be 'pre_deployment' or 'post_deployment'.
+
+Default value: `post_deployment`
 
 Defined or used in: `scripts/vortex/notify-email.sh`
 
@@ -1335,7 +1351,7 @@ Defined or used in: `.env`, `scripts/vortex/notify-email.sh`
 
 ### `VORTEX_NOTIFY_EMAIL_PROJECT`
 
-Project name to notify.
+Email notification project name.
 
 Default value: `${VORTEX_NOTIFY_PROJECT}`
 
@@ -1343,7 +1359,7 @@ Defined or used in: `scripts/vortex/notify-email.sh`
 
 ### `VORTEX_NOTIFY_EMAIL_PR_NUMBER`
 
-Git reference to notify about.
+Email notification pull request number.
 
 Default value: `${VORTEX_NOTIFY_PR_NUMBER}`
 
@@ -1361,41 +1377,77 @@ Default value: `webmaster@your-site-domain.example|Webmaster`
 
 Defined or used in: `.env`, `scripts/vortex/notify-email.sh`
 
-### `VORTEX_NOTIFY_EMAIL_REF`
-
-Git reference to notify about.
-
-Default value: `${VORTEX_NOTIFY_REF}`
-
-Defined or used in: `scripts/vortex/notify-email.sh`
-
 ### `VORTEX_NOTIFY_ENVIRONMENT_TYPE`
 
-Deployment environment type: production, uat, dev, pr.
+Notification environment type: production, uat, dev, pr.
+
+Default value: `UNDEFINED`
+
+Defined or used in: `scripts/vortex/notify.sh`
+
+### `VORTEX_NOTIFY_ENVIRONMENT_URL`
+
+Notification deployment environment URL.
+
+Default value: `UNDEFINED`
+
+Defined or used in: `scripts/vortex/notify.sh`
+
+### `VORTEX_NOTIFY_EVENT`
+
+Notification event type.
+
+Can be 'pre_deployment' or 'post_deployment'.
+
+Default value: `post_deployment`
+
+Defined or used in: `scripts/vortex/notify.sh`
+
+### `VORTEX_NOTIFY_GITHUB_BRANCH`
+
+GitHub notification git branch name.
+
+Default value: `${VORTEX_NOTIFY_BRANCH}`
+
+Defined or used in: `scripts/vortex/notify-github.sh`
+
+### `VORTEX_NOTIFY_GITHUB_ENVIRONMENT_TYPE`
+
+GitHub notification environment type: production, uat, dev, pr.
 
 Default value: `PR`
 
 Defined or used in: `scripts/vortex/notify-github.sh`
 
-### `VORTEX_NOTIFY_ENVIRONMENT_URL`
+### `VORTEX_NOTIFY_GITHUB_ENVIRONMENT_URL`
 
-Deployment environment URL.
+GitHub notification deployment environment URL.
 
-Default value: `UNDEFINED`
+Default value: `${VORTEX_NOTIFY_ENVIRONMENT_URL}`
 
-Defined or used in: `scripts/vortex/notify-github.sh`, `scripts/vortex/notify-jira.sh`, `scripts/vortex/notify-slack.sh`, `scripts/vortex/notify-webhook.sh`
+Defined or used in: `scripts/vortex/notify-github.sh`
 
-### `VORTEX_NOTIFY_EVENT`
+### `VORTEX_NOTIFY_GITHUB_EVENT`
 
-The event to notify about. Can be 'pre_deployment' or 'post_deployment'.
+GitHub notification event type. Can be 'pre_deployment' or 'post_deployment'.
 
-Default value: `UNDEFINED`
+Default value: `${VORTEX_NOTIFY_EVENT}`
 
-Defined or used in: `scripts/vortex/notify-github.sh`, `scripts/vortex/notify-slack.sh`, `scripts/vortex/notify.sh`
+Defined or used in: `scripts/vortex/notify-github.sh`
+
+### `VORTEX_NOTIFY_GITHUB_PR_NUMBER`
+
+GitHub notification pull request number.
+
+If set, the environment type will be set to 'pr-[`${VORTEX_NOTIFY_GITHUB_PR_NUMBER}`](#vortex_notify_github_pr_number)'.
+
+Default value: `${VORTEX_NOTIFY_PR_NUMBER}`
+
+Defined or used in: `scripts/vortex/notify-github.sh`
 
 ### `VORTEX_NOTIFY_GITHUB_REPOSITORY`
 
-Deployment repository.
+GitHub notification repository in owner/repo format.
 
 Default value: `UNDEFINED`
 
@@ -1413,7 +1465,7 @@ Defined or used in: `ACQUIA ENVIRONMENT`, `LAGOON ENVIRONMENT`, `scripts/vortex/
 
 ### `VORTEX_NOTIFY_JIRA_ASSIGNEE`
 
-Assign the ticket to this account.
+JIRA notification assignee email.
 
 If left empty - no assignment will be performed.
 
@@ -1421,9 +1473,17 @@ Default value: `UNDEFINED`
 
 Defined or used in: `scripts/vortex/notify-jira.sh`
 
+### `VORTEX_NOTIFY_JIRA_BRANCH`
+
+JIRA notification git branch name.
+
+Default value: `${VORTEX_NOTIFY_BRANCH}`
+
+Defined or used in: `scripts/vortex/notify-jira.sh`
+
 ### `VORTEX_NOTIFY_JIRA_COMMENT_PREFIX`
 
-Deployment comment prefix.
+JIRA notification comment prefix.
 
 Default value: `Deployed to `
 
@@ -1431,9 +1491,25 @@ Defined or used in: `scripts/vortex/notify-jira.sh`
 
 ### `VORTEX_NOTIFY_JIRA_ENDPOINT`
 
-JIRA API endpoint.
+JIRA notification API endpoint.
 
 Default value: `https://jira.atlassian.com`
+
+Defined or used in: `scripts/vortex/notify-jira.sh`
+
+### `VORTEX_NOTIFY_JIRA_ENVIRONMENT_URL`
+
+JIRA notification deployment environment URL.
+
+Default value: `${VORTEX_NOTIFY_ENVIRONMENT_URL}`
+
+Defined or used in: `scripts/vortex/notify-jira.sh`
+
+### `VORTEX_NOTIFY_JIRA_EVENT`
+
+JIRA notification event type. Can be 'pre_deployment' or 'post_deployment'.
+
+Default value: `post_deployment`
 
 Defined or used in: `scripts/vortex/notify-jira.sh`
 
@@ -1449,7 +1525,7 @@ Defined or used in: `ACQUIA ENVIRONMENT`, `LAGOON ENVIRONMENT`, `scripts/vortex/
 
 ### `VORTEX_NOTIFY_JIRA_TRANSITION`
 
-State to move the ticket to.
+JIRA notification state to transition to.
 
 If left empty - no transition will be performed.
 
@@ -1477,7 +1553,7 @@ Defined or used in: `ACQUIA ENVIRONMENT`, `LAGOON ENVIRONMENT`, `scripts/vortex/
 
 ### `VORTEX_NOTIFY_NEWRELIC_APPID`
 
-Optional NewRelic Application ID.
+New Relic notification application ID (auto-discovered if not provided).
 
 Will be discovered automatically from application name if not provided.
 
@@ -1487,15 +1563,23 @@ Defined or used in: `scripts/vortex/notify-newrelic.sh`
 
 ### `VORTEX_NOTIFY_NEWRELIC_APP_NAME`
 
-NewRelic application name as it appears in the dashboard.
+New Relic notification application name as it appears in the dashboard.
 
-Default value: `${VORTEX_NOTIFY_NEWRELIC_PROJECT}-${VORTEX_NOTIFY_NEWRELIC_REF}`
+Default value: `${VORTEX_NOTIFY_NEWRELIC_PROJECT}-${VORTEX_NOTIFY_NEWRELIC_BRANCH}`
+
+Defined or used in: `scripts/vortex/notify-newrelic.sh`
+
+### `VORTEX_NOTIFY_NEWRELIC_BRANCH`
+
+New Relic notification git branch name.
+
+Default value: `${VORTEX_NOTIFY_BRANCH}`
 
 Defined or used in: `scripts/vortex/notify-newrelic.sh`
 
 ### `VORTEX_NOTIFY_NEWRELIC_CHANGELOG`
 
-Optional NewRelic notification changelog.
+New Relic notification deployment changelog.
 
 Defaults to the description.
 
@@ -1505,39 +1589,39 @@ Defined or used in: `scripts/vortex/notify-newrelic.sh`
 
 ### `VORTEX_NOTIFY_NEWRELIC_DESCRIPTION`
 
-Optional NewRelic notification description.
+New Relic notification deployment description.
 
-Default value: `${VORTEX_NOTIFY_NEWRELIC_REF} deployed`
+Default value: `${VORTEX_NOTIFY_NEWRELIC_BRANCH} deployed`
 
 Defined or used in: `scripts/vortex/notify-newrelic.sh`
 
 ### `VORTEX_NOTIFY_NEWRELIC_ENDPOINT`
 
-Optional NewRelic endpoint.
+New Relic notification API endpoint.
 
 Default value: `https://api.newrelic.com/v2`
 
 Defined or used in: `scripts/vortex/notify-newrelic.sh`
 
+### `VORTEX_NOTIFY_NEWRELIC_EVENT`
+
+New Relic notification event type. Can be 'pre_deployment' or 'post_deployment'.
+
+Default value: `post_deployment`
+
+Defined or used in: `scripts/vortex/notify-newrelic.sh`
+
 ### `VORTEX_NOTIFY_NEWRELIC_PROJECT`
 
-Project name to notify.
+New Relic notification project name.
 
 Default value: `${VORTEX_NOTIFY_PROJECT}`
 
 Defined or used in: `scripts/vortex/notify-newrelic.sh`
 
-### `VORTEX_NOTIFY_NEWRELIC_REF`
-
-Deployment reference, such as a git branch or pr.
-
-Default value: `${VORTEX_NOTIFY_REF}`
-
-Defined or used in: `scripts/vortex/notify-newrelic.sh`
-
 ### `VORTEX_NOTIFY_NEWRELIC_SHA`
 
-Deployment commit reference, such as a git SHA.
+New Relic notification git commit SHA.
 
 Default value: `${VORTEX_NOTIFY_SHA}`
 
@@ -1545,7 +1629,7 @@ Defined or used in: `scripts/vortex/notify-newrelic.sh`
 
 ### `VORTEX_NOTIFY_NEWRELIC_USER`
 
-Optional name of the user performing the deployment.
+New Relic notification user performing deployment.
 
 Default value: `Deployment robot`
 
@@ -1553,7 +1637,7 @@ Defined or used in: `scripts/vortex/notify-newrelic.sh`
 
 ### `VORTEX_NOTIFY_PROJECT`
 
-The project to notify about.
+Notification project name.
 
 Default value: `${VORTEX_PROJECT}`
 
@@ -1561,49 +1645,63 @@ Defined or used in: `scripts/vortex/notify.sh`
 
 ### `VORTEX_NOTIFY_PR_NUMBER`
 
-Deployment PR number.
-
-If set, the environment type will be set to 'pr-[`${VORTEX_NOTIFY_PR_NUMBER}`](#vortex_notify_pr_number)'.
-
-Default value: `UNDEFINED`
-
-Defined or used in: `scripts/vortex/notify-github.sh`, `scripts/vortex/notify-slack.sh`
-
-### `VORTEX_NOTIFY_REF`
-
-Git reference to notify about.
-
-Default value: `UNDEFINED`
-
-Defined or used in: `scripts/vortex/notify-slack.sh`, `scripts/vortex/notify-webhook.sh`
-
-### `VORTEX_NOTIFY_SHA`
-
-Git commit SHA.
-
-Default value: `UNDEFINED`
-
-Defined or used in: `scripts/vortex/notify-slack.sh`
-
-### `VORTEX_NOTIFY_SKIP`
-
-Flag to skip running of all notifications.
+Notification pull request number.
 
 Default value: `UNDEFINED`
 
 Defined or used in: `scripts/vortex/notify.sh`
 
+### `VORTEX_NOTIFY_SHA`
+
+Notification git commit SHA.
+
+Default value: `UNDEFINED`
+
+Defined or used in: `scripts/vortex/notify.sh`
+
+### `VORTEX_NOTIFY_SKIP`
+
+Notification skip flag.
+
+Default value: `UNDEFINED`
+
+Defined or used in: `scripts/vortex/notify.sh`
+
+### `VORTEX_NOTIFY_SLACK_BRANCH`
+
+Slack notification git branch name.
+
+Default value: `${VORTEX_NOTIFY_BRANCH}`
+
+Defined or used in: `scripts/vortex/notify-slack.sh`
+
 ### `VORTEX_NOTIFY_SLACK_CHANNEL`
 
-Slack channel to post to (optional, overrides webhook default).<br/>Format: #channel-name or @username
+Slack notification target channel (optional, overrides webhook default).<br/>Format: #channel-name or @username
 
 Default value: `UNDEFINED`
 
 Defined or used in: `scripts/vortex/notify-slack.sh`
 
+### `VORTEX_NOTIFY_SLACK_ENVIRONMENT_URL`
+
+Slack notification deployment environment URL.
+
+Default value: `${VORTEX_NOTIFY_ENVIRONMENT_URL}`
+
+Defined or used in: `scripts/vortex/notify-slack.sh`
+
+### `VORTEX_NOTIFY_SLACK_EVENT`
+
+Slack notification event type. Can be 'pre_deployment' or 'post_deployment'.
+
+Default value: `post_deployment`
+
+Defined or used in: `scripts/vortex/notify-slack.sh`
+
 ### `VORTEX_NOTIFY_SLACK_ICON_EMOJI`
 
-Slack bot icon emoji (optional).
+Slack notification bot icon emoji (optional).
 
 Default value: `:rocket:`
 
@@ -1611,15 +1709,31 @@ Defined or used in: `scripts/vortex/notify-slack.sh`
 
 ### `VORTEX_NOTIFY_SLACK_PROJECT`
 
-Project name to notify.
+Slack notification project name.
 
 Default value: `${VORTEX_NOTIFY_PROJECT}`
 
 Defined or used in: `scripts/vortex/notify-slack.sh`
 
+### `VORTEX_NOTIFY_SLACK_PR_NUMBER`
+
+Slack notification pull request number.
+
+Default value: `${VORTEX_NOTIFY_PR_NUMBER}`
+
+Defined or used in: `scripts/vortex/notify-slack.sh`
+
+### `VORTEX_NOTIFY_SLACK_SHA`
+
+Slack notification git commit SHA.
+
+Default value: `${VORTEX_NOTIFY_SHA}`
+
+Defined or used in: `scripts/vortex/notify-slack.sh`
+
 ### `VORTEX_NOTIFY_SLACK_USERNAME`
 
-Slack bot username (optional).
+Slack notification bot display name (optional).
 
 Default value: `Deployment Bot`
 
@@ -1633,9 +1747,33 @@ Default value: `UNDEFINED`
 
 Defined or used in: `ACQUIA ENVIRONMENT`, `LAGOON ENVIRONMENT`, `scripts/vortex/notify-slack.sh`
 
+### `VORTEX_NOTIFY_WEBHOOK_BRANCH`
+
+Webhook notification git branch name.
+
+Default value: `${VORTEX_NOTIFY_BRANCH}`
+
+Defined or used in: `scripts/vortex/notify-webhook.sh`
+
+### `VORTEX_NOTIFY_WEBHOOK_ENVIRONMENT_URL`
+
+Webhook notification deployment environment URL.
+
+Default value: `${VORTEX_NOTIFY_ENVIRONMENT_URL}`
+
+Defined or used in: `scripts/vortex/notify-webhook.sh`
+
+### `VORTEX_NOTIFY_WEBHOOK_EVENT`
+
+Webhook notification event type. Can be 'pre_deployment' or 'post_deployment'.
+
+Default value: `post_deployment`
+
+Defined or used in: `scripts/vortex/notify-webhook.sh`
+
 ### `VORTEX_NOTIFY_WEBHOOK_HEADERS`
 
-Webhook headers.<br/>Separate multiple headers with a pipe `|`.<br/>Example: `Content-type: application/json|Authorization: Bearer API_KEY`.
+Webhook notification pipe-separated headers.<br/>Separate multiple headers with a pipe `|`.<br/>Example: `Content-type: application/json|Authorization: Bearer API_KEY`.
 
 Default value: `Content-type: application/json`
 
@@ -1643,7 +1781,7 @@ Defined or used in: `scripts/vortex/notify-webhook.sh`
 
 ### `VORTEX_NOTIFY_WEBHOOK_METHOD`
 
-Webhook method like POST, GET, PUT.
+Webhook notification HTTP method like POST, GET, PUT.
 
 Default value: `POST`
 
@@ -1651,7 +1789,7 @@ Defined or used in: `scripts/vortex/notify-webhook.sh`
 
 ### `VORTEX_NOTIFY_WEBHOOK_PAYLOAD`
 
-Webhook message body as json format.
+Webhook notification JSON payload.
 
 Default value: `${VORTEX_NOTIFY_WEBHOOK_PAYLOAD:-{\"channel\": \"Channel 1\", \"message\": \"%message%\", \"project\": \"%project%\", \"ref\": \"%ref%\", \"timestamp\": \"%timestamp%\", \"environment_url\": \"%environment_url%\"}}`
 
@@ -1659,7 +1797,7 @@ Defined or used in: `scripts/vortex/notify-webhook.sh`
 
 ### `VORTEX_NOTIFY_WEBHOOK_PROJECT`
 
-Project name to notify.
+Webhook notification project name.
 
 Default value: `${VORTEX_NOTIFY_PROJECT}`
 
@@ -1667,7 +1805,7 @@ Defined or used in: `scripts/vortex/notify-webhook.sh`
 
 ### `VORTEX_NOTIFY_WEBHOOK_RESPONSE_STATUS`
 
-The pattern of response code return by curl.
+Webhook notification expected HTTP status.
 
 Default value: `200`
 

--- a/.vortex/installer/tests/Fixtures/install/hosting_acquia/hooks/library/notify-deployment.sh
+++ b/.vortex/installer/tests/Fixtures/install/hosting_acquia/hooks/library/notify-deployment.sh
@@ -9,7 +9,6 @@ set -e
 site="${1}"
 target_env="${2}"
 branch="${3}"
-ref="${4:-${branch}}"
 
 # Custom domain name for the environment, including subdomain.
 # Examples: "dev.example.com", "test.example.com", "www.example.com"
@@ -27,7 +26,6 @@ fi
 
 export VORTEX_NOTIFY_PROJECT="${site}"
 export VORTEX_NOTIFY_BRANCH="${branch}"
-export VORTEX_NOTIFY_REF="${ref}"
 export VORTEX_NOTIFY_SHA="${target_env}"
 export VORTEX_NOTIFY_ENVIRONMENT_URL="${url}"
 

--- a/.vortex/installer/tests/Fixtures/install/hosting_lagoon/.lagoon.yml
+++ b/.vortex/installer/tests/Fixtures/install/hosting_lagoon/.lagoon.yml
@@ -25,12 +25,10 @@ tasks:
         name: Notify about pre-deployment.
         command: |
           if [ -n "$LAGOON_PR_NUMBER" ]; then
-            export VORTEX_NOTIFY_REF=$LAGOON_PR_NUMBER
             export VORTEX_NOTIFY_SHA=${LAGOON_PR_HEAD_SHA#origin/}
             export VORTEX_NOTIFY_BRANCH=$LAGOON_PR_HEAD_BRANCH
             export VORTEX_NOTIFY_PR_NUMBER="${LAGOON_PR_NUMBER:-}"
           else
-            export VORTEX_NOTIFY_REF=$LAGOON_GIT_BRANCH
             export VORTEX_NOTIFY_SHA=$LAGOON_GIT_SHA
             export VORTEX_NOTIFY_BRANCH=$LAGOON_GIT_BRANCH
           fi
@@ -83,12 +81,10 @@ tasks:
         name: Send deployment notifications
         command: |
           if [ -n "$LAGOON_PR_NUMBER" ]; then
-            export VORTEX_NOTIFY_REF=$LAGOON_PR_NUMBER
             export VORTEX_NOTIFY_SHA=${LAGOON_PR_HEAD_SHA#origin/}
             export VORTEX_NOTIFY_BRANCH=$LAGOON_PR_HEAD_BRANCH
             export VORTEX_NOTIFY_PR_NUMBER="${LAGOON_PR_NUMBER:-}"
           else
-            export VORTEX_NOTIFY_REF=$LAGOON_GIT_BRANCH
             export VORTEX_NOTIFY_SHA=$LAGOON_GIT_SHA
             export VORTEX_NOTIFY_BRANCH=$LAGOON_GIT_BRANCH
           fi

--- a/.vortex/installer/tests/Fixtures/install/hosting_project_name___acquia/hooks/library/notify-deployment.sh
+++ b/.vortex/installer/tests/Fixtures/install/hosting_project_name___acquia/hooks/library/notify-deployment.sh
@@ -9,7 +9,6 @@ set -e
 site="${1}"
 target_env="${2}"
 branch="${3}"
-ref="${4:-${branch}}"
 
 # Custom domain name for the environment, including subdomain.
 # Examples: "dev.example.com", "test.example.com", "www.example.com"
@@ -27,7 +26,6 @@ fi
 
 export VORTEX_NOTIFY_PROJECT="${site}"
 export VORTEX_NOTIFY_BRANCH="${branch}"
-export VORTEX_NOTIFY_REF="${ref}"
 export VORTEX_NOTIFY_SHA="${target_env}"
 export VORTEX_NOTIFY_ENVIRONMENT_URL="${url}"
 

--- a/.vortex/installer/tests/Fixtures/install/hosting_project_name___lagoon/.lagoon.yml
+++ b/.vortex/installer/tests/Fixtures/install/hosting_project_name___lagoon/.lagoon.yml
@@ -25,12 +25,10 @@ tasks:
         name: Notify about pre-deployment.
         command: |
           if [ -n "$LAGOON_PR_NUMBER" ]; then
-            export VORTEX_NOTIFY_REF=$LAGOON_PR_NUMBER
             export VORTEX_NOTIFY_SHA=${LAGOON_PR_HEAD_SHA#origin/}
             export VORTEX_NOTIFY_BRANCH=$LAGOON_PR_HEAD_BRANCH
             export VORTEX_NOTIFY_PR_NUMBER="${LAGOON_PR_NUMBER:-}"
           else
-            export VORTEX_NOTIFY_REF=$LAGOON_GIT_BRANCH
             export VORTEX_NOTIFY_SHA=$LAGOON_GIT_SHA
             export VORTEX_NOTIFY_BRANCH=$LAGOON_GIT_BRANCH
           fi
@@ -83,12 +81,10 @@ tasks:
         name: Send deployment notifications
         command: |
           if [ -n "$LAGOON_PR_NUMBER" ]; then
-            export VORTEX_NOTIFY_REF=$LAGOON_PR_NUMBER
             export VORTEX_NOTIFY_SHA=${LAGOON_PR_HEAD_SHA#origin/}
             export VORTEX_NOTIFY_BRANCH=$LAGOON_PR_HEAD_BRANCH
             export VORTEX_NOTIFY_PR_NUMBER="${LAGOON_PR_NUMBER:-}"
           else
-            export VORTEX_NOTIFY_REF=$LAGOON_GIT_BRANCH
             export VORTEX_NOTIFY_SHA=$LAGOON_GIT_SHA
             export VORTEX_NOTIFY_BRANCH=$LAGOON_GIT_BRANCH
           fi

--- a/.vortex/installer/tests/Fixtures/install/provision_database_lagoon/.lagoon.yml
+++ b/.vortex/installer/tests/Fixtures/install/provision_database_lagoon/.lagoon.yml
@@ -25,12 +25,10 @@ tasks:
         name: Notify about pre-deployment.
         command: |
           if [ -n "$LAGOON_PR_NUMBER" ]; then
-            export VORTEX_NOTIFY_REF=$LAGOON_PR_NUMBER
             export VORTEX_NOTIFY_SHA=${LAGOON_PR_HEAD_SHA#origin/}
             export VORTEX_NOTIFY_BRANCH=$LAGOON_PR_HEAD_BRANCH
             export VORTEX_NOTIFY_PR_NUMBER="${LAGOON_PR_NUMBER:-}"
           else
-            export VORTEX_NOTIFY_REF=$LAGOON_GIT_BRANCH
             export VORTEX_NOTIFY_SHA=$LAGOON_GIT_SHA
             export VORTEX_NOTIFY_BRANCH=$LAGOON_GIT_BRANCH
           fi
@@ -83,12 +81,10 @@ tasks:
         name: Send deployment notifications
         command: |
           if [ -n "$LAGOON_PR_NUMBER" ]; then
-            export VORTEX_NOTIFY_REF=$LAGOON_PR_NUMBER
             export VORTEX_NOTIFY_SHA=${LAGOON_PR_HEAD_SHA#origin/}
             export VORTEX_NOTIFY_BRANCH=$LAGOON_PR_HEAD_BRANCH
             export VORTEX_NOTIFY_PR_NUMBER="${LAGOON_PR_NUMBER:-}"
           else
-            export VORTEX_NOTIFY_REF=$LAGOON_GIT_BRANCH
             export VORTEX_NOTIFY_SHA=$LAGOON_GIT_SHA
             export VORTEX_NOTIFY_BRANCH=$LAGOON_GIT_BRANCH
           fi

--- a/.vortex/tests/bats/unit/notify-email.bats
+++ b/.vortex/tests/bats/unit/notify-email.bats
@@ -13,7 +13,7 @@ load ../_helper.bash
   export VORTEX_NOTIFY_PROJECT="testproject"
   export DRUPAL_SITE_EMAIL="testproject@example.com"
   export VORTEX_NOTIFY_EMAIL_RECIPIENTS="john@example.com|John Doe, jane@example.com|Jane Doe, jim@example.com"
-  export VORTEX_NOTIFY_REF="develop"
+  export VORTEX_NOTIFY_BRANCH="develop"
   export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
   run ./scripts/vortex/notify.sh
   assert_success
@@ -40,7 +40,7 @@ load ../_helper.bash
   export VORTEX_NOTIFY_PROJECT="testproject"
   export DRUPAL_SITE_EMAIL="testproject@example.com"
   export VORTEX_NOTIFY_EMAIL_RECIPIENTS="john@example.com|John Doe, jane@example.com|Jane Doe"
-  export VORTEX_NOTIFY_REF="develop"
+  export VORTEX_NOTIFY_BRANCH="develop"
   export VORTEX_NOTIFY_PR_NUMBER="123"
   export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
   run ./scripts/vortex/notify.sh
@@ -56,6 +56,28 @@ load ../_helper.bash
   assert_output_contains 'Site testproject "PR-123" has been deployed'
   assert_output_contains "and is available at https://develop.testproject.com."
 
+  assert_output_contains "Finished dispatching notifications."
+
+  popd >/dev/null || exit 1
+}
+
+@test "Notify: email, pre_deployment skip" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_NOTIFY_CHANNELS="email"
+  export VORTEX_NOTIFY_EVENT="pre_deployment"
+  export VORTEX_NOTIFY_PROJECT="testproject"
+  export DRUPAL_SITE_EMAIL="testproject@example.com"
+  export VORTEX_NOTIFY_EMAIL_RECIPIENTS="john@example.com"
+  export VORTEX_NOTIFY_BRANCH="develop"
+  export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
+  run ./scripts/vortex/notify.sh
+  assert_success
+
+  assert_output_contains "Started dispatching notifications."
+  assert_output_contains "Started email notification."
+  assert_output_contains "Skipping email notification for pre_deployment event."
+  assert_output_not_contains "Notification email(s) sent"
   assert_output_contains "Finished dispatching notifications."
 
   popd >/dev/null || exit 1

--- a/.vortex/tests/bats/unit/notify-jira.bats
+++ b/.vortex/tests/bats/unit/notify-jira.bats
@@ -53,3 +53,24 @@ load ../_helper.bash
 
   popd >/dev/null || exit 1
 }
+
+@test "Notify: jira, pre_deployment skip" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_NOTIFY_CHANNELS="jira"
+  export VORTEX_NOTIFY_EVENT="pre_deployment"
+  export VORTEX_NOTIFY_JIRA_USER="john.doe@example.com"
+  export VORTEX_NOTIFY_JIRA_TOKEN="token12345"
+  export VORTEX_NOTIFY_BRANCH="feature/proj-1234-some-description"
+  export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
+  run ./scripts/vortex/notify.sh
+  assert_success
+
+  assert_output_contains "Started dispatching notifications."
+  assert_output_contains "Started JIRA notification."
+  assert_output_contains "Skipping JIRA notification for pre_deployment event."
+  assert_output_not_contains "Extracting issue"
+  assert_output_contains "Finished dispatching notifications."
+
+  popd >/dev/null || exit 1
+}

--- a/.vortex/tests/bats/unit/notify-newrelic.bats
+++ b/.vortex/tests/bats/unit/notify-newrelic.bats
@@ -19,7 +19,7 @@ load ../_helper.bash
   export VORTEX_NOTIFY_PROJECT="testproject"
   export VORTEX_NOTIFY_NEWRELIC_APIKEY="key1234"
   export VORTEX_NOTIFY_EMAIL_RECIPIENTS="john@example.com|John Doe,jane@example.com|Jane Doe"
-  export VORTEX_NOTIFY_REF="develop"
+  export VORTEX_NOTIFY_BRANCH="develop"
   export VORTEX_NOTIFY_SHA="123456"
 
   run ./scripts/vortex/notify.sh
@@ -44,6 +44,27 @@ load ../_helper.bash
 
   assert_output_contains "Finished New Relic notification."
 
+  assert_output_contains "Finished dispatching notifications."
+
+  popd >/dev/null || exit 1
+}
+
+@test "Notify: newrelic, pre_deployment skip" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_NOTIFY_CHANNELS="newrelic"
+  export VORTEX_NOTIFY_EVENT="pre_deployment"
+  export VORTEX_NOTIFY_PROJECT="testproject"
+  export VORTEX_NOTIFY_NEWRELIC_APIKEY="key1234"
+  export VORTEX_NOTIFY_BRANCH="develop"
+  export VORTEX_NOTIFY_SHA="123456"
+  run ./scripts/vortex/notify.sh
+  assert_success
+
+  assert_output_contains "Started dispatching notifications."
+  assert_output_contains "Started New Relic notification."
+  assert_output_contains "Skipping New Relic notification for pre_deployment event."
+  assert_output_not_contains "Discovering APP id"
   assert_output_contains "Finished dispatching notifications."
 
   popd >/dev/null || exit 1

--- a/.vortex/tests/bats/unit/notify-slack.bats
+++ b/.vortex/tests/bats/unit/notify-slack.bats
@@ -14,7 +14,7 @@ load ../_helper.bash
 
   export VORTEX_NOTIFY_CHANNELS="slack"
   export VORTEX_NOTIFY_PROJECT="testproject"
-  export VORTEX_NOTIFY_REF="develop"
+  export VORTEX_NOTIFY_BRANCH="develop"
   export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
   export VORTEX_NOTIFY_SLACK_WEBHOOK="https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX"
 
@@ -41,7 +41,7 @@ load ../_helper.bash
 
   export VORTEX_NOTIFY_CHANNELS="slack"
   export VORTEX_NOTIFY_PROJECT="testproject"
-  export VORTEX_NOTIFY_REF="feature-123"
+  export VORTEX_NOTIFY_BRANCH="feature-123"
   export VORTEX_NOTIFY_PR_NUMBER="123"
   export VORTEX_NOTIFY_ENVIRONMENT_URL="https://pr-123.testproject.com"
   export VORTEX_NOTIFY_SLACK_WEBHOOK="https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX"
@@ -70,7 +70,7 @@ load ../_helper.bash
   export VORTEX_NOTIFY_CHANNELS="slack"
   export VORTEX_NOTIFY_EVENT="pre_deployment"
   export VORTEX_NOTIFY_PROJECT="testproject"
-  export VORTEX_NOTIFY_REF="develop"
+  export VORTEX_NOTIFY_BRANCH="develop"
   export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
   export VORTEX_NOTIFY_SLACK_WEBHOOK="https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX"
 
@@ -94,7 +94,7 @@ load ../_helper.bash
 
   export VORTEX_NOTIFY_CHANNELS="slack"
   export VORTEX_NOTIFY_PROJECT="testproject"
-  export VORTEX_NOTIFY_REF="develop"
+  export VORTEX_NOTIFY_BRANCH="develop"
   export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
   # No VORTEX_NOTIFY_SLACK_WEBHOOK set
 
@@ -117,7 +117,7 @@ load ../_helper.bash
 
   export VORTEX_NOTIFY_CHANNELS="slack"
   export VORTEX_NOTIFY_PROJECT="testproject"
-  export VORTEX_NOTIFY_REF="develop"
+  export VORTEX_NOTIFY_BRANCH="develop"
   export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
   export VORTEX_NOTIFY_SLACK_WEBHOOK="https://hooks.slack.com/services/INVALID"
 
@@ -140,7 +140,7 @@ load ../_helper.bash
 
   export VORTEX_NOTIFY_CHANNELS="slack"
   export VORTEX_NOTIFY_PROJECT="testproject"
-  export VORTEX_NOTIFY_REF="develop"
+  export VORTEX_NOTIFY_BRANCH="develop"
   export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
   export VORTEX_NOTIFY_SLACK_WEBHOOK="https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX"
   export VORTEX_NOTIFY_SLACK_CHANNEL="#custom-deployments"
@@ -167,7 +167,7 @@ load ../_helper.bash
 
   export VORTEX_NOTIFY_CHANNELS="slack"
   export VORTEX_NOTIFY_PROJECT="testproject"
-  export VORTEX_NOTIFY_REF="develop"
+  export VORTEX_NOTIFY_BRANCH="develop"
   export VORTEX_NOTIFY_SHA="abc123def456789012345678901234567890abcd"
   export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
   export VORTEX_NOTIFY_SLACK_WEBHOOK="https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX"

--- a/.vortex/tests/bats/unit/notify-webhook.bats
+++ b/.vortex/tests/bats/unit/notify-webhook.bats
@@ -14,7 +14,7 @@ load ../_helper.bash
 
   export VORTEX_NOTIFY_CHANNELS="webhook"
   export VORTEX_NOTIFY_PROJECT="testproject"
-  export VORTEX_NOTIFY_REF="develop"
+  export VORTEX_NOTIFY_BRANCH="develop"
   export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
 
   export VORTEX_NOTIFY_WEBHOOK_URL="https://example-webhook-url.com"
@@ -44,7 +44,7 @@ load ../_helper.bash
 
   export VORTEX_NOTIFY_CHANNELS="webhook"
   export VORTEX_NOTIFY_PROJECT="testproject"
-  export VORTEX_NOTIFY_REF="develop"
+  export VORTEX_NOTIFY_BRANCH="develop"
   export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
 
   export VORTEX_NOTIFY_WEBHOOK_URL="https://example-webhook-url.com"
@@ -54,6 +54,29 @@ load ../_helper.bash
 
   run ./scripts/vortex/notify.sh
   assert_failure
+
+  popd >/dev/null || exit 1
+}
+
+@test "Notify: webhook, pre_deployment skip" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_NOTIFY_CHANNELS="webhook"
+  export VORTEX_NOTIFY_EVENT="pre_deployment"
+  export VORTEX_NOTIFY_PROJECT="testproject"
+  export VORTEX_NOTIFY_BRANCH="develop"
+  export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
+  export VORTEX_NOTIFY_WEBHOOK_URL="https://example-webhook-url.com"
+  export VORTEX_NOTIFY_WEBHOOK_METHOD="POST"
+  export VORTEX_NOTIFY_WEBHOOK_HEADERS="Content-type: application/json|Authorization: Bearer API_KEY"
+  export VORTEX_NOTIFY_WEBHOOK_PAYLOAD='{"channel": "Test channel 1", "message": "Test channel 1 message"}'
+  run ./scripts/vortex/notify.sh
+  assert_success
+
+  assert_output_contains "Started dispatching notifications."
+  assert_output_contains "Started Webhook notification."
+  assert_output_contains "Skipping Webhook notification for pre_deployment event."
+  assert_output_contains "Finished dispatching notifications."
 
   popd >/dev/null || exit 1
 }

--- a/.vortex/tests/bats/unit/notify.bats
+++ b/.vortex/tests/bats/unit/notify.bats
@@ -42,6 +42,79 @@ load ../_helper.bash
   popd >/dev/null || exit 1
 }
 
+@test "Notify: pre_deployment event allows all channels" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Mock curl for channels that actually send notifications during pre_deployment
+  mock_curl=$(mock_command "curl")
+  mock_set_output "${mock_curl}" "200" 1
+  mock_set_output "${mock_curl}" '{"id": "123456789", "state": "success"}' 2
+  mock_set_output "${mock_curl}" "200" 3
+
+  export VORTEX_NOTIFY_CHANNELS="email,slack,github,newrelic,webhook,jira"
+  export VORTEX_NOTIFY_EVENT="pre_deployment"
+  export VORTEX_NOTIFY_PROJECT="testproject"
+  export VORTEX_NOTIFY_BRANCH="develop"
+  export VORTEX_NOTIFY_SHA="abc123"
+  export VORTEX_NOTIFY_ENVIRONMENT_URL="https://test.example.com"
+
+  # Email required variables
+  export DRUPAL_SITE_EMAIL="test@example.com"
+  export VORTEX_NOTIFY_EMAIL_RECIPIENTS="test@example.com"
+
+  # Slack required variables
+  export VORTEX_NOTIFY_SLACK_WEBHOOK="https://hooks.slack.com/test"
+
+  # GitHub required variables
+  export VORTEX_NOTIFY_GITHUB_TOKEN="test_token"
+  export VORTEX_NOTIFY_GITHUB_REPOSITORY="owner/repo"
+
+  # NewRelic required variables
+  export VORTEX_NOTIFY_NEWRELIC_APIKEY="test_key"
+
+  # Webhook required variables
+  export VORTEX_NOTIFY_WEBHOOK_URL="https://webhook.example.com"
+
+  # JIRA required variables
+  export VORTEX_NOTIFY_JIRA_USER="test@example.com"
+  export VORTEX_NOTIFY_JIRA_TOKEN="test_token"
+
+  run ./scripts/vortex/notify.sh
+  assert_success
+
+  assert_output_contains "Started dispatching notifications."
+
+  # Email: should skip pre_deployment
+  assert_output_contains "Started email notification."
+  assert_output_contains "Skipping email notification for pre_deployment event."
+
+  # Slack: should execute for pre_deployment
+  assert_output_contains "Started Slack notification."
+  assert_output_contains "Notification sent to Slack."
+  assert_output_contains "Finished Slack notification."
+
+  # NewRelic: should skip pre_deployment
+  assert_output_contains "Started New Relic notification."
+  assert_output_contains "Skipping New Relic notification for pre_deployment event."
+
+  # GitHub: should execute for pre_deployment
+  assert_output_contains "Started GitHub notification for pre_deployment event."
+  assert_output_contains "Marked deployment as started."
+  assert_output_contains "Finished GitHub notification for pre_deployment event."
+
+  # Webhook: should skip pre_deployment
+  assert_output_contains "Started Webhook notification."
+  assert_output_contains "Skipping Webhook notification for pre_deployment event."
+
+  # JIRA: should skip pre_deployment
+  assert_output_contains "Started JIRA notification."
+  assert_output_contains "Skipping JIRA notification for pre_deployment event."
+
+  assert_output_contains "Finished dispatching notifications."
+
+  popd >/dev/null || exit 1
+}
+
 @test "Notify: custom type" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 

--- a/hooks/library/notify-deployment.sh
+++ b/hooks/library/notify-deployment.sh
@@ -9,7 +9,6 @@ set -e
 site="${1}"
 target_env="${2}"
 branch="${3}"
-ref="${4:-${branch}}"
 
 # Custom domain name for the environment, including subdomain.
 # Examples: "dev.example.com", "test.example.com", "www.example.com"
@@ -27,7 +26,6 @@ fi
 
 export VORTEX_NOTIFY_PROJECT="${site}"
 export VORTEX_NOTIFY_BRANCH="${branch}"
-export VORTEX_NOTIFY_REF="${ref}"
 export VORTEX_NOTIFY_SHA="${target_env}"
 export VORTEX_NOTIFY_ENVIRONMENT_URL="${url}"
 

--- a/scripts/vortex/notify.sh
+++ b/scripts/vortex/notify.sh
@@ -14,21 +14,36 @@ t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && if [ -f ./.env.local ]
 set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
-# The channels of the notifications.
+# Notification channels.
 #
 # Can be a combination of comma-separated values: email,slack,newrelic,github,jira,webhook
 VORTEX_NOTIFY_CHANNELS="${VORTEX_NOTIFY_CHANNELS:-email}"
 
-# The event to notify about.
+# Notification event type.
 #
-# Can be only 'pre_deployment' or 'post_deployment'. Used internally.
+# Can be 'pre_deployment' or 'post_deployment'.
 VORTEX_NOTIFY_EVENT="${VORTEX_NOTIFY_EVENT:-post_deployment}"
 
-# Flag to skip running of all notifications.
+# Notification skip flag.
 VORTEX_NOTIFY_SKIP="${VORTEX_NOTIFY_SKIP:-}"
 
-# The project to notify about.
+# Notification project name.
 VORTEX_NOTIFY_PROJECT="${VORTEX_NOTIFY_PROJECT:-${VORTEX_PROJECT:-}}"
+
+# Notification git branch name.
+VORTEX_NOTIFY_BRANCH="${VORTEX_NOTIFY_BRANCH:-}"
+
+# Notification pull request number.
+VORTEX_NOTIFY_PR_NUMBER="${VORTEX_NOTIFY_PR_NUMBER:-}"
+
+# Notification git commit SHA.
+VORTEX_NOTIFY_SHA="${VORTEX_NOTIFY_SHA:-}"
+
+# Notification deployment environment URL.
+VORTEX_NOTIFY_ENVIRONMENT_URL="${VORTEX_NOTIFY_ENVIRONMENT_URL:-}"
+
+# Notification environment type: production, uat, dev, pr.
+VORTEX_NOTIFY_ENVIRONMENT_TYPE="${VORTEX_NOTIFY_ENVIRONMENT_TYPE:-}"
 
 # ------------------------------------------------------------------------------
 
@@ -44,14 +59,8 @@ info "Started dispatching notifications."
 
 [ -n "${VORTEX_NOTIFY_SKIP:-}" ] && pass "Skipping dispatching notifications." && exit 0
 
-# Narrow-down the notification type based on the event.
-# @note This logic may be moved into notification scripts in the future.
-if [ "${VORTEX_NOTIFY_EVENT:-}" == "pre_deployment" ]; then
-  VORTEX_NOTIFY_CHANNELS="github"
-elif [ "${VORTEX_NOTIFY_EVENT:-}" == "post_deployment" ]; then
-  # Preserve the value.
-  true
-else
+# Validate event type (scripts will handle event-specific logic).
+if [ "${VORTEX_NOTIFY_EVENT}" != "pre_deployment" ] && [ "${VORTEX_NOTIFY_EVENT}" != "post_deployment" ]; then
   fail "Unsupported event ${VORTEX_NOTIFY_EVENT} provided." && exit 1
 fi
 


### PR DESCRIPTION
Breaking change:

Removed `VORTEX_NOTIFY_REF`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Granular per-channel variables (Email, GitHub, Jira, New Relic, Slack, Webhook) and new global notification context vars: branch, PR number, SHA, environment URL/type, channels list.

* **Behavior**
  * Channels can opt into pre_deployment/post_deployment; several channels now explicitly skip pre_deployment. Generic ref variable removed in favor of branch-specific names.

* **Documentation**
  * Docs expanded to list new global and per-channel variables and updated descriptions.

* **Tests**
  * Added and updated unit tests for pre_deployment skip and multi-channel dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->