### PR TITLE
[#1958] Fixed `patches.lock.json` not excluded during Vortex development.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ recipes/*
 #;< VORTEX_DEV
 #; Ignore these files in Vortex itself, but do not ignore in consumer site.
 /composer.lock
+/patches.lock.json
 #;> VORTEX_DEV
 
 # Ignore dependencies cache files.


### PR DESCRIPTION
Related to #1958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git ignore configuration to properly manage lock files in development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->