### PR TITLE
[#1895] Added fresh DB download support for Acquia.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -120,10 +120,10 @@ commands:
 
   #;< !PROVISION_TYPE_PROFILE
   download-db:
-    usage: Download database. Run with "--no-cache" option to force fresh database backup.
+    usage: Download database. Run with "--fresh" option to force fresh database backup.
     aliases: [fetch-db]
     cmd: |
-      case " $* " in *" --no-cache "*) export VORTEX_DB_DOWNLOAD_NO_CACHE=1;; esac
+      case " $* " in *" --fresh "*) export VORTEX_DB_DOWNLOAD_FRESH=1;; esac
       ./scripts/vortex/download-db.sh
   #;> !PROVISION_TYPE_PROFILE
 

--- a/.vortex/docs/content/workflows/development.mdx
+++ b/.vortex/docs/content/workflows/development.mdx
@@ -47,7 +47,7 @@ To fetch the database with the latest data from the production environment,
 use the `ahoy fetch-db` command, which will download the latest database
 dump from the production environment into a `.data` directory. If there was a
 download attempt on the same day (locally or from CI), it will download the
-cached database dump. Use `ahoy fetch-db --no-cache` to create a new database
+cached database dump. Use `ahoy fetch-db --fresh` to create a new database
 dump regardless of the cache.
 
 :::note

--- a/.vortex/docs/content/workflows/variables.mdx
+++ b/.vortex/docs/content/workflows/variables.mdx
@@ -586,6 +586,22 @@ Default value: `./.data`
 
 Defined or used in: `.env`, `scripts/vortex/download-db-acquia.sh`, `scripts/vortex/download-db-container-registry.sh`, `scripts/vortex/download-db-ftp.sh`, `scripts/vortex/download-db-lagoon.sh`, `scripts/vortex/download-db-url.sh`, `scripts/vortex/download-db.sh`, `scripts/vortex/provision.sh`
 
+### `VORTEX_DB_DOWNLOAD_ACQUIA_BACKUP_MAX_WAIT`
+
+Maximum time in seconds to wait for backup completion.
+
+Default value: `600`
+
+Defined or used in: `scripts/vortex/download-db-acquia.sh`
+
+### `VORTEX_DB_DOWNLOAD_ACQUIA_BACKUP_WAIT_INTERVAL`
+
+Interval in seconds to wait between backup status checks.
+
+Default value: `10`
+
+Defined or used in: `scripts/vortex/download-db-acquia.sh`
+
 ### `VORTEX_DB_DOWNLOAD_ACQUIA_DB_NAME`
 
 Acquia database name to download the database from.
@@ -611,6 +627,14 @@ Always override existing downloaded DB dump.
 Default value: `1`
 
 Defined or used in: `.env.local.example`, `scripts/vortex/download-db.sh`
+
+### `VORTEX_DB_DOWNLOAD_FRESH`
+
+Flag to download a fresh copy of the database by triggering a new backup.
+
+Default value: `UNDEFINED`
+
+Defined or used in: `scripts/vortex/download-db-acquia.sh`, `scripts/vortex/download-db-lagoon.sh`
 
 ### `VORTEX_DB_DOWNLOAD_FTP_FILE`
 
@@ -699,14 +723,6 @@ Defined or used in: `scripts/vortex/download-db-lagoon.sh`
 The SSH user of the Lagoon environment.
 
 Default value: `${LAGOON_PROJECT}-${VORTEX_DB_DOWNLOAD_ENVIRONMENT}`
-
-Defined or used in: `scripts/vortex/download-db-lagoon.sh`
-
-### `VORTEX_DB_DOWNLOAD_NO_CACHE`
-
-Flag to download a fresh copy of the database.
-
-Default value: `UNDEFINED`
 
 Defined or used in: `scripts/vortex/download-db-lagoon.sh`
 

--- a/.vortex/installer/tests/Fixtures/install/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/_baseline/.ahoy.yml
@@ -112,10 +112,10 @@ commands:
     cmd: ahoy cli ./scripts/vortex/login.sh
 
   download-db:
-    usage: Download database. Run with "--no-cache" option to force fresh database backup.
+    usage: Download database. Run with "--fresh" option to force fresh database backup.
     aliases: [fetch-db]
     cmd: |
-      case " $* " in *" --no-cache "*) export VORTEX_DB_DOWNLOAD_NO_CACHE=1;; esac
+      case " $* " in *" --fresh "*) export VORTEX_DB_DOWNLOAD_FRESH=1;; esac
       ./scripts/vortex/download-db.sh
 
   reload-db:

--- a/.vortex/installer/tests/Fixtures/install/provision_profile/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/install/provision_profile/.ahoy.yml
@@ -3,10 +3,10 @@
      cmd: ahoy cli ./scripts/vortex/login.sh
  
 -  download-db:
--    usage: Download database. Run with "--no-cache" option to force fresh database backup.
+-    usage: Download database. Run with "--fresh" option to force fresh database backup.
 -    aliases: [fetch-db]
 -    cmd: |
--      case " $* " in *" --no-cache "*) export VORTEX_DB_DOWNLOAD_NO_CACHE=1;; esac
+-      case " $* " in *" --fresh "*) export VORTEX_DB_DOWNLOAD_FRESH=1;; esac
 -      ./scripts/vortex/download-db.sh
 -
    reload-db:

--- a/.vortex/tests/bats/unit/download-db-lagoon.bats
+++ b/.vortex/tests/bats/unit/download-db-lagoon.bats
@@ -140,7 +140,7 @@ load ../_helper.bash
 
   export LAGOON_PROJECT="testproject"
   export VORTEX_DB_DOWNLOAD_ENVIRONMENT="main"
-  export VORTEX_DB_DOWNLOAD_NO_CACHE="1"
+  export VORTEX_DB_DOWNLOAD_FRESH="1"
   export VORTEX_DB_DIR=".data"
   export VORTEX_DB_FILE="db.sql"
 

--- a/scripts/vortex/download-db-lagoon.sh
+++ b/scripts/vortex/download-db-lagoon.sh
@@ -23,7 +23,7 @@ set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
 # Flag to download a fresh copy of the database.
-VORTEX_DB_DOWNLOAD_NO_CACHE="${VORTEX_DB_DOWNLOAD_NO_CACHE:-}"
+VORTEX_DB_DOWNLOAD_FRESH="${VORTEX_DB_DOWNLOAD_FRESH:-}"
 
 # Lagoon project name.
 LAGOON_PROJECT="${LAGOON_PROJECT:?Missing required environment variable LAGOON_PROJECT.}"
@@ -100,7 +100,7 @@ if [ ! -d "${VORTEX_DB_DIR}" ]; then
   mkdir -p "${VORTEX_DB_DIR}"
 fi
 
-if [ "$VORTEX_DB_DOWNLOAD_NO_CACHE" == "1" ]; then
+if [ "$VORTEX_DB_DOWNLOAD_FRESH" = "1" ]; then
   note "Database dump refresh requested. Will create a new dump."
 fi
 
@@ -115,7 +115,7 @@ task "Discovering or creating a database dump on Lagoon."
 ssh \
   "${ssh_opts[@]}" \
   "${VORTEX_DB_DOWNLOAD_LAGOON_SSH_USER}@${VORTEX_DB_DOWNLOAD_LAGOON_SSH_HOST}" service=cli container=cli \
-  "if [ ! -f \"${VORTEX_DB_DOWNLOAD_LAGOON_REMOTE_DIR}/${VORTEX_DB_DOWNLOAD_LAGOON_REMOTE_FILE}\" ] || [ \"${VORTEX_DB_DOWNLOAD_NO_CACHE}\" == \"1\" ] ; then \
+  "if [ ! -f \"${VORTEX_DB_DOWNLOAD_LAGOON_REMOTE_DIR}/${VORTEX_DB_DOWNLOAD_LAGOON_REMOTE_FILE}\" ] || [ \"${VORTEX_DB_DOWNLOAD_FRESH}\" = \"1\" ] ; then \
      [ -n \"${VORTEX_DB_DOWNLOAD_LAGOON_REMOTE_FILE_CLEANUP}\" ] && rm -f \"${VORTEX_DB_DOWNLOAD_LAGOON_REMOTE_DIR}\"\/${VORTEX_DB_DOWNLOAD_LAGOON_REMOTE_FILE_CLEANUP} && echo \"Removed previously created DB dumps.\"; \
      echo \"      > Creating a database dump ${VORTEX_DB_DOWNLOAD_LAGOON_REMOTE_DIR}/${VORTEX_DB_DOWNLOAD_LAGOON_REMOTE_FILE}.\"; \
      /app/vendor/bin/drush --root=./${WEBROOT} sql:dump --structure-tables-key=common --structure-tables-list=ban,event_log_track,flood,login_security_track,purge_queue,queue,webform_submission,webform_submission_data,webform_submission_log,watchdog,cache* --extra-dump='--disable-ssl --no-tablespaces' > \"${VORTEX_DB_DOWNLOAD_LAGOON_REMOTE_DIR}/${VORTEX_DB_DOWNLOAD_LAGOON_REMOTE_FILE}\"; \


### PR DESCRIPTION
Closes #1895


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fresh-backup workflow to create new DB dumps on demand, with configurable poll interval and max wait.

* **Documentation**
  * Updated help text and docs to use the new --fresh flag and document fresh-backup behavior and new variables.

* **Chores**
  * Renamed the database refresh option from --no-cache to --fresh and updated runtime usage and environment variables.

* **Tests**
  * Added/updated unit tests covering fresh backup creation, failures, timeouts, and download flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->