### PR TITLE
Updated PHPUnit helpers to 0.15

### DIFF
--- a/.vortex/installer/composer.json
+++ b/.vortex/installer/composer.json
@@ -33,7 +33,7 @@
         "symfony/yaml": "^7.3.5"
     },
     "require-dev": {
-        "alexskrypnyk/phpunit-helpers": "^0.14",
+        "alexskrypnyk/phpunit-helpers": "^0.15",
         "bamarni/composer-bin-plugin": "^1.8.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.2.0",
         "drevops/phpcs-standard": "^0.6",

--- a/.vortex/installer/composer.lock
+++ b/.vortex/installer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6497c1e1d3894ddb90fecf9eba3e7ba4",
+    "content-hash": "5c8e3c6386e7c0d51fb46ea9990f6d60",
     "packages": [
         {
             "name": "alexskrypnyk/file",
@@ -3512,16 +3512,16 @@
     "packages-dev": [
         {
             "name": "alexskrypnyk/phpunit-helpers",
-            "version": "0.14.0",
+            "version": "0.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AlexSkrypnyk/phpunit-helpers.git",
-                "reference": "1696f830a33441e55522089cbdb33279870f43f6"
+                "reference": "60242281d31b5abe2d2e025522dbdefadb227f03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AlexSkrypnyk/phpunit-helpers/zipball/1696f830a33441e55522089cbdb33279870f43f6",
-                "reference": "1696f830a33441e55522089cbdb33279870f43f6",
+                "url": "https://api.github.com/repos/AlexSkrypnyk/phpunit-helpers/zipball/60242281d31b5abe2d2e025522dbdefadb227f03",
+                "reference": "60242281d31b5abe2d2e025522dbdefadb227f03",
                 "shasum": ""
             },
             "require": {
@@ -3533,6 +3533,7 @@
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^1",
+                "drevops/phpcs-standard": "^0.6",
                 "drupal/coder": "^8.3",
                 "ergebnis/composer-normalize": "^2.42",
                 "laravel/serializable-closure": "^2.0",
@@ -3575,7 +3576,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-11-22T23:33:35+00:00"
+            "time": "2025-11-28T12:21:28+00:00"
         },
         {
             "name": "bamarni/composer-bin-plugin",

--- a/.vortex/tests/composer.json
+++ b/.vortex/tests/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "alexskrypnyk/file": "^0.15",
-        "alexskrypnyk/phpunit-helpers": "^0.12.2",
+        "alexskrypnyk/phpunit-helpers": "^0.15",
         "alexskrypnyk/shellvar": "^1.2.1",
         "czproject/git-php": "^4.5",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.1.2",

--- a/.vortex/tests/composer.lock
+++ b/.vortex/tests/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d07f0fa0a62f9d6fe847936922a0750",
+    "content-hash": "de84fd16df3c77e8606959aab7cfd834",
     "packages": [
         {
             "name": "cweagans/composer-configurable-plugin",
@@ -256,16 +256,16 @@
         },
         {
             "name": "alexskrypnyk/phpunit-helpers",
-            "version": "0.12.2",
+            "version": "0.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AlexSkrypnyk/phpunit-helpers.git",
-                "reference": "99012db4d4f8dd0cf3b21a2e9931719490d3c7ef"
+                "reference": "60242281d31b5abe2d2e025522dbdefadb227f03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AlexSkrypnyk/phpunit-helpers/zipball/99012db4d4f8dd0cf3b21a2e9931719490d3c7ef",
-                "reference": "99012db4d4f8dd0cf3b21a2e9931719490d3c7ef",
+                "url": "https://api.github.com/repos/AlexSkrypnyk/phpunit-helpers/zipball/60242281d31b5abe2d2e025522dbdefadb227f03",
+                "reference": "60242281d31b5abe2d2e025522dbdefadb227f03",
                 "shasum": ""
             },
             "require": {
@@ -277,6 +277,7 @@
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^1",
+                "drevops/phpcs-standard": "^0.6",
                 "drupal/coder": "^8.3",
                 "ergebnis/composer-normalize": "^2.42",
                 "laravel/serializable-closure": "^2.0",
@@ -319,7 +320,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-09-27T02:35:38+00:00"
+            "time": "2025-11-28T12:21:28+00:00"
         },
         {
             "name": "alexskrypnyk/shellvar",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the development dependency alexskrypnyk/phpunit-helpers to ^0.15 across development manifests (installer and tests) to align testing tooling and improve consistency across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->