### PR TITLE
Added installer artifact to dev docs Netlify deployment.

### DIFF
--- a/.github/workflows/vortex-test-docs.yml
+++ b/.github/workflows/vortex-test-docs.yml
@@ -2,15 +2,16 @@
 name: Vortex - Test docs
 
 on:
-  push:
-    tags:
-      - '**'
-    branches:
-      - '**'
+  workflow_run:
+    workflows: ['Vortex - Test installer']
+    types:
+      - completed
 
 jobs:
   vortex-test-docs:
     runs-on: ubuntu-latest
+    # Only run if installer workflow succeeded
+    if: github.event.workflow_run.conclusion == 'success'
 
     steps:
       - name: Checkout code
@@ -27,6 +28,20 @@ jobs:
         uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
         with:
           php-version: 8.3
+
+      - name: Download installer artifact
+        uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc # v8
+        with:
+          workflow: vortex-test-installer.yml
+          name: vortex-installer
+          path: .vortex/docs/static
+          if_no_artifact_found: fail
+          allow_forks: true
+
+      - name: Copy installer to docs
+        run: |
+          mv .vortex/docs/static/installer.phar .vortex/docs/static/install
+          php .vortex/docs/static/install --version
 
       - name: Check docs up-to-date
         run: |

--- a/.github/workflows/vortex-test-installer.yml
+++ b/.github/workflows/vortex-test-installer.yml
@@ -86,7 +86,15 @@ jobs:
         working-directory: .vortex/installer
 
       - name: Test PHAR
-        run: ./build/installer.phar --no-interaction --destination=example || exit 1
+        run: |
+          ./build/installer.phar --version
+          ./build/installer.phar --no-interaction --no-cleanup --destination=test || exit 1
         working-directory: .vortex/installer
-        env:
-          GITHUB_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+
+      - name: Upload installer artifact
+        if: matrix.php-versions == '8.3'
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: vortex-installer
+          path: .vortex/installer/build/installer.phar
+          if-no-files-found: error


### PR DESCRIPTION
- Upload installer PHAR as artifact in vortex-test-installer (PHP 8.3 only).
- Changed vortex-test-docs to trigger via workflow_run after installer completes.
- Download and include installer in Netlify docs deployment.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now triggers when the installer workflow completes and only runs if that workflow succeeded.
  * Documentation build step fetches the produced installer artifact, places it into the docs install location, and prints its version before checking docs.
  * Installer test workflow now uploads the built installer for a specific PHP matrix entry and prints/version-checks the PHAR during testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->