### PR TITLE
[#2104] Added SemVer+CalVer versioning support for Vortex development.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -683,7 +683,7 @@ workflows:
               # - release/2023-04-17, release/2023-04-17.123 (date-based)
               # - hotfix/123.456.789, hotfix/123.456.789-rc.1213 (per https://semver.org/)
               # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              only: /^(production|main|master|develop|1.x|2.x)$|^project\/[a-zA-z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -15,6 +15,10 @@ on:
       - main
       - master
       - develop
+      #;< VORTEX_DEV
+      - 1.x
+      - 2.x
+      #;> VORTEX_DEV
       - release/**
       - hotfix/**
       - project/**
@@ -32,6 +36,10 @@ on:
       - main
       - master
       - develop
+      #;< VORTEX_DEV
+      - 1.x
+      - 2.x
+      #;> VORTEX_DEV
       - release/**
       - hotfix/**
       - project/**

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -6,6 +6,10 @@ on:
       - '*'
     branches:
       - develop
+      #;< VORTEX_DEV
+      - 1.x
+      - 2.x
+      #;> VORTEX_DEV
 
 permissions:
   contents: write

--- a/.github/workflows/vortex-test-common.yml
+++ b/.github/workflows/vortex-test-common.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - develop
+      - 1.x
+      - 2.x
   pull_request:
     branches:
       - develop
+      - 1.x
+      - 2.x
       - 'feature/**'
       - 'bugfix/**'
 

--- a/.github/workflows/vortex-test-docs.yml
+++ b/.github/workflows/vortex-test-docs.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           publish-dir: '.vortex/docs/build'
-          production-branch: develop
+          production-branch: 1.x
           deploy-message: "Deploy from GitHub Actions"
           enable-pull-request-comment: true
           enable-commit-comment: true

--- a/.github/workflows/vortex-test-installer.yml
+++ b/.github/workflows/vortex-test-installer.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - develop
+      - 1.x
+      - 2.x
   pull_request:
     branches:
       - develop
+      - 1.x
+      - 2.x
       - 'feature/**'
       - 'bugfix/**'
 

--- a/.vortex/docs/content/README.mdx
+++ b/.vortex/docs/content/README.mdx
@@ -66,7 +66,7 @@ Refer to [Contributing](contributing) for more details.
 ## ⚖️ License
 
 **Vortex** is licensed under the [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.en.html) license. See
-the [LICENSE](https://github.com/drevops/vortex/blob/develop/LICENSE) file for more details.
+the [LICENSE](https://github.com/drevops/vortex/blob/1.x/LICENSE) file for more details.
 
 :::tip
 

--- a/.vortex/docs/content/continuous-integration/circleci.mdx
+++ b/.vortex/docs/content/continuous-integration/circleci.mdx
@@ -29,7 +29,7 @@ Before you begin, ensure you have:
 
 [Log in to CircleCI](https://app.circleci.com/) and add your repository as a new
 project. CircleCI will connect to your GitHub account, detect the
-[`.circleci/config.yml`](https://github.com/drevops/vortex/blob/develop/.circleci/config.yml)
+[`.circleci/config.yml`](https://github.com/drevops/vortex/blob/1.x/.circleci/config.yml)
 configuration file, and start running builds automatically when you push code.
 
 ### 2. Add SSH key for database download
@@ -84,7 +84,7 @@ same provider, you can use a single key for both operations.
 
 CircleCI uses SSH key fingerprints to load the correct keys into the runner
 container. Update the YAML anchors in your
-[`.circleci/config.yml`](https://github.com/drevops/vortex/blob/develop/.circleci/config.yml)
+[`.circleci/config.yml`](https://github.com/drevops/vortex/blob/1.x/.circleci/config.yml)
 file:
 
 - `db_ssh_fingerprint` - your database download SSH key fingerprint

--- a/.vortex/docs/content/continuous-integration/github-actions.mdx
+++ b/.vortex/docs/content/continuous-integration/github-actions.mdx
@@ -29,7 +29,7 @@ Before you begin, ensure you have:
 
 GitHub Actions is enabled by default. Navigate to the **Actions** tab in your
 repository to verify the workflow is detected. Vortex provides the workflow file
-at [`.github/workflows/build-test-deploy.yml`](https://github.com/drevops/vortex/blob/develop/.github/workflows/build-test-deploy.yml).
+at [`.github/workflows/build-test-deploy.yml`](https://github.com/drevops/vortex/blob/1.x/.github/workflows/build-test-deploy.yml).
 
 No additional setup is required to enable the workflow.
 

--- a/.vortex/docs/content/contributing/code-of-conduct.mdx
+++ b/.vortex/docs/content/contributing/code-of-conduct.mdx
@@ -6,5 +6,5 @@ sidebar_position: 3
 # Code of conduct
 
 Please note that this project is released with
-a [Contributor Code of Conduct](https://github.com/drevops/vortex/blob/develop/CODE_OF_CONDUCT.md). By participating in this
+a [Contributor Code of Conduct](https://github.com/drevops/vortex/blob/1.x/CODE_OF_CONDUCT.md). By participating in this
 project you agree to abide by its terms.

--- a/.vortex/docs/content/contributing/maintenance/documentation.mdx
+++ b/.vortex/docs/content/contributing/maintenance/documentation.mdx
@@ -10,7 +10,7 @@ There are 2 types of the documentation that **Vortex** provides:
 ## www.vortextemplate.com
 
 The Documentation (this site) is written in Markdown and located in
-[`.vortex/docs`](https://github.com/drevops/vortex/blob/develop/.vortex/docs) directory. This is
+[`.vortex/docs`](https://github.com/drevops/vortex/blob/1.x/.vortex/docs) directory. This is
 removed when you install **Vortex** for a
 consumer site.
 
@@ -54,7 +54,7 @@ An automated continuous integration build publishes this documentation.
 ## Consumer site documentation
 
 **Vortex** provides a scaffold of the consumer site documentation in the
-[`docs`](https://github.com/drevops/vortex/blob/develop/docs) directory.
+[`docs`](https://github.com/drevops/vortex/blob/1.x/docs) directory.
 
 After **Vortex** is installed into the consumer site, these docs are
 intended to be used by the site maintainers and stay up-to-date with the

--- a/.vortex/docs/content/contributing/maintenance/release.mdx
+++ b/.vortex/docs/content/contributing/maintenance/release.mdx
@@ -1,6 +1,68 @@
 # Release
 
-Follow the steps below to release a new version of **Vortex**:
+## Versioning Strategy
+
+Vortex uses **SemVer+CalVer** format for releases: `MAJOR.MINOR.PATCH-YYYY.MM.0`
+
+### Semantic Version (MAJOR.MINOR.PATCH)
+
+- **MAJOR**: Breaking changes that require migration or significant updates
+- **MINOR**: New features, backward compatible
+- **PATCH**: Bug fixes, backward compatible
+
+### Calendar Version (`YYYY.MM.0`)
+
+- Reflects the release date
+- Helps track release timeline
+- Always ends with `.0`
+- `YY` - Short year - `6`, `16`, `106`
+- `MM` - Short month - `1`, `2` ... `11`, `12`
+
+### Version Examples
+
+- `1.0.0-2025.11.0` - First major release, November 2025
+- `1.1.0-2025.12.0` - New features added, December 2025
+- `1.1.1-2025.12.0` - Bug fix release, same month
+- `2.0.0-2026.1.0` - Breaking changes, January 2026
+
+### Version Numbering Guidelines
+
+When creating a new release, determine the version based on the changes:
+
+1. **Bump MAJOR** when making incompatible breaking changes:
+   - Removing features or configuration options
+   - Changing default behavior that breaks existing workflows
+   - Updating to new major versions of core dependencies (e.g., Drupal 11)
+
+2. **Bump MINOR** when adding functionality in a backward compatible manner:
+   - Adding new optional features
+   - Adding new scripts or commands
+   - Enhancing existing features without breaking changes
+
+3. **Bump PATCH** when making backward compatible bug fixes:
+   - Fixing bugs or errors
+   - Security patches
+   - Documentation updates
+   - Minor improvements that don't change functionality
+
+4. **Set CalVer** to the release date in `YYYY.MM.0` format:
+   - Always use the year and month of the release
+   - Always end with `.0`
+
+### Branch Strategy
+
+- `1.x` - Current stable release branch
+- `2.x` - Development branch for 2.x releases (future)
+
+:::note
+Vortex uses **GitHub Flow** with version branches (`1.x`, `2.x`) instead of GitFlow.
+The `develop` branch is deprecated for Vortex development.
+Consumer projects created from Vortex continue to use GitFlow with `develop`.
+:::
+
+## Release Process
+
+Follow the steps below to release a new version of the Vortex:
 
 1. Run renovate bot locally to update all dependencies outside of the schedule:
 ```
@@ -13,6 +75,6 @@ renovate --schedule= --force-cli=true drevops/vortex
 6. Increment minor version of all packages in `composer.json`. Run `composer update -W && composer bump`.
 7. Update minor version of dependencies in theme's `package.json`.
 8. Increment the cache version in `.circleci/config.yml` and `.github/workflows/build-test-deploy.yml`.
-9. Update documentation with `cd .vortex && ahoy update-docs`.
+9. Updated documentation with `cd .vortex && ahoy update-docs`.
 10. Update installer video with `cd .vortex && ahoy update-installer-video`.
 11. Create new release notes using [release template](./release_template.md).

--- a/.vortex/docs/content/drupal/module-scaffold.mdx
+++ b/.vortex/docs/content/drupal/module-scaffold.mdx
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Module scaffold
 
-[Module scaffold](https://github.com/drevops/vortex/tree/develop/web/modules/custom/ys_base)
+[Module scaffold](https://github.com/drevops/vortex/tree/1.x/web/modules/custom/ys_base)
 is an example of a Drupal module.
 
 We recommend creating a custom `ys_base` module for your project to hold
@@ -24,7 +24,7 @@ machine name for a theme name.
 
 ## Deploy file
 
-The [`ys_base.deploy.php`](https://github.com/drevops/vortex/blob/develop/web/modules/custom/ys_base/ys_base.deploy.php)
+The [`ys_base.deploy.php`](https://github.com/drevops/vortex/blob/1.x/web/modules/custom/ys_base/ys_base.deploy.php)
 file is an example of a Drush deploy file that can be used
 to run deployment commands during the site [provisioning](provision) process.
 

--- a/.vortex/docs/content/drupal/provision.mdx
+++ b/.vortex/docs/content/drupal/provision.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 # Provision
 
 The provisioning process, handled by the
-[`provision.sh`](https://github.com/drevops/vortex/blob/develop/scripts/vortex/provision.sh)
+[`provision.sh`](https://github.com/drevops/vortex/blob/1.x/scripts/vortex/provision.sh)
 script, sets up a
 Drupal site on already assembled codebase by either importing an existing
 database from the dump or installing a fresh instance of Drupal using a profile,

--- a/.vortex/docs/content/drupal/settings.mdx
+++ b/.vortex/docs/content/drupal/settings.mdx
@@ -10,15 +10,15 @@ environment-specific behavior — is controlled through the `settings.php` and
 extends these files to support consistent setup across environments.
 
 **Vortex** ships with its own streamlined version of
-the [`settings.php`](https://github.com/drevops/vortex/blob/develop/web/sites/default/settings.php) and
-[`services.yml`](https://github.com/drevops/vortex/blob/develop/web/sites/default/services.yml) files.
+the [`settings.php`](https://github.com/drevops/vortex/blob/1.x/web/sites/default/settings.php) and
+[`services.yml`](https://github.com/drevops/vortex/blob/1.x/web/sites/default/services.yml) files.
 
 It provides logic to detect the current environment (such as local, CI, or
 production) and apply settings conditionally. You can also define configuration
 overrides for individual modules if needed.
 
-The default **Drupal Scaffold**'s [`default.settings.php`](https://github.com/drevops/vortex/blob/develop/web/sites/default/default.settings.php)
-and [`default.services.yml`](https://github.com/drevops/vortex/blob/develop/web/sites/default/default.services.yml)
+The default **Drupal Scaffold**'s [`default.settings.php`](https://github.com/drevops/vortex/blob/1.x/web/sites/default/default.settings.php)
+and [`default.services.yml`](https://github.com/drevops/vortex/blob/1.x/web/sites/default/default.services.yml)
 files are also provided if you choose to use them instead.
 
 ## Approach
@@ -98,7 +98,7 @@ import EnvironmentIndicatorModuleSettingsExample from '!!raw-loader!./../../../.
 
 ## Settings file structure
 
-The [`settings.php`](https://github.com/drevops/vortex/blob/develop/web/sites/default/settings.php)
+The [`settings.php`](https://github.com/drevops/vortex/blob/1.x/web/sites/default/settings.php)
 file is organized into the following sections:
 
 - [Database](#database)
@@ -282,7 +282,7 @@ import LocalServicesExample from '!!raw-loader!./../../../../web/sites/default/e
 
 ## Testing settings with unit tests
 
-**Vortex** includes a [set of unit tests](https://github.com/drevops/vortex/blob/develop/tests/phpunit/Drupal)
+**Vortex** includes a [set of unit tests](https://github.com/drevops/vortex/blob/1.x/tests/phpunit/Drupal)
 to verify that settings are applied correctly for each detected environment
 type.
 

--- a/.vortex/docs/content/drupal/theme-scaffold.mdx
+++ b/.vortex/docs/content/drupal/theme-scaffold.mdx
@@ -4,7 +4,7 @@ sidebar_position: 6
 
 # Theme scaffold
 
-[Theme scaffold](https://github.com/drevops/vortex/tree/develop/web/themes/custom/your_site_theme)
+[Theme scaffold](https://github.com/drevops/vortex/tree/1.x/web/themes/custom/your_site_theme)
 is an example of a Drupal theme.
 
 We recommend creating a custom `your_site_theme` theme for your project to place

--- a/.vortex/docs/content/features.mdx
+++ b/.vortex/docs/content/features.mdx
@@ -29,16 +29,16 @@ import {
 
     ### Settings and environment detection
 
-    - Pre-configured [general settings](https://github.com/drevops/vortex/blob/develop/web/sites/default/settings.php)
+    - Pre-configured [general settings](https://github.com/drevops/vortex/blob/1.x/web/sites/default/settings.php)
     - Environment type detection based on the hosting provider
     - Optimised per-module settings for quick start
     - Multi-database configuration for MySQL and MariaDB
 
     ### Module & theme scaffolds
 
-    - [Custom module scaffold](https://github.com/drevops/vortex/blob/develop/web/modules/custom/ys_base)
-    - [Custom theme scaffold](https://github.com/drevops/vortex/blob/develop/web/themes/custom/your_site_theme)
-    - [Tests scaffold](https://github.com/drevops/vortex/blob/develop/web/modules/custom/ys_base/tests)
+    - [Custom module scaffold](https://github.com/drevops/vortex/blob/1.x/web/modules/custom/ys_base)
+    - [Custom theme scaffold](https://github.com/drevops/vortex/blob/1.x/web/themes/custom/your_site_theme)
+    - [Tests scaffold](https://github.com/drevops/vortex/blob/1.x/web/modules/custom/ys_base/tests)
 
     ### Admin modules
 
@@ -198,7 +198,7 @@ import {
 
     ### Development workflow automation
 
-    - [Pull request template](https://github.com/drevops/vortex/blob/develop/.github/PULL_REQUEST_TEMPLATE.md) for consistent reviews
+    - [Pull request template](https://github.com/drevops/vortex/blob/1.x/.github/PULL_REQUEST_TEMPLATE.md) for consistent reviews
     - [Release drafter](https://github.com/release-drafter/release-drafter) for automated changelog
     - [PR auto-assign](https://github.com/toshimaru/auto-author-assign) for review assignments
     - [PR auto-label](https://github.com/eps1lon/actions-label-merge-conflict) for merge conflicts
@@ -210,8 +210,8 @@ import {
 
     ### Project Documentation
 
-    - Customized [README.md](https://github.com/drevops/vortex/blob/develop/README.dist.md) for easy onboarding
-    - [Scaffold for project-specific documentation](https://github.com/drevops/vortex/blob/develop/docs) for easy documentation management
+    - Customized [README.md](https://github.com/drevops/vortex/blob/1.x/README.dist.md) for easy onboarding
+    - [Scaffold for project-specific documentation](https://github.com/drevops/vortex/blob/1.x/docs) for easy documentation management
 
     ### Vortex Documentation
 

--- a/.vortex/docs/content/hosting/acquia.mdx
+++ b/.vortex/docs/content/hosting/acquia.mdx
@@ -36,14 +36,14 @@ When code is deployed, Vortex automatically:
 3. **Sends notifications** - Notifies configured channels about the deployment
 
 This is implemented using [Acquia Cloud Hooks](https://docs.acquia.com/cloud-platform/develop/api/cloud-hooks/) -
-pre-configured scripts in the [`hooks/`](https://github.com/drevops/vortex/tree/develop/hooks)
+pre-configured scripts in the [`hooks/`](https://github.com/drevops/vortex/tree/1.x/hooks)
 directory that trigger on code deployments, code updates, and database copy
 operations.
 
 ### Environment detection
 
 Vortex automatically detects when running on Acquia and loads appropriate
-settings from [`web/sites/default/includes/providers/settings.acquia.php`](https://github.com/drevops/vortex/blob/develop/web/sites/default/includes/providers/settings.acquia.php).
+settings from [`web/sites/default/includes/providers/settings.acquia.php`](https://github.com/drevops/vortex/blob/1.x/web/sites/default/includes/providers/settings.acquia.php).
 This includes Acquia-specific configurations for caching, file paths, and
 environment variables.
 
@@ -57,7 +57,7 @@ Before you begin, ensure you have:
 
 ### 1. Configure environment variables
 
-Add the following variables to your [`.env`](https://github.com/drevops/vortex/blob/develop/.env)
+Add the following variables to your [`.env`](https://github.com/drevops/vortex/blob/1.x/.env)
 file:
 
 | Variable | Description |

--- a/.vortex/docs/content/hosting/lagoon.mdx
+++ b/.vortex/docs/content/hosting/lagoon.mdx
@@ -34,14 +34,14 @@ When code is deployed, Vortex automatically:
 2. **Sends notifications** - Notifies configured channels about the deployment
 
 This is implemented using post-rollout tasks defined in the
-[`.lagoon.yml`](https://github.com/drevops/vortex/blob/develop/.lagoon.yml)
+[`.lagoon.yml`](https://github.com/drevops/vortex/blob/1.x/.lagoon.yml)
 configuration file, which also defines Docker image mappings and
 environment-specific configurations.
 
 ### Environment detection
 
 Vortex automatically detects when running on Lagoon and loads appropriate
-settings from [`web/sites/default/includes/providers/settings.lagoon.php`](https://github.com/drevops/vortex/blob/develop/web/sites/default/includes/providers/settings.lagoon.php).
+settings from [`web/sites/default/includes/providers/settings.lagoon.php`](https://github.com/drevops/vortex/blob/1.x/web/sites/default/includes/providers/settings.lagoon.php).
 This includes Lagoon-specific configurations for caching, file paths, and
 environment variables provided by the platform.
 
@@ -56,7 +56,7 @@ Before you begin, ensure you have:
 
 ### 1. Configure environment variables
 
-Add the following variables to your [`.env`](https://github.com/drevops/vortex/blob/develop/.env)
+Add the following variables to your [`.env`](https://github.com/drevops/vortex/blob/1.x/.env)
 file:
 
 | Variable | Description |

--- a/.vortex/docs/content/tools/ahoy.mdx
+++ b/.vortex/docs/content/tools/ahoy.mdx
@@ -10,7 +10,7 @@ with zero code and dependencies.
 Usually, Ahoy is used to wrap the commands to make the development workflow
 consistent and easy to use.
 
-**Vortex** comes with [pre-configured Ahoy file](https://github.com/drevops/vortex/blob/develop/.ahoy.yml) that has
+**Vortex** comes with [pre-configured Ahoy file](https://github.com/drevops/vortex/blob/1.x/.ahoy.yml) that has
 commands wrapped around the most common tasks:
 
 - Working with containers
@@ -18,7 +18,7 @@ commands wrapped around the most common tasks:
 - Running tests
 - Running code quality checks
 
-It also provides an example of [local Ahoy file](https://github.com/drevops/vortex/blob/develop/.ahoy.local.example.yml)
+It also provides an example of [local Ahoy file](https://github.com/drevops/vortex/blob/1.x/.ahoy.local.example.yml)
 to be used in your projects. Once copied to `.ahoy.local.yml`, the file will
 be excluded from the repository and can be used to add local project-specific
 commands.

--- a/.vortex/docs/content/tools/behat.mdx
+++ b/.vortex/docs/content/tools/behat.mdx
@@ -6,7 +6,7 @@ https://docs.behat.org/en/latest/user_guide.html
 
 > A php framework for auto-testing your business expectations.
 
-**Vortex** comes with [pre-configured Behat profiles](https://github.com/drevops/vortex/blob/develop/behat.yml) for Drupal projects.
+**Vortex** comes with [pre-configured Behat profiles](https://github.com/drevops/vortex/blob/1.x/behat.yml) for Drupal projects.
 
 ## Usage
 
@@ -63,7 +63,7 @@ import TabItem from '@theme/TabItem';
 
 See [configuration reference](https://docs.behat.org/en/latest/user_guide/configuration.html).
 
-All global configuration takes place in the [`behat.yml`](https://github.com/drevops/vortex/blob/develop/behat.yml) file.
+All global configuration takes place in the [`behat.yml`](https://github.com/drevops/vortex/blob/1.x/behat.yml) file.
 
 By default, Behat will run all tests defined in `tests/behat/features` directory.
 
@@ -172,7 +172,7 @@ keep the test run time low.
 
 ### `FeatureContext.php`
 
-The [`FeatureContext.php`](https://github.com/drevops/vortex/blob/develop/tests/behat/bootstrap/FeatureContext.php)
+The [`FeatureContext.php`](https://github.com/drevops/vortex/blob/1.x/tests/behat/bootstrap/FeatureContext.php)
 file is a Behat custom context file that is loaded by default. This is where
 custom step definitions and hooks should be placed.
 
@@ -181,7 +181,7 @@ include those traits in the `FeatureContext.php` file. There are already
 several traits included from the [Behat Steps](https://github.com/drevops/behat-steps)
 package.
 
-There are also example tests in the [`tests/behat/features`](https://github.com/drevops/vortex/blob/develop/tests/behat/features)
+There are also example tests in the [`tests/behat/features`](https://github.com/drevops/vortex/blob/1.x/tests/behat/features)
 directory that can be used as a starting point for writing tests. These tests
 define `@smoke` tests for the homepage and login page as well as tests for
 contributed modules.

--- a/.vortex/docs/content/tools/eslint.mdx
+++ b/.vortex/docs/content/tools/eslint.mdx
@@ -9,7 +9,7 @@ sidebar_label: ESLint
 
 > ESLint is a tool for identifying and reporting on patterns found in ECMAScript/JavaScript code, with the goal of making code more consistent and avoiding bugs.
 
-**Vortex** comes with [pre-configured ESLint ruleset](https://github.com/drevops/vortex/blob/develop/.eslintrc.json) for Drupal projects, along with [Prettier](https://prettier.io/) integration for automatic code formatting.
+**Vortex** comes with [pre-configured ESLint ruleset](https://github.com/drevops/vortex/blob/1.x/.eslintrc.json) for Drupal projects, along with [Prettier](https://prettier.io/) integration for automatic code formatting.
 
 :::info
 ESLint in **Vortex** is configured to lint **custom modules only** (`web/modules/custom`). Custom themes should maintain their own ESLint configuration within the theme directory.
@@ -56,7 +56,7 @@ ESLint supports automatic fixing of many violations using the `--fix` flag. Pret
 
 See [configuration reference](https://eslint.org/docs/latest/use/configure/).
 
-All global configuration takes place in the [`.eslintrc.json`](https://github.com/drevops/vortex/blob/develop/.eslintrc.json) file.
+All global configuration takes place in the [`.eslintrc.json`](https://github.com/drevops/vortex/blob/1.x/.eslintrc.json) file.
 
 By default, ESLint will check against the following rules:
 
@@ -101,7 +101,7 @@ When you run `ahoy lint-fe-fix`, both ESLint's `--fix` and Prettier's formatting
 
 ### Global ignoring
 
-Ignoring paths **globally** takes place in the [`.eslintignore`](https://github.com/drevops/vortex/blob/develop/.eslintignore) file:
+Ignoring paths **globally** takes place in the [`.eslintignore`](https://github.com/drevops/vortex/blob/1.x/.eslintignore) file:
 
 ```text
 node_modules/

--- a/.vortex/docs/content/tools/gherkin-lint.mdx
+++ b/.vortex/docs/content/tools/gherkin-lint.mdx
@@ -4,7 +4,7 @@ https://github.com/dantleech/gherkin-lint-php
 
 > Provides a Gherkin linter for PHP.
 
-**Vortex** comes with [Gherkin Lint configuration](https://github.com/drevops/vortex/blob/develop/gherkinlint.json) for Behat tests.
+**Vortex** comes with [Gherkin Lint configuration](https://github.com/drevops/vortex/blob/1.x/gherkinlint.json) for Behat tests.
 
 ## Usage
 
@@ -28,7 +28,7 @@ import TabItem from '@theme/TabItem';
 
 See [configuration reference](https://github.com/dantleech/gherkin-lint-php?tab=readme-ov-file#configuration) and [rules](https://github.com/dantleech/gherkin-lint-php/blob/master/docs/rules.md).
 
-All global configuration takes place in the [`gherkinlint.json`](https://github.com/drevops/vortex/blob/develop/gherkinlint.json) file.
+All global configuration takes place in the [`gherkinlint.json`](https://github.com/drevops/vortex/blob/1.x/gherkinlint.json) file.
 The values are merged with the default configuration.
 
 To check enabled rules, run
@@ -39,7 +39,7 @@ vendor/bin/gherkinlint rules
 
 ## Ignoring
 
-Ignoring rules **globally** takes place in the  [`gherkinlint.json`](https://github.com/drevops/vortex/blob/develop/gherkinlint.json) file.
+Ignoring rules **globally** takes place in the  [`gherkinlint.json`](https://github.com/drevops/vortex/blob/1.x/gherkinlint.json) file.
 
 ```json
 {

--- a/.vortex/docs/content/tools/git-artifact.mdx
+++ b/.vortex/docs/content/tools/git-artifact.mdx
@@ -11,8 +11,8 @@ which files get transferred, and overwrites the destination repository's history
 with each push, while preserving the source history.
 
 **Vortex** comes
-with [pre-configured `.gitignore.artifact`](https://github.com/drevops/vortex/blob/develop/.gitignore.artifact)
-file and [deployment script](https://github.com/drevops/vortex/blob/develop/scripts/vortex/deploy-artifact.sh)
+with [pre-configured `.gitignore.artifact`](https://github.com/drevops/vortex/blob/1.x/.gitignore.artifact)
+file and [deployment script](https://github.com/drevops/vortex/blob/1.x/scripts/vortex/deploy-artifact.sh)
 to build the artifact in continuous integration pipeline and push it to the
 remote repository in Acquia.
 

--- a/.vortex/docs/content/tools/phpcs.mdx
+++ b/.vortex/docs/content/tools/phpcs.mdx
@@ -12,7 +12,7 @@ https://github.com/squizlabs/PHP_CodeSniffer
 > violations. PHP_CodeSniffer is an essential development tool that ensures your
 > code remains clean and consistent.
 
-**Vortex** comes with [pre-configured PHPCS ruleset](https://github.com/drevops/vortex/blob/develop/phpcs.xml) for Drupal projects.
+**Vortex** comes with [pre-configured PHPCS ruleset](https://github.com/drevops/vortex/blob/1.x/phpcs.xml) for Drupal projects.
 
 ## Usage
 
@@ -53,7 +53,7 @@ import TabItem from '@theme/TabItem';
 
 See [configuration reference](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options).
 
-All global configuration takes place in the [`phpcs.xml`](https://github.com/drevops/vortex/blob/develop/phpcs.xml) file.
+All global configuration takes place in the [`phpcs.xml`](https://github.com/drevops/vortex/blob/1.x/phpcs.xml) file.
 
 By default, PHPCS will check against the following rules:
 
@@ -78,7 +78,7 @@ Run checks against platform version specified in `composer.json` key `config.pla
 
 ## Ignoring
 
-Ignoring rules **globally** takes place in the [`phpcs.xml`](https://github.com/drevops/vortex/blob/develop/phpcs.xml) file:
+Ignoring rules **globally** takes place in the [`phpcs.xml`](https://github.com/drevops/vortex/blob/1.x/phpcs.xml) file:
 
 ```xml
 <!-- Comment about why this rules is excluded. -->

--- a/.vortex/docs/content/tools/phpmd.mdx
+++ b/.vortex/docs/content/tools/phpmd.mdx
@@ -14,7 +14,7 @@ https://github.com/phpmd/phpmd
 > - Overcomplicated expressions
 > - Unused parameters, methods, properties
 
-**Vortex** comes with [pre-configured PHPMD ruleset](https://github.com/drevops/vortex/blob/develop/phpmd.xml)
+**Vortex** comes with [pre-configured PHPMD ruleset](https://github.com/drevops/vortex/blob/1.x/phpmd.xml)
 for Drupal projects.
 
 ## Usage
@@ -39,7 +39,7 @@ import TabItem from '@theme/TabItem';
 
 See [configuration reference](https://phpmd.org/documentation/index.html).
 
-All global configuration takes place in the [`phpmd.xml`](https://github.com/drevops/vortex/blob/develop/phpmd.xml)
+All global configuration takes place in the [`phpmd.xml`](https://github.com/drevops/vortex/blob/1.x/phpmd.xml)
 file.
 
 Targets include custom modules and themes, settings and tests.
@@ -54,7 +54,7 @@ exclusion patterns to exclude files and directories.
 ## Ignoring
 
 Ignoring rules **globally** takes place in
-the [`phpmd.xml`](https://github.com/drevops/vortex/blob/develop/phpmd.xml) file:
+the [`phpmd.xml`](https://github.com/drevops/vortex/blob/1.x/phpmd.xml) file:
 
 ```xml
 <rule ref="rulesets/cleancode.xml/MissingImport">

--- a/.vortex/docs/content/tools/phpstan.mdx
+++ b/.vortex/docs/content/tools/phpstan.mdx
@@ -13,7 +13,7 @@ https://phpstan.org/user-guide/getting-started
 > line
 > of the code can be checked before you run the actual line.
 
-**Vortex** comes with [pre-configured PHPStan ruleset](https://github.com/drevops/vortex/blob/develop/phpstan.neon)
+**Vortex** comes with [pre-configured PHPStan ruleset](https://github.com/drevops/vortex/blob/1.x/phpstan.neon)
 for
 Drupal projects.
 
@@ -47,7 +47,7 @@ Rector. See [Rector](rector.mdx) for more information.
 See [configuration reference](https://phpstan.org/config-reference).
 
 All global configuration takes place in
-the [`phpstan.neon`](https://github.com/drevops/vortex/blob/develop/phpstan.neon)
+the [`phpstan.neon`](https://github.com/drevops/vortex/blob/1.x/phpstan.neon)
 file.
 
 By default, PHPStan will check with the Drupal context in mind thanks to
@@ -69,7 +69,7 @@ parameters:
 ## Ignoring
 
 Ignoring rules **globally** takes place in
-the [`phpstan.neon`](https://github.com/drevops/vortex/blob/develop/phpstan.neon) file:
+the [`phpstan.neon`](https://github.com/drevops/vortex/blob/1.x/phpstan.neon) file:
 
 ```yaml
 parameters:

--- a/.vortex/docs/content/tools/phpunit.mdx
+++ b/.vortex/docs/content/tools/phpunit.mdx
@@ -8,7 +8,7 @@ https://github.com/sebastianbergmann/phpunit/
 
 > PHPUnit is a programmer-oriented testing framework for PHP.
 
-**Vortex** comes with [pre-configured PHPCS ruleset](https://github.com/drevops/vortex/blob/develop/phpunit.xml) for Drupal projects.
+**Vortex** comes with [pre-configured PHPCS ruleset](https://github.com/drevops/vortex/blob/1.x/phpunit.xml) for Drupal projects.
 
 ## Usage
 
@@ -82,7 +82,7 @@ import TabItem from '@theme/TabItem';
 
 See [configuration reference](https://docs.phpunit.de/en/10.4/configuration.html).
 
-All global configuration takes place in the [`phpunit.xml`](https://github.com/drevops/vortex/blob/develop/phpunit.xml) file.
+All global configuration takes place in the [`phpunit.xml`](https://github.com/drevops/vortex/blob/1.x/phpunit.xml) file.
 
 By default, PHPUnit will run tests for custom modules and themes, Drupal
 settings and continuous integration configuration.

--- a/.vortex/docs/content/tools/rector.mdx
+++ b/.vortex/docs/content/tools/rector.mdx
@@ -8,7 +8,7 @@ https://github.com/rectorphp/rector
 
 > Rector instantly upgrades and refactors the PHP code of your application.
 
-**Vortex** comes with [pre-configured Rector configuration](https://github.com/drevops/vortex/blob/develop/rector.php)
+**Vortex** comes with [pre-configured Rector configuration](https://github.com/drevops/vortex/blob/1.x/rector.php)
 for Drupal projects. The configuration is based on
 the configuration provided
 by [Drupal Rector](https://github.com/palantirnet/drupal-rector).
@@ -69,7 +69,7 @@ import TabItem from '@theme/TabItem';
 See [configuration reference](https://getrector.com/documentation).
 
 All global configuration takes place in
-the [`rector.php`](https://github.com/drevops/vortex/blob/develop/rector.php)
+the [`rector.php`](https://github.com/drevops/vortex/blob/1.x/rector.php)
 file.
 
 Targets include custom modules and themes, settings and tests.
@@ -94,7 +94,7 @@ on [Ignoring Rules Or Paths](https://getrector.com/documentation/ignoring-rules-
 page.
 
 Ignoring rules **globally** takes place in
-the [`rector.php`](https://github.com/drevops/vortex/blob/develop/rector.php) file:
+the [`rector.php`](https://github.com/drevops/vortex/blob/1.x/rector.php) file:
 
 ```php
 ->withSkip([

--- a/.vortex/docs/content/tools/renovate.mdx
+++ b/.vortex/docs/content/tools/renovate.mdx
@@ -6,7 +6,7 @@ sidebar_label: Renovate
 
 **Vortex** uses [Renovate](https://renovatebot.com) for automated dependency updates.
 
-The configuration is stored in [`renovate.json`](https://github.com/drevops/vortex/blob/develop/renovate.json). It is
+The configuration is stored in [`renovate.json`](https://github.com/drevops/vortex/blob/1.x/renovate.json). It is
 based on [Renovate configuration for automated Drupal dependency updates](https://github.com/drevops/renovate-drupal)
 project.
 

--- a/.vortex/docs/content/tools/twig-cs-fixer.mdx
+++ b/.vortex/docs/content/tools/twig-cs-fixer.mdx
@@ -6,7 +6,7 @@ https://github.com/VincentLanglet/Twig-CS-Fixer
 >
 > Twig CS Fixer aims to be what phpcs is to php. It checks your codebase for violations on coding standards.
 
-**Vortex** comes with [pre-configured Twig-cs-fixer ruleset](https://github.com/drevops/vortex/blob/develop/.twig-cs-fixer.php) for Drupal projects.
+**Vortex** comes with [pre-configured Twig-cs-fixer ruleset](https://github.com/drevops/vortex/blob/1.x/.twig-cs-fixer.php) for Drupal projects.
 
 ## Usage
 
@@ -30,7 +30,7 @@ import TabItem from '@theme/TabItem';
 
 See [configuration reference](https://github.com/VincentLanglet/Twig-CS-Fixer/blob/main/docs/configuration.md).
 
-All global configuration takes place in the [`.twig-cs-fixer.php`](https://github.com/drevops/vortex/blob/develop/.twig-cs-fixer.php) file.
+All global configuration takes place in the [`.twig-cs-fixer.php`](https://github.com/drevops/vortex/blob/1.x/.twig-cs-fixer.php) file.
 
 Targets include custom modules and themes.
 
@@ -44,7 +44,7 @@ $finder->in(__DIR__ . '/web/themes/custom');
 
 ## Ignoring
 
-Ignoring rules **globally** takes place in the  [`.twig-cs-fixer.php`](https://github.com/drevops/vortex/blob/develop/.twig-cs-fixer.php) file:
+Ignoring rules **globally** takes place in the  [`.twig-cs-fixer.php`](https://github.com/drevops/vortex/blob/1.x/.twig-cs-fixer.php) file:
 
 ```php
 $finder->exclude('myCustomDirectory');

--- a/.vortex/docs/content/workflows/deployment.mdx
+++ b/.vortex/docs/content/workflows/deployment.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 # Deployment
 
 Deployment to a remote location is performed by the
-[`scripts/vortex/deploy.sh`](https://github.com/drevops/vortex/blob/develop/scripts/vortex/deploy.sh) _router_
+[`scripts/vortex/deploy.sh`](https://github.com/drevops/vortex/blob/1.x/scripts/vortex/deploy.sh) _router_
 script.
 
 The script runs in continuous integration pipeline only after all tests pass.

--- a/.vortex/docs/content/workflows/testing.mdx
+++ b/.vortex/docs/content/workflows/testing.mdx
@@ -51,16 +51,16 @@ These reports are usually used in continuous integration to track tests performa
 
 ### Boilerplate
 
-**Vortex** provides Unit, Kernel and Functional tests boilerplate for custom [modules](https://github.com/drevops/vortex/blob/develop/web/modules/custom/ys_base/tests/src),
-[themes](https://github.com/drevops/vortex/blob/develop/web/themes/custom/your_site_theme/tests/src) and
-[scripts](https://github.com/drevops/vortex/blob/develop/tests/phpunit).
+**Vortex** provides Unit, Kernel and Functional tests boilerplate for custom [modules](https://github.com/drevops/vortex/blob/1.x/web/modules/custom/ys_base/tests/src),
+[themes](https://github.com/drevops/vortex/blob/1.x/web/themes/custom/your_site_theme/tests/src) and
+[scripts](https://github.com/drevops/vortex/blob/1.x/tests/phpunit).
 
 These boilerplate tests run in continuous integration pipeline when you install
 **Vortex** and can be used as a starting point for writing your own.
 
 #### Drupal settings tests
 
-**Vortex** provides [Drupal settings tests](https://github.com/drevops/vortex/blob/develop/tests/phpunit/Drupal/DrupalSettingsTest.php)
+**Vortex** provides [Drupal settings tests](https://github.com/drevops/vortex/blob/1.x/tests/phpunit/Drupal/DrupalSettingsTest.php)
 to check that Drupal settings are correct based on the environment type the site
 is running: with the number of custom modules multiplied by the number of
 environment types, it is easy to miss certain settings which may lead to
@@ -71,7 +71,7 @@ changes made to the `settings.php` file.
 
 #### Continuous integration pipeline configuration tests
 
-**Vortex** provides a [continuous integration pipeline configuration tests](https://github.com/drevops/vortex/blob/develop/tests/phpunit/CircleCiConfigTest.php)
+**Vortex** provides a [continuous integration pipeline configuration tests](https://github.com/drevops/vortex/blob/1.x/tests/phpunit/CircleCiConfigTest.php)
 to check that the continuous integration configuration is correct. It is
 intended to be used in your site and kept up-to-date with the continuous
 integration configurations.
@@ -86,8 +86,8 @@ testing. Behat allows to write human-readable stories that describe the behavior
 of the application. Behat tests primarily focus on critical user journeys,
 serving as comprehensive end-to-end validations.
 
-**Vortex** provides full Behat support, including configuration in [`behat.yml`](https://github.com/drevops/vortex/blob/develop/behat.yml)
-and a [browser container](https://github.com/drevops/vortex/blob/develop/docker-compose.yml) to run tests interactively in a real browser with
+**Vortex** provides full Behat support, including configuration in [`behat.yml`](https://github.com/drevops/vortex/blob/1.x/behat.yml)
+and a [browser container](https://github.com/drevops/vortex/blob/1.x/docker-compose.yml) to run tests interactively in a real browser with
 a VNC viewer.
 
 Additional features include:
@@ -100,7 +100,7 @@ Additional features include:
 
 ### FeatureContext
 
-The [`FeatureContext.php`](https://github.com/drevops/vortex/blob/develop/tests/behat/bootstrap/FeatureContext.php) file comes with
+The [`FeatureContext.php`](https://github.com/drevops/vortex/blob/1.x/tests/behat/bootstrap/FeatureContext.php) file comes with
 included steps from [Behat steps](https://github.com/drevops/behat-steps) package.
 
 You can add your custom steps into this file.
@@ -162,8 +162,8 @@ stability.
 
 ### Boilerplate test features
 
-**Vortex** provides BDD [tests boilerplate](https://github.com/drevops/vortex/blob/develop/tests/behat/features) for [homepage](https://github.com/drevops/vortex/blob/develop/tests/behat/features/homepage.feature)
-and [login](https://github.com/drevops/vortex/blob/develop/tests/behat/features/login.feature)
+**Vortex** provides BDD [tests boilerplate](https://github.com/drevops/vortex/blob/1.x/tests/behat/features) for [homepage](https://github.com/drevops/vortex/blob/1.x/tests/behat/features/homepage.feature)
+and [login](https://github.com/drevops/vortex/blob/1.x/tests/behat/features/login.feature)
 user journeys.
 
 These boilerplate tests run in continuous integration pipeline when you install

--- a/.vortex/docs/docusaurus.config.js
+++ b/.vortex/docs/docusaurus.config.js
@@ -45,7 +45,7 @@ const config = {
           path: 'content',
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: 'https://github.com/drevops/vortex/tree/develop/.vortex/docs/',
+          editUrl: 'https://github.com/drevops/vortex/tree/1.x/.vortex/docs/',
         },
         blog: false,
         theme: {

--- a/.vortex/installer/src/Prompts/Handlers/CiProvider.php
+++ b/.vortex/installer/src/Prompts/Handlers/CiProvider.php
@@ -109,6 +109,13 @@ class CiProvider extends AbstractHandler {
       File::removeTokenAsync('CI_PROVIDER_CIRCLECI');
       File::removeTokenAsync('SETTINGS_PROVIDER_CIRCLECI');
     }
+    else {
+      // Replace deploy branch regex to remove Vortex development branches.
+      // CircleCI config does not support wildards or regexes as multiple values
+      // for branch filters, so we have to hardcode the allowed branches as a
+      // single regex and then remove the unwanted branches from it.
+      File::replaceContentInFile($t . '/.circleci/config.yml', 'only: /^(production|main|master|develop|1.x|2.x)', 'only: /^(production|main|master|develop)');
+    }
 
     if ($remove_gha && $remove_circleci) {
       @unlink($t . '/docs/ci.md');

--- a/.vortex/installer/tests/Functional/Handlers/CiProviderHandlerProcessTest.php
+++ b/.vortex/installer/tests/Functional/Handlers/CiProviderHandlerProcessTest.php
@@ -7,6 +7,7 @@ namespace DrevOps\VortexInstaller\Tests\Functional\Handlers;
 use DrevOps\VortexInstaller\Prompts\Handlers\AiCodeInstructions;
 use DrevOps\VortexInstaller\Prompts\Handlers\CiProvider;
 use DrevOps\VortexInstaller\Prompts\PromptManager;
+use DrevOps\VortexInstaller\Tests\Functional\FunctionalTestCase;
 use DrevOps\VortexInstaller\Utils\Env;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -20,12 +21,20 @@ class CiProviderHandlerProcessTest extends AbstractHandlerProcessTestCase {
           Env::put(PromptManager::makeEnvName(CiProvider::id()), CiProvider::GITHUB_ACTIONS);
           Env::put(PromptManager::makeEnvName(AiCodeInstructions::id()), AiCodeInstructions::CLAUDE);
         }),
+        static::cw(function (FunctionalTestCase $test): void {
+          $test->assertFileNotContainsString(static::$sut . '/.github/workflows/build-test-deploy.yml', '1.x');
+          $test->assertFileNotContainsString(static::$sut . '/.github/workflows/build-test-deploy.yml', '2.x');
+        }),
       ],
 
       'ciprovider, circleci' => [
         static::cw(function (): void {
           Env::put(PromptManager::makeEnvName(CiProvider::id()), CiProvider::CIRCLECI);
           Env::put(PromptManager::makeEnvName(AiCodeInstructions::id()), AiCodeInstructions::CLAUDE);
+        }),
+        static::cw(function (FunctionalTestCase $test): void {
+          $test->assertFileNotContainsString(static::$sut . '/.circleci/config.yml', '1.x');
+          $test->assertFileNotContainsString(static::$sut . '/.circleci/config.yml', '2.x');
         }),
       ],
     ];

--- a/.vortex/installer/tests/Unit/Downloader/DownloaderTest.php
+++ b/.vortex/installer/tests/Unit/Downloader/DownloaderTest.php
@@ -768,6 +768,55 @@ class DownloaderTest extends UnitTestCase {
         'expectedException' => \RuntimeException::class,
         'expectedMessage' => 'Invalid repository URL',
       ],
+      'SemVer+CalVer format - single release' => [
+        'repo' => 'https://github.com/drevops/vortex',
+        'releaseData' => [
+          ['tag_name' => '1.0.0-2025.11.0', 'draft' => FALSE],
+        ],
+        'throwException' => FALSE,
+        'skipMockSetup' => FALSE,
+        'expectedVersion' => '1.0.0-2025.11.0',
+        'expectedException' => NULL,
+        'expectedMessage' => NULL,
+      ],
+      'SemVer+CalVer format - multiple releases' => [
+        'repo' => 'https://github.com/drevops/vortex',
+        'releaseData' => [
+          ['tag_name' => '1.2.0-2025.12.0', 'draft' => FALSE],
+          ['tag_name' => '1.1.0-2025.11.0', 'draft' => FALSE],
+          ['tag_name' => '1.0.0-2025.10.0', 'draft' => FALSE],
+        ],
+        'throwException' => FALSE,
+        'skipMockSetup' => FALSE,
+        'expectedVersion' => '1.2.0-2025.12.0',
+        'expectedException' => NULL,
+        'expectedMessage' => NULL,
+      ],
+      'SemVer+CalVer format - skip draft' => [
+        'repo' => 'https://github.com/drevops/vortex',
+        'releaseData' => [
+          ['tag_name' => '2.0.0-2026.01.0', 'draft' => TRUE],
+          ['tag_name' => '1.0.0-2025.11.0', 'draft' => FALSE],
+        ],
+        'throwException' => FALSE,
+        'skipMockSetup' => FALSE,
+        'expectedVersion' => '1.0.0-2025.11.0',
+        'expectedException' => NULL,
+        'expectedMessage' => NULL,
+      ],
+      'Mixed format - SemVer+CalVer and CalVer' => [
+        'repo' => 'https://github.com/drevops/vortex',
+        'releaseData' => [
+          ['tag_name' => '1.0.0-2025.11.0', 'draft' => FALSE],
+          ['tag_name' => '25.10.0', 'draft' => FALSE],
+          ['tag_name' => '25.9.0', 'draft' => FALSE],
+        ],
+        'throwException' => FALSE,
+        'skipMockSetup' => FALSE,
+        'expectedVersion' => '1.0.0-2025.11.0',
+        'expectedException' => NULL,
+        'expectedMessage' => NULL,
+      ],
     ];
   }
 


### PR DESCRIPTION
Closes #2104


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD now triggers on versioned branches (1.x and 2.x); docs deployment target switched to 1.x and docs test job statuses updated.

* **Documentation**
  * Many documentation links and the docs "edit" target updated to point to 1.x.
  * Added a Versioning Strategy (SemVer+CalVer) with branch and release guidance.

* **Tests**
  * Added/expanded tests for release-version selection and generated workflow outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->