### PR TITLE
[#1950] Added `--destination` to `build` and `check-requirements` Installer's commands.

### DIFF
--- a/.vortex/installer/src/Command/DestinationAwareTrait.php
+++ b/.vortex/installer/src/Command/DestinationAwareTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\VortexInstaller\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Provides destination directory option for commands.
+ */
+trait DestinationAwareTrait {
+
+  /**
+   * Add the destination option to the command.
+   */
+  protected function addDestinationOption(): void {
+    $this->addOption(
+      'destination',
+      'd',
+      InputOption::VALUE_REQUIRED,
+      'Target directory for the operation. Defaults to current directory.'
+    );
+  }
+
+  /**
+   * Get the destination directory from input.
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   *   The input interface.
+   *
+   * @return string
+   *   The validated destination directory path.
+   *
+   * @throws \InvalidArgumentException
+   *   If the destination directory does not exist.
+   */
+  protected function getDestination(InputInterface $input): string {
+    $destination = $input->getOption('destination');
+
+    if ($destination === NULL || $destination === '') {
+      return getcwd() ?: '.';
+    }
+
+    if (!is_string($destination)) {
+      throw new \InvalidArgumentException('Destination must be a string.');
+    }
+
+    if (!is_dir($destination)) {
+      throw new \InvalidArgumentException(
+        sprintf('Destination directory does not exist: %s', $destination)
+      );
+    }
+
+    return realpath($destination) ?: $destination;
+  }
+
+}

--- a/.vortex/installer/src/Command/InstallCommand.php
+++ b/.vortex/installer/src/Command/InstallCommand.php
@@ -498,8 +498,13 @@ EOF
     $starter = $responses[Starter::id()] ?? Starter::LOAD_DATABASE_DEMO;
     $is_profile = in_array($starter, [Starter::INSTALL_PROFILE_CORE, Starter::INSTALL_PROFILE_DRUPALCMS], TRUE);
 
+    $args = ['--destination' => $this->config->getDst()];
+    if ($is_profile) {
+      $args['--profile'] = '1';
+    }
+
     $runner = $this->getCommandRunner();
-    $runner->run('build', args: $is_profile ? ['--profile' => '1'] : [], output: $output);
+    $runner->run('build', args: $args, output: $output);
 
     return $runner->getExitCode() === RunnerInterface::EXIT_SUCCESS;
   }
@@ -629,10 +634,9 @@ EOT;
    */
   public function footerBuildSucceeded(): void {
     $output = '';
-    $prefix = '  ';
 
-    $output .= 'Get site info:' . $prefix . 'ahoy info' . PHP_EOL;
-    $output .= 'Login:' . $prefix . $prefix . $prefix . 'ahoy login' . PHP_EOL;
+    $output .= 'Get site info: ahoy info' . PHP_EOL;
+    $output .= 'Login:         ahoy login' . PHP_EOL;
     $output .= PHP_EOL;
 
     $handler_output = $this->promptManager->runPostBuild(self::BUILD_RESULT_SUCCESS);

--- a/.vortex/installer/tests/Helpers/TuiOutput.php
+++ b/.vortex/installer/tests/Helpers/TuiOutput.php
@@ -157,6 +157,10 @@ class TuiOutput {
 
   const CHECK_REQUIREMENTS_AVAILABLE = 'Available: docker, docker-compose, ahoy, pygmy';
 
+  const DESTINATION_NOT_EXIST = 'Destination directory does not exist:';
+
+  const DESTINATION_MUST_BE_STRING = 'Destination must be a string.';
+
   /**
    * Mark constants as present (should contain in output).
    *


### PR DESCRIPTION
Related to #1950


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --destination option to target a custom directory for build and requirement checks.

* **Improvements**
  * Commands now consistently use the selected destination as the working directory, improving path resolution and process behavior.
  * Footer output spacing refined for clearer display.

* **Bug Fixes**
  * Better validation and clearer error messages for non-string, non-existent, or non-directory destination inputs.

* **Tests**
  * Added functional scenarios and pre-run hooks for valid/invalid destination handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->