### PR TITLE
[#2181] Updated `ahoy test` to run only PHPUnit tests and fixed test discovery in submodules.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -236,13 +236,10 @@ commands:
       ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
       #;> DRUPAL_THEME
 
+  #;< TOOL_PHPUNIT
   test:
-    usage: Run all tests.
-    cmd: |
-      ahoy test-unit
-      ahoy test-kernel
-      ahoy test-functional
-      ahoy test-bdd
+    usage: Run all PHPUnit tests.
+    cmd: ahoy cli vendor/bin/phpunit "$@"
 
   test-unit:
     usage: Run PHPUnit unit tests.
@@ -255,11 +252,14 @@ commands:
   test-functional:
     usage: Run PHPUnit functional tests.
     cmd: ahoy cli vendor/bin/phpunit --testsuite=functional "$@"
+  #;> TOOL_PHPUNIT
 
+  #;< TOOL_BEHAT
   test-bdd:
     usage: Run BDD tests.
     aliases: [test-behat]
     cmd: ahoy cli php -d memory_limit=-1 vendor/bin/behat --colors "$@"
+  #;> TOOL_BEHAT
 
   debug:
     usage: Enable PHP Xdebug.

--- a/.vortex/installer/src/Prompts/Handlers/Theme.php
+++ b/.vortex/installer/src/Prompts/Handlers/Theme.php
@@ -202,11 +202,15 @@ class Theme extends AbstractHandler {
     File::removeLine($tmpDir . '/phpmd.xml', '<exclude-pattern>*/web/themes/contrib/*</exclude-pattern>');
 
     File::removeLine($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/*/tests/src/Unit</directory>');
+    File::removeLine($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/**/tests/src/Unit</directory>');
     File::removeLine($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/*/tests/src/Kernel</directory>');
+    File::removeLine($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/**/tests/src/Kernel</directory>');
     File::removeLine($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/*/tests/src/Functional</directory>');
+    File::removeLine($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/**/tests/src/Functional</directory>');
     File::removeLine($tmpDir . '/phpunit.xml', '<directory>web/themes/custom</directory>');
     File::removeLine($tmpDir . '/phpunit.xml', '<directory suffix="Test.php">web/themes/custom</directory>');
     File::removeLine($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/*/node_modules</directory>');
+    File::removeLine($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/**/node_modules</directory>');
 
     File::removeLine($tmpDir . '/rector.php', "__DIR__ . '/web/themes/custom',");
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
@@ -220,12 +220,8 @@ commands:
       ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
 
   test:
-    usage: Run all tests.
-    cmd: |
-      ahoy test-unit
-      ahoy test-kernel
-      ahoy test-functional
-      ahoy test-bdd
+    usage: Run all PHPUnit tests.
+    cmd: ahoy cli vendor/bin/phpunit "$@"
 
   test-unit:
     usage: Run PHPUnit unit tests.

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/phpunit.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/phpunit.xml
@@ -6,19 +6,24 @@
  https://www.drupal.org/node/2116263 for details.
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="web/core/tests/bootstrap.php"
-         colors="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
-         failOnWarning="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
-         displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
-         failOnPhpunitDeprecation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         bootstrap="web/core/tests/bootstrap.php"
          cacheResult="false"
+         colors="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         failOnPhpunitDeprecation="true"
+         failOnSkipped="true"
+         failOnWarning="true"
+         stopOnError="true"
+         stopOnFailure="true"
+         stopOnRisky="true"
+         stopOnWarning="true"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          cacheDirectory=".phpunit.cache">
     <php>
@@ -62,16 +67,16 @@
     <testsuites>
         <testsuite name="unit">
             <directory>tests/phpunit</directory>
-            <directory>web/modules/custom/*/tests/src/Unit</directory>
-            <directory>web/themes/custom/*/tests/src/Unit</directory>
+            <directory>web/modules/custom/**/tests/src/Unit</directory>
+            <directory>web/themes/custom/**/tests/src/Unit</directory>
         </testsuite>
         <testsuite name="kernel">
-            <directory>web/modules/custom/*/tests/src/Kernel</directory>
-            <directory>web/themes/custom/*/tests/src/Kernel</directory>
+            <directory>web/modules/custom/**/tests/src/Kernel</directory>
+            <directory>web/themes/custom/**/tests/src/Kernel</directory>
         </testsuite>
         <testsuite name="functional">
-            <directory>web/modules/custom/*/tests/src/Functional</directory>
-            <directory>web/themes/custom/*/tests/src/Functional</directory>
+            <directory>web/modules/custom/**/tests/src/Functional</directory>
+            <directory>web/themes/custom/**/tests/src/Functional</directory>
         </testsuite>
 
         <!-- Not implemented. -->
@@ -107,9 +112,9 @@
         </include>
         <exclude>
             <directory suffix="Test.php">web/modules/custom</directory>
-            <directory>web/modules/custom/*/node_modules</directory>
+            <directory>web/modules/custom/**/node_modules</directory>
             <directory suffix="Test.php">web/themes/custom</directory>
-            <directory>web/themes/custom/*/node_modules</directory>
+            <directory>web/themes/custom/**/node_modules</directory>
             <directory>tests</directory>
         </exclude>
     </source>

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/phpunit.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/phpunit.xml
@@ -1,36 +1,36 @@
-@@ -6,7 +6,7 @@
-  https://www.drupal.org/node/2116263 for details.
- -->
- <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+@@ -9,7 +9,7 @@
+          beStrictAboutChangesToGlobalState="true"
+          beStrictAboutOutputDuringTests="true"
+          beStrictAboutTestsThatDoNotTestAnything="true"
 -         bootstrap="web/core/tests/bootstrap.php"
 +         bootstrap="docroot/core/tests/bootstrap.php"
+          cacheResult="false"
           colors="true"
-          beStrictAboutTestsThatDoNotTestAnything="true"
-          beStrictAboutOutputDuringTests="true"
-@@ -62,16 +62,16 @@
+          displayDetailsOnPhpunitDeprecations="true"
+@@ -67,16 +67,16 @@
      <testsuites>
          <testsuite name="unit">
              <directory>tests/phpunit</directory>
--            <directory>web/modules/custom/*/tests/src/Unit</directory>
--            <directory>web/themes/custom/*/tests/src/Unit</directory>
-+            <directory>docroot/modules/custom/*/tests/src/Unit</directory>
-+            <directory>docroot/themes/custom/*/tests/src/Unit</directory>
+-            <directory>web/modules/custom/**/tests/src/Unit</directory>
+-            <directory>web/themes/custom/**/tests/src/Unit</directory>
++            <directory>docroot/modules/custom/**/tests/src/Unit</directory>
++            <directory>docroot/themes/custom/**/tests/src/Unit</directory>
          </testsuite>
          <testsuite name="kernel">
--            <directory>web/modules/custom/*/tests/src/Kernel</directory>
--            <directory>web/themes/custom/*/tests/src/Kernel</directory>
-+            <directory>docroot/modules/custom/*/tests/src/Kernel</directory>
-+            <directory>docroot/themes/custom/*/tests/src/Kernel</directory>
+-            <directory>web/modules/custom/**/tests/src/Kernel</directory>
+-            <directory>web/themes/custom/**/tests/src/Kernel</directory>
++            <directory>docroot/modules/custom/**/tests/src/Kernel</directory>
++            <directory>docroot/themes/custom/**/tests/src/Kernel</directory>
          </testsuite>
          <testsuite name="functional">
--            <directory>web/modules/custom/*/tests/src/Functional</directory>
--            <directory>web/themes/custom/*/tests/src/Functional</directory>
-+            <directory>docroot/modules/custom/*/tests/src/Functional</directory>
-+            <directory>docroot/themes/custom/*/tests/src/Functional</directory>
+-            <directory>web/modules/custom/**/tests/src/Functional</directory>
+-            <directory>web/themes/custom/**/tests/src/Functional</directory>
++            <directory>docroot/modules/custom/**/tests/src/Functional</directory>
++            <directory>docroot/themes/custom/**/tests/src/Functional</directory>
          </testsuite>
  
          <!-- Not implemented. -->
-@@ -100,16 +100,16 @@
+@@ -105,16 +105,16 @@
      </coverage>
      <source>
          <include>
@@ -45,13 +45,13 @@
          </include>
          <exclude>
 -            <directory suffix="Test.php">web/modules/custom</directory>
--            <directory>web/modules/custom/*/node_modules</directory>
+-            <directory>web/modules/custom/**/node_modules</directory>
 -            <directory suffix="Test.php">web/themes/custom</directory>
--            <directory>web/themes/custom/*/node_modules</directory>
+-            <directory>web/themes/custom/**/node_modules</directory>
 +            <directory suffix="Test.php">docroot/modules/custom</directory>
-+            <directory>docroot/modules/custom/*/node_modules</directory>
++            <directory>docroot/modules/custom/**/node_modules</directory>
 +            <directory suffix="Test.php">docroot/themes/custom</directory>
-+            <directory>docroot/themes/custom/*/node_modules</directory>
++            <directory>docroot/themes/custom/**/node_modules</directory>
              <directory>tests</directory>
          </exclude>
      </source>

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/phpunit.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/phpunit.xml
@@ -1,36 +1,36 @@
-@@ -6,7 +6,7 @@
-  https://www.drupal.org/node/2116263 for details.
- -->
- <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+@@ -9,7 +9,7 @@
+          beStrictAboutChangesToGlobalState="true"
+          beStrictAboutOutputDuringTests="true"
+          beStrictAboutTestsThatDoNotTestAnything="true"
 -         bootstrap="web/core/tests/bootstrap.php"
 +         bootstrap="docroot/core/tests/bootstrap.php"
+          cacheResult="false"
           colors="true"
-          beStrictAboutTestsThatDoNotTestAnything="true"
-          beStrictAboutOutputDuringTests="true"
-@@ -62,16 +62,16 @@
+          displayDetailsOnPhpunitDeprecations="true"
+@@ -67,16 +67,16 @@
      <testsuites>
          <testsuite name="unit">
              <directory>tests/phpunit</directory>
--            <directory>web/modules/custom/*/tests/src/Unit</directory>
--            <directory>web/themes/custom/*/tests/src/Unit</directory>
-+            <directory>docroot/modules/custom/*/tests/src/Unit</directory>
-+            <directory>docroot/themes/custom/*/tests/src/Unit</directory>
+-            <directory>web/modules/custom/**/tests/src/Unit</directory>
+-            <directory>web/themes/custom/**/tests/src/Unit</directory>
++            <directory>docroot/modules/custom/**/tests/src/Unit</directory>
++            <directory>docroot/themes/custom/**/tests/src/Unit</directory>
          </testsuite>
          <testsuite name="kernel">
--            <directory>web/modules/custom/*/tests/src/Kernel</directory>
--            <directory>web/themes/custom/*/tests/src/Kernel</directory>
-+            <directory>docroot/modules/custom/*/tests/src/Kernel</directory>
-+            <directory>docroot/themes/custom/*/tests/src/Kernel</directory>
+-            <directory>web/modules/custom/**/tests/src/Kernel</directory>
+-            <directory>web/themes/custom/**/tests/src/Kernel</directory>
++            <directory>docroot/modules/custom/**/tests/src/Kernel</directory>
++            <directory>docroot/themes/custom/**/tests/src/Kernel</directory>
          </testsuite>
          <testsuite name="functional">
--            <directory>web/modules/custom/*/tests/src/Functional</directory>
--            <directory>web/themes/custom/*/tests/src/Functional</directory>
-+            <directory>docroot/modules/custom/*/tests/src/Functional</directory>
-+            <directory>docroot/themes/custom/*/tests/src/Functional</directory>
+-            <directory>web/modules/custom/**/tests/src/Functional</directory>
+-            <directory>web/themes/custom/**/tests/src/Functional</directory>
++            <directory>docroot/modules/custom/**/tests/src/Functional</directory>
++            <directory>docroot/themes/custom/**/tests/src/Functional</directory>
          </testsuite>
  
          <!-- Not implemented. -->
-@@ -100,16 +100,16 @@
+@@ -105,16 +105,16 @@
      </coverage>
      <source>
          <include>
@@ -45,13 +45,13 @@
          </include>
          <exclude>
 -            <directory suffix="Test.php">web/modules/custom</directory>
--            <directory>web/modules/custom/*/node_modules</directory>
+-            <directory>web/modules/custom/**/node_modules</directory>
 -            <directory suffix="Test.php">web/themes/custom</directory>
--            <directory>web/themes/custom/*/node_modules</directory>
+-            <directory>web/themes/custom/**/node_modules</directory>
 +            <directory suffix="Test.php">docroot/modules/custom</directory>
-+            <directory>docroot/modules/custom/*/node_modules</directory>
++            <directory>docroot/modules/custom/**/node_modules</directory>
 +            <directory suffix="Test.php">docroot/themes/custom</directory>
-+            <directory>docroot/themes/custom/*/node_modules</directory>
++            <directory>docroot/themes/custom/**/node_modules</directory>
              <directory>tests</directory>
          </exclude>
      </source>

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.ahoy.yml
@@ -44,4 +44,4 @@
 -      ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  
    test:
-     usage: Run all tests.
+     usage: Run all PHPUnit tests.

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/phpunit.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/phpunit.xml
@@ -1,20 +1,20 @@
-@@ -63,15 +63,12 @@
+@@ -68,15 +68,12 @@
          <testsuite name="unit">
              <directory>tests/phpunit</directory>
-             <directory>web/modules/custom/*/tests/src/Unit</directory>
--            <directory>web/themes/custom/*/tests/src/Unit</directory>
+             <directory>web/modules/custom/**/tests/src/Unit</directory>
+-            <directory>web/themes/custom/**/tests/src/Unit</directory>
          </testsuite>
          <testsuite name="kernel">
-             <directory>web/modules/custom/*/tests/src/Kernel</directory>
--            <directory>web/themes/custom/*/tests/src/Kernel</directory>
+             <directory>web/modules/custom/**/tests/src/Kernel</directory>
+-            <directory>web/themes/custom/**/tests/src/Kernel</directory>
          </testsuite>
          <testsuite name="functional">
-             <directory>web/modules/custom/*/tests/src/Functional</directory>
--            <directory>web/themes/custom/*/tests/src/Functional</directory>
+             <directory>web/modules/custom/**/tests/src/Functional</directory>
+-            <directory>web/themes/custom/**/tests/src/Functional</directory>
          </testsuite>
  
          <!-- Not implemented. -->
-@@ -101,7 +98,6 @@
+@@ -106,7 +103,6 @@
      <source>
          <include>
              <directory>web/modules/custom</directory>
@@ -22,12 +22,12 @@
              <directory>web/sites/default/includes</directory>
              <directory>web/sites/default/settings.php</directory>
          </include>
-@@ -108,8 +104,6 @@
+@@ -113,8 +109,6 @@
          <exclude>
              <directory suffix="Test.php">web/modules/custom</directory>
-             <directory>web/modules/custom/*/node_modules</directory>
+             <directory>web/modules/custom/**/node_modules</directory>
 -            <directory suffix="Test.php">web/themes/custom</directory>
--            <directory>web/themes/custom/*/node_modules</directory>
+-            <directory>web/themes/custom/**/node_modules</directory>
              <directory>tests</directory>
          </exclude>
      </source>

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.ahoy.yml
@@ -44,4 +44,4 @@
 -      ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  
    test:
-     usage: Run all tests.
+     usage: Run all PHPUnit tests.

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/phpunit.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/phpunit.xml
@@ -1,20 +1,20 @@
-@@ -63,15 +63,12 @@
+@@ -68,15 +68,12 @@
          <testsuite name="unit">
              <directory>tests/phpunit</directory>
-             <directory>web/modules/custom/*/tests/src/Unit</directory>
--            <directory>web/themes/custom/*/tests/src/Unit</directory>
+             <directory>web/modules/custom/**/tests/src/Unit</directory>
+-            <directory>web/themes/custom/**/tests/src/Unit</directory>
          </testsuite>
          <testsuite name="kernel">
-             <directory>web/modules/custom/*/tests/src/Kernel</directory>
--            <directory>web/themes/custom/*/tests/src/Kernel</directory>
+             <directory>web/modules/custom/**/tests/src/Kernel</directory>
+-            <directory>web/themes/custom/**/tests/src/Kernel</directory>
          </testsuite>
          <testsuite name="functional">
-             <directory>web/modules/custom/*/tests/src/Functional</directory>
--            <directory>web/themes/custom/*/tests/src/Functional</directory>
+             <directory>web/modules/custom/**/tests/src/Functional</directory>
+-            <directory>web/themes/custom/**/tests/src/Functional</directory>
          </testsuite>
  
          <!-- Not implemented. -->
-@@ -101,7 +98,6 @@
+@@ -106,7 +103,6 @@
      <source>
          <include>
              <directory>web/modules/custom</directory>
@@ -22,12 +22,12 @@
              <directory>web/sites/default/includes</directory>
              <directory>web/sites/default/settings.php</directory>
          </include>
-@@ -108,8 +104,6 @@
+@@ -113,8 +109,6 @@
          <exclude>
              <directory suffix="Test.php">web/modules/custom</directory>
-             <directory>web/modules/custom/*/node_modules</directory>
+             <directory>web/modules/custom/**/node_modules</directory>
 -            <directory suffix="Test.php">web/themes/custom</directory>
--            <directory>web/themes/custom/*/node_modules</directory>
+-            <directory>web/themes/custom/**/node_modules</directory>
              <directory>tests</directory>
          </exclude>
      </source>

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.ahoy.yml
@@ -44,4 +44,4 @@
 -      ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  
    test:
-     usage: Run all tests.
+     usage: Run all PHPUnit tests.

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/phpunit.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/phpunit.xml
@@ -1,20 +1,20 @@
-@@ -63,15 +63,12 @@
+@@ -68,15 +68,12 @@
          <testsuite name="unit">
              <directory>tests/phpunit</directory>
-             <directory>web/modules/custom/*/tests/src/Unit</directory>
--            <directory>web/themes/custom/*/tests/src/Unit</directory>
+             <directory>web/modules/custom/**/tests/src/Unit</directory>
+-            <directory>web/themes/custom/**/tests/src/Unit</directory>
          </testsuite>
          <testsuite name="kernel">
-             <directory>web/modules/custom/*/tests/src/Kernel</directory>
--            <directory>web/themes/custom/*/tests/src/Kernel</directory>
+             <directory>web/modules/custom/**/tests/src/Kernel</directory>
+-            <directory>web/themes/custom/**/tests/src/Kernel</directory>
          </testsuite>
          <testsuite name="functional">
-             <directory>web/modules/custom/*/tests/src/Functional</directory>
--            <directory>web/themes/custom/*/tests/src/Functional</directory>
+             <directory>web/modules/custom/**/tests/src/Functional</directory>
+-            <directory>web/themes/custom/**/tests/src/Functional</directory>
          </testsuite>
  
          <!-- Not implemented. -->
-@@ -101,7 +98,6 @@
+@@ -106,7 +103,6 @@
      <source>
          <include>
              <directory>web/modules/custom</directory>
@@ -22,12 +22,12 @@
              <directory>web/sites/default/includes</directory>
              <directory>web/sites/default/settings.php</directory>
          </include>
-@@ -108,8 +104,6 @@
+@@ -113,8 +109,6 @@
          <exclude>
              <directory suffix="Test.php">web/modules/custom</directory>
-             <directory>web/modules/custom/*/node_modules</directory>
+             <directory>web/modules/custom/**/node_modules</directory>
 -            <directory suffix="Test.php">web/themes/custom</directory>
--            <directory>web/themes/custom/*/node_modules</directory>
+-            <directory>web/themes/custom/**/node_modules</directory>
              <directory>tests</directory>
          </exclude>
      </source>

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.ahoy.yml
@@ -18,18 +18,14 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -218,31 +212,6 @@
+@@ -218,27 +212,6 @@
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
 -
 -  test:
--    usage: Run all tests.
--    cmd: |
--      ahoy test-unit
--      ahoy test-kernel
--      ahoy test-functional
--      ahoy test-bdd
+-    usage: Run all PHPUnit tests.
+-    cmd: ahoy cli vendor/bin/phpunit "$@"
 -
 -  test-unit:
 -    usage: Run PHPUnit unit tests.

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.ahoy.yml
@@ -18,18 +18,14 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -218,31 +212,6 @@
+@@ -218,27 +212,6 @@
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
 -
 -  test:
--    usage: Run all tests.
--    cmd: |
--      ahoy test-unit
--      ahoy test-kernel
--      ahoy test-functional
--      ahoy test-bdd
+-    usage: Run all PHPUnit tests.
+-    cmd: ahoy cli vendor/bin/phpunit "$@"
 -
 -  test-unit:
 -    usage: Run PHPUnit unit tests.

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.ahoy.yml
@@ -15,15 +15,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -225,7 +222,6 @@
-       ahoy test-unit
-       ahoy test-kernel
-       ahoy test-functional
--      ahoy test-bdd
- 
-   test-unit:
-     usage: Run PHPUnit unit tests.
-@@ -238,11 +234,6 @@
+@@ -234,11 +231,6 @@
    test-functional:
      usage: Run PHPUnit functional tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.ahoy.yml
@@ -15,15 +15,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -225,7 +222,6 @@
-       ahoy test-unit
-       ahoy test-kernel
-       ahoy test-functional
--      ahoy test-bdd
- 
-   test-unit:
-     usage: Run PHPUnit unit tests.
-@@ -238,11 +234,6 @@
+@@ -234,11 +231,6 @@
    test-functional:
      usage: Run PHPUnit functional tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.ahoy.yml
@@ -1,11 +1,10 @@
-@@ -222,22 +222,7 @@
-   test:
-     usage: Run all tests.
-     cmd: |
--      ahoy test-unit
--      ahoy test-kernel
--      ahoy test-functional
-       ahoy test-bdd
+@@ -219,22 +219,6 @@
+       ahoy cli "yarn run lint-fix"
+       ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
+ 
+-  test:
+-    usage: Run all PHPUnit tests.
+-    cmd: ahoy cli vendor/bin/phpunit "$@"
 -
 -  test-unit:
 -    usage: Run PHPUnit unit tests.
@@ -18,6 +17,7 @@
 -  test-functional:
 -    usage: Run PHPUnit functional tests.
 -    cmd: ahoy cli vendor/bin/phpunit --testsuite=functional "$@"
- 
+-
    test-bdd:
      usage: Run BDD tests.
+     aliases: [test-behat]

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.ahoy.yml
@@ -1,11 +1,10 @@
-@@ -222,22 +222,7 @@
-   test:
-     usage: Run all tests.
-     cmd: |
--      ahoy test-unit
--      ahoy test-kernel
--      ahoy test-functional
-       ahoy test-bdd
+@@ -219,22 +219,6 @@
+       ahoy cli "yarn run lint-fix"
+       ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
+ 
+-  test:
+-    usage: Run all PHPUnit tests.
+-    cmd: ahoy cli vendor/bin/phpunit "$@"
 -
 -  test-unit:
 -    usage: Run PHPUnit unit tests.
@@ -18,6 +17,7 @@
 -  test-functional:
 -    usage: Run PHPUnit functional tests.
 -    cmd: ahoy cli vendor/bin/phpunit --testsuite=functional "$@"
- 
+-
    test-bdd:
      usage: Run BDD tests.
+     aliases: [test-behat]

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.ahoy.yml
@@ -41,18 +41,14 @@
    lint-fe-fix:
      usage: Fix lint issues of front-end code.
      cmd: |
-@@ -218,31 +202,6 @@
+@@ -218,27 +202,6 @@
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
 -
 -  test:
--    usage: Run all tests.
--    cmd: |
--      ahoy test-unit
--      ahoy test-kernel
--      ahoy test-functional
--      ahoy test-bdd
+-    usage: Run all PHPUnit tests.
+-    cmd: ahoy cli vendor/bin/phpunit "$@"
 -
 -  test-unit:
 -    usage: Run PHPUnit unit tests.

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -424,7 +424,6 @@ trait SubtestAhoyTrait {
 
     $this->syncToHost('.logs');
     $this->assertFileExists('.logs/test_results/phpunit/phpunit.xml', 'PHPUnit test results XML file should exist');
-    $this->assertDirectoryExists('.logs/screenshots', 'Screenshots directory should exist after BDD tests');
 
     $this->removePathHostAndContainer('.logs');
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,19 +6,24 @@
  https://www.drupal.org/node/2116263 for details.
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="web/core/tests/bootstrap.php"
-         colors="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
-         failOnWarning="true"
-         displayDetailsOnTestsThatTriggerNotices="true"
-         displayDetailsOnTestsThatTriggerErrors="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
-         failOnPhpunitDeprecation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         bootstrap="web/core/tests/bootstrap.php"
          cacheResult="false"
+         colors="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         failOnPhpunitDeprecation="true"
+         failOnSkipped="true"
+         failOnWarning="true"
+         stopOnError="true"
+         stopOnFailure="true"
+         stopOnRisky="true"
+         stopOnWarning="true"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          cacheDirectory=".phpunit.cache">
     <php>
@@ -62,16 +67,16 @@
     <testsuites>
         <testsuite name="unit">
             <directory>tests/phpunit</directory>
-            <directory>web/modules/custom/*/tests/src/Unit</directory>
-            <directory>web/themes/custom/*/tests/src/Unit</directory>
+            <directory>web/modules/custom/**/tests/src/Unit</directory>
+            <directory>web/themes/custom/**/tests/src/Unit</directory>
         </testsuite>
         <testsuite name="kernel">
-            <directory>web/modules/custom/*/tests/src/Kernel</directory>
-            <directory>web/themes/custom/*/tests/src/Kernel</directory>
+            <directory>web/modules/custom/**/tests/src/Kernel</directory>
+            <directory>web/themes/custom/**/tests/src/Kernel</directory>
         </testsuite>
         <testsuite name="functional">
-            <directory>web/modules/custom/*/tests/src/Functional</directory>
-            <directory>web/themes/custom/*/tests/src/Functional</directory>
+            <directory>web/modules/custom/**/tests/src/Functional</directory>
+            <directory>web/themes/custom/**/tests/src/Functional</directory>
         </testsuite>
 
         <!-- Not implemented. -->
@@ -107,9 +112,9 @@
         </include>
         <exclude>
             <directory suffix="Test.php">web/modules/custom</directory>
-            <directory>web/modules/custom/*/node_modules</directory>
+            <directory>web/modules/custom/**/node_modules</directory>
             <directory suffix="Test.php">web/themes/custom</directory>
-            <directory>web/themes/custom/*/node_modules</directory>
+            <directory>web/themes/custom/**/node_modules</directory>
             <directory>tests</directory>
         </exclude>
     </source>


### PR DESCRIPTION
Closes #2181


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated default test command to run PHPUnit directly; added public commands: test-unit, test-kernel, test-functional.
  * test-bdd remains available; internal tooling wrappers added for test runners.
  * Enabled stricter PHPUnit checks, expanded stop/fail semantics, and disabled result caching.
  * Enabled recursive discovery of unit/kernel/functional tests and updated exclude patterns.
  * Removed post-BDD assertion requiring a screenshots directory.

* **Chores**
  * Broadened cleanup to cover nested theme test entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->