### PR TITLE
Fixed release drafter GHA not respecting `vars.VORTEX_RELEASE_VERSION_SCHEME` var set as GHA variable.

### DIFF
--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Load environment variables from .env
         run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"
+        env:
+          VORTEX_RELEASE_VERSION_SCHEME: ${{ vars.VORTEX_RELEASE_VERSION_SCHEME || 'calver' }}
 
       - name: Generate CalVer version
         if: ${{ contains(env.VORTEX_RELEASE_VERSION_SCHEME, 'calver') }}

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/draft-release-notes.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/draft-release-notes.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Load environment variables from .env
         run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"
+        env:
+          VORTEX_RELEASE_VERSION_SCHEME: ${{ vars.VORTEX_RELEASE_VERSION_SCHEME || 'calver' }}
 
       - name: Generate CalVer version
         if: ${{ contains(env.VORTEX_RELEASE_VERSION_SCHEME, 'calver') }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation workflow with configurable versioning scheme support, enabling more flexible release management and improved release note generation capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->