### PR TITLE
Updated `drevops/mariadb-drupal-data` to `26.1.0`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
       # Enforce fresh DB build (do not rely on fallback caches).
       VORTEX_CI_DB_CACHE_FALLBACK: 'no'
       # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:25.3.0
+      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:26.1.0
       # Deploy container image (if database-in-image storage is used).
       VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
       # Do not build the Drupal front-end.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the database container image used in nightly automated database workflows from version 25.3.0 to 26.1.0 (VORTEX_DB_IMAGE_BASE). No workflow steps, environment settings, control flow, or caching behavior were changed. This refreshes the base database image for nightly runs to pick up upstream fixes and improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->