### PR TITLE
Udated docker-wait-for-dependencies to 26.1.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -248,7 +248,7 @@ services:
 
   # Helper container to wait for services to become available.
   wait-for-dependencies:
-    image: drevops/docker-wait-for-dependencies:25.10.0
+    image: drevops/docker-wait-for-dependencies:26.1.0
     depends_on:
       #;< SERVICE_CLAMAV
       - clamav


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the infrastructure dependency image tag for the wait-for-dependencies container from 25.10.0 to 26.1.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->