### PR TITLE
[#2202] Updated Acquia settings to use env variables to include the cloud setting file.

### DIFF
--- a/.vortex/installer/src/Prompts/Handlers/HostingProjectName.php
+++ b/.vortex/installer/src/Prompts/Handlers/HostingProjectName.php
@@ -70,7 +70,10 @@ class HostingProjectName extends AbstractHandler {
       return $v;
     }
 
-    // Try to discover from settings.acquia.php.
+    // @deprecated Discovery from hardcoded path in settings.acquia.php. The
+    // new settings.acquia.php uses AH_SITE_GROUP environment variable instead
+    // of a hardcoded project name. Kept for backward compatibility with older
+    // installations.
     $acquia_settings_file = $this->dstDir . sprintf('/%s/sites/default/includes/providers/settings.acquia.php', $this->webroot);
     if (file_exists($acquia_settings_file)) {
       $content = file_get_contents($acquia_settings_file);
@@ -125,6 +128,10 @@ class HostingProjectName extends AbstractHandler {
     $w = $this->webroot;
 
     Env::writeValueDotenv('VORTEX_ACQUIA_APP_NAME', $v, $t . '/.env');
+    // @deprecated The settings.acquia.php no longer uses hardcoded project
+    // names - it uses AH_SITE_GROUP environment variable instead. This
+    // replacement is kept for backward compatibility with older installations
+    // that may still use the hardcoded path pattern.
     File::replaceContentInFile($t . '/' . $w . '/sites/default/includes/providers/settings.acquia.php', 'your_site', $v);
 
     Env::writeValueDotenv('LAGOON_PROJECT', $v, $t . '/.env');

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/sites/default/includes/providers/settings.acquia.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/sites/default/includes/providers/settings.acquia.php
@@ -19,13 +19,18 @@ if (!empty(getenv('AH_SITE_ENVIRONMENT'))) {
   $config['acquia_hosting_settings_autoconnect'] = FALSE;
 
   // Include Acquia environment settings.
-  if (file_exists('/var/www/site-php/star_wars/star_wars-settings.inc')) {
-    // @codeCoverageIgnoreStart
-    // @phpstan-ignore-next-line
-    require '/var/www/site-php/star_wars/star_wars-settings.inc';
-    // @codeCoverageIgnoreEnd
+  // The path is built dynamically from the AH_SITE_GROUP environment variable
+  // provided by Acquia Cloud.
+  $ah_site_group = getenv('AH_SITE_GROUP');
+  // @codeCoverageIgnoreStart
+  if (!empty($ah_site_group)) {
+    $ah_settings_file = sprintf('/var/www/site-php/%s/%s-settings.inc', $ah_site_group, $ah_site_group);
+    if (!file_exists($ah_settings_file)) {
+      throw new \RuntimeException(sprintf('Acquia settings file "%s" not found. Check Acquia Cloud environment configuration.', $ah_settings_file));
+    }
+    require $ah_settings_file;
   }
-
+  // @codeCoverageIgnoreEnd
   // Set the config sync directory to a `config_vcs_directory`, but still
   // allow overriding it with the DRUPAL_CONFIG_PATH environment variable.
   if (!empty($settings['config_vcs_directory'])) {

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/sites/default/includes/providers/settings.acquia.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/sites/default/includes/providers/settings.acquia.php
@@ -19,13 +19,18 @@ if (!empty(getenv('AH_SITE_ENVIRONMENT'))) {
   $config['acquia_hosting_settings_autoconnect'] = FALSE;
 
   // Include Acquia environment settings.
-  if (file_exists('/var/www/site-php/my_custom_acquia-project/my_custom_acquia-project-settings.inc')) {
-    // @codeCoverageIgnoreStart
-    // @phpstan-ignore-next-line
-    require '/var/www/site-php/my_custom_acquia-project/my_custom_acquia-project-settings.inc';
-    // @codeCoverageIgnoreEnd
+  // The path is built dynamically from the AH_SITE_GROUP environment variable
+  // provided by Acquia Cloud.
+  $ah_site_group = getenv('AH_SITE_GROUP');
+  // @codeCoverageIgnoreStart
+  if (!empty($ah_site_group)) {
+    $ah_settings_file = sprintf('/var/www/site-php/%s/%s-settings.inc', $ah_site_group, $ah_site_group);
+    if (!file_exists($ah_settings_file)) {
+      throw new \RuntimeException(sprintf('Acquia settings file "%s" not found. Check Acquia Cloud environment configuration.', $ah_settings_file));
+    }
+    require $ah_settings_file;
   }
-
+  // @codeCoverageIgnoreEnd
   // Set the config sync directory to a `config_vcs_directory`, but still
   // allow overriding it with the DRUPAL_CONFIG_PATH environment variable.
   if (!empty($settings['config_vcs_directory'])) {

--- a/.vortex/installer/tests/Functional/Handlers/HostingProjectNameHandlerProcessTest.php
+++ b/.vortex/installer/tests/Functional/Handlers/HostingProjectNameHandlerProcessTest.php
@@ -24,7 +24,6 @@ class HostingProjectNameHandlerProcessTest extends AbstractHandlerProcessTestCas
         static::cw(function (FunctionalTestCase $test): void {
           $test->assertSutContains([
             'VORTEX_ACQUIA_APP_NAME=my_custom_acquia-project',
-            '/site-php\/my_custom_acquia-project\/my_custom_acquia-project-settings\.inc/',
           ]);
         }),
       ],

--- a/web/sites/default/includes/providers/settings.acquia.php
+++ b/web/sites/default/includes/providers/settings.acquia.php
@@ -19,13 +19,18 @@ if (!empty(getenv('AH_SITE_ENVIRONMENT'))) {
   $config['acquia_hosting_settings_autoconnect'] = FALSE;
 
   // Include Acquia environment settings.
-  if (file_exists('/var/www/site-php/your_site/your_site-settings.inc')) {
-    // @codeCoverageIgnoreStart
-    // @phpstan-ignore-next-line
-    require '/var/www/site-php/your_site/your_site-settings.inc';
-    // @codeCoverageIgnoreEnd
+  // The path is built dynamically from the AH_SITE_GROUP environment variable
+  // provided by Acquia Cloud.
+  $ah_site_group = getenv('AH_SITE_GROUP');
+  // @codeCoverageIgnoreStart
+  if (!empty($ah_site_group)) {
+    $ah_settings_file = sprintf('/var/www/site-php/%s/%s-settings.inc', $ah_site_group, $ah_site_group);
+    if (!file_exists($ah_settings_file)) {
+      throw new \RuntimeException(sprintf('Acquia settings file "%s" not found. Check Acquia Cloud environment configuration.', $ah_settings_file));
+    }
+    require $ah_settings_file;
   }
-
+  // @codeCoverageIgnoreEnd
   // Set the config sync directory to a `config_vcs_directory`, but still
   // allow overriding it with the DRUPAL_CONFIG_PATH environment variable.
   if (!empty($settings['config_vcs_directory'])) {


### PR DESCRIPTION
Closes #2202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Configuration loading now supports environment-based site group values instead of relying on hardcoded paths.
  * Added deprecation notices guiding users away from legacy discovery sources.

* **Bug Fixes**
  * Improved error reporting when expected configuration files are missing.
  * Maintained backward compatibility to avoid breaking existing setups.

* **Tests**
  * Updated functional tests to reflect the new configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->