### PR TITLE
[#2261] Fixed Acquia settings to allow `DRUPAL_CONFIG_PATH` override independently of `config_vcs_directory`.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/sites/default/includes/providers/settings.acquia.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/sites/default/includes/providers/settings.acquia.php
@@ -31,22 +31,12 @@ if (!empty(getenv('AH_SITE_ENVIRONMENT'))) {
     require $ah_settings_file;
   }
   // @codeCoverageIgnoreEnd
-  // Set the config sync directory to a `config_vcs_directory`, but still
-  // allow overriding it with the DRUPAL_CONFIG_PATH environment variable.
-  if (!empty($settings['config_vcs_directory'])) {
-    $settings['config_sync_directory'] = getenv('DRUPAL_CONFIG_PATH') ?: $settings['config_vcs_directory'];
-  }
-
-  // Automatically create an Apache HTTP .htaccess file in writable directories.
-  $settings['auto_create_htaccess'] = TRUE;
-
   // Default all environments to 'dev', including ODE environments.
   $settings['environment'] = ENVIRONMENT_DEV;
 
   // Do not put any Acquia-specific settings in this code block. It is used
   // to explicitly map Acquia environments to $settings['environment']
   // variable only.
-  // Instead, use 'PER-ENVIRONMENT SETTINGS' section below.
   switch (getenv('AH_SITE_ENVIRONMENT')) {
     case 'prod':
       $settings['environment'] = ENVIRONMENT_PROD;
@@ -57,4 +47,18 @@ if (!empty(getenv('AH_SITE_ENVIRONMENT'))) {
       $settings['environment'] = ENVIRONMENT_STAGE;
       break;
   }
+
+  // Override the config sync directory with the DRUPAL_CONFIG_PATH environment
+  // variable if provided, or fall back to the config_vcs_directory setting
+  // provided by Acquia.
+  $drupal_config_path = getenv('DRUPAL_CONFIG_PATH');
+  if (!empty($drupal_config_path)) {
+    $settings['config_sync_directory'] = $drupal_config_path;
+  }
+  elseif (!empty($settings['config_vcs_directory'])) {
+    $settings['config_sync_directory'] = $settings['config_vcs_directory'];
+  }
+
+  // Automatically create an Apache HTTP .htaccess file in writable directories.
+  $settings['auto_create_htaccess'] = TRUE;
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/tests/phpunit/Drupal/EnvironmentSettingsTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/tests/phpunit/Drupal/EnvironmentSettingsTest.php
@@ -49,7 +49,7 @@
      ];
    }
  
-@@ -315,6 +359,177 @@
+@@ -315,6 +359,221 @@
      $settings['skip_permissions_hardening'] = TRUE;
      $settings['config_sync_directory'] = '../config/default';
      $settings['suspend_mail_send'] = TRUE;
@@ -222,6 +222,50 @@
 +      'bower_components',
 +    ];
 +    $settings['config_sync_directory'] = '../config/default';
++    $settings['hash_salt'] = hash('sha256', getenv('DATABASE_HOST') ?: 'localhost');
++    $settings['maintenance_theme'] = 'claro';
++    $settings['trusted_host_patterns'] = [
++      '^localhost$',
++    ];
++    $this->assertSettings($settings);
++  }
++
++  /**
++   * Test Acquia config_sync_directory override with DRUPAL_CONFIG_PATH.
++   */
++  public function testEnvironmentAcquiaConfigPathOverride(): void {
++    $this->setEnvVars([
++      'AH_SITE_ENVIRONMENT' => 1,
++      'DRUPAL_CONFIG_PATH' => 'custom_acquia_config',
++    ]);
++
++    $this->requireSettingsFile();
++
++    $config['acquia_hosting_settings_autoconnect'] = FALSE;
++    $config['config_split.config_split.dev']['status'] = TRUE;
++    $config['environment_indicator.indicator']['bg_color'] = '#4caf50';
++    $config['environment_indicator.indicator']['fg_color'] = '#000000';
++    $config['environment_indicator.indicator']['name'] = self::ENVIRONMENT_DEV;
++    $config['environment_indicator.settings']['favicon'] = TRUE;
++    $config['environment_indicator.settings']['toolbar_integration'] = [TRUE];
++    $config['robotstxt.settings']['content'] = "User-agent: *\nDisallow: /";
++    $config['shield.settings']['shield_enable'] = TRUE;
++    $config['system.performance']['cache']['page']['max_age'] = 900;
++    $this->assertConfig($config);
++
++    $settings['auto_create_htaccess'] = TRUE;
++    $settings['config_exclude_modules'] = [];
++    $settings['config_sync_directory'] = 'custom_acquia_config';
++    $settings['container_yamls'][0] = $this->app_root . '/' . $this->site_path . '/services.yml';
++    $settings['entity_update_batch_size'] = 50;
++    $settings['environment'] = self::ENVIRONMENT_DEV;
++    $settings['file_public_path'] = 'sites/default/files';
++    $settings['file_private_path'] = 'sites/default/files/private';
++    $settings['file_temp_path'] = '/tmp';
++    $settings['file_scan_ignore_directories'] = [
++      'node_modules',
++      'bower_components',
++    ];
 +    $settings['hash_salt'] = hash('sha256', getenv('DATABASE_HOST') ?: 'localhost');
 +    $settings['maintenance_theme'] = 'claro';
      $settings['trusted_host_patterns'] = [

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/sites/default/includes/providers/settings.acquia.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/sites/default/includes/providers/settings.acquia.php
@@ -31,22 +31,12 @@ if (!empty(getenv('AH_SITE_ENVIRONMENT'))) {
     require $ah_settings_file;
   }
   // @codeCoverageIgnoreEnd
-  // Set the config sync directory to a `config_vcs_directory`, but still
-  // allow overriding it with the DRUPAL_CONFIG_PATH environment variable.
-  if (!empty($settings['config_vcs_directory'])) {
-    $settings['config_sync_directory'] = getenv('DRUPAL_CONFIG_PATH') ?: $settings['config_vcs_directory'];
-  }
-
-  // Automatically create an Apache HTTP .htaccess file in writable directories.
-  $settings['auto_create_htaccess'] = TRUE;
-
   // Default all environments to 'dev', including ODE environments.
   $settings['environment'] = ENVIRONMENT_DEV;
 
   // Do not put any Acquia-specific settings in this code block. It is used
   // to explicitly map Acquia environments to $settings['environment']
   // variable only.
-  // Instead, use 'PER-ENVIRONMENT SETTINGS' section below.
   switch (getenv('AH_SITE_ENVIRONMENT')) {
     case 'prod':
       $settings['environment'] = ENVIRONMENT_PROD;
@@ -57,4 +47,18 @@ if (!empty(getenv('AH_SITE_ENVIRONMENT'))) {
       $settings['environment'] = ENVIRONMENT_STAGE;
       break;
   }
+
+  // Override the config sync directory with the DRUPAL_CONFIG_PATH environment
+  // variable if provided, or fall back to the config_vcs_directory setting
+  // provided by Acquia.
+  $drupal_config_path = getenv('DRUPAL_CONFIG_PATH');
+  if (!empty($drupal_config_path)) {
+    $settings['config_sync_directory'] = $drupal_config_path;
+  }
+  elseif (!empty($settings['config_vcs_directory'])) {
+    $settings['config_sync_directory'] = $settings['config_vcs_directory'];
+  }
+
+  // Automatically create an Apache HTTP .htaccess file in writable directories.
+  $settings['auto_create_htaccess'] = TRUE;
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/tests/phpunit/Drupal/EnvironmentSettingsTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/tests/phpunit/Drupal/EnvironmentSettingsTest.php
@@ -49,7 +49,7 @@
      ];
    }
  
-@@ -315,6 +359,177 @@
+@@ -315,6 +359,221 @@
      $settings['skip_permissions_hardening'] = TRUE;
      $settings['config_sync_directory'] = '../config/default';
      $settings['suspend_mail_send'] = TRUE;
@@ -222,6 +222,50 @@
 +      'bower_components',
 +    ];
 +    $settings['config_sync_directory'] = '../config/default';
++    $settings['hash_salt'] = hash('sha256', getenv('DATABASE_HOST') ?: 'localhost');
++    $settings['maintenance_theme'] = 'claro';
++    $settings['trusted_host_patterns'] = [
++      '^localhost$',
++    ];
++    $this->assertSettings($settings);
++  }
++
++  /**
++   * Test Acquia config_sync_directory override with DRUPAL_CONFIG_PATH.
++   */
++  public function testEnvironmentAcquiaConfigPathOverride(): void {
++    $this->setEnvVars([
++      'AH_SITE_ENVIRONMENT' => 1,
++      'DRUPAL_CONFIG_PATH' => 'custom_acquia_config',
++    ]);
++
++    $this->requireSettingsFile();
++
++    $config['acquia_hosting_settings_autoconnect'] = FALSE;
++    $config['config_split.config_split.dev']['status'] = TRUE;
++    $config['environment_indicator.indicator']['bg_color'] = '#4caf50';
++    $config['environment_indicator.indicator']['fg_color'] = '#000000';
++    $config['environment_indicator.indicator']['name'] = self::ENVIRONMENT_DEV;
++    $config['environment_indicator.settings']['favicon'] = TRUE;
++    $config['environment_indicator.settings']['toolbar_integration'] = [TRUE];
++    $config['robotstxt.settings']['content'] = "User-agent: *\nDisallow: /";
++    $config['shield.settings']['shield_enable'] = TRUE;
++    $config['system.performance']['cache']['page']['max_age'] = 900;
++    $this->assertConfig($config);
++
++    $settings['auto_create_htaccess'] = TRUE;
++    $settings['config_exclude_modules'] = [];
++    $settings['config_sync_directory'] = 'custom_acquia_config';
++    $settings['container_yamls'][0] = $this->app_root . '/' . $this->site_path . '/services.yml';
++    $settings['entity_update_batch_size'] = 50;
++    $settings['environment'] = self::ENVIRONMENT_DEV;
++    $settings['file_public_path'] = 'sites/default/files';
++    $settings['file_private_path'] = 'sites/default/files/private';
++    $settings['file_temp_path'] = '/tmp';
++    $settings['file_scan_ignore_directories'] = [
++      'node_modules',
++      'bower_components',
++    ];
 +    $settings['hash_salt'] = hash('sha256', getenv('DATABASE_HOST') ?: 'localhost');
 +    $settings['maintenance_theme'] = 'claro';
      $settings['trusted_host_patterns'] = [

--- a/tests/phpunit/Drupal/EnvironmentSettingsTest.php
+++ b/tests/phpunit/Drupal/EnvironmentSettingsTest.php
@@ -774,6 +774,50 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     ];
     $this->assertSettings($settings);
   }
+
+  /**
+   * Test Acquia config_sync_directory override with DRUPAL_CONFIG_PATH.
+   */
+  public function testEnvironmentAcquiaConfigPathOverride(): void {
+    $this->setEnvVars([
+      'AH_SITE_ENVIRONMENT' => 1,
+      'DRUPAL_CONFIG_PATH' => 'custom_acquia_config',
+    ]);
+
+    $this->requireSettingsFile();
+
+    $config['acquia_hosting_settings_autoconnect'] = FALSE;
+    $config['config_split.config_split.dev']['status'] = TRUE;
+    $config['environment_indicator.indicator']['bg_color'] = '#4caf50';
+    $config['environment_indicator.indicator']['fg_color'] = '#000000';
+    $config['environment_indicator.indicator']['name'] = self::ENVIRONMENT_DEV;
+    $config['environment_indicator.settings']['favicon'] = TRUE;
+    $config['environment_indicator.settings']['toolbar_integration'] = [TRUE];
+    $config['robotstxt.settings']['content'] = "User-agent: *\nDisallow: /";
+    $config['shield.settings']['shield_enable'] = TRUE;
+    $config['system.performance']['cache']['page']['max_age'] = 900;
+    $this->assertConfig($config);
+
+    $settings['auto_create_htaccess'] = TRUE;
+    $settings['config_exclude_modules'] = [];
+    $settings['config_sync_directory'] = 'custom_acquia_config';
+    $settings['container_yamls'][0] = $this->app_root . '/' . $this->site_path . '/services.yml';
+    $settings['entity_update_batch_size'] = 50;
+    $settings['environment'] = self::ENVIRONMENT_DEV;
+    $settings['file_public_path'] = 'sites/default/files';
+    $settings['file_private_path'] = 'sites/default/files/private';
+    $settings['file_temp_path'] = '/tmp';
+    $settings['file_scan_ignore_directories'] = [
+      'node_modules',
+      'bower_components',
+    ];
+    $settings['hash_salt'] = hash('sha256', getenv('DATABASE_HOST') ?: 'localhost');
+    $settings['maintenance_theme'] = 'claro';
+    $settings['trusted_host_patterns'] = [
+      '^localhost$',
+    ];
+    $this->assertSettings($settings);
+  }
   // phpcs:ignore #;> SETTINGS_PROVIDER_ACQUIA
   // phpcs:ignore #;< SETTINGS_PROVIDER_LAGOON
   /**

--- a/web/sites/default/includes/providers/settings.acquia.php
+++ b/web/sites/default/includes/providers/settings.acquia.php
@@ -31,22 +31,12 @@ if (!empty(getenv('AH_SITE_ENVIRONMENT'))) {
     require $ah_settings_file;
   }
   // @codeCoverageIgnoreEnd
-  // Set the config sync directory to a `config_vcs_directory`, but still
-  // allow overriding it with the DRUPAL_CONFIG_PATH environment variable.
-  if (!empty($settings['config_vcs_directory'])) {
-    $settings['config_sync_directory'] = getenv('DRUPAL_CONFIG_PATH') ?: $settings['config_vcs_directory'];
-  }
-
-  // Automatically create an Apache HTTP .htaccess file in writable directories.
-  $settings['auto_create_htaccess'] = TRUE;
-
   // Default all environments to 'dev', including ODE environments.
   $settings['environment'] = ENVIRONMENT_DEV;
 
   // Do not put any Acquia-specific settings in this code block. It is used
   // to explicitly map Acquia environments to $settings['environment']
   // variable only.
-  // Instead, use 'PER-ENVIRONMENT SETTINGS' section below.
   switch (getenv('AH_SITE_ENVIRONMENT')) {
     case 'prod':
       $settings['environment'] = ENVIRONMENT_PROD;
@@ -57,4 +47,18 @@ if (!empty(getenv('AH_SITE_ENVIRONMENT'))) {
       $settings['environment'] = ENVIRONMENT_STAGE;
       break;
   }
+
+  // Override the config sync directory with the DRUPAL_CONFIG_PATH environment
+  // variable if provided, or fall back to the config_vcs_directory setting
+  // provided by Acquia.
+  $drupal_config_path = getenv('DRUPAL_CONFIG_PATH');
+  if (!empty($drupal_config_path)) {
+    $settings['config_sync_directory'] = $drupal_config_path;
+  }
+  elseif (!empty($settings['config_vcs_directory'])) {
+    $settings['config_sync_directory'] = $settings['config_vcs_directory'];
+  }
+
+  // Automatically create an Apache HTTP .htaccess file in writable directories.
+  $settings['auto_create_htaccess'] = TRUE;
 }


### PR DESCRIPTION
Closes #2261


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for configuration path override behavior in Acquia environments.

* **Refactor**
  * Reorganized configuration sync directory and automatic htaccess handling for clearer, consolidated initialization while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->