### PR TITLE
[#1913] Allow to modify Drush PHP runtime configuration

### DIFF
--- a/.docker/cli.dockerfile
+++ b/.docker/cli.dockerfile
@@ -44,6 +44,11 @@ ENV COMPOSER_ALLOW_SUPERUSER=1 \
     SIMPLETEST_BASE_URL=http://nginx:8080 \
     SYMFONY_DEPRECATIONS_HELPER=disabled
 
+# Allow custom PHP runtime configuration for Drush CLI commands.
+# The leading colon appends to the default scan directories.
+# @see https://github.com/drevops/vortex/issues/1913
+ENV PHP_INI_SCAN_DIR="${PHP_INI_SCAN_DIR}:/app/drush/php-ini"
+
 # Starting from this line, Docker adds the result of each command as a
 # separate layer. These layers are cached and reused when the project is
 # rebuilt. Layers are only rebuilt if the files added with `ADD` have changed

--- a/.vortex/docs/content/tools/drush.mdx
+++ b/.vortex/docs/content/tools/drush.mdx
@@ -41,6 +41,33 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
+## PHP runtime configuration
+
+Vortex allows you to customize PHP runtime settings for Drush CLI commands
+by editing the `drush/php-ini/drush.ini` file.
+
+This file is auto-discovered via the `PHP_INI_SCAN_DIR` environment variable,
+which is pre-configured in both the Docker CLI container and Acquia deployment
+hooks.
+
+For example, to increase the memory limit for Drush operations:
+
+```ini
+; drush/php-ini/drush.ini
+memory_limit = 512M
+```
+
+Any valid PHP ini directive can be added to this file to adjust the runtime
+behavior of Drush commands.
+
+:::note
+
+The leading colon in the `PHP_INI_SCAN_DIR` value preserves the default scan
+directories. On Acquia, this ensures that the hosting provider's own PHP ini
+overrides (such as `sendmail_path`) are not lost.
+
+:::
+
 ## Aliases
 
 For Lagoon hosting, Drush site aliases are automatically generated for each

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.docker/cli.dockerfile
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.docker/cli.dockerfile
@@ -44,6 +44,11 @@ ENV COMPOSER_ALLOW_SUPERUSER=1 \
     SIMPLETEST_BASE_URL=http://nginx:8080 \
     SYMFONY_DEPRECATIONS_HELPER=disabled
 
+# Allow custom PHP runtime configuration for Drush CLI commands.
+# The leading colon appends to the default scan directories.
+# @see https://github.com/drevops/vortex/issues/1913
+ENV PHP_INI_SCAN_DIR="${PHP_INI_SCAN_DIR}:/app/drush/php-ini"
+
 # Starting from this line, Docker adds the result of each command as a
 # separate layer. These layers are cached and reused when the project is
 # rebuilt. Layers are only rebuilt if the files added with `ADD` have changed

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/drush/php-ini/drush.ini
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/drush/php-ini/drush.ini
@@ -1,0 +1,9 @@
+; Custom PHP runtime configuration for Drush CLI commands.
+;
+; This file is auto-discovered via the PHP_INI_SCAN_DIR environment variable.
+; Modify the values below to adjust PHP runtime settings for Drush commands.
+;
+; @see https://github.com/drevops/vortex/issues/1913
+
+; Increase memory limit for Drush operations (database imports, config sync).
+memory_limit = 512M

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/provision.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/provision.sh
@@ -11,6 +11,12 @@ target_env="${2}"
 
 pushd "/var/www/html/${site}.${target_env}" >/dev/null || exit 1
 
+# Allow custom PHP runtime configuration for Drush CLI commands.
+# The leading colon appends to the default scan directories.
+# @see https://github.com/drevops/vortex/issues/1913
+PHP_INI_SCAN_DIR="${PHP_INI_SCAN_DIR:-}:$(pwd)/drush/php-ini"
+export PHP_INI_SCAN_DIR
+
 # Do not unblock admin account.
 export VORTEX_UNBLOCK_ADMIN="${VORTEX_UNBLOCK_ADMIN:-0}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/provision.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/provision.sh
@@ -11,6 +11,12 @@ target_env="${2}"
 
 pushd "/var/www/html/${site}.${target_env}" >/dev/null || exit 1
 
+# Allow custom PHP runtime configuration for Drush CLI commands.
+# The leading colon appends to the default scan directories.
+# @see https://github.com/drevops/vortex/issues/1913
+PHP_INI_SCAN_DIR="${PHP_INI_SCAN_DIR:-}:$(pwd)/drush/php-ini"
+export PHP_INI_SCAN_DIR
+
 # Do not unblock admin account.
 export VORTEX_UNBLOCK_ADMIN="${VORTEX_UNBLOCK_ADMIN:-0}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.docker/cli.dockerfile
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.docker/cli.dockerfile
@@ -7,7 +7,7 @@
  ENV DRUPAL_THEME=${DRUPAL_THEME}
  
  ARG VORTEX_FRONTEND_BUILD_SKIP="0"
-@@ -84,12 +84,5 @@
+@@ -89,12 +89,5 @@
  
  # Create file directories and set correct permissions.
  RUN mkdir -p -m 2775 "/app/${WEBROOT}/${DRUPAL_PUBLIC_FILES}" "/app/${WEBROOT}/${DRUPAL_PRIVATE_FILES}" "${DRUPAL_TEMPORARY_FILES}"

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.docker/cli.dockerfile
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.docker/cli.dockerfile
@@ -7,7 +7,7 @@
  ENV DRUPAL_THEME=${DRUPAL_THEME}
  
  ARG VORTEX_FRONTEND_BUILD_SKIP="0"
-@@ -84,12 +84,5 @@
+@@ -89,12 +89,5 @@
  
  # Create file directories and set correct permissions.
  RUN mkdir -p -m 2775 "/app/${WEBROOT}/${DRUPAL_PUBLIC_FILES}" "/app/${WEBROOT}/${DRUPAL_PRIVATE_FILES}" "${DRUPAL_TEMPORARY_FILES}"

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.docker/cli.dockerfile
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.docker/cli.dockerfile
@@ -7,7 +7,7 @@
  ENV DRUPAL_THEME=${DRUPAL_THEME}
  
  ARG VORTEX_FRONTEND_BUILD_SKIP="0"
-@@ -84,12 +84,5 @@
+@@ -89,12 +89,5 @@
  
  # Create file directories and set correct permissions.
  RUN mkdir -p -m 2775 "/app/${WEBROOT}/${DRUPAL_PUBLIC_FILES}" "/app/${WEBROOT}/${DRUPAL_PRIVATE_FILES}" "${DRUPAL_TEMPORARY_FILES}"

--- a/.vortex/tests/phpunit/Functional/DockerComposeWorkflowTest.php
+++ b/.vortex/tests/phpunit/Functional/DockerComposeWorkflowTest.php
@@ -37,6 +37,8 @@ class DockerComposeWorkflowTest extends FunctionalTestCase {
 
     $this->subtestDockerComposeTimezone();
 
+    $this->subtestDockerComposeDrushPhpIni();
+
     $this->subtestSolr();
 
     $this->logSubstep('Installing development dependencies');

--- a/drush/php-ini/drush.ini
+++ b/drush/php-ini/drush.ini
@@ -1,0 +1,9 @@
+; Custom PHP runtime configuration for Drush CLI commands.
+;
+; This file is auto-discovered via the PHP_INI_SCAN_DIR environment variable.
+; Modify the values below to adjust PHP runtime settings for Drush commands.
+;
+; @see https://github.com/drevops/vortex/issues/1913
+
+; Increase memory limit for Drush operations (database imports, config sync).
+memory_limit = 512M

--- a/hooks/library/provision.sh
+++ b/hooks/library/provision.sh
@@ -11,6 +11,12 @@ target_env="${2}"
 
 pushd "/var/www/html/${site}.${target_env}" >/dev/null || exit 1
 
+# Allow custom PHP runtime configuration for Drush CLI commands.
+# The leading colon appends to the default scan directories.
+# @see https://github.com/drevops/vortex/issues/1913
+PHP_INI_SCAN_DIR="${PHP_INI_SCAN_DIR:-}:$(pwd)/drush/php-ini"
+export PHP_INI_SCAN_DIR
+
 # Do not unblock admin account.
 export VORTEX_UNBLOCK_ADMIN="${VORTEX_UNBLOCK_ADMIN:-0}"
 


### PR DESCRIPTION
## Summary

- Added `drush/php-ini/drush.ini` with configurable PHP runtime settings (default: `memory_limit=512M`) that are auto-discovered via `PHP_INI_SCAN_DIR`.
- Updated `.docker/cli.dockerfile` to set `PHP_INI_SCAN_DIR` so the CLI container automatically picks up the custom ini file.
- Updated `hooks/library/provision.sh` to export `PHP_INI_SCAN_DIR` for Acquia deployments.
- Added documentation section in `.vortex/docs/content/tools/drush.mdx` explaining how to modify Drush PHP runtime configuration.
- Added Docker Compose workflow test in `SubtestDockerComposeTrait` that verifies ini values are applied and can be changed.

Closes #1913

## Test plan

- [ ] Verify `drush/php-ini/drush.ini` exists with `memory_limit = 512M`.
- [ ] Build Docker stack and verify `php -r "echo ini_get('memory_limit');"` returns `512M` inside the CLI container.
- [ ] Change `memory_limit` in `drush.ini`, sync to container, and verify the new value is picked up.
- [ ] Verify the workflow test `subtestDockerComposeDrushPhpIni()` passes in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drush now supports custom PHP runtime configuration, enabling adjustments like memory_limit to better handle heavy operations (imports, config sync).

* **Documentation**
  * Added a guide describing how to provide and auto-discover editable PHP settings for Drush and recommended practices to avoid overriding hosting defaults.

* **Tests**
  * Added functional tests to validate the custom PHP configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->