### PR TITLE
Add config to Renovate to update root FE deps.

### DIFF
--- a/.vortex/docs/content/tools/renovate.mdx
+++ b/.vortex/docs/content/tools/renovate.mdx
@@ -12,18 +12,19 @@ project.
 
 ## Features
 
-1. Dual schedules for Drupal package updates:
+1. Dual schedules for Drupal package updates (root `composer.json` only):
     - Daily update schedule for critical Drupal core and related packages created in
       the `deps/drupal-minor-patch-core` branch.
     - Weekly update schedule for all other packages created in
       the `deps/drupal-minor-patch-contrib` branch.
-2. Container image updates in `Dockerfile` and `docker-compose.yml` files in the `deps/docker` branch.
-3. GitHub Actions updates in the `deps/github-actions` branch.
-4. Automatically adds a `dependencies` label to a pull request.
-5. Automatically adds assignees to a pull request.
-6. Configuration for running Renovate self-hosted instance using CircleCI.
-7. Manual trigger from GitHub Actions UI and CircleCI pipeline.
-8. Debug logging enabled for detailed troubleshooting.
+2. npm/yarn package updates (root `package.json` only) in the `deps/npm-minor-patch` branch.
+3. Container image updates in `.docker/` directory in the `deps/docker` branch.
+4. GitHub Actions updates in the `deps/github-actions` branch.
+5. Automatically adds a `dependencies` label to a pull request.
+6. Automatically adds assignees to a pull request.
+7. Configuration for running Renovate self-hosted instance using CircleCI.
+8. Manual trigger from GitHub Actions UI and CircleCI pipeline.
+9. Debug logging enabled for detailed troubleshooting.
 
 ## Self-hosted vs GitHub app
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/renovate.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/renovate.json
@@ -15,6 +15,7 @@
     "configMigration": true,
     "enabledManagers": [
         "composer",
+        "npm",
         "dockerfile",
         "docker-compose",
         "github-actions",
@@ -88,6 +89,39 @@
                 "drupal/core-project-message",
                 "drupal/core-recommended",
                 "drupal/core-dev"
+            ]
+        },
+        {
+            "groupName": "Major npm - skipped to update manually",
+            "matchDatasources": [
+                "npm"
+            ],
+            "matchFileNames": [
+                "package.json"
+            ],
+            "matchUpdateTypes": [
+                "major"
+            ],
+            "enabled": false,
+            "matchPackageNames": [
+                "/.*/"
+            ]
+        },
+        {
+            "groupName": "Minor and Patch npm",
+            "groupSlug": "npm-minor-patch",
+            "matchDatasources": [
+                "npm"
+            ],
+            "matchFileNames": [
+                "package.json"
+            ],
+            "separateMinorPatch": false,
+            "schedule": [
+                "before 2am on Sunday"
+            ],
+            "matchPackageNames": [
+                "/.*/"
             ]
         },
         {

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,7 @@
     "configMigration": true,
     "enabledManagers": [
         "composer",
+        "npm",
         "dockerfile",
         "docker-compose",
         "github-actions",
@@ -88,6 +89,39 @@
                 "drupal/core-project-message",
                 "drupal/core-recommended",
                 "drupal/core-dev"
+            ]
+        },
+        {
+            "groupName": "Major npm - skipped to update manually",
+            "matchDatasources": [
+                "npm"
+            ],
+            "matchFileNames": [
+                "package.json"
+            ],
+            "matchUpdateTypes": [
+                "major"
+            ],
+            "enabled": false,
+            "matchPackageNames": [
+                "/.*/"
+            ]
+        },
+        {
+            "groupName": "Minor and Patch npm",
+            "groupSlug": "npm-minor-patch",
+            "matchDatasources": [
+                "npm"
+            ],
+            "matchFileNames": [
+                "package.json"
+            ],
+            "separateMinorPatch": false,
+            "schedule": [
+                "before 2am on Sunday"
+            ],
+            "matchPackageNames": [
+                "/.*/"
             ]
         },
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * npm/yarn package dependencies are now automatically managed by Renovate, with minor and patch updates scheduled automatically and major updates requiring manual review.

* **Documentation**
  * Updated Renovate documentation to clarify supported dependency types and automation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->