### PR TITLE
Disabled Renovate for .vortex.

### DIFF
--- a/.vortex/installer/src/Prompts/Handlers/DependencyUpdatesProvider.php
+++ b/.vortex/installer/src/Prompts/Handlers/DependencyUpdatesProvider.php
@@ -79,10 +79,12 @@ class DependencyUpdatesProvider extends AbstractHandler {
     if ($v === self::RENOVATEBOT_CI) {
       File::removeTokenAsync('!DEPS_UPDATE_PROVIDER_CI');
       File::removeTokenAsync('DEPS_UPDATE_PROVIDER_APP');
+      File::replaceContentInFile($t . '/renovate.json', '/\s*"ignorePaths":\s*\[\s*"[^"]*"\s*\],?\n/s', "\n");
     }
     elseif ($v === self::RENOVATEBOT_APP) {
       File::removeTokenAsync('!DEPS_UPDATE_PROVIDER_APP');
       File::removeTokenAsync('DEPS_UPDATE_PROVIDER_CI');
+      File::replaceContentInFile($t . '/renovate.json', '/\s*"ignorePaths":\s*\[\s*"[^"]*"\s*\],?\n/s', "\n");
       @unlink($t . '/.github/workflows/update-dependencies.yml');
     }
     else {

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,9 @@
     "rangeStrategy": "bump",
     "timezone": "UTC",
     "configMigration": true,
+    "ignorePaths": [
+        ".vortex/**"
+    ],
     "enabledManagers": [
         "composer",
         "npm",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Renovate dependency updates now exclude the .vortex directory from processing, preventing unnecessary updates in internal configuration files.
  * Improved Renovate configuration handling when selecting CI or App provider options to ensure appropriate settings are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->