### PR TITLE
Remove the Docker builder cache to free up CI container space.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -68,7 +68,7 @@ commands:
   up:
     usage: Build and start containers.
     cmd: |
-      docker compose up -d "$@"
+      docker compose up --detach "$@"
       if docker compose logs | grep -q "\[Error\]"; then exit 1; fi
 
   down:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -262,7 +262,7 @@ jobs:
         continue-on-error: ${{ vars.VORTEX_CI_DCLINT_IGNORE_FAILURE == '1' }}
 
       - name: Build stack
-        run: docker compose up -d
+        run: docker compose up --detach && docker builder prune --all --force
 
       - name: Export built codebase
         if: ${{ matrix.instance == 0 && !startsWith(github.head_ref || github.ref_name, 'deps/') && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
@@ -50,7 +50,7 @@ commands:
   up:
     usage: Build and start containers.
     cmd: |
-      docker compose up -d "$@"
+      docker compose up --detach "$@"
       if docker compose logs | grep -q "\[Error\]"; then exit 1; fi
 
   down:

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -239,7 +239,7 @@ jobs:
         continue-on-error: ${{ vars.VORTEX_CI_DCLINT_IGNORE_FAILURE == '1' }}
 
       - name: Build stack
-        run: docker compose up -d
+        run: docker compose up --detach && docker builder prune --all --force
 
       - name: Export built codebase
         if: ${{ matrix.instance == 0 && !startsWith(github.head_ref || github.ref_name, 'deps/') && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -252,7 +252,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up -d
+          command: docker compose up --detach && docker builder prune --all --force
 
       - run:
           name: Export built codebase


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Docker container startup configuration in deployment pipelines
  * Added automated build cache cleanup during stack initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->