### PR TITLE
Simplified provision to use direct commands.

### DIFF
--- a/.vortex/docs/content/drupal/provision.mdx
+++ b/.vortex/docs/content/drupal/provision.mdx
@@ -16,11 +16,12 @@ in every environment, ensuring consistency and eliminating manual steps.
 
 ## Rationale
 
-While `drush deploy` is a powerful tool for executing standard Drupal deployment
-steps (such as configuration import and database updates), it assumes that the
-site is already in a bootstrapped, stable state. In practice, especially during
-initial setup or provisioning in dynamic environments (like CI pipelines,
-container builds, or multisite setups), additional orchestration is needed.
+While Drush provides individual commands for deployment steps (such as
+`drush updatedb`, `drush config:import`, and `drush deploy:hook`), using them
+directly assumes the site is already in a bootstrapped, stable state. In
+practice, especially during initial setup or provisioning in dynamic
+environments (like CI pipelines, container builds, or multisite setups),
+additional orchestration is needed.
 
 The `provision.sh` script addresses these gaps by:
 
@@ -29,13 +30,13 @@ profile.
 - **Handling conditional logic:** It accounts for different runtime scenarios, such as skipping provisioning,
 enforcing fresh database imports, or using maintenance mode.
 - **Enforcing consistency:** The same provisioning logic runs across local, CI, staging, and production
-environments, eliminating “it works on my machine” issues.
+environments, eliminating "it works on my machine" issues.
 - **Supporting extensibility:** It allows for custom post-provisioning scripts, making it easy to layer in
 project-specific logic like enabling test modules or running migrations.
 
-In short, `provision.sh` wraps `drush deploy` in a consistent, repeatable, and
-configurable process — turning a manual setup step into a reliable automation
-layer.
+In short, `provision.sh` orchestrates standalone Drush commands in a consistent,
+repeatable, and configurable process — turning a manual setup step into a
+reliable automation layer.
 
 ## Database import vs full provisioning
 
@@ -46,10 +47,11 @@ layer.
 Runs the complete provisioning process including:
 
 - Database import from dump or profile installation
-- Configuration import via `drush config:import`
 - Database updates via `drush updatedb`
-- Post-provisioning custom scripts
+- Configuration import via `drush config:import` (if config files present)
 - Cache rebuilds
+- Deployment hooks
+- Post-provisioning custom scripts
 
 Use this when you want a fully configured site ready for development or deployment.
 
@@ -129,13 +131,13 @@ section.
    ▼
 ⑥ 🚧 Enable maintenance mode
    ▼
-   ⬇️ Import configuration
-   ▼
    🔄 Run DB updates
+   ▼
+   ⬇️ Import configuration (if config files present)
    ▼
    🧹 Rebuild caches
    ▼
-   🔄 Run deployment operations
+   🔄 Run deployment hooks
    ▼
 ⑦ 😷 Run DB sanitization
    ▼

--- a/.vortex/tests/bats/unit/provision.bats
+++ b/.vortex/tests/bats/unit/provision.bats
@@ -105,7 +105,7 @@ assert_provision_info() {
 
     # Deployment and configuration updates.
     "- Updated site UUID from the configuration with"
-    "- Running deployment operations via 'drush deploy'."
+    "- Importing configuration."
     "- Importing config_split configuration."
 
     # Database updates.
@@ -118,10 +118,10 @@ assert_provision_info() {
     "@drush -y cache:rebuild"
     "Cache was rebuilt."
 
-    # Post configuration import updates.
-    "Running deployment operations via 'drush deploy:hook'."
+    # Deployment hooks.
+    "Running deployment hooks."
     "@drush -y deploy:hook"
-    "Completed deployment operations via 'drush deploy:hook'."
+    "Completed deployment hooks."
 
     # Database sanitization.
     "Sanitizing database."
@@ -239,7 +239,7 @@ assert_provision_info() {
 
     # Deployment and configuration updates.
     "- Updated site UUID from the configuration with"
-    "- Running deployment operations via 'drush deploy'."
+    "- Importing configuration."
     "- Importing config_split configuration."
 
     # Database updates.
@@ -252,10 +252,10 @@ assert_provision_info() {
     "@drush -y cache:rebuild"
     "Cache was rebuilt."
 
-    # Post configuration import updates.
-    "Running deployment operations via 'drush deploy:hook'."
+    # Deployment hooks.
+    "Running deployment hooks."
     "@drush -y deploy:hook"
-    "Completed deployment operations via 'drush deploy:hook'."
+    "Completed deployment hooks."
 
     # Database sanitization.
     "- Sanitizing database."
@@ -374,7 +374,7 @@ assert_provision_info() {
 
     # Deployment and configuration updates.
     "- Updated site UUID from the configuration with"
-    "- Running deployment operations via 'drush deploy'."
+    "- Importing configuration."
     "- Importing config_split configuration."
 
     # Database updates.
@@ -387,10 +387,10 @@ assert_provision_info() {
     "@drush -y cache:rebuild"
     "Cache was rebuilt."
 
-    # Post configuration import updates.
-    "Running deployment operations via 'drush deploy:hook'."
+    # Deployment hooks.
+    "Running deployment hooks."
     "@drush -y deploy:hook"
-    "Completed deployment operations via 'drush deploy:hook'."
+    "Completed deployment hooks."
 
     # Database sanitization.
     "Sanitizing database."
@@ -513,28 +513,33 @@ assert_provision_info() {
     "@drush -y maint:set 1"
     "Enabled maintenance mode."
 
-    # Deployment and configuration updates.
+    # UUID setup.
     "@drush -y config-set system.site uuid ${mocked_uuid}"
     "Updated site UUID from the configuration with ${mocked_uuid}"
-    "Running deployment operations via 'drush deploy'."
-    "@drush -y deploy"
-    "Completed deployment operations via 'drush deploy'."
+
+    # Database updates.
+    "Running database updates."
+    "@drush -y updatedb --no-cache-clear"
+    "Completed running database updates."
+
+    # Configuration import.
+    "Importing configuration."
+    "@drush -y config:import"
+    "Completed configuration import."
     "@drush -y pm:list --status=enabled # config_split"
     "Importing config_split configuration."
     "@drush -y config:import"
     "Completed config_split configuration import."
 
-    # Database updates.
-    "- Running database updates."
-    "- Completed running database updates."
-
     # Cache rebuild.
-    "- Rebuilding cache."
-    "- Cache was rebuilt."
+    "Rebuilding cache."
+    "@drush -y cache:rebuild"
+    "Cache was rebuilt."
 
-    # Post configuration import updates.
-    "- Running deployment operations via 'drush deploy:hook'."
-    "- Completed deployment operations via 'drush deploy:hook'."
+    # Deployment hooks.
+    "Running deployment hooks."
+    "@drush -y deploy:hook"
+    "Completed deployment hooks."
 
     # Database sanitization.
     "Sanitizing database."
@@ -657,7 +662,7 @@ assert_provision_info() {
 
     # Deployment and configuration updates.
     "- Updated site UUID from the configuration with"
-    "- Running deployment operations via 'drush deploy'."
+    "- Importing configuration."
     "- Importing config_split configuration."
 
     # Database updates.
@@ -670,10 +675,10 @@ assert_provision_info() {
     "@drush -y cache:rebuild"
     "Cache was rebuilt."
 
-    # Post configuration import updates.
-    "Running deployment operations via 'drush deploy:hook'."
+    # Deployment hooks.
+    "Running deployment hooks."
     "@drush -y deploy:hook"
-    "Completed deployment operations via 'drush deploy:hook'."
+    "Completed deployment hooks."
 
     # Database sanitization.
     "Sanitizing database."
@@ -794,7 +799,7 @@ assert_provision_info() {
 
     # Deployment and configuration updates.
     "- Updated site UUID from the configuration with"
-    "- Running deployment operations via 'drush deploy'."
+    "- Importing configuration."
     "- Importing config_split configuration."
 
     # Database updates.
@@ -807,10 +812,10 @@ assert_provision_info() {
     "@drush -y cache:rebuild"
     "Cache was rebuilt."
 
-    # Post configuration import updates.
-    "Running deployment operations via 'drush deploy:hook'."
+    # Deployment hooks.
+    "Running deployment hooks."
     "@drush -y deploy:hook"
-    "Completed deployment operations via 'drush deploy:hook'."
+    "Completed deployment hooks."
 
     # Database sanitization.
     "- Sanitizing database."
@@ -930,7 +935,7 @@ assert_provision_info() {
 
     # Deployment and configuration updates.
     "- Updated site UUID from the configuration with"
-    "- Running deployment operations via 'drush deploy'."
+    "- Importing configuration."
     "- Importing config_split configuration."
 
     # Database updates.
@@ -943,10 +948,10 @@ assert_provision_info() {
     "@drush -y cache:rebuild"
     "Cache was rebuilt."
 
-    # Post configuration import updates.
-    "Running deployment operations via 'drush deploy:hook'."
+    # Deployment hooks.
+    "Running deployment hooks."
     "@drush -y deploy:hook"
-    "Completed deployment operations via 'drush deploy:hook'."
+    "Completed deployment hooks."
 
     # Database sanitization.
     "Sanitizing database."
@@ -1066,7 +1071,7 @@ assert_provision_info() {
 
     # Deployment and configuration updates.
     "- Updated site UUID from the configuration with"
-    "- Running deployment operations via 'drush deploy'."
+    "- Importing configuration."
     "- Importing config_split configuration."
 
     # Database updates.
@@ -1079,10 +1084,10 @@ assert_provision_info() {
     "@drush -y cache:rebuild"
     "Cache was rebuilt."
 
-    # Post configuration import updates.
-    "Running deployment operations via 'drush deploy:hook'."
+    # Deployment hooks.
+    "Running deployment hooks."
     "@drush -y deploy:hook"
-    "Completed deployment operations via 'drush deploy:hook'."
+    "Completed deployment hooks."
 
     # Database sanitization.
     "Sanitizing database."
@@ -1233,7 +1238,7 @@ assert_provision_info() {
 
     # Deployment and configuration updates.
     "- Updated site UUID from the configuration with"
-    "- Running deployment operations via drush deploy."
+    "- Importing configuration."
     "- Importing config_split configuration."
 
     # Database updates.
@@ -1246,10 +1251,10 @@ assert_provision_info() {
     "@drush -y cache:rebuild"
     "Cache was rebuilt."
 
-    # Post configuration import updates.
-    "Running deployment operations via 'drush deploy:hook'."
+    # Deployment hooks.
+    "Running deployment hooks."
     "@drush -y deploy:hook"
-    "Completed deployment operations via 'drush deploy:hook'."
+    "Completed deployment hooks."
 
     # Database sanitization.
     "Sanitizing database."
@@ -1370,7 +1375,7 @@ assert_provision_info() {
 
     # Deployment and configuration updates.
     "- Updated site UUID from the configuration with"
-    "- Running deployment operations via drush deploy."
+    "- Importing configuration."
     "- Importing config_split configuration."
 
     # Database updates.
@@ -1383,10 +1388,10 @@ assert_provision_info() {
     "@drush -y cache:rebuild"
     "Cache was rebuilt."
 
-    # Post configuration import updates.
-    "Running deployment operations via 'drush deploy:hook'."
+    # Deployment hooks.
+    "Running deployment hooks."
     "@drush -y deploy:hook"
-    "Completed deployment operations via 'drush deploy:hook'."
+    "Completed deployment hooks."
 
     # Database sanitization.
     "Sanitizing database."

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -209,8 +209,8 @@ trait SubtestAhoyTrait {
       'ahoy provision',
       [
         'Provisioning site from the database dump file.',
-        "Running deployment operations via 'drush deploy:hook'.",
         'Running database updates.',
+        'Running deployment hooks.',
       ],
       'Initial provision should complete successfully'
     );
@@ -230,8 +230,7 @@ trait SubtestAhoyTrait {
       'ahoy provision',
       [
         '* Provisioning site from the database dump file.',
-        // @note 'drush deploy:hook' runs only if config files exist.
-        "* Running deployment operations via 'drush deploy'.",
+        '* Importing configuration.',
         '! Import the listed configuration changes',
         '* There are no changes to import',
       ],
@@ -253,7 +252,7 @@ trait SubtestAhoyTrait {
       'ahoy provision',
       [
         'Provisioning site from the database dump file.',
-        "Running deployment operations via 'drush deploy'.",
+        'Importing configuration.',
         'Import the listed configuration changes',
       ],
       'Provision with updated config should complete successfully'
@@ -267,7 +266,7 @@ trait SubtestAhoyTrait {
       'ahoy provision',
       [
         'Provisioning site from the database dump file.',
-        "Running deployment operations via 'drush deploy'.",
+        'Importing configuration.',
       ],
       'Provision without DB should complete successfully'
     );
@@ -326,7 +325,7 @@ trait SubtestAhoyTrait {
       arg: $has_argument ? [$filename] : [],
       out: [
         '* Provisioning site from the database dump file.',
-        "! Running deployment operations via 'drush deploy:hook'.",
+        '! Running deployment hooks.',
         '! Running database updates.',
       ],
       txt: 'Import database dump ' . ($has_argument ? sprintf("from file '%s'", $filename) : 'from the default file')


### PR DESCRIPTION
## Summary

Replaced `drush deploy` in `provision.sh` with standalone Drush commands to
allow inserting logic between individual provisioning steps (needed for #1654).

The two conditional branches (config files exist vs not) are now a single
linear flow:

1. `drush updatedb` — always runs
2. `drush config:import` — only when config files are present
3. `drush cache:rebuild` — always runs
4. `drush deploy:hook` — always runs

## Changes

- **`scripts/vortex/provision.sh`** — replaced the `if/else` branching that
  called `drush deploy` (config path) or standalone commands (no-config path)
  with a single linear flow using standalone commands, where `config:import`
  runs conditionally.
- **`.vortex/docs/content/drupal/provision.mdx`** — updated the provisioning
  flow diagram to reflect the new command order (DB updates before config
  import), marked config import as conditional, and updated the rationale text
  to remove references to wrapping `drush deploy`.
- **`.vortex/tests/bats/unit/provision.bats`** — updated all 14 test cases to
  match the new output messages and command mocks. The config test now mocks
  standalone `updatedb`, `config:import`, `cache:rebuild`, and `deploy:hook`
  instead of `drush deploy`.
- **`.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php`** — updated
  provision and import-db integration test assertions to match the new output
  messages.

## Test plan

- [x] All 14 BATS provision unit tests pass.
- [ ] PHPUnit integration tests pass (require Docker environment).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Drupal provisioning documentation to clarify deployment workflow steps.

* **Improvements**
  * Enhanced provisioning process messaging to display configuration imports and deployment hooks as distinct steps instead of combined operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->