### PR TITLE
Fixed PHPUnit to run only in the first CI container + docs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,56 @@ jobs:
       #;< TOOL_PHPUNIT
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+
+      - run:
+          name: Process PHPUnit logs and coverage
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+            fi
+
+      - run:
+          name: Check code coverage threshold
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
+            PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
+            echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
+            if [ "${PERCENT//./}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
+              echo "FAIL: coverage too low"
+              exit 1
+            fi
+
+      - run:
+          name: Post coverage summary as PR comment
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
+            [ -z "${CIRCLE_PULL_REQUEST}" ] && exit 0
+            [ -z "${GITHUB_TOKEN}" ] && exit 0
+            COVERAGE_CONTENT=$(sed '/./,$!d' /tmp/artifacts/coverage/phpunit/coverage.txt)
+            PR_NUMBER=$(echo "${CIRCLE_PULL_REQUEST}" | cut -d'/' -f 7)
+            REPO_SLUG="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+            curl -s -X POST \
+              -H "Authorization: token ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${REPO_SLUG}/issues/${PR_NUMBER}/comments" \
+              -d "$(jq -n --arg body "\`\`\`
+            ${COVERAGE_CONTENT}
+            \`\`\`" '{body: $body}')"
+
+      - run:
+          name: Upload code coverage reports to Codecov
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
+              codecov -Z -s /tmp/artifacts/coverage;
+            fi
       #;> TOOL_PHPUNIT
 
       #;< TOOL_BEHAT
@@ -408,45 +457,6 @@ jobs:
 
       - store_artifacts:
           path: *artifacts
-
-      #;< TOOL_PHPUNIT
-      - run:
-          name: Check code coverage threshold
-          command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
-            RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
-            PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
-            echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
-            if [ "${PERCENT//./}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
-              echo "FAIL: coverage too low"
-              exit 1
-            fi
-
-      - run:
-          name: Post coverage summary as PR comment
-          command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
-            [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
-            [ -z "${CIRCLE_PULL_REQUEST}" ] && exit 0
-            [ -z "${GITHUB_TOKEN}" ] && exit 0
-            COVERAGE_CONTENT=$(sed '/./,$!d' /tmp/artifacts/coverage/phpunit/coverage.txt)
-            PR_NUMBER=$(echo "${CIRCLE_PULL_REQUEST}" | cut -d'/' -f 7)
-            REPO_SLUG="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
-            curl -s -X POST \
-              -H "Authorization: token ${GITHUB_TOKEN}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              "https://api.github.com/repos/${REPO_SLUG}/issues/${PR_NUMBER}/comments" \
-              -d "$(jq -n --arg body "\`\`\`
-            ${COVERAGE_CONTENT}
-            \`\`\`" '{body: $body}')"
-      #;> TOOL_PHPUNIT
-
-      - run:
-          name: Upload code coverage reports to Codecov
-          command: |
-            if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
-              codecov -Z -s /tmp/artifacts/coverage;
-            fi
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -357,8 +357,51 @@ jobs:
 
       #;< TOOL_PHPUNIT
       - name: Test with PHPUnit
+        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
         run: docker compose exec -T cli vendor/bin/phpunit
         continue-on-error: ${{ vars.VORTEX_CI_PHPUNIT_IGNORE_FAILURE == '1' }}
+
+      - name: Process PHPUnit logs and coverage
+        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        run: |
+          mkdir -p ".logs"
+          if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+             docker compose cp cli:/app/.logs/. ".logs/"
+          fi
+
+      - name: Check code coverage threshold
+        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        run: |
+          RATE=$(grep -om1 'line-rate="[0-9.]*"' .logs/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
+          PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
+          echo "Coverage: $PERCENT% (threshold: $VORTEX_CI_CODE_COVERAGE_THRESHOLD%)" | tee -a "$GITHUB_STEP_SUMMARY"
+          if [ "${PERCENT//./}" -lt "$((VORTEX_CI_CODE_COVERAGE_THRESHOLD*100))" ]; then
+            echo "FAIL: coverage too low"
+            exit 1
+          fi
+          { echo "COVERAGE_CONTENT<<EOF"; sed '/./,$!d' .logs/coverage/phpunit/coverage.txt; echo "EOF"; } >> "$GITHUB_ENV"
+        env:
+          VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
+
+      - name: Post coverage summary as PR comment
+        if: ${{ github.event_name == 'pull_request' && (matrix.instance == 0 || strategy.job-total == 1) && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        with:
+          message: |
+            ```
+            ${{ env.COVERAGE_CONTENT }}
+            ```
+          hide_and_recreate: true
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        if: ${{ (matrix.instance == 0 || strategy.job-total == 1) && env.CODECOV_TOKEN != '' }}
+        with:
+          directory: .logs/coverage
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       #;> TOOL_PHPUNIT
 
       #;< TOOL_BEHAT
@@ -391,42 +434,6 @@ jobs:
           path: .logs
           include-hidden-files: true
           if-no-files-found: error
-
-      #;< TOOL_PHPUNIT
-      - name: Check code coverage threshold
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-        run: |
-          RATE=$(grep -om1 'line-rate="[0-9.]*"' .logs/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
-          PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
-          echo "Coverage: $PERCENT% (threshold: $VORTEX_CI_CODE_COVERAGE_THRESHOLD%)" | tee -a "$GITHUB_STEP_SUMMARY"
-          if [ "${PERCENT//./}" -lt "$((VORTEX_CI_CODE_COVERAGE_THRESHOLD*100))" ]; then
-            echo "FAIL: coverage too low"
-            exit 1
-          fi
-          { echo "COVERAGE_CONTENT<<EOF"; sed '/./,$!d' .logs/coverage/phpunit/coverage.txt; echo "EOF"; } >> "$GITHUB_ENV"
-        env:
-          VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
-
-      - name: Post coverage summary as PR comment
-        if: ${{ github.event_name == 'pull_request' && (matrix.instance == 0 || strategy.job-total == 1) && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
-        with:
-          message: |
-            ```
-            ${{ env.COVERAGE_CONTENT }}
-            ```
-          hide_and_recreate: true
-
-      - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
-        if: ${{ env.CODECOV_TOKEN != '' }}
-        with:
-          directory: .logs/coverage
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      #;> TOOL_PHPUNIT
 
       - name: Upload exported codebase as an artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6

--- a/.vortex/docs/content/continuous-integration/README.mdx
+++ b/.vortex/docs/content/continuous-integration/README.mdx
@@ -35,10 +35,10 @@ import CodeLifecycle from '../_code-lifecycle.mdx';
 - Validates Composer lock and audits dependencies
 - Assembles the codebase by installing dependencies
 - Provisions a website
-- Lints code (only on the first instance)
-- Runs unit tests
-- Runs BDD tests
-- Generates code coverage reports
+- Lints code (first instance only)
+- Runs PHPUnit tests (first instance only)
+- Checks code coverage and posts PR comment (first instance only)
+- Runs BDD tests (distributed across all instances)
 - Collects and stores test results and artifacts
 
 ### 3. Deployment
@@ -101,6 +101,64 @@ The continuous integration pipeline is triggered by:
 - **Pull requests** to these branches
 - **Tags** matching semantic version (`1.2.3`, `1.2.3-rc.1`) or date-based (`2023-04-17`) patterns
 - **Scheduled runs** for automatic database caching
+
+## Test parallelism
+
+The build job runs across multiple parallel containers (2 by default) to speed
+up test execution. Since each container runs the full build and provision
+steps, the test workload is distributed to make the best use of each container.
+
+### What runs where
+
+| Task | First container | Other containers |
+|------|:---:|:---:|
+| Code linting (PHPCS, PHPStan, Rector, etc.) | ✓ | — |
+| PHPUnit tests | ✓ | — |
+| Code coverage check and PR comment | ✓ | — |
+| Behat tests | ✓ (profile `p0`) | ✓ (profile `p1`, `p2`, ...) |
+
+Linting, PHPUnit, and coverage reporting run exclusively on the first container
+to avoid duplicate work. Behat tests run on all containers using profile-based
+distribution.
+
+### Balancing Behat tests
+
+Because the first container handles linting, PHPUnit, and coverage in addition
+to Behat tests, it has more work to do than the other containers. To keep
+overall build time low, assign more Behat scenarios to the non-first containers.
+
+Behat scenarios are assigned to containers using profile tags. Tag a scenario
+with `@p0` to run it on the first container or `@p1` to run it on the second:
+
+```gherkin
+@p0
+Scenario: Quick smoke test
+  Given I go to the homepage
+  Then I should see "Welcome"
+
+@p1
+Scenario: Full content workflow
+  Given I am logged in as a content editor
+  ...
+```
+
+Scenarios without a profile tag default to the first container. When only one
+container is available, all scenarios run regardless of tags.
+
+:::tip
+
+As a rule of thumb, keep lightweight or smoke-test scenarios on the first
+container (`@p0`) and move heavier or more numerous scenarios to additional
+containers (`@p1`, `@p2`, etc.). This keeps the total build time closer to the
+duration of the longest single container rather than the sum of all tests.
+
+:::
+
+See the provider-specific pages for how to change the number of parallel
+containers:
+
+- [CircleCI — Change test parallelism](/docs/continuous-integration/circleci#change-test-parallelism)
+- [GitHub Actions — Change test parallelism](/docs/continuous-integration/github-actions#change-test-parallelism)
 
 ## Maintenance
 

--- a/.vortex/docs/content/continuous-integration/circleci.mdx
+++ b/.vortex/docs/content/continuous-integration/circleci.mdx
@@ -146,6 +146,14 @@ build:
   parallelism: 4  # Run tests across 4 containers
 ```
 
+When adding more containers, distribute Behat scenarios across them using
+profile tags (`@p0`, `@p1`, `@p2`, etc.) in your feature files. Since the first
+container also runs linting, PHPUnit, and coverage, assign more Behat scenarios
+to the additional containers to keep build times balanced.
+
+See [Test parallelism](/docs/continuous-integration#test-parallelism) for details
+on how tests are distributed across containers.
+
 ### SSH access for debugging
 
 CircleCI provides built-in SSH access to debug failing builds. Click the

--- a/.vortex/docs/content/continuous-integration/github-actions.mdx
+++ b/.vortex/docs/content/continuous-integration/github-actions.mdx
@@ -141,6 +141,14 @@ strategy:
     instance: [0, 1, 2, 3]  # Run tests across 4 containers
 ```
 
+When adding more containers, distribute Behat scenarios across them using
+profile tags (`@p0`, `@p1`, `@p2`, etc.) in your feature files. Since the first
+container also runs linting, PHPUnit, and coverage, assign more Behat scenarios
+to the additional containers to keep build times balanced.
+
+See [Test parallelism](/docs/continuous-integration#test-parallelism) for details
+on how tests are distributed across containers.
+
 ### Terminal access for debugging
 
 The workflow includes a `tmate` session for debugging. Trigger a manual workflow

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -315,8 +315,51 @@ jobs:
         timeout-minutes: 30
 
       - name: Test with PHPUnit
+        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
         run: docker compose exec -T cli vendor/bin/phpunit
         continue-on-error: ${{ vars.VORTEX_CI_PHPUNIT_IGNORE_FAILURE == '1' }}
+
+      - name: Process PHPUnit logs and coverage
+        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        run: |
+          mkdir -p ".logs"
+          if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+             docker compose cp cli:/app/.logs/. ".logs/"
+          fi
+
+      - name: Check code coverage threshold
+        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        run: |
+          RATE=$(grep -om1 'line-rate="[0-9.]*"' .logs/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
+          PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
+          echo "Coverage: $PERCENT% (threshold: $VORTEX_CI_CODE_COVERAGE_THRESHOLD%)" | tee -a "$GITHUB_STEP_SUMMARY"
+          if [ "${PERCENT//./}" -lt "$((VORTEX_CI_CODE_COVERAGE_THRESHOLD*100))" ]; then
+            echo "FAIL: coverage too low"
+            exit 1
+          fi
+          { echo "COVERAGE_CONTENT<<EOF"; sed '/./,$!d' .logs/coverage/phpunit/coverage.txt; echo "EOF"; } >> "$GITHUB_ENV"
+        env:
+          VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
+
+      - name: Post coverage summary as PR comment
+        if: ${{ github.event_name == 'pull_request' && (matrix.instance == 0 || strategy.job-total == 1) && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
+        uses: marocchino/sticky-pull-request-comment@__HASH__ # __VERSION__
+        with:
+          message: |
+            ```
+            ${{ env.COVERAGE_CONTENT }}
+            ```
+          hide_and_recreate: true
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@__HASH__ # __VERSION__
+        if: ${{ (matrix.instance == 0 || strategy.job-total == 1) && env.CODECOV_TOKEN != '' }}
+        with:
+          directory: .logs/coverage
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Test with Behat
         run: |
@@ -346,40 +389,6 @@ jobs:
           path: .logs
           include-hidden-files: true
           if-no-files-found: error
-
-      - name: Check code coverage threshold
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-        run: |
-          RATE=$(grep -om1 'line-rate="[0-9.]*"' .logs/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
-          PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
-          echo "Coverage: $PERCENT% (threshold: $VORTEX_CI_CODE_COVERAGE_THRESHOLD%)" | tee -a "$GITHUB_STEP_SUMMARY"
-          if [ "${PERCENT//./}" -lt "$((VORTEX_CI_CODE_COVERAGE_THRESHOLD*100))" ]; then
-            echo "FAIL: coverage too low"
-            exit 1
-          fi
-          { echo "COVERAGE_CONTENT<<EOF"; sed '/./,$!d' .logs/coverage/phpunit/coverage.txt; echo "EOF"; } >> "$GITHUB_ENV"
-        env:
-          VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
-
-      - name: Post coverage summary as PR comment
-        if: ${{ github.event_name == 'pull_request' && (matrix.instance == 0 || strategy.job-total == 1) && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
-        uses: marocchino/sticky-pull-request-comment@__HASH__ # __VERSION__
-        with:
-          message: |
-            ```
-            ${{ env.COVERAGE_CONTENT }}
-            ```
-          hide_and_recreate: true
-
-      - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@__HASH__ # __VERSION__
-        if: ${{ env.CODECOV_TOKEN != '' }}
-        with:
-          directory: .logs/coverage
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload exported codebase as an artifact
         uses: actions/upload-artifact@__HASH__ # __VERSION__

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -335,35 +335,18 @@ jobs:
 
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
-          name: Test with Behat
+          name: Process PHPUnit logs and coverage
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
-            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
-          no_output_timeout: 30m
-
-      - run:
-          name: Process test logs and artifacts
-          command: |
-            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
-              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
-              fi
             fi
-          when: always
-
-      - store_test_results:
-          path: *test_results
-
-      - store_artifacts:
-          path: *artifacts
 
       - run:
           name: Check code coverage threshold
@@ -398,9 +381,38 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
+
+      - run:
+          name: Test with Behat
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
+          no_output_timeout: 30m
+
+      - run:
+          name: Process test logs and artifacts
+          command: |
+            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
+                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+              fi
+            fi
+          when: always
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *artifacts
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -335,35 +335,18 @@ jobs:
 
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
-          name: Test with Behat
+          name: Process PHPUnit logs and coverage
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
-            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
-          no_output_timeout: 30m
-
-      - run:
-          name: Process test logs and artifacts
-          command: |
-            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
-              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
-              fi
             fi
-          when: always
-
-      - store_test_results:
-          path: *test_results
-
-      - store_artifacts:
-          path: *artifacts
 
       - run:
           name: Check code coverage threshold
@@ -398,9 +381,38 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
+
+      - run:
+          name: Test with Behat
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
+          no_output_timeout: 30m
+
+      - run:
+          name: Process test logs and artifacts
+          command: |
+            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
+                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+              fi
+            fi
+          when: always
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *artifacts
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
@@ -335,35 +335,18 @@ jobs:
 
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
-          name: Test with Behat
+          name: Process PHPUnit logs and coverage
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
-            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
-          no_output_timeout: 30m
-
-      - run:
-          name: Process test logs and artifacts
-          command: |
-            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
-              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
-              fi
             fi
-          when: always
-
-      - store_test_results:
-          path: *test_results
-
-      - store_artifacts:
-          path: *artifacts
 
       - run:
           name: Check code coverage threshold
@@ -398,9 +381,38 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
+
+      - run:
+          name: Test with Behat
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
+          no_output_timeout: 30m
+
+      - run:
+          name: Process test logs and artifacts
+          command: |
+            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
+                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+              fi
+            fi
+          when: always
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *artifacts
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -397,76 +397,3 @@
+@@ -406,76 +406,3 @@
          timeout-minutes: 120 # Cancel the action after 15 minutes, regardless of whether a connection has been established.
          with:
            detached: true

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -335,35 +335,18 @@ jobs:
 
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
-          name: Test with Behat
+          name: Process PHPUnit logs and coverage
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
-            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
-          no_output_timeout: 30m
-
-      - run:
-          name: Process test logs and artifacts
-          command: |
-            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
-              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
-              fi
             fi
-          when: always
-
-      - store_test_results:
-          path: *test_results
-
-      - store_artifacts:
-          path: *artifacts
 
       - run:
           name: Check code coverage threshold
@@ -398,9 +381,38 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
+
+      - run:
+          name: Test with Behat
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
+          no_output_timeout: 30m
+
+      - run:
+          name: Process test logs and artifacts
+          command: |
+            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
+                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+              fi
+            fi
+          when: always
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *artifacts
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -335,35 +335,18 @@ jobs:
 
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
-          name: Test with Behat
+          name: Process PHPUnit logs and coverage
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
-            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
-          no_output_timeout: 30m
-
-      - run:
-          name: Process test logs and artifacts
-          command: |
-            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
-              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
-              fi
             fi
-          when: always
-
-      - store_test_results:
-          path: *test_results
-
-      - store_artifacts:
-          path: *artifacts
 
       - run:
           name: Check code coverage threshold
@@ -398,9 +381,38 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
+
+      - run:
+          name: Test with Behat
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
+          no_output_timeout: 30m
+
+      - run:
+          name: Process test logs and artifacts
+          command: |
+            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
+                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+              fi
+            fi
+          when: always
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *artifacts
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -344,35 +344,18 @@ jobs:
 
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
-          name: Test with Behat
+          name: Process PHPUnit logs and coverage
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
-            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
-          no_output_timeout: 30m
-
-      - run:
-          name: Process test logs and artifacts
-          command: |
-            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
-              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
-              fi
             fi
-          when: always
-
-      - store_test_results:
-          path: *test_results
-
-      - store_artifacts:
-          path: *artifacts
 
       - run:
           name: Check code coverage threshold
@@ -407,9 +390,38 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
+
+      - run:
+          name: Test with Behat
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
+          no_output_timeout: 30m
+
+      - run:
+          name: Process test logs and artifacts
+          command: |
+            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
+                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+              fi
+            fi
+          when: always
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *artifacts
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -164,7 +164,7 @@
        - name: Login to container registry
          run: ./scripts/vortex/login-container-registry.sh
  
-@@ -401,7 +267,6 @@
+@@ -410,7 +276,6 @@
    deploy:
      runs-on: ubuntu-latest
      needs: build

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -335,35 +335,18 @@ jobs:
 
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
-          name: Test with Behat
+          name: Process PHPUnit logs and coverage
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
-            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
-          no_output_timeout: 30m
-
-      - run:
-          name: Process test logs and artifacts
-          command: |
-            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
-              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
-              fi
             fi
-          when: always
-
-      - store_test_results:
-          path: *test_results
-
-      - store_artifacts:
-          path: *artifacts
 
       - run:
           name: Check code coverage threshold
@@ -398,9 +381,38 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
+
+      - run:
+          name: Test with Behat
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
+          no_output_timeout: 30m
+
+      - run:
+          name: Process test logs and artifacts
+          command: |
+            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
+                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+              fi
+            fi
+          when: always
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *artifacts
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -311,35 +311,18 @@ jobs:
 
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
-          name: Test with Behat
+          name: Process PHPUnit logs and coverage
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
-            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
-          no_output_timeout: 30m
-
-      - run:
-          name: Process test logs and artifacts
-          command: |
-            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
-              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
-              fi
             fi
-          when: always
-
-      - store_test_results:
-          path: *test_results
-
-      - store_artifacts:
-          path: *artifacts
 
       - run:
           name: Check code coverage threshold
@@ -374,9 +357,38 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
+
+      - run:
+          name: Test with Behat
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
+          no_output_timeout: 30m
+
+      - run:
+          name: Process test logs and artifacts
+          command: |
+            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
+                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+              fi
+            fi
+          when: always
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *artifacts
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -10,33 +10,24 @@
        - name: Lint module code with NodeJS linters
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: docker compose exec -T cli bash -c "yarn run lint"
-@@ -314,22 +309,6 @@
+@@ -312,65 +307,6 @@
+             docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+           fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./scripts/vortex/provision.sh
-         timeout-minutes: 30
- 
+-        timeout-minutes: 30
+-
 -      - name: Test with PHPUnit
+-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: docker compose exec -T cli vendor/bin/phpunit
 -        continue-on-error: ${{ vars.VORTEX_CI_PHPUNIT_IGNORE_FAILURE == '1' }}
 -
--      - name: Test with Behat
+-      - name: Process PHPUnit logs and coverage
+-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: |
--          # shellcheck disable=SC2170
--          if [ ${{ strategy.job-total }} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${{ strategy.job-index }}}"; fi
--          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
--          docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
--            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
--        env:
--          VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
--        continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
--        timeout-minutes: 30
--
-       - name: Process test logs and artifacts
-         if: always()
-         run: |
-@@ -346,40 +325,6 @@
-           path: .logs
-           include-hidden-files: true
-           if-no-files-found: error
+-          mkdir -p ".logs"
+-          if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+-             docker compose cp cli:/app/.logs/. ".logs/"
+-          fi
 -
 -      - name: Check code coverage threshold
 -        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
@@ -64,13 +55,24 @@
 -
 -      - name: Upload coverage report to Codecov
 -        uses: codecov/codecov-action@__HASH__ # __VERSION__
--        if: ${{ env.CODECOV_TOKEN != '' }}
+-        if: ${{ (matrix.instance == 0 || strategy.job-total == 1) && env.CODECOV_TOKEN != '' }}
 -        with:
 -          directory: .logs/coverage
 -          fail_ci_if_error: true
 -          token: ${{ secrets.CODECOV_TOKEN }}
 -        env:
 -          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+-
+-      - name: Test with Behat
+-        run: |
+-          # shellcheck disable=SC2170
+-          if [ ${{ strategy.job-total }} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${{ strategy.job-index }}}"; fi
+-          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+-          docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
+-        env:
+-          VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
+-        continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
+         timeout-minutes: 30
  
-       - name: Upload exported codebase as an artifact
-         uses: actions/upload-artifact@__HASH__ # __VERSION__
+       - name: Process test logs and artifacts

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -345,13 +345,6 @@ jobs:
       - store_artifacts:
           path: *artifacts
 
-      - run:
-          name: Upload code coverage reports to Codecov
-          command: |
-            if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
-              codecov -Z -s /tmp/artifacts/coverage;
-            fi
-
       - persist_to_workspace:
           root: /tmp/workspace
           paths:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -10,10 +10,10 @@
        - name: Lint module code with NodeJS linters
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: docker compose exec -T cli bash -c "yarn run lint"
-@@ -317,18 +312,6 @@
-       - name: Test with PHPUnit
-         run: docker compose exec -T cli vendor/bin/phpunit
-         continue-on-error: ${{ vars.VORTEX_CI_PHPUNIT_IGNORE_FAILURE == '1' }}
+@@ -360,18 +355,6 @@
+           token: ${{ secrets.CODECOV_TOKEN }}
+         env:
+           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 -
 -      - name: Test with Behat
 -        run: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -329,25 +329,18 @@ jobs:
 
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
-          name: Process test logs and artifacts
+          name: Process PHPUnit logs and coverage
           command: |
-            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
-              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
-              fi
             fi
-          when: always
-
-      - store_test_results:
-          path: *test_results
-
-      - store_artifacts:
-          path: *artifacts
 
       - run:
           name: Check code coverage threshold
@@ -382,9 +375,28 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
+
+      - run:
+          name: Process test logs and artifacts
+          command: |
+            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
+                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+              fi
+            fi
+          when: always
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *artifacts
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -329,35 +329,18 @@ jobs:
 
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
-          name: Test with Behat
+          name: Process PHPUnit logs and coverage
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
-            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
-          no_output_timeout: 30m
-
-      - run:
-          name: Process test logs and artifacts
-          command: |
-            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
-              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
-              fi
             fi
-          when: always
-
-      - store_test_results:
-          path: *test_results
-
-      - store_artifacts:
-          path: *artifacts
 
       - run:
           name: Check code coverage threshold
@@ -392,9 +375,38 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
+
+      - run:
+          name: Test with Behat
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
+          no_output_timeout: 30m
+
+      - run:
+          name: Process test logs and artifacts
+          command: |
+            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
+                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+              fi
+            fi
+          when: always
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *artifacts
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd_circleci/.circleci/config.yml
@@ -329,35 +329,18 @@ jobs:
 
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
-          name: Test with Behat
+          name: Process PHPUnit logs and coverage
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
-            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
-          no_output_timeout: 30m
-
-      - run:
-          name: Process test logs and artifacts
-          command: |
-            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
-              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
-              fi
             fi
-          when: always
-
-      - store_test_results:
-          path: *test_results
-
-      - store_artifacts:
-          path: *artifacts
 
       - run:
           name: Check code coverage threshold
@@ -392,9 +375,38 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
+
+      - run:
+          name: Test with Behat
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
+          no_output_timeout: 30m
+
+      - run:
+          name: Process test logs and artifacts
+          command: |
+            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
+                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+              fi
+            fi
+          when: always
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *artifacts
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -329,35 +329,18 @@ jobs:
 
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
-          name: Test with Behat
+          name: Process PHPUnit logs and coverage
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
-            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
-          no_output_timeout: 30m
-
-      - run:
-          name: Process test logs and artifacts
-          command: |
-            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
-              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
-              fi
             fi
-          when: always
-
-      - store_test_results:
-          path: *test_results
-
-      - store_artifacts:
-          path: *artifacts
 
       - run:
           name: Check code coverage threshold
@@ -392,9 +375,38 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
+
+      - run:
+          name: Test with Behat
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
+          no_output_timeout: 30m
+
+      - run:
+          name: Process test logs and artifacts
+          command: |
+            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
+                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+              fi
+            fi
+          when: always
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *artifacts
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -1,18 +1,19 @@
-@@ -314,10 +314,6 @@
+@@ -314,53 +314,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./scripts/vortex/provision.sh
          timeout-minutes: 30
  
 -      - name: Test with PHPUnit
+-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: docker compose exec -T cli vendor/bin/phpunit
 -        continue-on-error: ${{ vars.VORTEX_CI_PHPUNIT_IGNORE_FAILURE == '1' }}
 -
-       - name: Test with Behat
-         run: |
-           # shellcheck disable=SC2170
-@@ -346,40 +342,6 @@
-           path: .logs
-           include-hidden-files: true
-           if-no-files-found: error
+-      - name: Process PHPUnit logs and coverage
+-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        run: |
+-          mkdir -p ".logs"
+-          if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+-             docker compose cp cli:/app/.logs/. ".logs/"
+-          fi
 -
 -      - name: Check code coverage threshold
 -        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
@@ -40,13 +41,14 @@
 -
 -      - name: Upload coverage report to Codecov
 -        uses: codecov/codecov-action@__HASH__ # __VERSION__
--        if: ${{ env.CODECOV_TOKEN != '' }}
+-        if: ${{ (matrix.instance == 0 || strategy.job-total == 1) && env.CODECOV_TOKEN != '' }}
 -        with:
 -          directory: .logs/coverage
 -          fail_ci_if_error: true
 -          token: ${{ secrets.CODECOV_TOKEN }}
 -        env:
 -          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
- 
-       - name: Upload exported codebase as an artifact
-         uses: actions/upload-artifact@__HASH__ # __VERSION__
+-
+       - name: Test with Behat
+         run: |
+           # shellcheck disable=SC2170

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -361,13 +361,6 @@ jobs:
       - store_artifacts:
           path: *artifacts
 
-      - run:
-          name: Upload code coverage reports to Codecov
-          command: |
-            if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
-              codecov -Z -s /tmp/artifacts/coverage;
-            fi
-
       - persist_to_workspace:
           root: /tmp/workspace
           paths:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -329,35 +329,18 @@ jobs:
 
       - run:
           name: Test with PHPUnit
-          command: docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
-          name: Test with Behat
+          name: Process PHPUnit logs and coverage
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
-            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
-              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
-          no_output_timeout: 30m
-
-      - run:
-          name: Process test logs and artifacts
-          command: |
-            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
-              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
-              fi
             fi
-          when: always
-
-      - store_test_results:
-          path: *test_results
-
-      - store_artifacts:
-          path: *artifacts
 
       - run:
           name: Check code coverage threshold
@@ -392,9 +375,38 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
+
+      - run:
+          name: Test with Behat
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+              [ "${VORTEX_CI_BEHAT_IGNORE_FAILURE:-0}" -eq 1 ]
+          no_output_timeout: 30m
+
+      - run:
+          name: Process test logs and artifacts
+          command: |
+            mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
+            if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+              if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
+                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+              fi
+            fi
+          when: always
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *artifacts
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -35,33 +35,24 @@
        - name: Lint module code with NodeJS linters
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: docker compose exec -T cli bash -c "yarn run lint"
-@@ -314,22 +289,6 @@
+@@ -312,65 +287,6 @@
+             docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+           fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./scripts/vortex/provision.sh
-         timeout-minutes: 30
- 
+-        timeout-minutes: 30
+-
 -      - name: Test with PHPUnit
+-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: docker compose exec -T cli vendor/bin/phpunit
 -        continue-on-error: ${{ vars.VORTEX_CI_PHPUNIT_IGNORE_FAILURE == '1' }}
 -
--      - name: Test with Behat
+-      - name: Process PHPUnit logs and coverage
+-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: |
--          # shellcheck disable=SC2170
--          if [ ${{ strategy.job-total }} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${{ strategy.job-index }}}"; fi
--          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
--          docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
--            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
--        env:
--          VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
--        continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
--        timeout-minutes: 30
--
-       - name: Process test logs and artifacts
-         if: always()
-         run: |
-@@ -346,40 +305,6 @@
-           path: .logs
-           include-hidden-files: true
-           if-no-files-found: error
+-          mkdir -p ".logs"
+-          if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
+-             docker compose cp cli:/app/.logs/. ".logs/"
+-          fi
 -
 -      - name: Check code coverage threshold
 -        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
@@ -89,13 +80,24 @@
 -
 -      - name: Upload coverage report to Codecov
 -        uses: codecov/codecov-action@__HASH__ # __VERSION__
--        if: ${{ env.CODECOV_TOKEN != '' }}
+-        if: ${{ (matrix.instance == 0 || strategy.job-total == 1) && env.CODECOV_TOKEN != '' }}
 -        with:
 -          directory: .logs/coverage
 -          fail_ci_if_error: true
 -          token: ${{ secrets.CODECOV_TOKEN }}
 -        env:
 -          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+-
+-      - name: Test with Behat
+-        run: |
+-          # shellcheck disable=SC2170
+-          if [ ${{ strategy.job-total }} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${{ strategy.job-index }}}"; fi
+-          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
+-          docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
+-            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
+-        env:
+-          VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
+-        continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
+         timeout-minutes: 30
  
-       - name: Upload exported codebase as an artifact
-         uses: actions/upload-artifact@__HASH__ # __VERSION__
+       - name: Process test logs and artifacts

--- a/.vortex/tests/phpunit/Functional/PostBuildTest.php
+++ b/.vortex/tests/phpunit/Functional/PostBuildTest.php
@@ -45,7 +45,7 @@ class PostBuildTest extends FunctionalTestCase {
    * Test that CircleCI artifacts are saved correctly.
    *
    * Verifies that:
-   * - PHPUnit coverage reports are generated for both parallel runners
+   * - PHPUnit coverage reports are generated on runner 0 only
    * - Behat feature files are saved for both parallel runners
    * - Feature files are split correctly between runners (e.g., clamav.feature
    *   on runner 0 but not runner 1, search.feature on runner 1 but not
@@ -74,11 +74,12 @@ class PostBuildTest extends FunctionalTestCase {
       $this->assertStringNotContainsString('search.feature', $artifact_paths_runner0_str, 'Runner 0 should NOT have search.feature');
 
       // Verify runner 1 artifacts.
+      // PHPUnit only runs on runner 0, so runner 1 should not have coverage.
       $artifact_paths_runner1 = $this->circleCiExtractArtifactPaths($artifacts_data, 1);
       $artifact_paths_runner1_str = implode("\n", $artifact_paths_runner1);
 
-      $this->assertStringContainsString('coverage/phpunit/cobertura.xml', $artifact_paths_runner1_str, 'Runner 1 should have PHPUnit cobertura coverage');
-      $this->assertStringContainsString('coverage/phpunit/.coverage-html/index.html', $artifact_paths_runner1_str, 'Runner 1 should have PHPUnit HTML coverage');
+      $this->assertStringNotContainsString('coverage/phpunit/cobertura.xml', $artifact_paths_runner1_str, 'Runner 1 should NOT have PHPUnit cobertura coverage');
+      $this->assertStringNotContainsString('coverage/phpunit/.coverage-html/index.html', $artifact_paths_runner1_str, 'Runner 1 should NOT have PHPUnit HTML coverage');
 
       $this->assertStringContainsString('homepage.feature', $artifact_paths_runner1_str, 'Runner 1 should have homepage.feature');
       $this->assertStringContainsString('login.feature', $artifact_paths_runner1_str, 'Runner 1 should have login.feature');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reintroduced Behat test stage and separated PHPUnit/Behat execution to avoid duplicate runs across parallel nodes.
  * Made test and coverage uploads aware of primary-node gating.

* **Documentation**
  * Added "Test parallelism" guidance and container-distribution tips, including scenario-tagging recommendations and provider links.

* **Tests**
  * Updated CI test expectations to reflect single-node coverage handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->