### PR TITLE
[#2350] Fixed local settings file being included during settings unit tests.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/tests/phpunit/Drupal/SettingsTestCase.php
@@ -213,7 +213,9 @@ abstract class SettingsTestCase extends TestCase {
     $settings = $pre_settings;
     $databases = [];
 
+    putenv('DRUPAL_SETTINGS_LOCAL_SKIP=1');
     require $app_root . DIRECTORY_SEPARATOR . $site_path . DIRECTORY_SEPARATOR . 'settings.php';
+    putenv('DRUPAL_SETTINGS_LOCAL_SKIP');
 
     $this->app_root = $app_root;
     $this->site_path = $site_path;

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/sites/default/settings.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/sites/default/settings.php
@@ -180,7 +180,7 @@ if (file_exists($app_root . '/' . $site_path . '/includes/modules')) {
 //
 // Keep this code block at the end of this file to take full effect.
 // @codeCoverageIgnoreStart
-if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php') && getenv('DRUPAL_SETTINGS_LOCAL_SKIP') !== '1') {
   require $app_root . '/' . $site_path . '/settings.local.php';
 }
 // @codeCoverageIgnoreEnd

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/sites/default/settings.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/sites/default/settings.php
@@ -180,7 +180,7 @@ if (file_exists($app_root . '/' . $site_path . '/includes/modules')) {
 //
 // Keep this code block at the end of this file to take full effect.
 // @codeCoverageIgnoreStart
-if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php') && getenv('DRUPAL_SETTINGS_LOCAL_SKIP') !== '1') {
   require $app_root . '/' . $site_path . '/settings.local.php';
 }
 // @codeCoverageIgnoreEnd

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/sites/default/settings.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/sites/default/settings.php
@@ -180,7 +180,7 @@ if (file_exists($app_root . '/' . $site_path . '/includes/modules')) {
 //
 // Keep this code block at the end of this file to take full effect.
 // @codeCoverageIgnoreStart
-if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php') && getenv('DRUPAL_SETTINGS_LOCAL_SKIP') !== '1') {
   require $app_root . '/' . $site_path . '/settings.local.php';
 }
 // @codeCoverageIgnoreEnd

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/tests/phpunit/Drupal/SettingsTestCase.php
@@ -14,7 +14,7 @@
     */
    protected function setEnvVars(array $vars): void {
      // Unset the existing environment variable if not set in the test.
-@@ -308,7 +306,6 @@
+@@ -310,7 +308,6 @@
     * @param string $message
     *   Message to display on failure.
     *

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/tests/phpunit/Drupal/SettingsTestCase.php
@@ -14,7 +14,7 @@
     */
    protected function setEnvVars(array $vars): void {
      // Unset the existing environment variable if not set in the test.
-@@ -308,7 +306,6 @@
+@@ -310,7 +308,6 @@
     * @param string $message
     *   Message to display on failure.
     *

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd/tests/phpunit/Drupal/SettingsTestCase.php
@@ -6,7 +6,7 @@
     */
    protected function setEnvVars(array $vars): void {
      // Unset the existing environment variable if not set in the test.
-@@ -308,7 +307,6 @@
+@@ -310,7 +309,6 @@
     * @param string $message
     *   Message to display on failure.
     *

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd_circleci/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd_circleci/tests/phpunit/Drupal/SettingsTestCase.php
@@ -6,7 +6,7 @@
     */
    protected function setEnvVars(array $vars): void {
      // Unset the existing environment variable if not set in the test.
-@@ -308,7 +307,6 @@
+@@ -310,7 +309,6 @@
     * @param string $message
     *   Message to display on failure.
     *

--- a/.vortex/tests/phpunit/Functional/AhoyWorkflowTest.php
+++ b/.vortex/tests/phpunit/Functional/AhoyWorkflowTest.php
@@ -94,6 +94,8 @@ class AhoyWorkflowTest extends FunctionalTestCase {
 
     $this->subtestAhoyTestUnit();
 
+    $this->subtestAhoyTestUnitSettingsLocalSkip();
+
     $this->subtestAhoyTestKernel();
 
     $this->subtestAhoyTestFunctional();

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -437,6 +437,25 @@ trait SubtestAhoyTrait {
     $this->logStepFinish();
   }
 
+  protected function subtestAhoyTestUnitSettingsLocalSkip(string $webroot = 'web'): void {
+    $this->logStepStart();
+
+    $this->logSubstep('Create settings.local.php to verify DRUPAL_SETTINGS_LOCAL_SKIP works');
+    $this->createDevelopmentSettings($webroot);
+    $this->syncToContainer($webroot . '/sites/default/settings.local.php');
+    $this->syncToContainer($webroot . '/sites/default/services.local.yml');
+
+    $this->logSubstep('Run unit tests with settings.local.php present');
+    $this->cmd('ahoy test-unit --no-coverage --group=drupal_settings', 'OK (', txt: 'Settings unit tests pass with settings.local.php present');
+
+    $this->logSubstep('Clean up settings.local.php');
+    $this->removeDevelopmentSettings($webroot);
+    $this->removePathHostAndContainer($webroot . '/sites/default/settings.local.php');
+    $this->removePathHostAndContainer($webroot . '/sites/default/services.local.yml');
+
+    $this->logStepFinish();
+  }
+
   protected function subtestAhoyTestKernel(string $webroot = 'web'): void {
     $this->logStepStart();
 

--- a/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/tests/phpunit/Drupal/SettingsTestCase.php
@@ -49,7 +49,6 @@ abstract class SettingsTestCase extends TestCase {
    */
   final const ENVIRONMENT_PROD = 'prod';
 
-
   /**
    * Defines a constant for the allowed environment variables.
    *
@@ -217,7 +216,9 @@ abstract class SettingsTestCase extends TestCase {
     $settings = $pre_settings;
     $databases = [];
 
+    putenv('DRUPAL_SETTINGS_LOCAL_SKIP=1');
     require $app_root . DIRECTORY_SEPARATOR . $site_path . DIRECTORY_SEPARATOR . 'settings.php';
+    putenv('DRUPAL_SETTINGS_LOCAL_SKIP');
 
     $this->app_root = $app_root;
     $this->site_path = $site_path;

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -190,7 +190,7 @@ if (file_exists($app_root . '/' . $site_path . '/settings.migration.php')) {
 //
 // Keep this code block at the end of this file to take full effect.
 // @codeCoverageIgnoreStart
-if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php') && getenv('DRUPAL_SETTINGS_LOCAL_SKIP') !== '1') {
   require $app_root . '/' . $site_path . '/settings.local.php';
 }
 // @codeCoverageIgnoreEnd


### PR DESCRIPTION
Closes #2350


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new checkpoint in the test workflow to cover local settings configuration scenarios.
  * Added a test subroutine to verify behavior when local settings are intentionally skipped during unit tests.
  * Introduced a temporary environment flag used during test execution to control whether local settings are loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->