### PR TITLE
Fixed GH test token not being passed to tests in CI.

### DIFF
--- a/.github/workflows/vortex-test-common.yml
+++ b/.github/workflows/vortex-test-common.yml
@@ -29,6 +29,7 @@ jobs:
         # Prevent GitHub overriding the Docker config.
         DOCKER_CONFIG: /root/.docker
         VORTEX_DOCTOR_CHECK_MINIMAL: 1
+        TEST_GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
         TEST_PACKAGE_TOKEN: ${{ secrets.TEST_PACKAGE_TOKEN }}
         TEST_VORTEX_CONTAINER_REGISTRY_USER: ${{ secrets.TEST_VORTEX_CONTAINER_REGISTRY_USER }}
         TEST_VORTEX_CONTAINER_REGISTRY_PASS: ${{ secrets.TEST_VORTEX_CONTAINER_REGISTRY_PASS }}
@@ -129,6 +130,7 @@ jobs:
         # Prevent GitHub overriding the Docker config.
         DOCKER_CONFIG: /root/.docker
         VORTEX_DOCTOR_CHECK_MINIMAL: 1
+        TEST_GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
         TEST_PACKAGE_TOKEN: ${{ secrets.TEST_PACKAGE_TOKEN }}
         TEST_VORTEX_CONTAINER_REGISTRY_USER: ${{ secrets.TEST_VORTEX_CONTAINER_REGISTRY_USER }}
         TEST_VORTEX_CONTAINER_REGISTRY_PASS: ${{ secrets.TEST_VORTEX_CONTAINER_REGISTRY_PASS }}

--- a/.github/workflows/vortex-test-installer.yml
+++ b/.github/workflows/vortex-test-installer.yml
@@ -58,7 +58,7 @@ jobs:
         run: composer test-coverage
         working-directory: .vortex/installer
         env:
-          GITHUB_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
 
       - name: Generate video for installer (not used in the final artifact)
         run: |
@@ -95,6 +95,8 @@ jobs:
           ./build/installer.phar --version
           ./build/installer.phar --no-interaction --no-cleanup --destination=test || exit 1
         working-directory: .vortex/installer
+        env:
+          GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
 
       - name: Upload installer artifact
         if: matrix.php-versions == '8.2'

--- a/.vortex/tests/bats/_helper.bash
+++ b/.vortex/tests/bats/_helper.bash
@@ -50,7 +50,6 @@ setup() {
   # Override real secrets with test secrets.
   # For the development of the tests locally, export `TEST_` variables in your
   # shell before running the tests.
-  export PACKAGE_TOKEN="${TEST_PACKAGE_TOKEN:-}"
   export VORTEX_CONTAINER_REGISTRY_USER="${TEST_VORTEX_CONTAINER_REGISTRY_USER:-}"
   export VORTEX_CONTAINER_REGISTRY_PASS="${TEST_VORTEX_CONTAINER_REGISTRY_PASS:-}"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to use TEST_GITHUB_TOKEN for authentication in test execution environments across multiple workflow files.
  * Removed legacy token references from test setup scripts to streamline authentication configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->