### PR TITLE
[#2388] Switched to PHP 8.4.

### DIFF
--- a/.docker/cli.dockerfile
+++ b/.docker/cli.dockerfile
@@ -4,10 +4,10 @@
 #
 # hadolint global ignore=DL3018,SC2174
 #
-# @see https://hub.docker.com/r/uselagoon/php-8.3-cli-drupal/tags
+# @see https://hub.docker.com/r/uselagoon/php-8.4-cli-drupal/tags
 # @see https://github.com/uselagoon/lagoon-images/tree/main/images/php-cli-drupal
 
-FROM uselagoon/php-8.3-cli-drupal:26.2.0
+FROM uselagoon/php-8.4-cli-drupal:26.2.0
 
 # Add missing variables.
 # @todo Remove once https://github.com/uselagoon/lagoon/issues/3121 is resolved.

--- a/.docker/php.dockerfile
+++ b/.docker/php.dockerfile
@@ -5,14 +5,14 @@
 #
 # hadolint global ignore=DL3018
 #
-# @see https://hub.docker.com/r/uselagoon/php-8.3-fpm/tags
+# @see https://hub.docker.com/r/uselagoon/php-8.4-fpm/tags
 # @see https://github.com/uselagoon/lagoon-images/tree/main/images/php-fpm
 
 ARG CLI_IMAGE
 # hadolint ignore=DL3006
 FROM ${CLI_IMAGE:-cli} AS cli
 
-FROM uselagoon/php-8.3-fpm:26.2.0
+FROM uselagoon/php-8.4-fpm:26.2.0
 
 RUN apk add --no-cache tzdata
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.docker/cli.dockerfile
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.docker/cli.dockerfile
@@ -4,10 +4,10 @@
 #
 # hadolint global ignore=DL3018,SC2174
 #
-# @see https://hub.docker.com/r/uselagoon/php-8.3-cli-drupal/tags
+# @see https://hub.docker.com/r/uselagoon/php-8.4-cli-drupal/tags
 # @see https://github.com/uselagoon/lagoon-images/tree/main/images/php-cli-drupal
 
-FROM uselagoon/php-8.3-cli-drupal:__VERSION__
+FROM uselagoon/php-8.4-cli-drupal:__VERSION__
 
 # Add missing variables.
 # @todo Remove once https://github.com/uselagoon/lagoon/issues/3121 is resolved.

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.docker/php.dockerfile
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.docker/php.dockerfile
@@ -5,14 +5,14 @@
 #
 # hadolint global ignore=DL3018
 #
-# @see https://hub.docker.com/r/uselagoon/php-8.3-fpm/tags
+# @see https://hub.docker.com/r/uselagoon/php-8.4-fpm/tags
 # @see https://github.com/uselagoon/lagoon-images/tree/main/images/php-fpm
 
 ARG CLI_IMAGE
 # hadolint ignore=DL3006
 FROM ${CLI_IMAGE:-cli} AS cli
 
-FROM uselagoon/php-8.3-fpm:__VERSION__
+FROM uselagoon/php-8.4-fpm:__VERSION__
 
 RUN apk add --no-cache tzdata
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/phpcs.xml
@@ -27,7 +27,7 @@
     <arg name="parallel" value="10"/>
 
     <!-- Lint code against platform version specified in composer.json key "config.platform.php". -->
-    <config name="testVersion" value="8.3"/>
+    <config name="testVersion" value="8.4"/>
 
     <!-- Exclude theme assets. -->
     <exclude-pattern>web\/themes\/custom\/.*\/build\/.*</exclude-pattern>

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/phpunit.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/phpunit.xml
@@ -28,7 +28,7 @@
          cacheDirectory=".phpunit.cache">
     <php>
         <!-- Set error reporting to E_ALL. -->
-        <ini name="error_reporting" value="32767"/>
+        <ini name="error_reporting" value="30719"/>
         <!-- Do not limit the amount of memory tests take to run. -->
         <ini name="memory_limit" value="-1"/>
         <env name="SIMPLETEST_BASE_URL" value="http://nginx:8080"/>

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/rector.php
@@ -79,9 +79,9 @@ return RectorConfig::configure()
     '*/vendor/*',
     '*/node_modules/*',
   ])
-  // PHP version upgrade sets - modernizes syntax to PHP 8.3.
-  // Includes all rules from PHP 5.3 through 8.3.
-  ->withPhpSets(php83: TRUE)
+  // PHP version upgrade sets - modernizes syntax to PHP 8.4.
+  // Includes all rules from PHP 5.3 through 8.4.
+  ->withPhpSets(php84: TRUE)
   // Code quality improvement sets.
   ->withPreparedSets(
     codeQuality: TRUE,

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/tests/phpunit/Drupal/SettingsTestCase.php
@@ -176,15 +176,7 @@ abstract class SettingsTestCase extends TestCase {
   protected static function getRealEnvVarsFilteredNoValues(array $prefixes = []): array {
     $vars = getenv();
 
-    $vars = array_filter(array_keys($vars), static function (string $key) use ($prefixes): bool {
-      foreach ($prefixes as $prefix) {
-        if (str_starts_with($key, $prefix)) {
-          return TRUE;
-        }
-      }
-
-      return FALSE;
-    });
+    $vars = array_filter(array_keys($vars), static fn(string $key): bool => array_any($prefixes, fn($prefix): bool => str_starts_with($key, (string) $prefix)));
 
     return array_fill_keys($vars, NULL);
   }

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/phpcs.xml
@@ -14,7 +14,7 @@
  
      <rule ref="Drupal"/>
 @@ -30,10 +30,10 @@
-     <config name="testVersion" value="8.3"/>
+     <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->
 -    <exclude-pattern>web\/themes\/custom\/.*\/build\/.*</exclude-pattern>

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/tests/phpunit/Drupal/SettingsTestCase.php
@@ -1,4 +1,4 @@
-@@ -202,7 +202,7 @@
+@@ -194,7 +194,7 @@
     * Require settings file.
     */
    protected function requireSettingsFile(array $pre_settings = [], array $pre_config = []): void {

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/phpcs.xml
@@ -14,7 +14,7 @@
  
      <rule ref="Drupal"/>
 @@ -30,10 +30,10 @@
-     <config name="testVersion" value="8.3"/>
+     <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->
 -    <exclude-pattern>web\/themes\/custom\/.*\/build\/.*</exclude-pattern>

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/tests/phpunit/Drupal/SettingsTestCase.php
@@ -1,4 +1,4 @@
-@@ -202,7 +202,7 @@
+@@ -194,7 +194,7 @@
     * Require settings file.
     */
    protected function requireSettingsFile(array $pre_settings = [], array $pre_config = []): void {

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/phpcs.xml
@@ -7,7 +7,7 @@
      <file>web/sites/default/includes</file>
      <file>tests</file>
 @@ -30,10 +29,6 @@
-     <config name="testVersion" value="8.3"/>
+     <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->
 -    <exclude-pattern>web\/themes\/custom\/.*\/build\/.*</exclude-pattern>

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/phpcs.xml
@@ -7,7 +7,7 @@
      <file>web/sites/default/includes</file>
      <file>tests</file>
 @@ -30,10 +29,6 @@
-     <config name="testVersion" value="8.3"/>
+     <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->
 -    <exclude-pattern>web\/themes\/custom\/.*\/build\/.*</exclude-pattern>

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/phpcs.xml
@@ -7,7 +7,7 @@
      <file>web/sites/default/includes</file>
      <file>tests</file>
 @@ -30,10 +29,6 @@
-     <config name="testVersion" value="8.3"/>
+     <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->
 -    <exclude-pattern>web\/themes\/custom\/.*\/build\/.*</exclude-pattern>

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/tests/phpunit/Drupal/SettingsTestCase.php
@@ -14,7 +14,7 @@
     */
    protected function setEnvVars(array $vars): void {
      // Unset the existing environment variable if not set in the test.
-@@ -310,7 +308,6 @@
+@@ -302,7 +300,6 @@
     * @param string $message
     *   Message to display on failure.
     *

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/tests/phpunit/Drupal/SettingsTestCase.php
@@ -14,7 +14,7 @@
     */
    protected function setEnvVars(array $vars): void {
      // Unset the existing environment variable if not set in the test.
-@@ -310,7 +308,6 @@
+@@ -302,7 +300,6 @@
     * @param string $message
     *   Message to display on failure.
     *

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/phpcs.xml
@@ -7,7 +7,7 @@
      <file>web/sites/default/includes</file>
      <file>tests</file>
 @@ -30,10 +29,6 @@
-     <config name="testVersion" value="8.3"/>
+     <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->
 -    <exclude-pattern>web\/themes\/custom\/.*\/build\/.*</exclude-pattern>

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/phpcs.xml
@@ -7,7 +7,7 @@
      <file>web/sites/default/includes</file>
      <file>tests</file>
 @@ -30,10 +29,6 @@
-     <config name="testVersion" value="8.3"/>
+     <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->
 -    <exclude-pattern>web\/themes\/custom\/.*\/build\/.*</exclude-pattern>

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/phpcs.xml
@@ -7,7 +7,7 @@
      <file>web/sites/default/includes</file>
      <file>tests</file>
 @@ -30,10 +29,6 @@
-     <config name="testVersion" value="8.3"/>
+     <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->
 -    <exclude-pattern>web\/themes\/custom\/.*\/build\/.*</exclude-pattern>

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd/tests/phpunit/Drupal/SettingsTestCase.php
@@ -6,7 +6,7 @@
     */
    protected function setEnvVars(array $vars): void {
      // Unset the existing environment variable if not set in the test.
-@@ -310,7 +309,6 @@
+@@ -302,7 +301,6 @@
     * @param string $message
     *   Message to display on failure.
     *

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd_circleci/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd_circleci/tests/phpunit/Drupal/SettingsTestCase.php
@@ -6,7 +6,7 @@
     */
    protected function setEnvVars(array $vars): void {
      // Unset the existing environment variable if not set in the test.
-@@ -310,7 +309,6 @@
+@@ -302,7 +301,6 @@
     * @param string $message
     *   Message to display on failure.
     *

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/phpcs.xml
@@ -7,7 +7,7 @@
      <file>web/sites/default/includes</file>
      <file>tests</file>
 @@ -30,10 +29,6 @@
-     <config name="testVersion" value="8.3"/>
+     <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->
 -    <exclude-pattern>web\/themes\/custom\/.*\/build\/.*</exclude-pattern>

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestDockerComposeTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestDockerComposeTrait.php
@@ -307,10 +307,12 @@ trait SubtestDockerComposeTrait {
       '1024M',
       'PHP memory_limit should be 1024M after second change'
     );
+    $this->processRun('docker compose exec -T cli php -r "echo E_ALL;"');
+    $e_all = trim($this->processGet()->getOutput());
     $this->cmd(
       'docker compose exec -T cli php -r "echo ini_get(\'error_reporting\');"',
-      '32767',
-      'PHP error_reporting should be 32767 (E_ALL) from drush.ini'
+      $e_all,
+      'PHP error_reporting should be E_ALL from drush.ini'
     );
 
     $this->logSubstep('Restore drush.ini to original state.');

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "proprietary",
     "type": "project",
     "require": {
-        "php": ">=8.3",
+        "php": ">=8.4",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^2.0",
         "drupal/admin_toolbar": "^3.6.3",
@@ -98,7 +98,7 @@
         "bump-after-update": true,
         "discard-changes": true,
         "platform": {
-            "php": "8.3.30"
+            "php": "8.4.17"
         },
         "sort-packages": true
     },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -27,7 +27,7 @@
     <arg name="parallel" value="10"/>
 
     <!-- Lint code against platform version specified in composer.json key "config.platform.php". -->
-    <config name="testVersion" value="8.3"/>
+    <config name="testVersion" value="8.4"/>
 
     <!-- Exclude theme assets. -->
     <exclude-pattern>web\/themes\/custom\/.*\/build\/.*</exclude-pattern>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,7 +11,7 @@ parameters:
 
   level: 7
 
-  phpVersion: 80330
+  phpVersion: 80417
 
   paths:
     - web/modules/custom

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,7 +28,7 @@
          cacheDirectory=".phpunit.cache">
     <php>
         <!-- Set error reporting to E_ALL. -->
-        <ini name="error_reporting" value="32767"/>
+        <ini name="error_reporting" value="30719"/>
         <!-- Do not limit the amount of memory tests take to run. -->
         <ini name="memory_limit" value="-1"/>
         <env name="SIMPLETEST_BASE_URL" value="http://nginx:8080"/>

--- a/rector.php
+++ b/rector.php
@@ -79,9 +79,9 @@ return RectorConfig::configure()
     '*/vendor/*',
     '*/node_modules/*',
   ])
-  // PHP version upgrade sets - modernizes syntax to PHP 8.3.
-  // Includes all rules from PHP 5.3 through 8.3.
-  ->withPhpSets(php83: TRUE)
+  // PHP version upgrade sets - modernizes syntax to PHP 8.4.
+  // Includes all rules from PHP 5.3 through 8.4.
+  ->withPhpSets(php84: TRUE)
   // Code quality improvement sets.
   ->withPreparedSets(
     codeQuality: TRUE,

--- a/tests/phpunit/Drupal/SettingsTestCase.php
+++ b/tests/phpunit/Drupal/SettingsTestCase.php
@@ -179,15 +179,7 @@ abstract class SettingsTestCase extends TestCase {
   protected static function getRealEnvVarsFilteredNoValues(array $prefixes = []): array {
     $vars = getenv();
 
-    $vars = array_filter(array_keys($vars), static function (string $key) use ($prefixes): bool {
-      foreach ($prefixes as $prefix) {
-        if (str_starts_with($key, $prefix)) {
-          return TRUE;
-        }
-      }
-
-      return FALSE;
-    });
+    $vars = array_filter(array_keys($vars), static fn(string $key): bool => array_any($prefixes, fn($prefix): bool => str_starts_with($key, (string) $prefix)));
 
     return array_fill_keys($vars, NULL);
   }


### PR DESCRIPTION
Closes #2388

## Summary

Upgraded the project's PHP runtime from 8.3 to 8.4 across all relevant configuration files. The Docker base images for the CLI and FPM containers were updated to the PHP 8.4 Lagoon variants, and the Composer platform constraint and static analysis tools were aligned to the new version. Rector's ruleset was also updated to target PHP 8.4 syntax modernisation.

## Changes

**Docker images** (`.docker/cli.dockerfile`, `.docker/php.dockerfile`)
- Switched base images from `uselagoon/php-8.3-cli-drupal:26.2.0` and `uselagoon/php-8.3-fpm:26.2.0` to their PHP 8.4 equivalents at the same image tag.

**Composer** (`composer.json`)
- Bumped `require.php` constraint from `>=8.3` to `>=8.4`.
- Updated `config.platform.php` from `8.3.30` to `8.4.17`.

**Static analysis / linting tools**
- `phpcs.xml`: Updated `testVersion` from `8.3` to `8.4`.
- `phpstan.neon`: Updated `phpVersion` from `80330` to `80417`.
- `rector.php`: Switched `withPhpSets(php83: TRUE)` to `withPhpSets(php84: TRUE)` so Rector applies PHP 8.4 modernisation rules.

## Before / After

```
Before                                  After
────────────────────────────────────    ────────────────────────────────────
Docker CLI image                        Docker CLI image
  uselagoon/php-8.3-cli-drupal:26.2.0    uselagoon/php-8.4-cli-drupal:26.2.0

Docker FPM image                        Docker FPM image
  uselagoon/php-8.3-fpm:26.2.0           uselagoon/php-8.4-fpm:26.2.0

composer.json                           composer.json
  require.php        >=8.3               require.php        >=8.4
  platform.php       8.3.30              platform.php       8.4.17

phpcs.xml                               phpcs.xml
  testVersion        8.3                 testVersion        8.4

phpstan.neon                            phpstan.neon
  phpVersion         80330               phpVersion         80417

rector.php                              rector.php
  withPhpSets(php83: TRUE)               withPhpSets(php84: TRUE)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Project toolchain and configs updated to target PHP 8.4.
  * PHP requirements and platform settings raised from 8.3 → 8.4.
  * Runtime/container base images updated to PHP 8.4.
  * Linting and static analysis targets adjusted for PHP 8.4.
* **Tests**
  * Minor test updates: modernized assertions, one expectation made dynamic for robustness; test error-reporting level adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->