### PR TITLE
[#1904] Allow to manually run deploy from GHA UI.

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -40,9 +40,19 @@ on:
 
   workflow_dispatch:
     inputs:
+      deploy_target:
+        type: string
+        description: 'Deploy target: "<branch>" or "PR-<num>"'
+        required: false
+        default: ''
+      override_db:
+        type: boolean
+        description: 'Override existing database'
+        required: false
+        default: false
       enable_terminal:
         type: boolean
-        description: 'Enable terminal session.'
+        description: 'Enable terminal session'
         required: false
         default: false
   #;< !PROVISION_TYPE_PROFILE
@@ -65,7 +75,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     #;< !PROVISION_TYPE_PROFILE
-    if: ${{ github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
     #;> !PROVISION_TYPE_PROFILE
 
     container:
@@ -183,7 +193,7 @@ jobs:
   #;< !PROVISION_TYPE_PROFILE
   database:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || !startsWith(github.head_ref, 'project/') }}
+    if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 
     container:
       # https://hub.docker.com/r/drevops/ci-runner
@@ -300,7 +310,7 @@ jobs:
     runs-on: ubuntu-latest
     #;< !PROVISION_TYPE_PROFILE
     needs: database
-    if: ${{ github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
     #;> !PROVISION_TYPE_PROFILE
 
     strategy:
@@ -538,7 +548,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, lint]
     #;< !PROVISION_TYPE_PROFILE
-    if: ${{ github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
     #;> !PROVISION_TYPE_PROFILE
 
     container:
@@ -554,6 +564,21 @@ jobs:
       - name: Preserve $HOME set in the container
         run: echo HOME=/root >> "$GITHUB_ENV" # https://github.com/actions/runner/issues/863
 
+      - name: Resolve deploy target
+        if: ${{ inputs.deploy_target }}
+        env:
+          DEPLOY_TARGET: ${{ inputs.deploy_target }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo "DEPLOY_BRANCH=${DEPLOY_TARGET}"
+            if echo "${DEPLOY_TARGET}" | grep -iq '^pr-'; then
+              echo "DEPLOY_PR_NUMBER=${DEPLOY_TARGET#*-}"
+              echo "DEPLOY_PR_HEAD_SHA=$(gh pr view "${DEPLOY_TARGET#*-}" --repo "${{ github.repository }}" --json headRefOid --jq '.headRefOid')"
+              echo "DEPLOY_BRANCH=$(gh pr view "${DEPLOY_TARGET#*-}" --repo "${{ github.repository }}" --json headRefName --jq '.headRefName')"
+            fi
+          } >> "$GITHUB_ENV"
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -562,7 +587,7 @@ jobs:
           # Do not persist credentials after checkout
           # to allow using the custom credentials to push to a remote repo.
           persist-credentials: false
-          ref: ${{ github.head_ref || github.ref_name }}
+          ref: ${{ env.DEPLOY_BRANCH || github.head_ref || github.ref_name }}
 
       - name: Fix Git ownership permissions
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -570,15 +595,16 @@ jobs:
       - name: Load environment variables from .env
         run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"
 
+      # Artifact deployments do not work for manual deploys as the build job is skipped.
       - name: Download exported codebase as an artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        if: ${{ contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
+        if: ${{ !inputs.deploy_target && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
         with:
           name: code-artifact
           path: "/tmp/artifacts"
 
       - name: Unpack downloaded exported codebase
-        if: ${{ contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
+        if: ${{ !inputs.deploy_target && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
         run: |
           mkdir -p /tmp/workspace
           tar -xpf /tmp/artifacts/code.tar -C /tmp/workspace
@@ -596,10 +622,9 @@ jobs:
         run: ./scripts/vortex/deploy.sh
         env:
           VORTEX_DEPLOY_MODE: ${{ startsWith(github.ref, 'refs/tags/') && 'tag' || 'branch' }}
-          # Get branch for PR from 'head_ref' or for branch from 'ref_name'.
-          VORTEX_DEPLOY_BRANCH: ${{ github.head_ref || github.ref_name }}
-          VORTEX_DEPLOY_PR: ${{ github.event.number }}
-          VORTEX_DEPLOY_PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          VORTEX_DEPLOY_BRANCH: ${{ env.DEPLOY_BRANCH || github.head_ref || github.ref_name }}
+          VORTEX_DEPLOY_PR: ${{ env.DEPLOY_PR_NUMBER || github.event.number }}
+          VORTEX_DEPLOY_PR_HEAD: ${{ env.DEPLOY_PR_HEAD_SHA || github.event.pull_request.head.sha }}
           VORTEX_DEPLOY_ARTIFACT_SRC: /tmp/workspace/code
           VORTEX_DEPLOY_ARTIFACT_ROOT: ${{ github.workspace }}
           VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE: ${{ vars.VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE }}
@@ -610,5 +635,6 @@ jobs:
           VORTEX_DEPLOY_ALLOW_SKIP: ${{ vars.VORTEX_DEPLOY_ALLOW_SKIP }}
           VORTEX_DEPLOY_SKIP_PRS: ${{ vars.VORTEX_DEPLOY_SKIP_PRS }}
           VORTEX_DEPLOY_SKIP_BRANCHES: ${{ vars.VORTEX_DEPLOY_SKIP_BRANCHES }}
+          VORTEX_DEPLOY_ACTION: ${{ inputs.override_db && 'deploy_override_db' || '' }}
         timeout-minutes: 30
   #;> DEPLOYMENT

--- a/.vortex/docs/content/continuous-integration/github-actions.mdx
+++ b/.vortex/docs/content/continuous-integration/github-actions.mdx
@@ -165,6 +165,32 @@ to the additional containers to keep build times balanced.
 See [Test parallelism](/docs/continuous-integration#test-parallelism) for details
 on how tests are distributed across containers.
 
+### Manual deployment
+
+The workflow supports triggering deployments directly from the GitHub UI without
+running `lint`, `build`, or `test` jobs. Navigate to **Actions → Database, Build,
+Test and Deploy → Run workflow** and provide:
+
+| Input           | Description                                                                      |
+|-----------------|----------------------------------------------------------------------------------|
+| `deploy_target` | Branch name (e.g., `develop`) or PR reference (e.g., `PR-123`, case-insensitive) |
+| `override_db`   | Override the existing database in the deployment environment                     |
+
+When `deploy_target` is set, all other jobs are skipped and only the deploy
+job runs. For PR targets, the workflow resolves the PR's head branch and
+commit SHA automatically.
+
+When `override_db` is checked, the database in the existing deployment
+environment will be overridden with a fresh copy taken from the production
+environment.
+
+:::note
+
+Artifact-based deployments do not work with manual deploys as the build job
+is skipped.
+
+:::
+
 ### Terminal access for debugging
 
 The workflow includes a `tmate` session for debugging. Trigger a manual workflow

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -37,9 +37,19 @@ on:
 
   workflow_dispatch:
     inputs:
+      deploy_target:
+        type: string
+        description: 'Deploy target: "<branch>" or "PR-<num>"'
+        required: false
+        default: ''
+      override_db:
+        type: boolean
+        description: 'Override existing database'
+        required: false
+        default: false
       enable_terminal:
         type: boolean
-        description: 'Enable terminal session.'
+        description: 'Enable terminal session'
         required: false
         default: false
   schedule:
@@ -59,7 +69,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 
     container:
       # https://hub.docker.com/r/drevops/ci-runner
@@ -159,7 +169,7 @@ jobs:
 
   database:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || !startsWith(github.head_ref, 'project/') }}
+    if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 
     container:
       # https://hub.docker.com/r/drevops/ci-runner
@@ -264,7 +274,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: database
-    if: ${{ github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 
     strategy:
       # A matrix to run multiple jobs in parallel.
@@ -485,7 +495,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [build, lint]
-    if: ${{ github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
 
     container:
       # https://hub.docker.com/r/drevops/ci-runner
@@ -500,6 +510,21 @@ jobs:
       - name: Preserve $HOME set in the container
         run: echo HOME=/root >> "$GITHUB_ENV" # https://github.com/actions/runner/issues/863
 
+      - name: Resolve deploy target
+        if: ${{ inputs.deploy_target }}
+        env:
+          DEPLOY_TARGET: ${{ inputs.deploy_target }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo "DEPLOY_BRANCH=${DEPLOY_TARGET}"
+            if echo "${DEPLOY_TARGET}" | grep -iq '^pr-'; then
+              echo "DEPLOY_PR_NUMBER=${DEPLOY_TARGET#*-}"
+              echo "DEPLOY_PR_HEAD_SHA=$(gh pr view "${DEPLOY_TARGET#*-}" --repo "${{ github.repository }}" --json headRefOid --jq '.headRefOid')"
+              echo "DEPLOY_BRANCH=$(gh pr view "${DEPLOY_TARGET#*-}" --repo "${{ github.repository }}" --json headRefName --jq '.headRefName')"
+            fi
+          } >> "$GITHUB_ENV"
+
       - name: Checkout code
         uses: actions/checkout@__HASH__ # __VERSION__
         with:
@@ -508,7 +533,7 @@ jobs:
           # Do not persist credentials after checkout
           # to allow using the custom credentials to push to a remote repo.
           persist-credentials: false
-          ref: ${{ github.head_ref || github.ref_name }}
+          ref: ${{ env.DEPLOY_BRANCH || github.head_ref || github.ref_name }}
 
       - name: Fix Git ownership permissions
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -516,15 +541,16 @@ jobs:
       - name: Load environment variables from .env
         run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"
 
+      # Artifact deployments do not work for manual deploys as the build job is skipped.
       - name: Download exported codebase as an artifact
         uses: actions/download-artifact@__HASH__ # __VERSION__
-        if: ${{ contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
+        if: ${{ !inputs.deploy_target && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
         with:
           name: code-artifact
           path: "/tmp/artifacts"
 
       - name: Unpack downloaded exported codebase
-        if: ${{ contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
+        if: ${{ !inputs.deploy_target && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
         run: |
           mkdir -p /tmp/workspace
           tar -xpf /tmp/artifacts/code.tar -C /tmp/workspace
@@ -542,10 +568,9 @@ jobs:
         run: ./scripts/vortex/deploy.sh
         env:
           VORTEX_DEPLOY_MODE: ${{ startsWith(github.ref, 'refs/tags/') && 'tag' || 'branch' }}
-          # Get branch for PR from 'head_ref' or for branch from 'ref_name'.
-          VORTEX_DEPLOY_BRANCH: ${{ github.head_ref || github.ref_name }}
-          VORTEX_DEPLOY_PR: ${{ github.event.number }}
-          VORTEX_DEPLOY_PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          VORTEX_DEPLOY_BRANCH: ${{ env.DEPLOY_BRANCH || github.head_ref || github.ref_name }}
+          VORTEX_DEPLOY_PR: ${{ env.DEPLOY_PR_NUMBER || github.event.number }}
+          VORTEX_DEPLOY_PR_HEAD: ${{ env.DEPLOY_PR_HEAD_SHA || github.event.pull_request.head.sha }}
           VORTEX_DEPLOY_ARTIFACT_SRC: /tmp/workspace/code
           VORTEX_DEPLOY_ARTIFACT_ROOT: ${{ github.workspace }}
           VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE: ${{ vars.VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE }}
@@ -556,4 +581,5 @@ jobs:
           VORTEX_DEPLOY_ALLOW_SKIP: ${{ vars.VORTEX_DEPLOY_ALLOW_SKIP }}
           VORTEX_DEPLOY_SKIP_PRS: ${{ vars.VORTEX_DEPLOY_SKIP_PRS }}
           VORTEX_DEPLOY_SKIP_BRANCHES: ${{ vars.VORTEX_DEPLOY_SKIP_BRANCHES }}
+          VORTEX_DEPLOY_ACTION: ${{ inputs.override_db && 'deploy_override_db' || '' }}
         timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/db_download_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/db_download_source_acquia/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -239,6 +239,9 @@
+@@ -249,6 +249,9 @@
            VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./scripts/vortex/download-db.sh
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -481,79 +481,3 @@
+@@ -491,95 +491,3 @@
          timeout-minutes: 120 # Cancel the action after 15 minutes, regardless of whether a connection has been established.
          with:
            detached: true
@@ -6,7 +6,7 @@
 -  deploy:
 -    runs-on: ubuntu-latest
 -    needs: [build, lint]
--    if: ${{ github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+-    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
 -
 -    container:
 -      # https://hub.docker.com/r/drevops/ci-runner
@@ -21,6 +21,21 @@
 -      - name: Preserve $HOME set in the container
 -        run: echo HOME=/root >> "$GITHUB_ENV" # https://github.com/actions/runner/issues/863
 -
+-      - name: Resolve deploy target
+-        if: ${{ inputs.deploy_target }}
+-        env:
+-          DEPLOY_TARGET: ${{ inputs.deploy_target }}
+-          GH_TOKEN: ${{ github.token }}
+-        run: |
+-          {
+-            echo "DEPLOY_BRANCH=${DEPLOY_TARGET}"
+-            if echo "${DEPLOY_TARGET}" | grep -iq '^pr-'; then
+-              echo "DEPLOY_PR_NUMBER=${DEPLOY_TARGET#*-}"
+-              echo "DEPLOY_PR_HEAD_SHA=$(gh pr view "${DEPLOY_TARGET#*-}" --repo "${{ github.repository }}" --json headRefOid --jq '.headRefOid')"
+-              echo "DEPLOY_BRANCH=$(gh pr view "${DEPLOY_TARGET#*-}" --repo "${{ github.repository }}" --json headRefName --jq '.headRefName')"
+-            fi
+-          } >> "$GITHUB_ENV"
+-
 -      - name: Checkout code
 -        uses: actions/checkout@__HASH__ # __VERSION__
 -        with:
@@ -29,7 +44,7 @@
 -          # Do not persist credentials after checkout
 -          # to allow using the custom credentials to push to a remote repo.
 -          persist-credentials: false
--          ref: ${{ github.head_ref || github.ref_name }}
+-          ref: ${{ env.DEPLOY_BRANCH || github.head_ref || github.ref_name }}
 -
 -      - name: Fix Git ownership permissions
 -        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -37,15 +52,16 @@
 -      - name: Load environment variables from .env
 -        run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"
 -
+-      # Artifact deployments do not work for manual deploys as the build job is skipped.
 -      - name: Download exported codebase as an artifact
 -        uses: actions/download-artifact@__HASH__ # __VERSION__
--        if: ${{ contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
+-        if: ${{ !inputs.deploy_target && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
 -        with:
 -          name: code-artifact
 -          path: "/tmp/artifacts"
 -
 -      - name: Unpack downloaded exported codebase
--        if: ${{ contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
+-        if: ${{ !inputs.deploy_target && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
 -        run: |
 -          mkdir -p /tmp/workspace
 -          tar -xpf /tmp/artifacts/code.tar -C /tmp/workspace
@@ -63,10 +79,9 @@
 -        run: ./scripts/vortex/deploy.sh
 -        env:
 -          VORTEX_DEPLOY_MODE: ${{ startsWith(github.ref, 'refs/tags/') && 'tag' || 'branch' }}
--          # Get branch for PR from 'head_ref' or for branch from 'ref_name'.
--          VORTEX_DEPLOY_BRANCH: ${{ github.head_ref || github.ref_name }}
--          VORTEX_DEPLOY_PR: ${{ github.event.number }}
--          VORTEX_DEPLOY_PR_HEAD: ${{ github.event.pull_request.head.sha }}
+-          VORTEX_DEPLOY_BRANCH: ${{ env.DEPLOY_BRANCH || github.head_ref || github.ref_name }}
+-          VORTEX_DEPLOY_PR: ${{ env.DEPLOY_PR_NUMBER || github.event.number }}
+-          VORTEX_DEPLOY_PR_HEAD: ${{ env.DEPLOY_PR_HEAD_SHA || github.event.pull_request.head.sha }}
 -          VORTEX_DEPLOY_ARTIFACT_SRC: /tmp/workspace/code
 -          VORTEX_DEPLOY_ARTIFACT_ROOT: ${{ github.workspace }}
 -          VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE: ${{ vars.VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE }}
@@ -77,4 +92,5 @@
 -          VORTEX_DEPLOY_ALLOW_SKIP: ${{ vars.VORTEX_DEPLOY_ALLOW_SKIP }}
 -          VORTEX_DEPLOY_SKIP_PRS: ${{ vars.VORTEX_DEPLOY_SKIP_PRS }}
 -          VORTEX_DEPLOY_SKIP_BRANCHES: ${{ vars.VORTEX_DEPLOY_SKIP_BRANCHES }}
+-          VORTEX_DEPLOY_ACTION: ${{ inputs.override_db && 'deploy_override_db' || '' }}
 -        timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -239,6 +239,9 @@
+@@ -249,6 +249,9 @@
            VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./scripts/vortex/download-db.sh
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -239,6 +239,9 @@
+@@ -249,6 +249,9 @@
            VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./scripts/vortex/download-db.sh
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -240,6 +240,9 @@
+@@ -250,6 +250,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -362,6 +365,10 @@
+@@ -372,6 +375,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -240,6 +240,9 @@
+@@ -250,6 +250,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -362,6 +365,10 @@
+@@ -372,6 +375,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -240,6 +240,9 @@
+@@ -250,6 +250,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -362,6 +365,10 @@
+@@ -372,6 +375,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -240,6 +240,9 @@
+@@ -250,6 +250,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -362,6 +365,10 @@
+@@ -372,6 +375,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -240,6 +240,9 @@
+@@ -250,6 +250,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -362,6 +365,10 @@
+@@ -372,6 +375,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -240,6 +240,9 @@
+@@ -250,6 +250,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -362,6 +365,10 @@
+@@ -372,6 +375,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -240,6 +240,9 @@
+@@ -250,6 +250,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -362,6 +365,10 @@
+@@ -372,6 +375,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -1,5 +1,5 @@
-@@ -42,8 +42,6 @@
-         description: 'Enable terminal session.'
+@@ -52,8 +52,6 @@
+         description: 'Enable terminal session'
          required: false
          default: false
 -  schedule:
@@ -7,21 +7,21 @@
  
  defaults:
    run:
-@@ -59,7 +57,6 @@
+@@ -69,7 +67,6 @@
  
    lint:
      runs-on: ubuntu-latest
--    if: ${{ github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+-    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
  
      container:
        # https://hub.docker.com/r/drevops/ci-runner
-@@ -157,114 +154,8 @@
+@@ -167,114 +164,8 @@
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  
 -  database:
 -    runs-on: ubuntu-latest
--    if: ${{ github.event_name == 'push' || !startsWith(github.head_ref, 'project/') }}
+-    if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 -
 -    container:
 -      # https://hub.docker.com/r/drevops/ci-runner
@@ -126,11 +126,11 @@
    build:
      runs-on: ubuntu-latest
 -    needs: database
--    if: ${{ github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+-    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
  
      strategy:
        # A matrix to run multiple jobs in parallel.
-@@ -285,14 +176,6 @@
+@@ -295,14 +186,6 @@
          VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"
          VORTEX_SSH_REMOVE_ALL_KEYS: "1"
          VORTEX_DEBUG: ${{ vars.VORTEX_DEBUG }}
@@ -145,7 +145,7 @@
  
      steps:
        - name: Preserve $HOME set in the container
-@@ -314,29 +197,6 @@
+@@ -324,29 +207,6 @@
          run: composer validate --strict
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE == '1' }}
  
@@ -175,11 +175,11 @@
        - name: Login to container registry
          run: ./scripts/vortex/login-container-registry.sh
  
-@@ -485,7 +345,6 @@
+@@ -495,7 +355,6 @@
    deploy:
      runs-on: ubuntu-latest
      needs: [build, lint]
--    if: ${{ github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+-    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
  
      container:
        # https://hub.docker.com/r/drevops/ci-runner

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -152,11 +152,6 @@
+@@ -162,11 +162,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  
@@ -9,4 +9,4 @@
 -
    database:
      runs-on: ubuntu-latest
-     if: ${{ github.event_name == 'push' || !startsWith(github.head_ref, 'project/') }}
+     if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -152,11 +152,6 @@
+@@ -162,11 +162,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  
@@ -9,4 +9,4 @@
 -
    database:
      runs-on: ubuntu-latest
-     if: ${{ github.event_name == 'push' || !startsWith(github.head_ref, 'project/') }}
+     if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -152,11 +152,6 @@
+@@ -162,11 +162,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  
@@ -9,4 +9,4 @@
 -
    database:
      runs-on: ubuntu-latest
-     if: ${{ github.event_name == 'push' || !startsWith(github.head_ref, 'project/') }}
+     if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -124,22 +124,6 @@
+@@ -134,22 +134,6 @@
          run: docker compose exec -T cli composer normalize --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_NORMALIZE_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -144,10 +144,6 @@
+@@ -154,10 +154,6 @@
          run: docker compose exec -T cli vendor/bin/twig-cs-fixer
          continue-on-error: ${{ vars.VORTEX_CI_TWIG_CS_FIXER_IGNORE_FAILURE == '1' }}
  
@@ -9,7 +9,7 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -364,88 +360,6 @@
+@@ -374,88 +370,6 @@
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./scripts/vortex/provision.sh

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -114,7 +114,6 @@
+@@ -124,7 +124,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -147,10 +146,6 @@
+@@ -157,10 +156,6 @@
        - name: Lint code with Gherkin Lint
          run: docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features
          continue-on-error: ${{ vars.VORTEX_CI_GHERKIN_LINT_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -114,7 +114,6 @@
+@@ -124,7 +124,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -147,15 +146,6 @@
+@@ -157,15 +156,6 @@
        - name: Lint code with Gherkin Lint
          run: docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features
          continue-on-error: ${{ vars.VORTEX_CI_GHERKIN_LINT_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -144,10 +144,6 @@
+@@ -154,10 +154,6 @@
          run: docker compose exec -T cli vendor/bin/twig-cs-fixer
          continue-on-error: ${{ vars.VORTEX_CI_TWIG_CS_FIXER_IGNORE_FAILURE == '1' }}
  
@@ -9,7 +9,7 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -435,18 +431,6 @@
+@@ -445,18 +441,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -114,7 +114,6 @@
+@@ -124,7 +124,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -147,10 +146,6 @@
+@@ -157,10 +156,6 @@
        - name: Lint code with Gherkin Lint
          run: docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features
          continue-on-error: ${{ vars.VORTEX_CI_GHERKIN_LINT_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -114,7 +114,6 @@
+@@ -124,7 +124,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -147,15 +146,6 @@
+@@ -157,15 +156,6 @@
        - name: Lint code with Gherkin Lint
          run: docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features
          continue-on-error: ${{ vars.VORTEX_CI_GHERKIN_LINT_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -124,10 +124,6 @@
+@@ -134,10 +134,6 @@
          run: docker compose exec -T cli composer normalize --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_NORMALIZE_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -136,10 +136,6 @@
+@@ -146,10 +146,6 @@
          run: docker compose exec -T cli vendor/bin/rector --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_RECTOR_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -128,10 +128,6 @@
+@@ -138,10 +138,6 @@
          run: docker compose exec -T cli vendor/bin/phpcs
          continue-on-error: ${{ vars.VORTEX_CI_PHPCS_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -366,76 +366,6 @@
+@@ -376,76 +376,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./scripts/vortex/provision.sh
          timeout-minutes: 30
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -132,10 +132,6 @@
+@@ -142,10 +142,6 @@
          run: docker compose exec -T cli vendor/bin/phpstan
          continue-on-error: ${{ vars.VORTEX_CI_PHPSTAN_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -152,11 +152,6 @@
+@@ -162,11 +162,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  
@@ -9,4 +9,4 @@
 -
    database:
      runs-on: ubuntu-latest
-     if: ${{ github.event_name == 'push' || !startsWith(github.head_ref, 'project/') }}
+     if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -114,7 +114,6 @@
+@@ -124,7 +124,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -124,34 +123,10 @@
+@@ -134,34 +133,10 @@
          run: docker compose exec -T cli composer normalize --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_NORMALIZE_IGNORE_FAILURE == '1' }}
  
@@ -41,7 +41,7 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -364,88 +339,6 @@
+@@ -374,88 +349,6 @@
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./scripts/vortex/provision.sh


### PR DESCRIPTION
Closes #1904


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual deployment from the UI to a specific branch or PR (with automatic PR head resolution); manual deploys run only the deploy step and skip lint/build/test, and won’t use build artifacts.
  * New option to override the deployment database with a fresh production-derived copy.

* **Documentation**
  * Added guidance for the manual deployment workflow, usage notes, and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->