### PR TITLE
Updated PHPStan config to ignore array types for hooks '@return' params.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/phpstan.neon
@@ -30,8 +30,18 @@ parameters:
   treatPhpDocTypesAsCertain: false
 
   ignoreErrors:
-    -
-      # Since tests and data providers do not have to have parameter docblocks,
+    - # Hook implementations do not provide full type information for
+      # parameters or return values in iterable type arrays.
+      message: '#.*no value type specified in iterable type array#'
+      paths:
+        - web/modules/custom/*
+        - web/themes/custom/*
+    - # Included settings files are not aware about global variables.
+      message: '#Variable .* might not be defined.#'
+      paths:
+        - web/sites/default/includes
+      reportUnmatched: false
+    - # Since tests and data providers do not have to have parameter docblocks,
       # it is not possible to specify the type of the parameter, so we ignore
       # this error.
       message: '#.*no value type specified in iterable type array.#'
@@ -39,18 +49,4 @@ parameters:
         - web/modules/custom/*/tests/*
         - web/themes/custom/*/tests/*
         - tests/phpunit/*
-      reportUnmatched: false
-    -
-      # Hook implementations do not provide docblocks for parameters, so there
-      # is no way to provide this information.
-      message: '#.* with no value type specified in iterable type array#'
-      paths:
-        - web/modules/custom/*
-        - web/themes/custom/*
-      reportUnmatched: false
-    -
-      # Included settings files are not aware about global variables.
-      message: '#Variable .* might not be defined.#'
-      paths:
-        - web/sites/default/includes
       reportUnmatched: false

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/phpstan.neon
@@ -13,7 +13,23 @@
      - tests
  
    excludePaths:
-@@ -36,8 +36,8 @@
+@@ -34,12 +34,12 @@
+       # parameters or return values in iterable type arrays.
+       message: '#.*no value type specified in iterable type array#'
+       paths:
+-        - web/modules/custom/*
+-        - web/themes/custom/*
++        - docroot/modules/custom/*
++        - docroot/themes/custom/*
+     - # Included settings files are not aware about global variables.
+       message: '#Variable .* might not be defined.#'
+       paths:
+-        - web/sites/default/includes
++        - docroot/sites/default/includes
+       reportUnmatched: false
+     - # Since tests and data providers do not have to have parameter docblocks,
+       # it is not possible to specify the type of the parameter, so we ignore
+@@ -46,7 +46,7 @@
        # this error.
        message: '#.*no value type specified in iterable type array.#'
        paths:
@@ -22,21 +38,4 @@
 +        - docroot/modules/custom/*/tests/*
 +        - docroot/themes/custom/*/tests/*
          - tests/phpunit/*
-       reportUnmatched: false
-     -
-@@ -45,12 +45,12 @@
-       # is no way to provide this information.
-       message: '#.* with no value type specified in iterable type array#'
-       paths:
--        - web/modules/custom/*
--        - web/themes/custom/*
-+        - docroot/modules/custom/*
-+        - docroot/themes/custom/*
-       reportUnmatched: false
-     -
-       # Included settings files are not aware about global variables.
-       message: '#Variable .* might not be defined.#'
-       paths:
--        - web/sites/default/includes
-+        - docroot/sites/default/includes
        reportUnmatched: false

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/phpstan.neon
@@ -13,7 +13,23 @@
      - tests
  
    excludePaths:
-@@ -36,8 +36,8 @@
+@@ -34,12 +34,12 @@
+       # parameters or return values in iterable type arrays.
+       message: '#.*no value type specified in iterable type array#'
+       paths:
+-        - web/modules/custom/*
+-        - web/themes/custom/*
++        - docroot/modules/custom/*
++        - docroot/themes/custom/*
+     - # Included settings files are not aware about global variables.
+       message: '#Variable .* might not be defined.#'
+       paths:
+-        - web/sites/default/includes
++        - docroot/sites/default/includes
+       reportUnmatched: false
+     - # Since tests and data providers do not have to have parameter docblocks,
+       # it is not possible to specify the type of the parameter, so we ignore
+@@ -46,7 +46,7 @@
        # this error.
        message: '#.*no value type specified in iterable type array.#'
        paths:
@@ -22,21 +38,4 @@
 +        - docroot/modules/custom/*/tests/*
 +        - docroot/themes/custom/*/tests/*
          - tests/phpunit/*
-       reportUnmatched: false
-     -
-@@ -45,12 +45,12 @@
-       # is no way to provide this information.
-       message: '#.* with no value type specified in iterable type array#'
-       paths:
--        - web/modules/custom/*
--        - web/themes/custom/*
-+        - docroot/modules/custom/*
-+        - docroot/themes/custom/*
-       reportUnmatched: false
-     -
-       # Included settings files are not aware about global variables.
-       message: '#Variable .* might not be defined.#'
-       paths:
--        - web/sites/default/includes
-+        - docroot/sites/default/includes
        reportUnmatched: false

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/phpstan.neon
@@ -6,19 +6,18 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -37,7 +36,6 @@
+@@ -35,7 +34,6 @@
+       message: '#.*no value type specified in iterable type array#'
+       paths:
+         - web/modules/custom/*
+-        - web/themes/custom/*
+     - # Included settings files are not aware about global variables.
+       message: '#Variable .* might not be defined.#'
+       paths:
+@@ -47,6 +45,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*
 -        - web/themes/custom/*/tests/*
          - tests/phpunit/*
        reportUnmatched: false
-     -
-@@ -46,7 +44,6 @@
-       message: '#.* with no value type specified in iterable type array#'
-       paths:
-         - web/modules/custom/*
--        - web/themes/custom/*
-       reportUnmatched: false
-     -
-       # Included settings files are not aware about global variables.

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/phpstan.neon
@@ -6,19 +6,18 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -37,7 +36,6 @@
+@@ -35,7 +34,6 @@
+       message: '#.*no value type specified in iterable type array#'
+       paths:
+         - web/modules/custom/*
+-        - web/themes/custom/*
+     - # Included settings files are not aware about global variables.
+       message: '#Variable .* might not be defined.#'
+       paths:
+@@ -47,6 +45,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*
 -        - web/themes/custom/*/tests/*
          - tests/phpunit/*
        reportUnmatched: false
-     -
-@@ -46,7 +44,6 @@
-       message: '#.* with no value type specified in iterable type array#'
-       paths:
-         - web/modules/custom/*
--        - web/themes/custom/*
-       reportUnmatched: false
-     -
-       # Included settings files are not aware about global variables.

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/phpstan.neon
@@ -6,19 +6,18 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -37,7 +36,6 @@
+@@ -35,7 +34,6 @@
+       message: '#.*no value type specified in iterable type array#'
+       paths:
+         - web/modules/custom/*
+-        - web/themes/custom/*
+     - # Included settings files are not aware about global variables.
+       message: '#Variable .* might not be defined.#'
+       paths:
+@@ -47,6 +45,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*
 -        - web/themes/custom/*/tests/*
          - tests/phpunit/*
        reportUnmatched: false
-     -
-@@ -46,7 +44,6 @@
-       message: '#.* with no value type specified in iterable type array#'
-       paths:
-         - web/modules/custom/*
--        - web/themes/custom/*
-       reportUnmatched: false
-     -
-       # Included settings files are not aware about global variables.

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/phpstan.neon
@@ -1,8 +1,6 @@
-@@ -38,7 +38,6 @@
+@@ -48,5 +48,4 @@
        paths:
          - web/modules/custom/*/tests/*
          - web/themes/custom/*/tests/*
 -        - tests/phpunit/*
        reportUnmatched: false
-     -
-       # Hook implementations do not provide docblocks for parameters, so there

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/phpstan.neon
@@ -1,8 +1,6 @@
-@@ -38,7 +38,6 @@
+@@ -48,5 +48,4 @@
        paths:
          - web/modules/custom/*/tests/*
          - web/themes/custom/*/tests/*
 -        - tests/phpunit/*
        reportUnmatched: false
-     -
-       # Hook implementations do not provide docblocks for parameters, so there

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/phpstan.neon
@@ -6,19 +6,18 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -37,7 +36,6 @@
+@@ -35,7 +34,6 @@
+       message: '#.*no value type specified in iterable type array#'
+       paths:
+         - web/modules/custom/*
+-        - web/themes/custom/*
+     - # Included settings files are not aware about global variables.
+       message: '#Variable .* might not be defined.#'
+       paths:
+@@ -47,6 +45,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*
 -        - web/themes/custom/*/tests/*
          - tests/phpunit/*
        reportUnmatched: false
-     -
-@@ -46,7 +44,6 @@
-       message: '#.* with no value type specified in iterable type array#'
-       paths:
-         - web/modules/custom/*
--        - web/themes/custom/*
-       reportUnmatched: false
-     -
-       # Included settings files are not aware about global variables.

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/phpstan.neon
@@ -6,19 +6,18 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -37,7 +36,6 @@
+@@ -35,7 +34,6 @@
+       message: '#.*no value type specified in iterable type array#'
+       paths:
+         - web/modules/custom/*
+-        - web/themes/custom/*
+     - # Included settings files are not aware about global variables.
+       message: '#Variable .* might not be defined.#'
+       paths:
+@@ -47,6 +45,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*
 -        - web/themes/custom/*/tests/*
          - tests/phpunit/*
        reportUnmatched: false
-     -
-@@ -46,7 +44,6 @@
-       message: '#.* with no value type specified in iterable type array#'
-       paths:
-         - web/modules/custom/*
--        - web/themes/custom/*
-       reportUnmatched: false
-     -
-       # Included settings files are not aware about global variables.

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/phpstan.neon
@@ -6,19 +6,18 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -37,7 +36,6 @@
+@@ -35,7 +34,6 @@
+       message: '#.*no value type specified in iterable type array#'
+       paths:
+         - web/modules/custom/*
+-        - web/themes/custom/*
+     - # Included settings files are not aware about global variables.
+       message: '#Variable .* might not be defined.#'
+       paths:
+@@ -47,6 +45,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*
 -        - web/themes/custom/*/tests/*
          - tests/phpunit/*
        reportUnmatched: false
-     -
-@@ -46,7 +44,6 @@
-       message: '#.* with no value type specified in iterable type array#'
-       paths:
-         - web/modules/custom/*
--        - web/themes/custom/*
-       reportUnmatched: false
-     -
-       # Included settings files are not aware about global variables.

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/phpstan.neon
@@ -1,8 +1,6 @@
-@@ -38,7 +38,6 @@
+@@ -48,5 +48,4 @@
        paths:
          - web/modules/custom/*/tests/*
          - web/themes/custom/*/tests/*
 -        - tests/phpunit/*
        reportUnmatched: false
-     -
-       # Hook implementations do not provide docblocks for parameters, so there

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/phpstan.neon
@@ -1,8 +1,6 @@
-@@ -38,7 +38,6 @@
+@@ -48,5 +48,4 @@
        paths:
          - web/modules/custom/*/tests/*
          - web/themes/custom/*/tests/*
 -        - tests/phpunit/*
        reportUnmatched: false
-     -
-       # Hook implementations do not provide docblocks for parameters, so there

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/phpstan.neon
@@ -6,19 +6,18 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -37,7 +36,6 @@
+@@ -35,7 +34,6 @@
+       message: '#.*no value type specified in iterable type array#'
+       paths:
+         - web/modules/custom/*
+-        - web/themes/custom/*
+     - # Included settings files are not aware about global variables.
+       message: '#Variable .* might not be defined.#'
+       paths:
+@@ -47,6 +45,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*
 -        - web/themes/custom/*/tests/*
          - tests/phpunit/*
        reportUnmatched: false
-     -
-@@ -46,7 +44,6 @@
-       message: '#.* with no value type specified in iterable type array#'
-       paths:
-         - web/modules/custom/*
--        - web/themes/custom/*
-       reportUnmatched: false
-     -
-       # Included settings files are not aware about global variables.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,8 +30,18 @@ parameters:
   treatPhpDocTypesAsCertain: false
 
   ignoreErrors:
-    -
-      # Since tests and data providers do not have to have parameter docblocks,
+    - # Hook implementations do not provide full type information for
+      # parameters or return values in iterable type arrays.
+      message: '#.*no value type specified in iterable type array#'
+      paths:
+        - web/modules/custom/*
+        - web/themes/custom/*
+    - # Included settings files are not aware about global variables.
+      message: '#Variable .* might not be defined.#'
+      paths:
+        - web/sites/default/includes
+      reportUnmatched: false
+    - # Since tests and data providers do not have to have parameter docblocks,
       # it is not possible to specify the type of the parameter, so we ignore
       # this error.
       message: '#.*no value type specified in iterable type array.#'
@@ -39,18 +49,4 @@ parameters:
         - web/modules/custom/*/tests/*
         - web/themes/custom/*/tests/*
         - tests/phpunit/*
-      reportUnmatched: false
-    -
-      # Hook implementations do not provide docblocks for parameters, so there
-      # is no way to provide this information.
-      message: '#.* with no value type specified in iterable type array#'
-      paths:
-        - web/modules/custom/*
-        - web/themes/custom/*
-      reportUnmatched: false
-    -
-      # Included settings files are not aware about global variables.
-      message: '#Variable .* might not be defined.#'
-      paths:
-        - web/sites/default/includes
       reportUnmatched: false


### PR DESCRIPTION
## Summary

Updated the PHPStan `ignoreErrors` configuration in `phpstan.neon` and all installer test fixture variants to broaden the hook implementations rule. The previous pattern `#.* with no value type specified in iterable type array#` was too narrow and missed cases where the error message uses `@return` annotation wording; it has been replaced with a unified `#.*no value type specified in iterable type array#` pattern (without the leading `with`) that covers both parameter and return-value contexts. The entries were also reordered so the broader hook and settings ignores appear before the test-specific one, and `reportUnmatched: false` was removed from the hooks rule since matches are now guaranteed.

## Changes

- **`phpstan.neon`** — Replaced the two separate `ignoreErrors` entries for hook implementations and settings includes with consolidated, reordered entries; updated the hook rule pattern to match both parameter and return-value array-type errors.
- **Installer test fixtures (`_baseline`, `hosting_acquia`, `hosting_project_name___acquia`, `theme_claro`, `theme_olivero`, `theme_stark`, `tools_groups_no_fe_lint_no_theme`, `tools_groups_no_fe_lint_no_theme_circleci`, `tools_no_eslint_no_theme`, `tools_no_stylelint_no_theme`)** — Applied the same pattern and ordering changes; Acquia-hosted fixtures also updated paths from `web/` to `docroot/`.
- **`tools_groups_no_be_tests`, `tools_groups_no_be_tests_circleci`, `tools_no_phpunit`, `tools_no_phpunit_circleci`** — Updated diff line references to match the new line numbers after the reordering.
- **`tools_groups_no_fe_lint_no_theme`** — Removed a stale empty test file `web/modules/custom/sw_demo/js/-sw_demo.test.js`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined static analysis suppression rules to be more precise and adjusted reporting behavior for unmatched rules.
  * Improves diagnostics accuracy and visibility of real issues, supporting better code quality management without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->