### PR TITLE
Added 'drush' directory to '.gitignore.artifact' and sorted entries.

### DIFF
--- a/.gitignore.artifact
+++ b/.gitignore.artifact
@@ -4,11 +4,12 @@
 /*
 
 # Do not ignore required files.
+!.env
 !/config/
+!/drush/
 !/scripts/
 !/vendor/
 !composer.json
-!.env
 
 # Do not ignore webroot (manage Drupal Scaffold files using the composer.json)
 !web

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.gitignore.artifact
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.gitignore.artifact
@@ -4,11 +4,12 @@
 /*
 
 # Do not ignore required files.
+!.env
 !/config/
+!/drush/
 !/scripts/
 !/vendor/
 !composer.json
-!.env
 
 # Do not ignore webroot (manage Drupal Scaffold files using the composer.json)
 !web

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_gha/.gitignore.artifact
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_gha/.gitignore.artifact
@@ -4,11 +4,12 @@
 /*
 
 # Do not ignore required files.
+!.env
 !/config/
+!/drush/
 !/scripts/
 !/vendor/
 !composer.json
-!.env
 
 # Do not ignore webroot (manage Drupal Scaffold files using the composer.json)
 !web

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_artifact/.gitignore.artifact
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_artifact/.gitignore.artifact
@@ -4,11 +4,12 @@
 /*
 
 # Do not ignore required files.
+!.env
 !/config/
+!/drush/
 !/scripts/
 !/vendor/
 !composer.json
-!.env
 
 # Do not ignore webroot (manage Drupal Scaffold files using the composer.json)
 !web

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.gitignore.artifact
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.gitignore.artifact
@@ -4,11 +4,12 @@
 /*
 
 # Do not ignore required files.
+!.env
 !/config/
+!/drush/
 !/scripts/
 !/vendor/
 !composer.json
-!.env
 
 # Do not ignore webroot (manage Drupal Scaffold files using the composer.json)
 !docroot

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.gitignore.artifact
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.gitignore.artifact
@@ -4,11 +4,12 @@
 /*
 
 # Do not ignore required files.
+!.env
 !/config/
+!/drush/
 !/scripts/
 !/vendor/
 !composer.json
-!.env
 
 # Do not ignore webroot (manage Drupal Scaffold files using the composer.json)
 !docroot

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestDeploymentTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestDeploymentTrait.php
@@ -71,6 +71,7 @@ trait SubtestDeploymentTrait {
     $this->assertFileDoesNotExist($dir . '/.gitignore.artifact', '.gitignore.artifact should not exist in deployment');
 
     // Required directories should exist.
+    $this->assertDirectoryExists($dir . '/drush', 'Drush directory should exist in deployment');
     $this->assertDirectoryExists($dir . '/scripts', 'Scripts directory should exist in deployment');
     $this->assertDirectoryExists($dir . '/vendor', 'Vendor directory should exist in deployment');
 


### PR DESCRIPTION
## Summary

Added `!/drush/` to `.gitignore.artifact` so that the `drush/` directory is included in the git artifact deployment. Without this entry, drush site aliases and other drush configuration files were excluded from the artifact, causing drush commands to fail in production environments. The entries in the "Do not ignore required files" block were also sorted alphabetically for consistency. All installer fixture/snapshot files were updated to match.

## Changes

- **`.gitignore.artifact`** — Added `!/drush/` entry and sorted all entries in the "Do not ignore required files" block alphabetically (`!.env`, `!/config/`, `!/drush/`, `!/scripts/`, `!/vendor/`, `!composer.json`)
- **Installer fixtures** — Updated five fixture snapshots under `.vortex/installer/tests/Fixtures/` to reflect the same changes, keeping tests in sync with the source file
- **Deployment test** — Added assertion in `SubtestDeploymentTrait::assertDeploymentFilesPresent()` to verify the `drush` directory exists in the built artifact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control ignore rules to explicitly un-ignore certain required files (including .env) and add an exception for the drush directory.
* **Tests**
  * Added a deployment validation to automated tests to ensure the drush directory is present in build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->