### PR TITLE
[#2441] Fixed Acquia DB download to skip auth header on S3 redirect.

### DIFF
--- a/.vortex/tests/bats/unit/download-db-acquia.bats
+++ b/.vortex/tests/bats/unit/download-db-acquia.bats
@@ -35,7 +35,7 @@ load ../_helper.bash
 
     # Mock backup URL curl call with its message
     "Discovering backup URL."
-    '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # {"url":"https://backup.example.com/db.sql.gz","expires":"2024-01-01T01:00:00+00:00"}'
+    '@curl -s -o /dev/null -w %{redirect_url} -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # https://backup.example.com/db.sql.gz'
 
     # Mock file download curl call with its message and side effect to create zipped archive
     "Downloading DB dump into file .data/testdb_backup_backup-id-789.sql.gz."
@@ -224,7 +224,7 @@ load ../_helper.bash
 
     # Mock backup URL curl call with its message
     "Discovering backup URL."
-    '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # {"url":"https://backup.example.com/db.sql.gz"}'
+    '@curl -s -o /dev/null -w %{redirect_url} -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # https://backup.example.com/db.sql.gz'
 
     # Mock file download curl call with its message and side effect to create zipped archive
     "Downloading DB dump into file ./.data/testdb_backup_backup-id-789.sql.gz."
@@ -491,7 +491,7 @@ load ../_helper.bash
 
     # Rest of download steps...
     "[TASK] Discovering backup URL."
-    '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-new-123/actions/download # {"url":"https://backup.example.com/db-fresh.sql.gz"}'
+    '@curl -s -o /dev/null -w %{redirect_url} -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-new-123/actions/download # https://backup.example.com/db-fresh.sql.gz'
 
     "[TASK] Downloading DB dump into file .data/testdb_backup_backup-id-new-123.sql.gz."
     '@curl --progress-bar -L https://backup.example.com/db-fresh.sql.gz -o .data/testdb_backup_backup-id-new-123.sql.gz # 0 #  # echo "CREATE TABLE fresh (id INT);" | gzip > .data/testdb_backup_backup-id-new-123.sql.gz'

--- a/scripts/vortex/download-db-acquia.sh
+++ b/scripts/vortex/download-db-acquia.sh
@@ -255,11 +255,13 @@ else
     [ ! -d "${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR:-}" ] && note "Creating dump directory ${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR}" && mkdir -p "${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR}"
 
     task "Discovering backup URL."
-    backup_json=$(curl --progress-bar -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/environments/${env_id}/databases/${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}/backups/${backup_id}/actions/download")
-    [ "${VORTEX_DEBUG-}" = "1" ] && note "Backup URL API response: ${backup_json}"
-    backup_url=$(echo "${backup_json}" | extract_json_value "url")
+    # The Acquia API responds with a 302 redirect to the final S3 download URL.
+    # Capture the redirect URL without following it to avoid sending the
+    # Authorization header to S3 - the auth header is required only to query
+    # the Acquia API.
+    backup_url=$(curl -s -o /dev/null -w "%{redirect_url}" -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/environments/${env_id}/databases/${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}/backups/${backup_id}/actions/download")
     [ "${VORTEX_DEBUG-}" = "1" ] && note "Extracted backup URL: ${backup_url}"
-    [ -z "${backup_url}" ] && fail "Unable to discover backup URL for backup ID '${backup_id}'. API response: ${backup_json}" && exit 1
+    [ -z "${backup_url}" ] && fail "Unable to discover backup URL for backup ID '${backup_id}'." && exit 1
 
     task "Downloading DB dump into file ${file_name_compressed}."
     curl --progress-bar -L "${backup_url}" -o "${file_name_compressed}"
@@ -268,10 +270,10 @@ else
     # shellcheck disable=SC2181
     [ "${download_result}" -ne 0 ] && fail "Unable to download database ${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}. curl exit code: ${download_result}" && exit 1
 
-    # Check if the downloaded file exists and has content
+    # Check if the downloaded file exists and has content. Leave the file in
+    # place on failure so it can be inspected.
     if [ ! -f "${file_name_compressed}" ] || [ ! -s "${file_name_compressed}" ]; then
       fail "Downloaded file is empty or missing: ${file_name_compressed}"
-      rm -f "${file_name_compressed}"
       exit 1
     fi
 
@@ -283,24 +285,25 @@ else
   task "Expanding DB file ${file_name_compressed} into ${file_name}."
   [ "${VORTEX_DEBUG-}" = "1" ] && note "Starting decompression of ${file_name_compressed}"
 
-  # Test the gzip file first to ensure it's valid
+  # Test the gzip file first to ensure it's valid. Leave the file in place
+  # on failure so it can be inspected.
   if ! gunzip -t "${file_name_compressed}" 2>/dev/null; then
     fail "Downloaded file is not a valid gzip archive: ${file_name_compressed}"
-    rm -f "${file_name_compressed}"
     exit 1
   fi
 
   gunzip -c "${file_name_compressed}" >"${file_name}"
   decompress_result=$?
   [ "${VORTEX_DEBUG-}" = "1" ] && note "Decompression result: ${decompress_result}"
-  rm "${file_name_compressed}"
 
-  # Check decompression result and file validity
+  # Check decompression result and file validity. Leave both files in place
+  # on failure so they can be inspected.
   if [ "${decompress_result}" != 0 ] || [ ! -f "${file_name}" ] || [ ! -s "${file_name}" ]; then
     fail "Unable to process DB dump file \"${file_name}\". Decompression exit code: ${decompress_result}"
-    rm -f "${file_name_compressed}" "${file_name}"
     exit 1
   fi
+
+  rm "${file_name_compressed}"
 
   [ "${VORTEX_DEBUG-}" = "1" ] && note "Decompression completed successfully"
 fi


### PR DESCRIPTION
Closes #2441

## Summary

Fixed two bugs in `scripts/vortex/download-db-acquia.sh` that caused Acquia DB downloads to fail.

The Acquia API `actions/download` endpoint returns a 302 redirect to a presigned S3 URL. The previous implementation followed the redirect with `-L`, which could send the `Authorization: Bearer` header to S3 - S3 presigned URLs reject requests that carry extra auth headers, causing the download to return an error body instead of the archive. The fix captures only the redirect URL (without following it) and then makes a separate, auth-free curl call to S3.

Additionally, error branches that deleted partially-downloaded or corrupt files with `rm -f` were changed to leave those files in place so they can be inspected when something goes wrong.

## Changes

### `scripts/vortex/download-db-acquia.sh`

- **Auth header leak fix**: replaced `curl --progress-bar -L ... | extract_json_value "url"` with `curl -s -o /dev/null -w "%{redirect_url}" ...` to capture the S3 redirect URL without following it and without forwarding the `Authorization` header. The JSON-parsing branch was removed because the API only ever responds with a redirect, not a JSON body.
- **Preserve files on failure**: removed three `rm -f` calls from error branches (empty/missing download, invalid gzip, decompression failure) so the corrupt file is kept for inspection.
- **Move cleanup to success path**: moved `rm "${file_name_compressed}"` to after the decompression validity check so the compressed file is only deleted on a fully successful run.

### `.vortex/tests/bats/unit/download-db-acquia.bats`

- Updated three test-case curl mocks for the "Discovering backup URL" step to match the new `curl -s -o /dev/null -w %{redirect_url}` signature and to return a plain URL string instead of a JSON body.

## Before / After

**OLD flow**

```
Acquia API call
  curl --progress-bar -L
       -H "Authorization: Bearer <token>"
       https://…/actions/download
    │
    │  302 redirect (followed by -L)
    ▼
  S3 presigned URL  ← Authorization header forwarded here
    │
    │  S3 rejects extra auth → returns error XML body
    ▼
  Corrupt/empty file saved locally
    │
    │  gzip check or size check fails
    ▼
  rm -f  ← evidence deleted, nothing to inspect
```

**NEW flow**

```
Acquia API call (capture redirect only)
  curl -s -o /dev/null -w "%{redirect_url}"
       -H "Authorization: Bearer <token>"
       https://…/actions/download
    │
    │  302 redirect URL extracted, connection closed
    ▼
  backup_url = "https://s3.amazonaws.com/…?X-Amz-Signature=…"

S3 download (no auth header)
  curl --progress-bar -L "${backup_url}"
    │
    │  S3 accepts presigned URL, streams archive
    ▼
  Valid .sql.gz file saved locally
    │
    ├─ success → gunzip → rm compressed file
    │
    └─ failure → files left in place for inspection
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error diagnostics for Acquia database backup operations by preserving intermediate files for inspection when download or decompression fails, enabling improved troubleshooting
  * Optimized backup URL discovery mechanism

* **Tests**
  * Updated test cases for Acquia backup URL discovery functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->