### PR TITLE
[#2355] Hardened Renovate config with PR limits, GHA auto-merge and dashboard labels.

### DIFF
--- a/.vortex/docs/content/tools/renovate.mdx
+++ b/.vortex/docs/content/tools/renovate.mdx
@@ -25,6 +25,11 @@ Assignees can be configured in the `assignees` field.
 | **Container images** | All images in `.docker/` and `docker-compose.yml` | Major, minor, patch | Daily before 3 AM UTC |
 | **GitHub Actions** | All actions (pinned to digests) | Major, minor, patch | Daily before 3 AM UTC |
 
+Updates in the **GitHub Actions** group are auto-merged after CI passes. This
+requires "Allow auto-merge" to be enabled in the repository settings
+(*Settings > General > Pull Requests*). All other groups open PRs for
+manual review.
+
 ### Disabled updates
 
 These are intentionally skipped by Renovate — update them manually:
@@ -37,6 +42,17 @@ These are intentionally skipped by Renovate — update them manually:
 | PHP language version | `php` constraint in `composer.json` | Major version upgrades may introduce breaking changes |
 | JS language versions | `node`, `yarn` in `package.json` | Major version upgrades may introduce breaking changes |
 | JS non-root packages | Any `package.json` not at the root | Theme dependencies are managed separately |
+
+### PR throughput and presentation
+
+- **Concurrent PR limit:** `prConcurrentLimit: 10` - at most 10 open PRs
+  across all groups at any time.
+- **Hourly PR limit:** `prHourlyLimit: 0` - no hourly cap; the per-group
+  schedules above provide throttling.
+- **PR body table:** `commitBodyTable: true` - multi-package group PRs
+  include a version-comparison table in the body.
+- **Dashboard labels:** the Renovate dependency dashboard issue is labeled
+  `Dependencies` (`dependencyDashboardLabels`).
 
 ## Self-hosted vs GitHub app
 

--- a/.vortex/docs/content/tools/renovate.mdx
+++ b/.vortex/docs/content/tools/renovate.mdx
@@ -26,9 +26,14 @@ Assignees can be configured in the `assignees` field.
 | **GitHub Actions** | All actions (pinned to digests) | Major, minor, patch | Daily before 3 AM UTC |
 
 Updates in the **GitHub Actions** group are auto-merged after CI passes. This
-requires "Allow auto-merge" to be enabled in the repository settings
-(*Settings > General > Pull Requests*). All other groups open PRs for
-manual review.
+requires two repository settings:
+
+1. **"Allow auto-merge"** enabled under *Settings > General > Pull Requests*.
+2. **"Require status checks to pass before merging"** configured in the base
+   branch's branch protection rules, with at least one required status check
+   selected - otherwise GitHub may merge even if CI is red.
+
+All other groups open PRs for manual review.
 
 ### Disabled updates
 
@@ -49,8 +54,8 @@ These are intentionally skipped by Renovate — update them manually:
   across all groups at any time.
 - **Hourly PR limit:** `prHourlyLimit: 0` - no hourly cap; the per-group
   schedules above provide throttling.
-- **PR body table:** `commitBodyTable: true` - multi-package group PRs
-  include a version-comparison table in the body.
+- **Commit body table:** `commitBodyTable: true` - grouped update commits
+  include a version-comparison table in the commit message body.
 - **Dashboard labels:** the Renovate dependency dashboard issue is labeled
   `Dependencies` (`dependencyDashboardLabels`).
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/renovate.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/renovate.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:recommended"
     ],
@@ -6,10 +7,13 @@
     "labels": [
         "Dependencies"
     ],
-    "assignees": [],
-    "ignorePresets": [
-        ":prHourlyLimit2"
+    "dependencyDashboardLabels": [
+        "Dependencies"
     ],
+    "assignees": [],
+    "prConcurrentLimit": 10,
+    "prHourlyLimit": 0,
+    "commitBodyTable": true,
     "rangeStrategy": "bump",
     "timezone": "UTC",
     "configMigration": true,
@@ -186,7 +190,8 @@
             "matchManagers": [
                 "github-actions"
             ],
-            "pinDigests": true
+            "pinDigests": true,
+            "automerge": true
         }
     ],
     "customManagers": [

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/renovate.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/renovate.json
@@ -1,6 +1,6 @@
-@@ -11,7 +11,7 @@
-         ":prHourlyLimit2"
-     ],
+@@ -15,7 +15,7 @@
+     "prHourlyLimit": 0,
+     "commitBodyTable": true,
      "rangeStrategy": "bump",
 -    "timezone": "UTC",
 +    "timezone": "America/New_York",

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_gha/renovate.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_gha/renovate.json
@@ -1,6 +1,6 @@
-@@ -11,7 +11,7 @@
-         ":prHourlyLimit2"
-     ],
+@@ -15,7 +15,7 @@
+     "prHourlyLimit": 0,
+     "commitBodyTable": true,
      "rangeStrategy": "bump",
 -    "timezone": "UTC",
 +    "timezone": "America/New_York",

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:recommended"
     ],
@@ -6,10 +7,13 @@
     "labels": [
         "Dependencies"
     ],
-    "assignees": [],
-    "ignorePresets": [
-        ":prHourlyLimit2"
+    "dependencyDashboardLabels": [
+        "Dependencies"
     ],
+    "assignees": [],
+    "prConcurrentLimit": 10,
+    "prHourlyLimit": 0,
+    "commitBodyTable": true,
     "rangeStrategy": "bump",
     "timezone": "UTC",
     "configMigration": true,
@@ -189,7 +193,8 @@
             "matchManagers": [
                 "github-actions"
             ],
-            "pinDigests": true
+            "pinDigests": true,
+            "automerge": true
         }
     ],
     "customManagers": [


### PR DESCRIPTION
Closes #2355

## Summary

Hardens the Renovate configuration based on a targeted gap analysis against the
[Akollade renovate-config](https://github.com/Akollade/renovate-config). The
changes add explicit PR throughput controls, improve PR body presentation, label
the dependency dashboard issue, and enable auto-merge for the GitHub Actions
group. Items that were out of scope or explicitly declined by the maintainer are
noted below; vulnerability-alerts configuration was split to #2466 to keep this
PR focused.

## Changes

### Renovate configuration (`renovate.json`)

- Added `$schema` pointing to the official Renovate JSON schema for IDE
  autocomplete and validation.
- Added `dependencyDashboardLabels: ["Dependencies"]` so the Renovate
  dependency dashboard issue carries the `Dependencies` label.
- Added `prConcurrentLimit: 10` - caps open Renovate PRs across all groups to
  10 at any time.
- Added `prHourlyLimit: 0` - removes the hourly cap; per-group schedules
  provide the throttling instead.
- Added `commitBodyTable: true` - multi-package group PRs include a
  version-comparison table in the PR body.
- Added `automerge: true` to the "GitHub Actions - All - Major, minor and
  patch" package rule - GHA update PRs are auto-merged after CI passes.
- Removed `ignorePresets: [":prHourlyLimit2"]` - now redundant because
  `prHourlyLimit: 0` is set explicitly.

### Documentation (`.vortex/docs/content/tools/renovate.mdx`)

- Added a note below the update-rules table explaining that GitHub Actions
  group PRs are auto-merged after CI passes and that "Allow auto-merge" must
  be enabled in repository settings (*Settings > General > Pull Requests*).
- Added a new "### PR throughput and presentation" subsection documenting
  `prConcurrentLimit`, `prHourlyLimit`, `commitBodyTable`, and
  `dependencyDashboardLabels`.

### Installer fixtures

Mechanical regeneration of `.vortex/installer/tests/Fixtures/handler_process/`
snapshots (`_baseline`, `timezone_circleci`, `timezone_gha`) via
`ahoy update-snapshots` to pick up the root `renovate.json` changes.

## Related work

- #2466 - `vulnerabilityAlerts` configuration (split off from this issue).

## Items explicitly out of scope

The following items from the gap analysis were reviewed and declined or deferred
by the maintainer:

- Docker digest pinning
- Drupal core patch/minor split
- Unstable version (alpha/beta/rc) approval gate
- Composer `require-dev` split
- `platformAutomerge: true`
- Container image auto-merge
- Per-tool grouping (phpstan/twig/drush)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub Actions dependency updates now auto-merge after CI passes when repository auto-merge and required status checks are enabled.
  * Multi-package PRs now include a version comparison table for easier review.

* **Changes**
  * Dependency dashboard and PR throughput tuned: higher concurrent PR limit, hourly rate adjusted, and dashboard labeling standardized as "Dependencies".
  * All other dependency groups continue to open PRs for manual review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->