### PR TITLE
[#2500] Set 'VORTEX_DOWNLOAD_DB_ENVIRONMENT' to 'main' for Lagoon DB source.

### DIFF
--- a/.vortex/installer/src/Prompts/Handlers/DatabaseDownloadSource.php
+++ b/.vortex/installer/src/Prompts/Handlers/DatabaseDownloadSource.php
@@ -109,6 +109,12 @@ class DatabaseDownloadSource extends AbstractHandler {
 
     Env::writeValueDotenv('VORTEX_DOWNLOAD_DB_SOURCE', $v, $t . '/.env');
 
+    // Lagoon identifies environments by branch name; the production branch
+    // is `main`. The shared default (`prod`) is correct for Acquia only.
+    if ($v === self::LAGOON) {
+      Env::writeValueDotenv('VORTEX_DOWNLOAD_DB_ENVIRONMENT', 'main', $t . '/.env');
+    }
+
     $types = [
       DatabaseDownloadSource::URL,
       DatabaseDownloadSource::FTP,

--- a/.vortex/installer/src/Prompts/Handlers/MigrationDownloadSource.php
+++ b/.vortex/installer/src/Prompts/Handlers/MigrationDownloadSource.php
@@ -108,6 +108,12 @@ class MigrationDownloadSource extends AbstractHandler {
       $v = $this->getResponseAsString();
 
       Env::writeValueDotenv('VORTEX_DOWNLOAD_DB2_SOURCE', $v, $t . '/.env');
+
+      // Lagoon identifies environments by branch name; the production branch
+      // is `main`. The shared default (`prod`) is correct for Acquia only.
+      if ($v === self::LAGOON) {
+        Env::writeValueDotenv('VORTEX_DOWNLOAD_DB2_ENVIRONMENT', 'main', $t . '/.env');
+      }
     }
 
     $types = [

--- a/.vortex/installer/tests/Fixtures/handler_process/db_download_source_lagoon/.env
+++ b/.vortex/installer/tests/Fixtures/handler_process/db_download_source_lagoon/.env
@@ -1,4 +1,4 @@
-@@ -155,13 +155,8 @@
+@@ -155,19 +155,14 @@
  VORTEX_DB_FILE=db.sql
  
  # Database download source.
@@ -13,6 +13,13 @@
  # Environment to download the database from.
  #
  # Applies to hosting environments.
+ # Note that depending on the hosting provider, this variable may represent
+ # a branch name or an environment name.
+-VORTEX_DOWNLOAD_DB_ENVIRONMENT=prod
++VORTEX_DOWNLOAD_DB_ENVIRONMENT=main
+ 
+ ################################################################################
+ #                             RELEASE VERSIONING                               #
 @@ -212,17 +207,3 @@
  # with optional names in the format "email|name".
  # Example: "to1@example.com|Jane Doe, to2@example.com|John Doe"

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_lagoon/.env
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_lagoon/.env
@@ -17,7 +17,7 @@
  #                           DATABASE SOURCE                                    #
  ################################################################################
  
-@@ -155,13 +167,8 @@
+@@ -155,19 +167,14 @@
  VORTEX_DB_FILE=db.sql
  
  # Database download source.
@@ -32,6 +32,13 @@
  # Environment to download the database from.
  #
  # Applies to hosting environments.
+ # Note that depending on the hosting provider, this variable may represent
+ # a branch name or an environment name.
+-VORTEX_DOWNLOAD_DB_ENVIRONMENT=prod
++VORTEX_DOWNLOAD_DB_ENVIRONMENT=main
+ 
+ ################################################################################
+ #                             RELEASE VERSIONING                               #
 @@ -185,7 +192,7 @@
  
  # Deployment occurs when tests pass in the CI environment.

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___lagoon/.env
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___lagoon/.env
@@ -17,7 +17,7 @@
  #                           DATABASE SOURCE                                    #
  ################################################################################
  
-@@ -155,13 +167,8 @@
+@@ -155,19 +167,14 @@
  VORTEX_DB_FILE=db.sql
  
  # Database download source.
@@ -32,6 +32,13 @@
  # Environment to download the database from.
  #
  # Applies to hosting environments.
+ # Note that depending on the hosting provider, this variable may represent
+ # a branch name or an environment name.
+-VORTEX_DOWNLOAD_DB_ENVIRONMENT=prod
++VORTEX_DOWNLOAD_DB_ENVIRONMENT=main
+ 
+ ################################################################################
+ #                             RELEASE VERSIONING                               #
 @@ -185,7 +192,7 @@
  
  # Deployment occurs when tests pass in the CI environment.

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_lagoon/.env
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_lagoon/.env
@@ -17,7 +17,7 @@
  #                           DATABASE SOURCE                                    #
  ################################################################################
  
-@@ -155,13 +167,8 @@
+@@ -155,19 +167,14 @@
  VORTEX_DB_FILE=db.sql
  
  # Database download source.
@@ -32,6 +32,13 @@
  # Environment to download the database from.
  #
  # Applies to hosting environments.
+ # Note that depending on the hosting provider, this variable may represent
+ # a branch name or an environment name.
+-VORTEX_DOWNLOAD_DB_ENVIRONMENT=prod
++VORTEX_DOWNLOAD_DB_ENVIRONMENT=main
+ 
+ ################################################################################
+ #                             RELEASE VERSIONING                               #
 @@ -185,7 +192,7 @@
  
  # Deployment occurs when tests pass in the CI environment.

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.env
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.env
@@ -17,7 +17,7 @@
 +# Environment to download the second database from.
 +#
 +# Applies to hosting environments.
-+VORTEX_DOWNLOAD_DB2_ENVIRONMENT=prod
++VORTEX_DOWNLOAD_DB2_ENVIRONMENT=main
 +
 +################################################################################
  #                             RELEASE VERSIONING                               #

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.env
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.env
@@ -17,7 +17,7 @@
  #                           DATABASE SOURCE                                    #
  ################################################################################
  
-@@ -155,13 +167,8 @@
+@@ -155,21 +167,34 @@
  VORTEX_DB_FILE=db.sql
  
  # Database download source.
@@ -32,8 +32,10 @@
  # Environment to download the database from.
  #
  # Applies to hosting environments.
-@@ -170,6 +177,24 @@
- VORTEX_DOWNLOAD_DB_ENVIRONMENT=prod
+ # Note that depending on the hosting provider, this variable may represent
+ # a branch name or an environment name.
+-VORTEX_DOWNLOAD_DB_ENVIRONMENT=prod
++VORTEX_DOWNLOAD_DB_ENVIRONMENT=main
  
  ################################################################################
 +#                       SECOND DATABASE (MIGRATION)                            #
@@ -51,7 +53,7 @@
 +# Environment to download the second database from.
 +#
 +# Applies to hosting environments.
-+VORTEX_DOWNLOAD_DB2_ENVIRONMENT=prod
++VORTEX_DOWNLOAD_DB2_ENVIRONMENT=main
 +
 +################################################################################
  #                             RELEASE VERSIONING                               #

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_database_lagoon/.env
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_database_lagoon/.env
@@ -17,7 +17,7 @@
  #                           DATABASE SOURCE                                    #
  ################################################################################
  
-@@ -155,13 +167,8 @@
+@@ -155,19 +167,14 @@
  VORTEX_DB_FILE=db.sql
  
  # Database download source.
@@ -32,6 +32,13 @@
  # Environment to download the database from.
  #
  # Applies to hosting environments.
+ # Note that depending on the hosting provider, this variable may represent
+ # a branch name or an environment name.
+-VORTEX_DOWNLOAD_DB_ENVIRONMENT=prod
++VORTEX_DOWNLOAD_DB_ENVIRONMENT=main
+ 
+ ################################################################################
+ #                             RELEASE VERSIONING                               #
 @@ -185,7 +192,7 @@
  
  # Deployment occurs when tests pass in the CI environment.


### PR DESCRIPTION
Closes #2500

## Summary

When the Vortex installer generates a `.env` file for a Lagoon-hosted project, it correctly sets `VORTEX_DOWNLOAD_DB_SOURCE=lagoon` but left `VORTEX_DOWNLOAD_DB_ENVIRONMENT` at the shared default of `prod`. Lagoon identifies environments by branch name rather than by an environment label, so `prod` is meaningless there - the correct value is `main` (matching `VORTEX_LAGOON_PRODUCTION_BRANCH=main`). This meant every freshly-installed Lagoon project would fail `ahoy download-db` out of the box until the developer manually corrected the value.

The fix adds a small conditional block in the two installer handlers (`DatabaseDownloadSource` and `MigrationDownloadSource`) that writes `VORTEX_DOWNLOAD_DB_ENVIRONMENT=main` (and `VORTEX_DOWNLOAD_DB2_ENVIRONMENT=main` for the migration database) whenever Lagoon is selected as the download source. The root `.env` default remains `prod`, which is correct for Acquia and the no-hosting path; the override only applies on the Lagoon code path.

## Changes

- **Installer handlers** (`.vortex/installer/src/Prompts/Handlers/DatabaseDownloadSource.php`, `MigrationDownloadSource.php`): added a conditional `Env::writeValueDotenv()` call after the source is written - if the selected source is `lagoon`, the corresponding environment variable is set to `main` instead of relying on the `prod` default.
- **Test fixtures**: regenerated 7 `.env` snapshot diffs under `.vortex/installer/tests/Fixtures/handler_process/*lagoon*/` to assert the new behavior - all Lagoon scenarios now expect `VORTEX_DOWNLOAD_DB_ENVIRONMENT=main` (and `VORTEX_DOWNLOAD_DB2_ENVIRONMENT=main` for migration scenarios) in the generated output.

## Before / After

```
Installer run - user picks Lagoon as DB source
┌─────────────────────────────────────────────────────────┐
│                  Generated .env (before)                │
├─────────────────────────────────────────────────────────┤
│ VORTEX_DOWNLOAD_DB_SOURCE=lagoon                        │
│ VORTEX_DOWNLOAD_DB_ENVIRONMENT=prod   ← wrong for Lagoon│
└─────────────────────────────────────────────────────────┘

                          ↓ after this fix

┌─────────────────────────────────────────────────────────┐
│                  Generated .env (after)                 │
├─────────────────────────────────────────────────────────┤
│ VORTEX_DOWNLOAD_DB_SOURCE=lagoon                        │
│ VORTEX_DOWNLOAD_DB_ENVIRONMENT=main   ← correct branch  │
└─────────────────────────────────────────────────────────┘

`ahoy download-db` works out of the box for new Lagoon projects.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installer configuration to properly set environment variables for Lagoon database sources, ensuring correct database environment identification during setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drevops/vortex/pull/2502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->