### PR TITLE
Clarified 'enable_terminal' workflow_dispatch label.

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -52,7 +52,7 @@ on:
         default: false
       enable_terminal:
         type: boolean
-        description: 'Enable terminal session'
+        description: 'Enable terminal session for CI jobs'
         required: false
         default: false
   #;< !PROVISION_TYPE_PROFILE

--- a/.vortex/docs/content/continuous-integration/github-actions.mdx
+++ b/.vortex/docs/content/continuous-integration/github-actions.mdx
@@ -194,8 +194,8 @@ is skipped.
 ### Terminal access for debugging
 
 The workflow includes a `tmate` session for debugging. Trigger a manual workflow
-run with the **Enable terminal session** option checked to get SSH connection
-details in the build logs. See [action-tmate](https://github.com/mxschmitt/action-tmate)
+run with the **Enable terminal session for CI jobs** option checked to get SSH
+connection details in the build logs. See [action-tmate](https://github.com/mxschmitt/action-tmate)
 for more information.
 
 ### Adjust build timeout

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -49,7 +49,7 @@ on:
         default: false
       enable_terminal:
         type: boolean
-        description: 'Enable terminal session'
+        description: 'Enable terminal session for CI jobs'
         required: false
         default: false
   schedule:

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -1,5 +1,5 @@
 @@ -52,8 +52,6 @@
-         description: 'Enable terminal session'
+         description: 'Enable terminal session for CI jobs'
          required: false
          default: false
 -  schedule:


### PR DESCRIPTION
## Summary

The `enable_terminal` `workflow_dispatch` input had a generic label ("Enable terminal session") that did not make clear it applies specifically to CI jobs rather than a local or general-purpose terminal. The label has been updated to "Enable terminal session for CI jobs" to eliminate that ambiguity. The corresponding docs paragraph has been updated to match.

## Changes

**Workflow file** (`.github/workflows/build-test-deploy.yml`):
- Renamed `enable_terminal.description` from `'Enable terminal session'` to `'Enable terminal session for CI jobs'`

**Documentation** (`.vortex/docs/content/continuous-integration/github-actions.mdx`):
- Updated the "Terminal access for debugging" paragraph to refer to the new label text

**Snapshot fixtures** (auto-regenerated):
- `.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml`
- `.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml`

## Before / After

The label shown in the GitHub Actions "Run workflow" form:

```
Before:
  Enable terminal session   [ ]

After:
  Enable terminal session for CI jobs   [ ]
```

Docs paragraph (before):

> run with the **Enable terminal session** option checked to get SSH connection
> details in the build logs.

Docs paragraph (after):

> run with the **Enable terminal session for CI jobs** option checked to get SSH
> connection details in the build logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub Actions documentation to reflect clearer wording for the terminal session option.

* **Chores**
  * Clarified workflow configuration description for the terminal session feature in CI jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drevops/vortex/pull/2504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->