### PR TITLE
Limited 'Vortex - Publish tooling' to 'main' and 'vortex-tooling' branches.

### DIFF
--- a/.github/workflows/vortex-publish-tooling.yml
+++ b/.github/workflows/vortex-publish-tooling.yml
@@ -1,17 +1,21 @@
 # This action is used for Vortex maintenance. It will not be used in the scaffolded project.
 #
 # Publishes the contents of '.vortex/tooling/' from this monorepo to the
-# 'drevops/vortex-tooling' repository on every push, mirroring the source
-# branch name. An empty commit is created when there are no file changes so
-# every source commit is reflected at the target. The published commit
-# subject matches the source commit subject; the body records provenance.
+# 'drevops/vortex-tooling' repository, mirroring the source branch name.
+# Runs only for 'main' and any branch whose name contains 'vortex-tooling'
+# so feature work that does not touch the tooling does not churn the
+# downstream repository. An empty commit is created when there are no file
+# changes so every source commit is reflected at the target. The published
+# commit subject matches the source commit subject; the body records
+# provenance.
 
 name: Vortex - Publish tooling
 
 on:
   push:
     branches:
-      - '**'
+      - main
+      - '**vortex-tooling**'
 
 concurrency:
   group: vortex-publish-tooling-${{ github.ref }}


### PR DESCRIPTION
## Summary

- The `Vortex - Publish tooling` workflow was running on every branch push, mirroring all feature branches to `drevops/vortex-tooling`. This churns the downstream repo with commits that have nothing to do with the tooling.
- The `on.push.branches` filter is narrowed to `main` and any branch whose name contains `vortex-tooling`, so only intentional tooling work is mirrored downstream.
- The branch `feature/vortex-tooling-scope` itself matches the new `**vortex-tooling**` pattern, so pushing this PR doubles as a live smoke-test of the filter.

## Change

```yaml
# Before
on:
  push:
    branches:
      - '**'

# After
on:
  push:
    branches:
      - main
      - '**vortex-tooling**'
```

## Test plan

- [ ] Confirm this PR's push triggered the `Vortex - Publish tooling` workflow (branch name contains `vortex-tooling`).
- [ ] After merge to `main`, confirm the workflow runs once on the `main` push.
- [ ] Push a new unrelated feature branch (no `vortex-tooling` in the name) and confirm the workflow does NOT run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified the publish workflow trigger to execute only on the main branch and branches matching the vortex-tooling pattern, replacing the previous behavior of running on all branches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drevops/vortex/pull/2508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->