### PR TITLE
[#2174] Added cross-tool aliases for Ahoy commands.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -18,6 +18,7 @@ commands:
 
   build:
     usage: Build or rebuild the project.
+    aliases: [rebuild]
     cmd: |
       ahoy confirm "All containers, build files and database will be removed. Proceed?" && export AHOY_CONFIRM_RESPONSE=y && export AHOY_CONFIRM_WAIT_SKIP=1 || exit 0
       ahoy reset                          # Reset the project.
@@ -32,6 +33,7 @@ commands:
 
   info:
     usage: Show information about this project.
+    aliases: [status, describe, ps]
     cmd: |
       export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
       export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
@@ -75,6 +77,7 @@ commands:
 
   down:
     usage: Stop and remove containers, images, volumes and networks.
+    aliases: [destroy]
     cmd: |
       ahoy confirm "Running this command will remove your current database. Are you sure?" || exit 0
       if [ -f "docker-compose.yml" ]; then docker compose down --remove-orphans --volumes > /dev/null 2>&1; fi
@@ -101,6 +104,7 @@ commands:
   # arguments that contain spaces.
   cli:
     usage: Start a shell or run a command inside the CLI service container.
+    aliases: [ssh, shell]
     cmd: |
       if [ "${#}" -ne 0 ]; then
         docker compose exec $(env | cut -f1 -d= | grep "TERM\|COMPOSE_\|GITHUB_\|PACKAGE_\|DOCKER_\|DRUPAL_\|VORTEX_" | sed 's/^/-e /') cli bash -c "$*"
@@ -136,7 +140,7 @@ commands:
   #;< !PROVISION_TYPE_PROFILE
   download-db:
     usage: Download database. Run with "--fresh" option to force fresh database backup.
-    aliases: [fetch-db]
+    aliases: [fetch-db, db-download, db-fetch]
     cmd: |
       ahoy require-tooling
       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
@@ -145,7 +149,7 @@ commands:
   #;< MIGRATION
   download-db2:
     usage: Download second database (migration). Run with "--fresh" to force.
-    aliases: [fetch-db2]
+    aliases: [fetch-db2, db2-download, db2-fetch]
     cmd: |
       ahoy require-tooling
       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
@@ -180,12 +184,14 @@ commands:
 
   export-db:
     usage: Export database dump or database image (if VORTEX_DB_IMAGE variable is set).
+    aliases: [db-export, db-dump, dump-db]
     cmd: |
       ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/export-db "$@"
 
   import-db:
     usage: Import database from dump.
+    aliases: [db-import]
     cmd: VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 VORTEX_PROVISION_DB="$@" ahoy cli ./vendor/drevops/vortex-tooling/src/provision
 
   pull-db:
@@ -194,6 +200,7 @@ commands:
 
   reset:
     usage: Remove containers, all build files. Use with `hard` to reset repository to the last commit.
+    aliases: [prune, delete]
     cmd: |
       ahoy confirm "All containers and build files will be removed. Proceed?" || exit 0
       AHOY_CONFIRM_RESPONSE=y ahoy down || true
@@ -203,6 +210,7 @@ commands:
 
   fei:
     usage: Install front-end assets.
+    aliases: [fe-install]
     cmd: |
       ahoy cli "yarn install --frozen-lockfile"
       #;< DRUPAL_THEME
@@ -212,14 +220,17 @@ commands:
   #;< DRUPAL_THEME
   fe:
     usage: Build front-end assets.
+    aliases: [fe-build]
     cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build"
 
   fed:
     usage: Build front-end assets for development.
+    aliases: [fe-build-dev]
     cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build-dev"
 
   few:
     usage: Watch front-end assets during development.
+    aliases: [fe-watch]
     cmd: |
       ahoy cli "pkill -9 -f grunt" || true
       ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run watch"
@@ -278,6 +289,7 @@ commands:
   #;< TOOL_PHPUNIT
   test:
     usage: Run all PHPUnit tests.
+    aliases: [phpunit]
     cmd: ahoy cli vendor/bin/phpunit "$@"
 
   test-unit:
@@ -312,6 +324,7 @@ commands:
 
   debug:
     usage: Enable PHP Xdebug.
+    aliases: [xdebug]
     cmd: |
       ahoy cli php -v | grep -q Xdebug && echo "Debug configuration is already enabled. Use 'ahoy up' to disable." || \
       (XDEBUG_ENABLE=true ahoy up cli php nginx && sleep 1 && ahoy cli php -v | grep -q Xdebug && echo "Enabled debug configuration. Use 'ahoy up' to disable.")
@@ -325,6 +338,7 @@ commands:
 
   doctor:
     usage: Find problems with current project setup.
+    aliases: [diagnose, health]
     cmd: |
       ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/doctor "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
@@ -15,6 +15,7 @@ commands:
 
   build:
     usage: Build or rebuild the project.
+    aliases: [rebuild]
     cmd: |
       ahoy confirm "All containers, build files and database will be removed. Proceed?" && export AHOY_CONFIRM_RESPONSE=y && export AHOY_CONFIRM_WAIT_SKIP=1 || exit 0
       ahoy reset                          # Reset the project.
@@ -27,6 +28,7 @@ commands:
 
   info:
     usage: Show information about this project.
+    aliases: [status, describe, ps]
     cmd: |
       export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
       export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
@@ -55,6 +57,7 @@ commands:
 
   down:
     usage: Stop and remove containers, images, volumes and networks.
+    aliases: [destroy]
     cmd: |
       ahoy confirm "Running this command will remove your current database. Are you sure?" || exit 0
       if [ -f "docker-compose.yml" ]; then docker compose down --remove-orphans --volumes > /dev/null 2>&1; fi
@@ -81,6 +84,7 @@ commands:
   # arguments that contain spaces.
   cli:
     usage: Start a shell or run a command inside the CLI service container.
+    aliases: [ssh, shell]
     cmd: |
       if [ "${#}" -ne 0 ]; then
         docker compose exec $(env | cut -f1 -d= | grep "TERM\|COMPOSE_\|GITHUB_\|PACKAGE_\|DOCKER_\|DRUPAL_\|VORTEX_" | sed 's/^/-e /') cli bash -c "$*"
@@ -113,7 +117,7 @@ commands:
 
   download-db:
     usage: Download database. Run with "--fresh" option to force fresh database backup.
-    aliases: [fetch-db]
+    aliases: [fetch-db, db-download, db-fetch]
     cmd: |
       ahoy require-tooling
       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
@@ -137,12 +141,14 @@ commands:
 
   export-db:
     usage: Export database dump or database image (if VORTEX_DB_IMAGE variable is set).
+    aliases: [db-export, db-dump, dump-db]
     cmd: |
       ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/export-db "$@"
 
   import-db:
     usage: Import database from dump.
+    aliases: [db-import]
     cmd: VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 VORTEX_PROVISION_DB="$@" ahoy cli ./vendor/drevops/vortex-tooling/src/provision
 
   pull-db:
@@ -151,6 +157,7 @@ commands:
 
   reset:
     usage: Remove containers, all build files. Use with `hard` to reset repository to the last commit.
+    aliases: [prune, delete]
     cmd: |
       ahoy confirm "All containers and build files will be removed. Proceed?" || exit 0
       AHOY_CONFIRM_RESPONSE=y ahoy down || true
@@ -160,20 +167,24 @@ commands:
 
   fei:
     usage: Install front-end assets.
+    aliases: [fe-install]
     cmd: |
       ahoy cli "yarn install --frozen-lockfile"
       ahoy cli "yarn --cwd=${WEBROOT}/themes/custom/${DRUPAL_THEME} install --frozen-lockfile"
 
   fe:
     usage: Build front-end assets.
+    aliases: [fe-build]
     cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build"
 
   fed:
     usage: Build front-end assets for development.
+    aliases: [fe-build-dev]
     cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build-dev"
 
   few:
     usage: Watch front-end assets during development.
+    aliases: [fe-watch]
     cmd: |
       ahoy cli "pkill -9 -f grunt" || true
       ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run watch"
@@ -226,6 +237,7 @@ commands:
 
   test:
     usage: Run all PHPUnit tests.
+    aliases: [phpunit]
     cmd: ahoy cli vendor/bin/phpunit "$@"
 
   test-unit:
@@ -255,6 +267,7 @@ commands:
 
   debug:
     usage: Enable PHP Xdebug.
+    aliases: [xdebug]
     cmd: |
       ahoy cli php -v | grep -q Xdebug && echo "Debug configuration is already enabled. Use 'ahoy up' to disable." || \
       (XDEBUG_ENABLE=true ahoy up cli php nginx && sleep 1 && ahoy cli php -v | grep -q Xdebug && echo "Enabled debug configuration. Use 'ahoy up' to disable.")
@@ -268,6 +281,7 @@ commands:
 
   doctor:
     usage: Find problems with current project setup.
+    aliases: [diagnose, health]
     cmd: |
       ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/doctor "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/custom_modules_search_without_solr/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/custom_modules_search_without_solr/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -30,7 +30,6 @@
+@@ -32,7 +32,6 @@
      cmd: |
        export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
        export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -30,6 +30,7 @@
+@@ -32,6 +32,7 @@
      cmd: |
        export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
        export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
@@ -6,7 +6,7 @@
        export VORTEX_HOST_SOLR_PORT=$(docker compose port solr 8983 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_SELENIUM_VNC_PORT=$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_HAS_SEQUELACE=$(uname -a | grep -i -q darwin && mdfind -name 'Sequel Ace' 2>/dev/null | grep -q "Ace" && echo 1 || true)
-@@ -43,6 +44,14 @@
+@@ -45,6 +46,14 @@
        open "mysql://${DATABASE_USERNAME:-drupal}:${DATABASE_PASSWORD:-drupal}@127.0.0.1:${VORTEX_HOST_DB_PORT}/drupal" -a "Sequel Ace" \
        || echo "Not a supported OS or Sequel Ace is not installed."
  
@@ -21,13 +21,13 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -119,6 +128,14 @@
+@@ -123,6 +132,14 @@
        case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:
 +    usage: Download second database (migration). Run with "--fresh" to force.
-+    aliases: [fetch-db2]
++    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
@@ -36,7 +36,7 @@
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -126,6 +143,13 @@
+@@ -130,6 +147,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -30,6 +30,7 @@
+@@ -32,6 +32,7 @@
      cmd: |
        export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
        export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
@@ -6,7 +6,7 @@
        export VORTEX_HOST_SOLR_PORT=$(docker compose port solr 8983 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_SELENIUM_VNC_PORT=$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_HAS_SEQUELACE=$(uname -a | grep -i -q darwin && mdfind -name 'Sequel Ace' 2>/dev/null | grep -q "Ace" && echo 1 || true)
-@@ -43,6 +44,14 @@
+@@ -45,6 +46,14 @@
        open "mysql://${DATABASE_USERNAME:-drupal}:${DATABASE_PASSWORD:-drupal}@127.0.0.1:${VORTEX_HOST_DB_PORT}/drupal" -a "Sequel Ace" \
        || echo "Not a supported OS or Sequel Ace is not installed."
  
@@ -21,13 +21,13 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -119,6 +128,14 @@
+@@ -123,6 +132,14 @@
        case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:
 +    usage: Download second database (migration). Run with "--fresh" to force.
-+    aliases: [fetch-db2]
++    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
@@ -36,7 +36,7 @@
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -126,6 +143,13 @@
+@@ -130,6 +147,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -30,6 +30,7 @@
+@@ -32,6 +32,7 @@
      cmd: |
        export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
        export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
@@ -6,7 +6,7 @@
        export VORTEX_HOST_SOLR_PORT=$(docker compose port solr 8983 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_SELENIUM_VNC_PORT=$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_HAS_SEQUELACE=$(uname -a | grep -i -q darwin && mdfind -name 'Sequel Ace' 2>/dev/null | grep -q "Ace" && echo 1 || true)
-@@ -43,6 +44,14 @@
+@@ -45,6 +46,14 @@
        open "mysql://${DATABASE_USERNAME:-drupal}:${DATABASE_PASSWORD:-drupal}@127.0.0.1:${VORTEX_HOST_DB_PORT}/drupal" -a "Sequel Ace" \
        || echo "Not a supported OS or Sequel Ace is not installed."
  
@@ -21,13 +21,13 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -119,6 +128,14 @@
+@@ -123,6 +132,14 @@
        case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:
 +    usage: Download second database (migration). Run with "--fresh" to force.
-+    aliases: [fetch-db2]
++    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
@@ -36,7 +36,7 @@
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -126,6 +143,13 @@
+@@ -130,6 +147,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -30,6 +30,7 @@
+@@ -32,6 +32,7 @@
      cmd: |
        export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
        export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
@@ -6,7 +6,7 @@
        export VORTEX_HOST_SOLR_PORT=$(docker compose port solr 8983 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_SELENIUM_VNC_PORT=$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_HAS_SEQUELACE=$(uname -a | grep -i -q darwin && mdfind -name 'Sequel Ace' 2>/dev/null | grep -q "Ace" && echo 1 || true)
-@@ -43,6 +44,14 @@
+@@ -45,6 +46,14 @@
        open "mysql://${DATABASE_USERNAME:-drupal}:${DATABASE_PASSWORD:-drupal}@127.0.0.1:${VORTEX_HOST_DB_PORT}/drupal" -a "Sequel Ace" \
        || echo "Not a supported OS or Sequel Ace is not installed."
  
@@ -21,13 +21,13 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -119,6 +128,14 @@
+@@ -123,6 +132,14 @@
        case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:
 +    usage: Download second database (migration). Run with "--fresh" to force.
-+    aliases: [fetch-db2]
++    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
@@ -36,7 +36,7 @@
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -126,6 +143,13 @@
+@@ -130,6 +147,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -30,6 +30,7 @@
+@@ -32,6 +32,7 @@
      cmd: |
        export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
        export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
@@ -6,7 +6,7 @@
        export VORTEX_HOST_SOLR_PORT=$(docker compose port solr 8983 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_SELENIUM_VNC_PORT=$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_HAS_SEQUELACE=$(uname -a | grep -i -q darwin && mdfind -name 'Sequel Ace' 2>/dev/null | grep -q "Ace" && echo 1 || true)
-@@ -43,6 +44,14 @@
+@@ -45,6 +46,14 @@
        open "mysql://${DATABASE_USERNAME:-drupal}:${DATABASE_PASSWORD:-drupal}@127.0.0.1:${VORTEX_HOST_DB_PORT}/drupal" -a "Sequel Ace" \
        || echo "Not a supported OS or Sequel Ace is not installed."
  
@@ -21,13 +21,13 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -119,6 +128,14 @@
+@@ -123,6 +132,14 @@
        case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:
 +    usage: Download second database (migration). Run with "--fresh" to force.
-+    aliases: [fetch-db2]
++    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
@@ -36,7 +36,7 @@
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -126,6 +143,13 @@
+@@ -130,6 +147,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -30,6 +30,7 @@
+@@ -32,6 +32,7 @@
      cmd: |
        export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
        export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
@@ -6,7 +6,7 @@
        export VORTEX_HOST_SOLR_PORT=$(docker compose port solr 8983 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_SELENIUM_VNC_PORT=$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_HAS_SEQUELACE=$(uname -a | grep -i -q darwin && mdfind -name 'Sequel Ace' 2>/dev/null | grep -q "Ace" && echo 1 || true)
-@@ -43,6 +44,14 @@
+@@ -45,6 +46,14 @@
        open "mysql://${DATABASE_USERNAME:-drupal}:${DATABASE_PASSWORD:-drupal}@127.0.0.1:${VORTEX_HOST_DB_PORT}/drupal" -a "Sequel Ace" \
        || echo "Not a supported OS or Sequel Ace is not installed."
  
@@ -21,13 +21,13 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -119,6 +128,14 @@
+@@ -123,6 +132,14 @@
        case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:
 +    usage: Download second database (migration). Run with "--fresh" to force.
-+    aliases: [fetch-db2]
++    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
@@ -36,7 +36,7 @@
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -126,6 +143,13 @@
+@@ -130,6 +147,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -30,6 +30,7 @@
+@@ -32,6 +32,7 @@
      cmd: |
        export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
        export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
@@ -6,7 +6,7 @@
        export VORTEX_HOST_SOLR_PORT=$(docker compose port solr 8983 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_SELENIUM_VNC_PORT=$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_HAS_SEQUELACE=$(uname -a | grep -i -q darwin && mdfind -name 'Sequel Ace' 2>/dev/null | grep -q "Ace" && echo 1 || true)
-@@ -43,6 +44,14 @@
+@@ -45,6 +46,14 @@
        open "mysql://${DATABASE_USERNAME:-drupal}:${DATABASE_PASSWORD:-drupal}@127.0.0.1:${VORTEX_HOST_DB_PORT}/drupal" -a "Sequel Ace" \
        || echo "Not a supported OS or Sequel Ace is not installed."
  
@@ -21,13 +21,13 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -119,6 +128,14 @@
+@@ -123,6 +132,14 @@
        case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:
 +    usage: Download second database (migration). Run with "--fresh" to force.
-+    aliases: [fetch-db2]
++    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
@@ -36,7 +36,7 @@
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -126,6 +143,13 @@
+@@ -130,6 +147,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -30,6 +30,7 @@
+@@ -32,6 +32,7 @@
      cmd: |
        export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
        export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
@@ -6,7 +6,7 @@
        export VORTEX_HOST_SOLR_PORT=$(docker compose port solr 8983 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_SELENIUM_VNC_PORT=$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_HAS_SEQUELACE=$(uname -a | grep -i -q darwin && mdfind -name 'Sequel Ace' 2>/dev/null | grep -q "Ace" && echo 1 || true)
-@@ -43,6 +44,14 @@
+@@ -45,6 +46,14 @@
        open "mysql://${DATABASE_USERNAME:-drupal}:${DATABASE_PASSWORD:-drupal}@127.0.0.1:${VORTEX_HOST_DB_PORT}/drupal" -a "Sequel Ace" \
        || echo "Not a supported OS or Sequel Ace is not installed."
  
@@ -21,13 +21,13 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -119,6 +128,14 @@
+@@ -123,6 +132,14 @@
        case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:
 +    usage: Download second database (migration). Run with "--fresh" to force.
-+    aliases: [fetch-db2]
++    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
@@ -36,7 +36,7 @@
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -126,6 +143,13 @@
+@@ -130,6 +147,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -30,6 +30,7 @@
+@@ -32,6 +32,7 @@
      cmd: |
        export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
        export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
@@ -6,7 +6,7 @@
        export VORTEX_HOST_SOLR_PORT=$(docker compose port solr 8983 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_SELENIUM_VNC_PORT=$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_HAS_SEQUELACE=$(uname -a | grep -i -q darwin && mdfind -name 'Sequel Ace' 2>/dev/null | grep -q "Ace" && echo 1 || true)
-@@ -43,6 +44,14 @@
+@@ -45,6 +46,14 @@
        open "mysql://${DATABASE_USERNAME:-drupal}:${DATABASE_PASSWORD:-drupal}@127.0.0.1:${VORTEX_HOST_DB_PORT}/drupal" -a "Sequel Ace" \
        || echo "Not a supported OS or Sequel Ace is not installed."
  
@@ -21,13 +21,13 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -119,6 +128,14 @@
+@@ -123,6 +132,14 @@
        case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:
 +    usage: Download second database (migration). Run with "--fresh" to force.
-+    aliases: [fetch-db2]
++    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
@@ -36,7 +36,7 @@
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -126,6 +143,13 @@
+@@ -130,6 +147,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/non_interactive_config_file/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/non_interactive_config_file/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -99,10 +99,6 @@
+@@ -103,10 +103,6 @@
      usage: Run Drush commands in the CLI service container.
      cmd: ahoy cli "vendor/bin/drush -l \${VORTEX_LOCALDEV_URL} $*"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.ahoy.yml
@@ -1,10 +1,10 @@
-@@ -111,14 +111,6 @@
+@@ -115,14 +115,6 @@
      usage: Unblock user 1 and generate a one time login link.
      cmd: ahoy cli ./vendor/drevops/vortex-tooling/src/login
  
 -  download-db:
 -    usage: Download database. Run with "--fresh" option to force fresh database backup.
--    aliases: [fetch-db]
+-    aliases: [fetch-db, db-download, db-fetch]
 -    cmd: |
 -      ahoy require-tooling
 -      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac

--- a/.vortex/installer/tests/Fixtures/handler_process/services_no_redis/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/services_no_redis/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -99,10 +99,6 @@
+@@ -103,10 +103,6 @@
      usage: Run Drush commands in the CLI service container.
      cmd: ahoy cli "vendor/bin/drush -l \${VORTEX_LOCALDEV_URL} $*"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/services_no_solr/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/services_no_solr/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -30,7 +30,6 @@
+@@ -32,7 +32,6 @@
      cmd: |
        export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
        export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)

--- a/.vortex/installer/tests/Fixtures/handler_process/services_none/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/services_none/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -30,7 +30,6 @@
+@@ -32,7 +32,6 @@
      cmd: |
        export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-${PWD##*/}}
        export VORTEX_HOST_DB_PORT=$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
@@ -6,7 +6,7 @@
        export VORTEX_HOST_SELENIUM_VNC_PORT=$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2)
        export VORTEX_HOST_HAS_SEQUELACE=$(uname -a | grep -i -q darwin && mdfind -name 'Sequel Ace' 2>/dev/null | grep -q "Ace" && echo 1 || true)
        ahoy cli ./vendor/drevops/vortex-tooling/src/info "$@"
-@@ -98,10 +97,6 @@
+@@ -102,10 +101,6 @@
    drush:
      usage: Run Drush commands in the CLI service container.
      cmd: ahoy cli "vendor/bin/drush -l \${VORTEX_LOCALDEV_URL} $*"

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -21,7 +21,6 @@
+@@ -22,7 +22,6 @@
        ahoy up --build --force-recreate    # Start the stack.
        ahoy composer install               # Install Composer dependencies.
        ahoy fei                            # Install front-end dependencies.
@@ -6,22 +6,25 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -162,22 +161,7 @@
-     usage: Install front-end assets.
+@@ -170,25 +169,7 @@
+     aliases: [fe-install]
      cmd: |
        ahoy cli "yarn install --frozen-lockfile"
 -      ahoy cli "yarn --cwd=${WEBROOT}/themes/custom/${DRUPAL_THEME} install --frozen-lockfile"
  
 -  fe:
 -    usage: Build front-end assets.
+-    aliases: [fe-build]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build"
 -
 -  fed:
 -    usage: Build front-end assets for development.
+-    aliases: [fe-build-dev]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build-dev"
 -
 -  few:
 -    usage: Watch front-end assets during development.
+-    aliases: [fe-watch]
 -    cmd: |
 -      ahoy cli "pkill -9 -f grunt" || true
 -      ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run watch"
@@ -29,7 +32,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -198,7 +182,6 @@
+@@ -209,7 +190,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
        ahoy cli "yarn run lint"
@@ -37,7 +40,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -222,7 +205,6 @@
+@@ -233,7 +213,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -21,7 +21,6 @@
+@@ -22,7 +22,6 @@
        ahoy up --build --force-recreate    # Start the stack.
        ahoy composer install               # Install Composer dependencies.
        ahoy fei                            # Install front-end dependencies.
@@ -6,22 +6,25 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -162,22 +161,7 @@
-     usage: Install front-end assets.
+@@ -170,25 +169,7 @@
+     aliases: [fe-install]
      cmd: |
        ahoy cli "yarn install --frozen-lockfile"
 -      ahoy cli "yarn --cwd=${WEBROOT}/themes/custom/${DRUPAL_THEME} install --frozen-lockfile"
  
 -  fe:
 -    usage: Build front-end assets.
+-    aliases: [fe-build]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build"
 -
 -  fed:
 -    usage: Build front-end assets for development.
+-    aliases: [fe-build-dev]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build-dev"
 -
 -  few:
 -    usage: Watch front-end assets during development.
+-    aliases: [fe-watch]
 -    cmd: |
 -      ahoy cli "pkill -9 -f grunt" || true
 -      ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run watch"
@@ -29,7 +32,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -198,7 +182,6 @@
+@@ -209,7 +190,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
        ahoy cli "yarn run lint"
@@ -37,7 +40,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -222,7 +205,6 @@
+@@ -233,7 +213,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -21,7 +21,6 @@
+@@ -22,7 +22,6 @@
        ahoy up --build --force-recreate    # Start the stack.
        ahoy composer install               # Install Composer dependencies.
        ahoy fei                            # Install front-end dependencies.
@@ -6,22 +6,25 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -162,22 +161,7 @@
-     usage: Install front-end assets.
+@@ -170,25 +169,7 @@
+     aliases: [fe-install]
      cmd: |
        ahoy cli "yarn install --frozen-lockfile"
 -      ahoy cli "yarn --cwd=${WEBROOT}/themes/custom/${DRUPAL_THEME} install --frozen-lockfile"
  
 -  fe:
 -    usage: Build front-end assets.
+-    aliases: [fe-build]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build"
 -
 -  fed:
 -    usage: Build front-end assets for development.
+-    aliases: [fe-build-dev]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build-dev"
 -
 -  few:
 -    usage: Watch front-end assets during development.
+-    aliases: [fe-watch]
 -    cmd: |
 -      ahoy cli "pkill -9 -f grunt" || true
 -      ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run watch"
@@ -29,7 +32,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -198,7 +182,6 @@
+@@ -209,7 +190,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
        ahoy cli "yarn run lint"
@@ -37,7 +40,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -222,7 +205,6 @@
+@@ -233,7 +213,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -181,18 +181,9 @@
+@@ -192,18 +192,9 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
@@ -17,7 +17,7 @@
    lint-fe:
      usage: Lint front-end code.
      cmd: |
-@@ -208,14 +199,7 @@
+@@ -219,14 +210,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -181,18 +181,9 @@
+@@ -192,18 +192,9 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
@@ -17,7 +17,7 @@
    lint-fe:
      usage: Lint front-end code.
      cmd: |
-@@ -208,14 +199,7 @@
+@@ -219,14 +210,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -183,7 +183,6 @@
+@@ -194,7 +194,6 @@
      cmd: |
        ahoy lint-be
        ahoy lint-fe
@@ -6,7 +6,7 @@
  
    lint-be:
      usage: Lint back-end code.
-@@ -200,11 +199,6 @@
+@@ -211,11 +210,6 @@
        ahoy cli "yarn run lint"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint"
  
@@ -18,12 +18,13 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -224,34 +218,9 @@
+@@ -235,35 +229,9 @@
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  
 -  test:
 -    usage: Run all PHPUnit tests.
+-    aliases: [phpunit]
 -    cmd: ahoy cli vendor/bin/phpunit "$@"
 -
 -  test-unit:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -183,7 +183,6 @@
+@@ -194,7 +194,6 @@
      cmd: |
        ahoy lint-be
        ahoy lint-fe
@@ -6,7 +6,7 @@
  
    lint-be:
      usage: Lint back-end code.
-@@ -200,11 +199,6 @@
+@@ -211,11 +210,6 @@
        ahoy cli "yarn run lint"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint"
  
@@ -18,12 +18,13 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -224,34 +218,9 @@
+@@ -235,35 +229,9 @@
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  
 -  test:
 -    usage: Run all PHPUnit tests.
+-    aliases: [phpunit]
 -    cmd: ahoy cli vendor/bin/phpunit "$@"
 -
 -  test-unit:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -197,7 +197,6 @@
+@@ -208,7 +208,6 @@
      usage: Lint front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
@@ -6,7 +6,7 @@
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint"
  
    lint-tests:
-@@ -221,7 +220,6 @@
+@@ -232,7 +231,6 @@
      usage: Fix lint issues of front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
@@ -14,7 +14,7 @@
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  
    test:
-@@ -243,10 +241,6 @@
+@@ -255,10 +253,6 @@
    test-functional-javascript:
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -197,7 +197,6 @@
+@@ -208,7 +208,6 @@
      usage: Lint front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
@@ -6,7 +6,7 @@
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint"
  
    lint-tests:
-@@ -221,7 +220,6 @@
+@@ -232,7 +231,6 @@
      usage: Fix lint issues of front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
@@ -14,7 +14,7 @@
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  
    test:
-@@ -243,10 +241,6 @@
+@@ -255,10 +253,6 @@
    test-functional-javascript:
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -20,8 +20,6 @@
+@@ -21,8 +21,6 @@
        ahoy reset                          # Reset the project.
        ahoy up --build --force-recreate    # Start the stack.
        ahoy composer install               # Install Composer dependencies.
@@ -7,26 +7,30 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -158,26 +156,6 @@
+@@ -165,30 +163,6 @@
          bash ./vendor/drevops/vortex-tooling/src/reset "$@"
        fi
  
 -  fei:
 -    usage: Install front-end assets.
+-    aliases: [fe-install]
 -    cmd: |
 -      ahoy cli "yarn install --frozen-lockfile"
 -      ahoy cli "yarn --cwd=${WEBROOT}/themes/custom/${DRUPAL_THEME} install --frozen-lockfile"
 -
 -  fe:
 -    usage: Build front-end assets.
+-    aliases: [fe-build]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build"
 -
 -  fed:
 -    usage: Build front-end assets for development.
+-    aliases: [fe-build-dev]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build-dev"
 -
 -  few:
 -    usage: Watch front-end assets during development.
+-    aliases: [fe-watch]
 -    cmd: |
 -      ahoy cli "pkill -9 -f grunt" || true
 -      ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run watch"
@@ -34,7 +38,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -197,8 +175,6 @@
+@@ -208,8 +182,6 @@
      usage: Lint front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
@@ -43,7 +47,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -221,8 +197,6 @@
+@@ -232,8 +204,6 @@
      usage: Fix lint issues of front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
@@ -52,7 +56,7 @@
  
    test:
      usage: Run all PHPUnit tests.
-@@ -243,10 +217,6 @@
+@@ -255,10 +225,6 @@
    test-functional-javascript:
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -20,8 +20,6 @@
+@@ -21,8 +21,6 @@
        ahoy reset                          # Reset the project.
        ahoy up --build --force-recreate    # Start the stack.
        ahoy composer install               # Install Composer dependencies.
@@ -7,26 +7,30 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -158,26 +156,6 @@
+@@ -165,30 +163,6 @@
          bash ./vendor/drevops/vortex-tooling/src/reset "$@"
        fi
  
 -  fei:
 -    usage: Install front-end assets.
+-    aliases: [fe-install]
 -    cmd: |
 -      ahoy cli "yarn install --frozen-lockfile"
 -      ahoy cli "yarn --cwd=${WEBROOT}/themes/custom/${DRUPAL_THEME} install --frozen-lockfile"
 -
 -  fe:
 -    usage: Build front-end assets.
+-    aliases: [fe-build]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build"
 -
 -  fed:
 -    usage: Build front-end assets for development.
+-    aliases: [fe-build-dev]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build-dev"
 -
 -  few:
 -    usage: Watch front-end assets during development.
+-    aliases: [fe-watch]
 -    cmd: |
 -      ahoy cli "pkill -9 -f grunt" || true
 -      ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run watch"
@@ -34,7 +38,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -197,8 +175,6 @@
+@@ -208,8 +182,6 @@
      usage: Lint front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
@@ -43,7 +47,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -221,8 +197,6 @@
+@@ -232,8 +204,6 @@
      usage: Fix lint issues of front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
@@ -52,7 +56,7 @@
  
    test:
      usage: Run all PHPUnit tests.
-@@ -243,10 +217,6 @@
+@@ -255,10 +225,6 @@
    test-functional-javascript:
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -183,7 +183,6 @@
+@@ -194,7 +194,6 @@
      cmd: |
        ahoy lint-be
        ahoy lint-fe
@@ -6,7 +6,7 @@
  
    lint-be:
      usage: Lint back-end code.
-@@ -203,8 +202,6 @@
+@@ -214,8 +213,6 @@
    lint-tests:
      usage: Lint tests code.
      cmd: |
@@ -15,7 +15,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -247,11 +244,6 @@
+@@ -259,11 +256,6 @@
    test-js:
      usage: Run Jest JavaScript unit tests.
      cmd: ahoy cli "yarn test"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -183,7 +183,6 @@
+@@ -194,7 +194,6 @@
      cmd: |
        ahoy lint-be
        ahoy lint-fe
@@ -6,7 +6,7 @@
  
    lint-be:
      usage: Lint back-end code.
-@@ -203,8 +202,6 @@
+@@ -214,8 +213,6 @@
    lint-tests:
      usage: Lint tests code.
      cmd: |
@@ -15,7 +15,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -247,11 +244,6 @@
+@@ -259,11 +256,6 @@
    test-js:
      usage: Run Jest JavaScript unit tests.
      cmd: ahoy cli "yarn test"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -21,7 +21,6 @@
+@@ -22,7 +22,6 @@
        ahoy up --build --force-recreate    # Start the stack.
        ahoy composer install               # Install Composer dependencies.
        ahoy fei                            # Install front-end dependencies.
@@ -6,22 +6,25 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -162,22 +161,7 @@
-     usage: Install front-end assets.
+@@ -170,25 +169,7 @@
+     aliases: [fe-install]
      cmd: |
        ahoy cli "yarn install --frozen-lockfile"
 -      ahoy cli "yarn --cwd=${WEBROOT}/themes/custom/${DRUPAL_THEME} install --frozen-lockfile"
  
 -  fe:
 -    usage: Build front-end assets.
+-    aliases: [fe-build]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build"
 -
 -  fed:
 -    usage: Build front-end assets for development.
+-    aliases: [fe-build-dev]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build-dev"
 -
 -  few:
 -    usage: Watch front-end assets during development.
+-    aliases: [fe-watch]
 -    cmd: |
 -      ahoy cli "pkill -9 -f grunt" || true
 -      ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run watch"
@@ -29,7 +32,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -198,7 +182,6 @@
+@@ -209,7 +190,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
        ahoy cli "yarn run lint"
@@ -37,7 +40,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -222,7 +205,6 @@
+@@ -233,7 +213,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -244,10 +244,6 @@
+@@ -256,10 +256,6 @@
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -244,10 +244,6 @@
+@@ -256,10 +256,6 @@
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -188,7 +188,6 @@
+@@ -199,7 +199,6 @@
    lint-be:
      usage: Lint back-end code.
      cmd: |
@@ -6,7 +6,7 @@
        ahoy cli vendor/bin/phpstan
        ahoy cli vendor/bin/rector --dry-run
        ahoy cli vendor/bin/phpmd . text phpmd.xml
-@@ -215,7 +214,6 @@
+@@ -226,7 +225,6 @@
      usage: Fix lint issues of back-end code.
      cmd: |
        ahoy cli vendor/bin/rector

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -188,7 +188,6 @@
+@@ -199,7 +199,6 @@
    lint-be:
      usage: Lint back-end code.
      cmd: |
@@ -6,7 +6,7 @@
        ahoy cli vendor/bin/phpstan
        ahoy cli vendor/bin/rector --dry-run
        ahoy cli vendor/bin/phpmd . text phpmd.xml
-@@ -215,7 +214,6 @@
+@@ -226,7 +225,6 @@
      usage: Fix lint issues of back-end code.
      cmd: |
        ahoy cli vendor/bin/rector

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -191,7 +191,6 @@
+@@ -202,7 +202,6 @@
        ahoy cli vendor/bin/phpcs
        ahoy cli vendor/bin/phpstan
        ahoy cli vendor/bin/rector --dry-run

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -191,7 +191,6 @@
+@@ -202,7 +202,6 @@
        ahoy cli vendor/bin/phpcs
        ahoy cli vendor/bin/phpstan
        ahoy cli vendor/bin/rector --dry-run

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -189,7 +189,6 @@
+@@ -200,7 +200,6 @@
      usage: Lint back-end code.
      cmd: |
        ahoy cli vendor/bin/phpcs

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -189,7 +189,6 @@
+@@ -200,7 +200,6 @@
      usage: Lint back-end code.
      cmd: |
        ahoy cli vendor/bin/phpcs

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.ahoy.yml
@@ -1,9 +1,10 @@
-@@ -224,26 +224,6 @@
+@@ -235,27 +235,6 @@
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  
 -  test:
 -    usage: Run all PHPUnit tests.
+-    aliases: [phpunit]
 -    cmd: ahoy cli vendor/bin/phpunit "$@"
 -
 -  test-unit:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.ahoy.yml
@@ -1,9 +1,10 @@
-@@ -224,26 +224,6 @@
+@@ -235,27 +235,6 @@
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  
 -  test:
 -    usage: Run all PHPUnit tests.
+-    aliases: [phpunit]
 -    cmd: ahoy cli vendor/bin/phpunit "$@"
 -
 -  test-unit:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -190,7 +190,6 @@
+@@ -201,7 +201,6 @@
      cmd: |
        ahoy cli vendor/bin/phpcs
        ahoy cli vendor/bin/phpstan
@@ -6,7 +6,7 @@
        ahoy cli vendor/bin/phpmd . text phpmd.xml
  
    lint-fe:
-@@ -214,7 +213,6 @@
+@@ -225,7 +224,6 @@
    lint-be-fix:
      usage: Fix lint issues of back-end code.
      cmd: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -190,7 +190,6 @@
+@@ -201,7 +201,6 @@
      cmd: |
        ahoy cli vendor/bin/phpcs
        ahoy cli vendor/bin/phpstan
@@ -6,7 +6,7 @@
        ahoy cli vendor/bin/phpmd . text phpmd.xml
  
    lint-fe:
-@@ -214,7 +213,6 @@
+@@ -225,7 +224,6 @@
    lint-be-fix:
      usage: Fix lint issues of back-end code.
      cmd: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -21,7 +21,6 @@
+@@ -22,7 +22,6 @@
        ahoy up --build --force-recreate    # Start the stack.
        ahoy composer install               # Install Composer dependencies.
        ahoy fei                            # Install front-end dependencies.
@@ -6,22 +6,25 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -162,22 +161,7 @@
-     usage: Install front-end assets.
+@@ -170,25 +169,7 @@
+     aliases: [fe-install]
      cmd: |
        ahoy cli "yarn install --frozen-lockfile"
 -      ahoy cli "yarn --cwd=${WEBROOT}/themes/custom/${DRUPAL_THEME} install --frozen-lockfile"
  
 -  fe:
 -    usage: Build front-end assets.
+-    aliases: [fe-build]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build"
 -
 -  fed:
 -    usage: Build front-end assets for development.
+-    aliases: [fe-build-dev]
 -    cmd: ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run build-dev"
 -
 -  few:
 -    usage: Watch front-end assets during development.
+-    aliases: [fe-watch]
 -    cmd: |
 -      ahoy cli "pkill -9 -f grunt" || true
 -      ahoy cli "cd ${WEBROOT}/themes/custom/${DRUPAL_THEME} && yarn run watch"
@@ -29,7 +32,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -198,7 +182,6 @@
+@@ -209,7 +190,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
        ahoy cli "yarn run lint"
@@ -37,7 +40,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -222,7 +205,6 @@
+@@ -233,7 +213,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -181,77 +181,24 @@
+@@ -192,78 +192,24 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
@@ -47,6 +47,7 @@
 -
 -  test:
 -    usage: Run all PHPUnit tests.
+-    aliases: [phpunit]
 -    cmd: ahoy cli vendor/bin/phpunit "$@"
 -
 -  test-unit:


### PR DESCRIPTION
Closes #2174

## Summary

Adds cross-tool aliases to `.ahoy.yml` so that users arriving from DDEV, Lando, DockSal, Wodby, and other Drupal/PHP dev environments can type their familiar verbs and have them work in Vortex without retraining muscle memory. No commands are renamed, no behaviour is changed — every alias is an additive entry that resolves to the same underlying command. The change is fully backwards compatible.

A follow-up tracking issue [#2509](https://github.com/drevops/vortex/issues/2509) captures five deferred items identified during scoping: `debug` rename, container lifecycle alignment, provision hook exposure, `update-self` command, and `pull-db` semantic clarity.

## Changes

### Aliases added (`.ahoy.yml`)

| Vortex command | New aliases |
|----------------|-------------|
| `cli` | `ssh`, `shell` |
| `info` | `status`, `describe`, `ps` |
| `reset` | `prune`, `delete` |
| `doctor` | `diagnose`, `health` |
| `import-db` | `db-import` |
| `export-db` | `db-export`, `db-dump`, `dump-db` |
| `download-db` | `db-download`, `db-fetch` (in addition to existing `fetch-db`) |
| `download-db2` | `db2-download`, `db2-fetch` (in addition to existing `fetch-db2`) |
| `debug` | `xdebug` |
| `test` | `phpunit` |
| `build` | `rebuild` |
| `down` | `destroy` |
| `fei` | `fe-install` |
| `fe` | `fe-build` |
| `fed` | `fe-build-dev` |
| `few` | `fe-watch` |

All 24 alias names were validated for uniqueness — no collisions with existing commands or other aliases.

### Snapshot fixtures regenerated (`.vortex/installer/tests/Fixtures/handler_process/`)

44 installer fixture files were auto-regenerated to reflect the new `aliases:` entries in the baseline and per-flavour `.ahoy.yml` snapshots. No logic was changed; the regeneration is a direct consequence of the alias additions above.

## Cross-tool semantic divergences (for reviewer awareness)

- **`down` → `destroy`**: Lando uses `destroy` to mean "containers + data removed", which aligns with what `ahoy down` does here. However, Wodby's `make down` is non-destructive (containers only). Wodby users may be surprised — the existing `confirm` prompt in `ahoy down` mitigates this by requiring explicit acknowledgement.
- **`build` → `rebuild`**: Lando's `rebuild` preserves DB volumes; Vortex's `build` does not (full provision, data wiped). This is a deliberate documented divergence — the alias provides the verb, not a change in behaviour.
- **`info` → `ps`**: `ps` in a Docker mental model typically lists running containers, not environment info. This alias is included for DockSal compatibility (`fin ps`) but reviewers may want a future docs note clarifying the distinction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added and expanded CLI command aliases for multiple development tasks including build, database operations, testing, and debugging utilities.
  * Reorganized command configuration structure while maintaining existing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drevops/vortex/pull/2510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->