### PR TITLE
Added Claude permissions and Vortex maintenance skills.

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ahoy:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.claude/skills/prepare-vortex-release/SKILL.md
+++ b/.claude/skills/prepare-vortex-release/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: prepare-vortex-release
+description: Prepare the Vortex codebase for a release - run checklist operations (deps, container images, PHP version, cache bumps, docs) and generate release notes at .artifacts/release-VERSION/release-notes.md. Stops at a pushed feature branch; does NOT open the PR. Triggered by phrases like 'prepare vortex release', 'vortex release prep', 'run vortex release checklist'.
+user-invocable: true
+---
+
+# Vortex Release Preparation
+
+When this skill is triggered, prepare a new release of the Vortex template.
+The user will provide the target version number (e.g., `1.37.0`).
+
+## Step 1: Read the release process
+
+Read `.vortex/docs/content/contributing/maintenance/release.mdx` for the
+official checklist and `.vortex/docs/content/contributing/maintenance/_release_template.md`
+for the release notes template.
+
+## Step 2: Determine the previous release
+
+Run `git tag --sort=-creatordate` to find the most recent tag (check the first few entries).
+This is the `PREVIOUS_VERSION`. Use `git log --oneline PREVIOUS_VERSION..HEAD`
+to get the exact commit range for this release.
+
+## Step 3: Run release checklist operations
+
+Work through each checklist item from the release process doc:
+
+1. **Dependencies** - Skip Renovate (user must run manually). Note as unchecked.
+2. **Container images** - Check current versions in CI configs, verify if latest.
+3. **PHP version** - Run `docker compose run --rm cli php -r "echo PHP_VERSION;"` and
+   `docker compose run --rm cli php -r "echo PHP_VERSION_ID;"` to get the container
+   PHP version. Update `composer.json` (`config.platform.php`), `phpstan.neon`
+   (`phpVersion`), and `phpcs.xml` (`testVersion`) if needed.
+4. **Composer packages** - Run `composer update -W` then check composer.json was bumped
+   (the project uses `bump-after-update` config).
+5. **Theme dependencies** - Run `yarn upgrade` in `web/themes/custom/your_site_theme/`.
+   Use yarn, NOT npm.
+6. **CI runner** - Check if `drevops/ci-runner` is at the latest version.
+7. **Cache version** - The cache key has the form `v<YY>.<M>.<minor>-db<DRUPAL_MAJOR>`.
+   Update both parts as follows in `.circleci/config.yml`,
+   `.circleci/vortex-test-common.yml`, and `.github/workflows/build-test-deploy.yml`:
+   - **`v<YY>.<M>.<minor>` prefix** - tracks the latest `uselagoon/*` container
+     image tag (e.g. `v26.4.0` for `uselagoon/mysql-8.4:26.4.0`). Lagoon
+     versions encode `YY.M.minor` (year, calendar month, minor), so this part
+     effectively follows the current month's release. Bump it whenever the
+     Lagoon containers were bumped during this release cycle.
+   - **`db<N>` suffix** - tracks the *Drupal core major version* (e.g. `db11`
+     for Drupal 11). It does NOT increment per release. Only change it when
+     the project moves between Drupal majors (e.g. `db10` → `db11`).
+   - Examples:
+     - Lagoon containers went `26.2.0` → `26.4.0`, still on Drupal 11:
+       `v26.2.0-db11` → `v26.4.0-db11`.
+     - Lagoon stayed at `26.4.0`, project moved to Drupal 12:
+       `v26.4.0-db11` → `v26.4.0-db12`.
+   - Do NOT increment the `db` suffix to "force a cache reset". That is the
+     job of changing the `v...` prefix. The `db<N>` suffix is a Drupal-major
+     marker, not a counter.
+8. **Documentation** - Run `cd .vortex && ahoy update-docs`. WARNING: this may
+   revert cache version changes in CI configs - re-apply the cache version
+   increment after running this command.
+
+## Step 4: Generate release notes
+
+The release-prep flow uses a single staging directory per release: `.artifacts/release-<full-version>/` (e.g. `.artifacts/release-1.38.0/`). Everything for that release lives inside this folder so reviewers have one place to look.
+
+Create the directory if it does not already exist:
+
+```
+mkdir -p .artifacts/release-<full-version>
+```
+
+Then copy the release template into the directory and fill it in at:
+
+```
+.artifacts/release-<full-version>/release-notes.md
+```
+
+This file is the **raw release body** (no frontmatter). It is the source for the GitHub release body when the tag is published. Marketing copies (with Obsidian frontmatter, etc.) are produced as separate files in the same folder by the parent `release-vortex` workflow - do NOT add frontmatter here.
+
+**Do NOT create `.artifacts/release-<full-version>.md` at the top level.** The previous convention of writing a single top-level `.artifacts/release-VERSION.md` has been retired. Everything lives inside the folder. If a stale top-level file is present from an earlier run, delete it.
+
+### Gathering change details
+
+For each non-trivial commit in the range:
+- Use `git show --stat HASH` to see files changed
+- Use `git show HASH -- path/to/key/file` to understand the actual change
+- Use `gh pr list --state merged --limit 50 --json number,title,author` to get
+  PR numbers and authors
+
+### Release notes format
+
+Follow this exact format (see `.artifacts/release-1.38.0/release-notes.md` from the most recent release as the canonical example):
+
+```markdown
+## VERSION - Short Title
+
+Summary paragraph (1-3 sentences).
+
+---
+
+## 🔍 Highlights
+
+- **Highlight Title**
+  Description paragraph.
+
+---
+
+## 💥 Breaking changes
+
+- Description of breaking change.
+
+---
+
+## What's new since PREVIOUS_VERSION
+
+### 🌀 Template
+
+- ✨ **New**
+ - [#ISSUE] Title from commit/PR. @author (#PR_NUMBER)
+    Description paragraph explaining what changed and why it matters to users.
+
+- 🛠 **Changed**
+ - ...
+
+- 🐞 **Fixed**
+ - ...
+
+- ⬆️ **Updated**
+ - Title. @author (#PR_NUMBER)
+ - Title. @[renovate[bot]](https://github.com/apps/renovate) (#PR_NUMBER)
+
+---
+
+### 🎛 Installer
+
+(same sub-sections)
+
+---
+
+### 📖 Documentation
+
+(same sub-sections)
+
+---
+
+## 📋 Release checklist
+
+- [x] or [ ] each item with current status notes in parentheses
+
+---
+
+**Full Changelog**: https://github.com/drevops/vortex/compare/PREVIOUS_VERSION...NEW_VERSION
+
+@username, @renovate[bot] and [renovate[bot]](https://github.com/apps/renovate)
+```
+
+### Entry format rules
+
+Each changelog entry follows this pattern. **The title line, the `What it does:` label, and the `How to use it:` label must all be wrapped in markdown bold (`**...**`).** Do not bold the body text after the labels.
+
+```
+ - **[#ISSUE] PR/commit title. @author (#PR_NUMBER)**
+    **What it does:** <one or two sentences>.
+    **How to use it:** <variable name(s), default value, or upgrade impact>.
+```
+
+Concrete examples:
+
+```
+- **[#2394] Added Jest for JavaScript unit testing. @username (#2418)**
+   **What it does:** Adds Jest as the JavaScript unit test runner, with coverage thresholds and CI integration matching the PHP test setup.
+   **How to use it:** Run `ahoy test-js` locally; CI runs it automatically. Place tests next to the JS source under `web/modules/custom/*/tests/`.
+
+- **Update PHP - All packages except core - Minor and patch. @[renovate[bot]](https://github.com/apps/renovate) (#2474)**
+```
+
+(Renovate Updated-section entries: bold the title only - they have no `What it does` / `How to use it` body.)
+
+Key rules:
+- The first line is the PR title with issue reference, author attribution, and PR number, wrapped in `**...**`.
+- The body must contain **two pieces of information** for any non-trivial entry:
+  1. **What the change does** (the behaviour, the new feature, the bug that was fixed).
+  2. **How to start using it** *or* **what effect it has on existing projects**.
+     - If the feature is opt-in or configurable: name the **environment variable / setting / flag** that turns it on, with default value (e.g. `VORTEX_PROVISION_CONFIG_IMPORT_REPEAT=1`, default `0`).
+     - If the feature is opt-out: name the disable variable and its default.
+     - If the feature applies automatically: state explicitly that no action is needed and what changes for existing projects.
+     - If the change is a fix: explain who was affected and whether their setup needs anything (e.g. "automatically applied on next provision; no configuration needed").
+     - For breaking changes: list the migration steps explicitly.
+- Read the actual diff to find the variable names. Do NOT guess. If `git show <hash>` shows new `VORTEX_*`, `DRUPAL_*`, or `*_SKIP` variables in `scripts/vortex/*.sh` or `web/sites/default/**/settings.*.php`, those are the variables to surface. Cross-reference `.vortex/docs/content/development/variables.mdx` for canonical naming.
+- Short fix entries that are purely internal (refactoring, test infrastructure, doc typos) may omit the "how to use" line.
+- Renovate bot entries in the Updated section do NOT need description paragraphs.
+- Author is `@GithubUsername` for humans, `@[renovate[bot]](https://github.com/apps/renovate)` for the bot.
+- PR number in parentheses: `(#2349)`.
+- Issue number in brackets at start: `[#2340]` (only if the commit message has one).
+- **Verify package names against `composer.json`** before naming third-party libraries (e.g. `drevops/behat-screenshot`, NOT `bex/behat-screenshot`). Run a quick `grep` check on the entry's package references.
+
+### Highlights selection rules
+
+The `## 🔍 Highlights` section is the part most readers will actually read. It must surface what users of Vortex (the people running Drupal projects on top of the template) actually benefit from. Choose 5-8 items, prioritising in this order:
+
+1. **Security / hardening** that applies automatically to every project (e.g. `.htaccess` blocks, default-on settings).
+2. **New testing or CI capabilities** that are practical to adopt (Jest, new test job, new lint).
+3. **New default modules / packages** that change what ships out of the box.
+4. **New deployment / operational levers** (manual triggers, per-channel routing).
+5. **Configurable behaviour changes** that improve reliability (e.g. opt-in repeat config import, fallback behaviour fixes).
+6. **Renovate / dependency-management improvements** that change how updates land.
+7. **Runtime / platform bumps** when they are breaking (PHP major.minor, container major bumps).
+
+DO NOT highlight:
+- Installer-only conveniences (e.g. installer flags) unless they unblock a category of users.
+- Internal CI tweaks that have no consumer-facing effect.
+- Pure refactors.
+- Single-vendor integrations that most users won't reach for (e.g. an optional Codecov prompt).
+
+If you are tempted to put an installer flag or an optional integration in highlights, ask: "Does the average Vortex consumer project benefit from this on day 1?". If no, move it down to its respective category section.
+
+### Categorisation
+
+- **Template**: Changes to the project template files (scripts, configs, CI, modules, theme)
+- **Installer**: Changes to `.vortex/installer/src/` code and installer-specific tests
+- **Documentation**: Changes to `.vortex/docs/` content
+
+Within each category:
+- **New**: New features, capabilities, or additions
+- **Changed**: Refactors, behaviour changes, improvements (non-breaking)
+- **Fixed**: Bug fixes
+- **Updated**: Dependency version bumps (group Renovate bot updates here)
+
+### Important
+
+- Many commits touch installer **fixtures** because template changes cascade into them.
+  Only list changes in the Installer section if they modify actual installer **source code**
+  (`*.vortex/installer/src/`) or installer-specific test logic.
+- Check for commits that touch both template and installer source - list the template
+  change under Template and the installer-specific change under Installer.
+
+## Command rules - CRITICAL
+
+NEVER use compound commands. Every Bash call must contain exactly ONE simple command.
+No `&&`, `||`, `;`, `|`, `<<<`, `$(...)`, or heredocs.

--- a/.claude/skills/prepare-vortex-release/SKILL.md
+++ b/.claude/skills/prepare-vortex-release/SKILL.md
@@ -65,13 +65,13 @@ The release-prep flow uses a single staging directory per release: `.artifacts/r
 
 Create the directory if it does not already exist:
 
-```
+```bash
 mkdir -p .artifacts/release-<full-version>
 ```
 
 Then copy the release template into the directory and fill it in at:
 
-```
+```text
 .artifacts/release-<full-version>/release-notes.md
 ```
 
@@ -158,7 +158,7 @@ Summary paragraph (1-3 sentences).
 
 Each changelog entry follows this pattern. **The title line, the `What it does:` label, and the `How to use it:` label must all be wrapped in markdown bold (`**...**`).** Do not bold the body text after the labels.
 
-```
+```markdown
  - **[#ISSUE] PR/commit title. @author (#PR_NUMBER)**
     **What it does:** <one or two sentences>.
     **How to use it:** <variable name(s), default value, or upgrade impact>.
@@ -166,7 +166,7 @@ Each changelog entry follows this pattern. **The title line, the `What it does:`
 
 Concrete examples:
 
-```
+```markdown
 - **[#2394] Added Jest for JavaScript unit testing. @username (#2418)**
    **What it does:** Adds Jest as the JavaScript unit test runner, with coverage thresholds and CI integration matching the PHP test setup.
    **How to use it:** Run `ahoy test-js` locally; CI runs it automatically. Place tests next to the JS source under `web/modules/custom/*/tests/`.
@@ -230,7 +230,7 @@ Within each category:
 
 - Many commits touch installer **fixtures** because template changes cascade into them.
   Only list changes in the Installer section if they modify actual installer **source code**
-  (`*.vortex/installer/src/`) or installer-specific test logic.
+  (`.vortex/installer/src/`) or installer-specific test logic.
 - Check for commits that touch both template and installer source - list the template
   change under Template and the installer-specific change under Installer.
 

--- a/.claude/skills/update-vortex-ci-runner/SKILL.md
+++ b/.claude/skills/update-vortex-ci-runner/SKILL.md
@@ -52,13 +52,13 @@ This branch is reused for Phase 2; do not create a new branch when the release v
 
 For every non-fixture file from Step 1, replace:
 
-```
+```text
 drevops/ci-runner:<VERSION>@sha256:<HASH>
 ```
 
 with:
 
-```
+```text
 drevops/ci-runner:canary
 ```
 
@@ -86,7 +86,7 @@ git push -u origin feature/update-ci-runner
 
 Invoke the `/open-pr` skill. PR title:
 
-```
+```text
 Tested 'drevops/ci-runner' canary build.
 ```
 
@@ -131,13 +131,13 @@ If docker is unavailable, use `docker manifest inspect drevops/ci-runner:<NEW_VE
 
 Rediscover files (rerun the grep from Phase 1 Step 1). Replace:
 
-```
+```text
 drevops/ci-runner:canary
 ```
 
 with:
 
-```
+```text
 drevops/ci-runner:<NEW_VERSION>@sha256:<NEW_HASH>
 ```
 
@@ -181,7 +181,7 @@ Do NOT merge: the user merges.
 | Mistake | Fix |
 |---------|-----|
 | Hardcoded list of files | Always grep: the list grows over time |
-| Included fixture files in edits | Exclude `*/Fixtures/*` and `*/tests/*` paths |
+| Included fixture files in edits | Exclude fixture snapshot paths only (for example `*/tests/Fixtures/*` and `*/test/Fixtures/*`) |
 | Kept SHA pin in canary phase | Strip SHA: canary tag must be unpinned to test moving target |
 | Used `git add .` | Stage specific files only |
 | Reported CI failure raw | Read failing step, form a hypothesis, then report |

--- a/.claude/skills/update-vortex-ci-runner/SKILL.md
+++ b/.claude/skills/update-vortex-ci-runner/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: update-vortex-ci-runner
+description: Use when testing a canary build of 'drevops/ci-runner' against a Vortex project before official release, or when incrementing the pinned 'drevops/ci-runner' version after a new release. Triggers on phrases like 'test ci-runner canary', 'update ci-runner', 'switch ci-runner to canary', 'bump ci-runner to X.Y.Z'.
+user-invocable: true
+---
+
+# Vortex Update CI Runner
+
+Two-phase workflow for verifying a new `drevops/ci-runner` release on a Vortex-based Drupal project:
+
+- **Phase 1 (Canary):** Switch all `drevops/ci-runner` image references to `:canary` (no SHA pin), open a PR, monitor CI. If green, STOP and notify the user so they can cut the official release.
+- **Phase 2 (Release):** After the user confirms a release version, roll the same PR forward to pin `:NEW_VERSION@sha256:NEW_SHA`, push, monitor CI. On green, notify the user the PR is ready to merge.
+
+## When to Use
+
+- User says 'test ci-runner canary' / 'switch ci-runner to canary' / 'try the new ci-runner'.
+- User says 'update ci-runner to X.Y.Z' (skip to Phase 2 if no canary needed).
+- Vortex release prep needs a ci-runner verification.
+
+Do NOT use for `uselagoon/*` images (Renovate handles those) or `ci-builder` (different image).
+
+## Prerequisites
+
+- Working in a Vortex-based project (look for `.vortex/` directory or `drevops/ci-runner` references).
+- `gh` CLI authenticated.
+- Docker available (only needed for the Phase 2 SHA lookup).
+- Clean working tree.
+
+## Phase 1: Canary
+
+### 1. Discover references
+
+The file list is not fixed: older or downstream projects may have it in more places. Always rediscover.
+
+```bash
+grep -rln "drevops/ci-runner" --include="*.yml" .
+```
+
+Repeat for `*.yaml` and `Dockerfile*`. **Exclude `*/tests/Fixtures/*` and `*/test/Fixtures/*` paths** since those are snapshots used by installer tests, not live CI configs.
+
+Record the current version and SHA before changing anything: you need to know what you are rolling forward from in case of rollback.
+
+### 2. Branch
+
+```bash
+git checkout -b feature/update-ci-runner
+```
+
+This branch is reused for Phase 2; do not create a new branch when the release version is provided.
+
+### 3. Replace image references
+
+For every non-fixture file from Step 1, replace:
+
+```
+drevops/ci-runner:<VERSION>@sha256:<HASH>
+```
+
+with:
+
+```
+drevops/ci-runner:canary
+```
+
+**Drop the SHA pin in canary mode.** Pinning a SHA defeats the canary: CI re-runs would test the same frozen build, not whatever the `canary` tag currently points to. The whole point of the canary phase is to track a moving target.
+
+Use the `Edit` tool with `replace_all: true` per file. Verify with grep afterwards: the only remaining hits should be in fixture paths.
+
+### 4. Commit and push
+
+Stage specific files (never `git add .`):
+
+```bash
+git add .github/workflows/build-test-deploy.yml
+```
+
+```bash
+git commit -m "Switched 'drevops/ci-runner' to 'canary' for verification."
+```
+
+```bash
+git push -u origin feature/update-ci-runner
+```
+
+### 5. Open PR
+
+Invoke the `/open-pr` skill. PR title:
+
+```
+Tested 'drevops/ci-runner' canary build.
+```
+
+PR body should note: this is a canary test (NOT for merge yet), the previous pinned version, files changed, and that the next step is for the user to release a new `drevops/ci-runner` once CI passes.
+
+### 6. Monitor CI
+
+Watch GitHub Actions via `gh pr checks <PR>` and CircleCI via the PR link.
+
+**On failure:** Diagnose before reporting. Common causes:
+
+- **Tool version drift** in canary (PHP, Node, Composer bumped in the ci-runner image but pinned in project configs: `composer.json` `config.platform.php`, `phpstan.neon` `phpVersion`, `phpcs.xml` `testVersion`).
+- A tool removed from the canary image.
+- Cache key issues (rare: cache keys are tied to Lagoon versions, not ci-runner).
+- Image pull / registry timeout.
+
+Report with: failing job name, failing step, ~30 lines of the most relevant log, and your hypothesis. Do not paste raw logs without a hypothesis.
+
+**On success:** STOP. Do not merge. Tell the user:
+
+> Canary verification passed: CI is green on `<PR URL>`. Ready for you to cut the new `drevops/ci-runner` release. Let me know the new version (e.g. `26.4.0`) when ready.
+
+## Phase 2: Release Pin
+
+Triggered when the user confirms a new released version (e.g. 'released as 26.4.0').
+
+### 1. Get the SHA digest
+
+```bash
+docker pull drevops/ci-runner:<NEW_VERSION>
+```
+
+```bash
+docker inspect --format="{{index .RepoDigests 0}}" drevops/ci-runner:<NEW_VERSION>
+```
+
+The output is `drevops/ci-runner@sha256:<HASH>`. Record `<HASH>`.
+
+If docker is unavailable, use `docker manifest inspect drevops/ci-runner:<NEW_VERSION>` and read the linux/amd64 digest.
+
+### 2. Replace canary references
+
+Rediscover files (rerun the grep from Phase 1 Step 1). Replace:
+
+```
+drevops/ci-runner:canary
+```
+
+with:
+
+```
+drevops/ci-runner:<NEW_VERSION>@sha256:<NEW_HASH>
+```
+
+### 3. Commit and push on the same branch
+
+```bash
+git commit -m "Updated 'drevops/ci-runner' to '<NEW_VERSION>'."
+```
+
+```bash
+git push
+```
+
+### 4. Update PR metadata
+
+```bash
+gh pr edit <PR> --title "Updated 'drevops/ci-runner' to '<NEW_VERSION>'."
+```
+
+Add a comment summarising the canary -> release transition.
+
+### 5. Monitor CI
+
+Same as Phase 1 Step 6. On success:
+
+> CI green on pinned `<NEW_VERSION>`. PR `<URL>` ready to merge.
+
+Do NOT merge: the user merges.
+
+## Red Flags
+
+- About to pin a SHA in Phase 1: don't. Canary needs the moving tag.
+- About to edit a file under `tests/Fixtures/`: don't. Those are test snapshots.
+- About to merge the PR: don't. User merges.
+- About to use `gh pr create`: don't. Use `/open-pr`.
+- About to start Phase 2 without Phase 1 CI green: confirm with user first.
+- Hardcoding the file list from this skill: don't. Always grep first.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Hardcoded list of files | Always grep: the list grows over time |
+| Included fixture files in edits | Exclude `*/Fixtures/*` and `*/tests/*` paths |
+| Kept SHA pin in canary phase | Strip SHA: canary tag must be unpinned to test moving target |
+| Used `git add .` | Stage specific files only |
+| Reported CI failure raw | Read failing step, form a hypothesis, then report |
+| Created PR via `gh pr create` | Use `/open-pr` skill |
+| New branch for Phase 2 | Reuse the Phase 1 branch and PR |

--- a/.gitignore
+++ b/.gitignore
@@ -46,10 +46,18 @@ web/sites/default/*
 # Ignore all recipes by default. Custom recipes should be added explicitly.
 recipes/*
 
+#;< AI_CODE_INSTRUCTIONS
+# Ignore all Claude files by default. Custom files should be added explicitly.
+!.claude
+.claude/*
+!.claude/settings.json
+#;> AI_CODE_INSTRUCTIONS
+
 #;< VORTEX_DEV
 #; Ignore these files in Vortex itself, but do not ignore in consumer site.
 /composer.lock
 /patches.lock.json
+!.claude/skills/
 #;> VORTEX_DEV
 
 # Ignore dependencies cache files.

--- a/.vortex/installer/src/Prompts/Handlers/AiCodeInstructions.php
+++ b/.vortex/installer/src/Prompts/Handlers/AiCodeInstructions.php
@@ -37,7 +37,7 @@ class AiCodeInstructions extends AbstractHandler {
       return NULL;
     }
 
-    return File::exists($this->dstDir . '/AGENTS.md') || File::exists($this->dstDir . '/CLAUDE.md');
+    return File::exists($this->dstDir . '/AGENTS.md') || File::exists($this->dstDir . '/CLAUDE.md') || File::exists($this->dstDir . '/.claude/settings.json');
   }
 
   /**
@@ -50,6 +50,8 @@ class AiCodeInstructions extends AbstractHandler {
     if (!$v) {
       File::remove($t . '/AGENTS.md');
       File::remove($t . '/CLAUDE.md');
+      File::remove($t . '/.claude');
+      File::removeTokenAsync('AI_CODE_INSTRUCTIONS');
     }
   }
 

--- a/.vortex/installer/src/Prompts/Handlers/Internal.php
+++ b/.vortex/installer/src/Prompts/Handlers/Internal.php
@@ -81,6 +81,7 @@ class Internal extends AbstractHandler {
 
     // Remove Vortex internal files.
     File::remove($t . DIRECTORY_SEPARATOR . '.vortex');
+    File::remove($t . DIRECTORY_SEPARATOR . '.claude' . DIRECTORY_SEPARATOR . 'skills');
 
     File::remove($t . '/.github/FUNDING.yml');
     File::remove($t . 'CODE_OF_CONDUCT.md');

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.claude/settings.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ahoy:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.gitignore
@@ -41,6 +41,11 @@ web/sites/default/*
 # Ignore all recipes by default. Custom recipes should be added explicitly.
 recipes/*
 
+# Ignore all Claude files by default. Custom files should be added explicitly.
+!.claude
+.claude/*
+!.claude/settings.json
+
 # Ignore dependencies cache files.
 /vendor
 /node_modules

--- a/.vortex/installer/tests/Fixtures/handler_process/ai_instructions_disabled/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/ai_instructions_disabled/.gitignore
@@ -1,0 +1,12 @@
+@@ -41,11 +41,6 @@
+ # Ignore all recipes by default. Custom recipes should be added explicitly.
+ recipes/*
+ 
+-# Ignore all Claude files by default. Custom files should be added explicitly.
+-!.claude
+-.claude/*
+-!.claude/settings.json
+-
+ # Ignore dependencies cache files.
+ /vendor
+ /node_modules

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.gitignore
@@ -67,7 +67,7 @@
  
  # Ignore all recipes by default. Custom recipes should be added explicitly.
  recipes/*
-@@ -44,10 +44,10 @@
+@@ -49,10 +49,10 @@
  # Ignore dependencies cache files.
  /vendor
  /node_modules

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.gitignore
@@ -67,7 +67,7 @@
  
  # Ignore all recipes by default. Custom recipes should be added explicitly.
  recipes/*
-@@ -44,10 +44,10 @@
+@@ -49,10 +49,10 @@
  # Ignore dependencies cache files.
  /vendor
  /node_modules

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.gitignore
@@ -1,4 +1,4 @@
-@@ -50,7 +50,6 @@
+@@ -55,7 +55,6 @@
  web/themes/**/build
  .data
  .logs

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.gitignore
@@ -1,4 +1,4 @@
-@@ -50,7 +50,6 @@
+@@ -55,7 +55,6 @@
  web/themes/**/build
  .data
  .logs

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.gitignore
@@ -1,4 +1,4 @@
-@@ -50,7 +50,6 @@
+@@ -55,7 +55,6 @@
  web/themes/**/build
  .data
  .logs

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.gitignore
@@ -1,4 +1,4 @@
-@@ -50,7 +50,6 @@
+@@ -55,7 +55,6 @@
  web/themes/**/build
  .data
  .logs

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.gitignore
@@ -1,4 +1,4 @@
-@@ -50,7 +50,6 @@
+@@ -55,7 +55,6 @@
  web/themes/**/build
  .data
  .logs

--- a/.vortex/installer/tests/Functional/Handlers/AiCodeInstructionsHandlerProcessTest.php
+++ b/.vortex/installer/tests/Functional/Handlers/AiCodeInstructionsHandlerProcessTest.php
@@ -16,6 +16,7 @@ class AiCodeInstructionsHandlerProcessTest extends AbstractHandlerProcessTestCas
       static::cw(function (AbstractHandlerProcessTestCase $test): void {
           $test->assertFileExists(static::$sut . '/AGENTS.md');
           $test->assertFileExists(static::$sut . '/CLAUDE.md');
+          $test->assertFileExists(static::$sut . '/.claude/settings.json');
       }),
     ];
     yield 'ai_instructions_disabled' => [
@@ -23,6 +24,7 @@ class AiCodeInstructionsHandlerProcessTest extends AbstractHandlerProcessTestCas
       static::cw(function (AbstractHandlerProcessTestCase $test): void {
           $test->assertFileDoesNotExist(static::$sut . '/AGENTS.md');
           $test->assertFileDoesNotExist(static::$sut . '/CLAUDE.md');
+          $test->assertDirectoryDoesNotExist(static::$sut . '/.claude');
       }),
     ];
   }

--- a/.vortex/installer/tests/Unit/Handlers/AiCodeInstructionsHandlerDiscoveryTest.php
+++ b/.vortex/installer/tests/Unit/Handlers/AiCodeInstructionsHandlerDiscoveryTest.php
@@ -36,6 +36,14 @@ class AiCodeInstructionsHandlerDiscoveryTest extends AbstractHandlerDiscoveryTes
         File::dump(static::$sut . '/CLAUDE.md');
       },
     ];
+    yield 'ai instructions - discovery - claude settings only' => [
+      [],
+      [AiCodeInstructions::id() => TRUE] + $expected_installed,
+      function (AbstractHandlerDiscoveryTestCase $test, Config $config): void {
+        $test->stubVortexProject($config);
+        File::dump(static::$sut . '/.claude/settings.json');
+      },
+    ];
     yield 'ai instructions - discovery - removed' => [
       [],
       [AiCodeInstructions::id() => FALSE] + $expected_installed,


### PR DESCRIPTION
## Summary

Commits a shared `.claude/settings.json` permission allowlist at the project level so all contributors get consistent Claude Code behavior without individual setup. Adds two Vortex maintenance skills (`prepare-vortex-release`, `update-vortex-ci-runner`) directly into the repository so they travel with the codebase rather than living in personal `~/.claude/skills/` directories. The installer is updated to propagate and clean up these new files correctly on consumer-site installs.

## Changes

### `.claude/settings.json` (new)

Committed shared Claude Code permissions allowlist that grants `ahoy:*` by default. All contributors to Vortex pick this up automatically; no per-machine setup required.

### `.claude/skills/` (new)

Two Vortex-specific maintenance skills moved from personal skill directories into the repository:

- `prepare-vortex-release/SKILL.md` - full release-prep checklist (deps, container images, PHP version, cache key bumps, docs, release notes generation).
- `update-vortex-ci-runner/SKILL.md` - two-phase canary/release workflow for verifying and pinning a new `drevops/ci-runner` image version.

Personal handles replaced with `@username` placeholder so the skills are contributor-neutral.

### `.gitignore`

Added an `AI_CODE_INSTRUCTIONS`-gated block that ignores `.claude/*` by default but explicitly allows `.claude/settings.json`. The existing `VORTEX_DEV` block gains `!.claude/skills/` so the maintenance skills directory is preserved in the Vortex repo but stripped from consumer sites.

### `.vortex/installer/src/Prompts/Handlers/AiCodeInstructions.php`

`discover()` now also returns `true` when `.claude/settings.json` exists (catches prior installs that have settings but not AGENTS.md/CLAUDE.md). `process()` now removes the entire `.claude/` directory and strips the `AI_CODE_INSTRUCTIONS` token block when the user answers NO to AI code instructions.

### `.vortex/installer/src/Prompts/Handlers/Internal.php`

Always strips `.claude/skills` from consumer-site installs, matching the existing `.vortex/` removal pattern - these are Vortex maintenance-only files.

### Installer test fixtures and tests

- Baseline fixture gains `.claude/settings.json`.
- `ai_instructions_disabled` fixture adds `.gitignore` diff and a stub `.claude/-settings.json` to represent the removed settings file.
- Several `tools_*` and `hosting_*` `.gitignore` fixture snapshots updated to reflect the new line-offset from the added `AI_CODE_INSTRUCTIONS` block.
- `AiCodeInstructionsHandlerProcessTest` asserts `.claude/settings.json` present when AI=YES and `.claude/` directory absent when AI=NO.
- `AiCodeInstructionsHandlerDiscoveryTest` adds a `claude settings only` case to cover discovery via `.claude/settings.json` alone.

## Before / After

```
Before                                  After
──────────────────────────────────────  ─────────────────────────────────────────
~/.claude/skills/                       .claude/
  prepare-vortex-release/SKILL.md         settings.json          ← shared perms
  update-vortex-ci-runner/SKILL.md        skills/
                                            prepare-vortex-release/SKILL.md
Personal, per-contributor only.             update-vortex-ci-runner/SKILL.md
                                        Versioned, travels with the repo.

.gitignore                              .gitignore
  (no .claude entries)                    #;< AI_CODE_INSTRUCTIONS
                                          !.claude
                                          .claude/*
                                          !.claude/settings.json
                                          #;> AI_CODE_INSTRUCTIONS
                                          (VORTEX_DEV block)
                                          !.claude/skills/

Installer (AI=NO)                       Installer (AI=NO)
  removes AGENTS.md                       removes AGENTS.md
  removes CLAUDE.md                       removes CLAUDE.md
                                          removes .claude/ directory
                                          strips AI_CODE_INSTRUCTIONS block

discover()                              discover()
  checks AGENTS.md                        checks AGENTS.md
  checks CLAUDE.md                        checks CLAUDE.md
                                          checks .claude/settings.json
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-powered skills to prepare Vortex template releases and to guide CI runner updates.
  * Installer now recognizes and manages Claude AI settings during project setup and cleanup.

* **Chores**
  * Updated ignore rules for AI-related files.
  * Expanded tests to cover AI settings discovery and installer cleanup behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drevops/vortex/pull/2514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->