### PR TITLE
Added audit ignore entries for advisories blocking Drupal core install.

### DIFF
--- a/.vortex/CLAUDE.md
+++ b/.vortex/CLAUDE.md
@@ -71,20 +71,28 @@ ahoy lint-markdown # Lint markdown files
 
 ## Cross-System Workflow
 
+**HARD RULE — Always commit before `ahoy update-snapshots`.** Snapshots are
+regenerated from the *committed* baseline. Any uncommitted changes to the
+template (root or `.vortex/`) will not be picked up and the snapshot diff
+will not reflect them. This applies to every snapshot run, no exceptions:
+template scripts, settings, configs, Dockerfiles, composer.json — all of it.
+
 When updating template scripts:
 
 1. Modify script in `.vortex/tooling/src/` (shipped scripts) or `scripts/custom/` (provision subscripts)
 2. Run `ahoy lint-scripts`
 3. Run `ahoy update-docs`
 4. Update BATS tests in `.vortex/tooling/tests/unit/`
-5. Run `ahoy update-snapshots`
+5. **Commit the changes**
+6. Run `ahoy update-snapshots`
+7. Commit the regenerated fixtures (separate commit or amend per task scope)
 
 When updating template files (settings, configs, etc.):
 
-1. Make and commit code changes first
-2. Then run `ahoy update-snapshots` — snapshots compare against the
-   committed baseline, so uncommitted changes will not be picked up
-   correctly
+1. Make the code change
+2. **Commit it**
+3. Run `ahoy update-snapshots`
+4. Commit the regenerated fixtures
 
 ## Environment Variables
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
@@ -96,16 +96,16 @@
             "tbachert/spi": true
         },
         "audit": {
-            "abandoned": "report",
-            "block-insecure": true,
             "ignore": {
+                "PKSA-1tmc-rt7x-12w6": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
                 "PKSA-dwsq-ppd2-mb1x": "symfony/polyfill-intl-idn __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
                 "PKSA-fbvq-z33h-r2np": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
                 "PKSA-g9zw-qxh8-pq8w": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
-                "PKSA-yd6k-t2gh-1m43": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
-                "PKSA-1tmc-rt7x-12w6": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
-                "PKSA-xx6c-6d96-db2w": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix."
-            }
+                "PKSA-xx6c-6d96-db2w": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
+                "PKSA-yd6k-t2gh-1m43": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix."
+            },
+            "abandoned": "report",
+            "block-insecure": true
         },
         "bump-after-update": true,
         "discard-changes": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
@@ -97,7 +97,15 @@
         },
         "audit": {
             "abandoned": "report",
-            "block-insecure": true
+            "block-insecure": true,
+            "ignore": {
+                "PKSA-dwsq-ppd2-mb1x": "symfony/polyfill-intl-idn __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
+                "PKSA-fbvq-z33h-r2np": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
+                "PKSA-g9zw-qxh8-pq8w": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
+                "PKSA-yd6k-t2gh-1m43": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
+                "PKSA-1tmc-rt7x-12w6": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
+                "PKSA-xx6c-6d96-db2w": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix."
+            }
         },
         "bump-after-update": true,
         "discard-changes": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -125,38 +125,38 @@
+@@ -133,38 +133,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -125,38 +125,38 @@
+@@ -133,38 +133,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
@@ -39,7 +39,7 @@
          },
          "audit": {
              "abandoned": "report",
-@@ -166,7 +173,20 @@
+@@ -174,7 +181,20 @@
          "patchLevel": {
              "drupal/core": "-p2"
          },

--- a/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
@@ -38,7 +38,7 @@
 +            "wikimedia/composer-merge-plugin": true
          },
          "audit": {
-             "abandoned": "report",
+             "ignore": {
 @@ -174,7 +181,20 @@
          "patchLevel": {
              "drupal/core": "-p2"

--- a/composer.json
+++ b/composer.json
@@ -107,16 +107,16 @@
             "tbachert/spi": true
         },
         "audit": {
-            "abandoned": "report",
-            "block-insecure": true,
             "ignore": {
+                "PKSA-1tmc-rt7x-12w6": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
                 "PKSA-dwsq-ppd2-mb1x": "symfony/polyfill-intl-idn v1.37.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
                 "PKSA-fbvq-z33h-r2np": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
                 "PKSA-g9zw-qxh8-pq8w": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
-                "PKSA-yd6k-t2gh-1m43": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
-                "PKSA-1tmc-rt7x-12w6": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
-                "PKSA-xx6c-6d96-db2w": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix."
-            }
+                "PKSA-xx6c-6d96-db2w": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
+                "PKSA-yd6k-t2gh-1m43": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix."
+            },
+            "abandoned": "report",
+            "block-insecure": true
         },
         "bump-after-update": true,
         "discard-changes": true,

--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,15 @@
         },
         "audit": {
             "abandoned": "report",
-            "block-insecure": true
+            "block-insecure": true,
+            "ignore": {
+                "PKSA-dwsq-ppd2-mb1x": "symfony/polyfill-intl-idn v1.37.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
+                "PKSA-fbvq-z33h-r2np": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
+                "PKSA-g9zw-qxh8-pq8w": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
+                "PKSA-yd6k-t2gh-1m43": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
+                "PKSA-1tmc-rt7x-12w6": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
+                "PKSA-xx6c-6d96-db2w": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix."
+            }
         },
         "bump-after-update": true,
         "discard-changes": true,


### PR DESCRIPTION
## Summary

`drupal/core-recommended` ~11.3.10 pins `twig/twig` to `~v3.26.0` and `symfony/polyfill-intl-idn` to `~v1.37.0`. Both ranges resolve only to versions covered by open security advisories, while the fixed versions (`twig/twig >=3.27.0` and `symfony/polyfill-intl-idn >=1.38.1`) fall outside the pinned constraints. As a result, `composer audit --locked` blocks `composer install` in CI. This PR adds a `config.audit.ignore` block to suppress those six advisories so Drupal core installs cleanly until upstream widens its constraints.

## Changes

- **`composer.json`** - added `config.audit.ignore` block with 6 entries: `PKSA-dwsq-ppd2-mb1x` (`symfony/polyfill-intl-idn` v1.37.0) and `PKSA-1tmc-rt7x-12w6`, `PKSA-fbvq-z33h-r2np`, `PKSA-g9zw-qxh8-pq8w`, `PKSA-xx6c-6d96-db2w`, `PKSA-yd6k-t2gh-1m43` (all `twig/twig` v3.26.0); each entry documents the affected package, version, root cause, and forward-looking note.
- **`.vortex/CLAUDE.md`** - promoted the "commit before `ahoy update-snapshots`" guidance to a HARD RULE at the top of the Cross-System Workflow section, and updated both the template-scripts and template-files checklists to make the commit step explicit and ordered.
- **Installer fixture snapshots** - regenerated four fixtures under `.vortex/installer/tests/Fixtures/handler_process/` (`_baseline`, `hosting_acquia`, `hosting_project_name___acquia`, `starter_drupal_cms_profile`) to reflect the new `audit.ignore` block in the baseline `composer.json`.

## Before / After

```
# Before
"audit": {
    "abandoned": "report",
    "block-insecure": true
}

# After
"audit": {
    "ignore": {
        "PKSA-1tmc-rt7x-12w6": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
        "PKSA-dwsq-ppd2-mb1x": "symfony/polyfill-intl-idn v1.37.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
        "PKSA-fbvq-z33h-r2np": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
        "PKSA-g9zw-qxh8-pq8w": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
        "PKSA-xx6c-6d96-db2w": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
        "PKSA-yd6k-t2gh-1m43": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix."
    },
    "abandoned": "report",
    "block-insecure": true
}
```

Related: #2518 (tracks removal once upstream fixes land).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development workflow documentation with improved guidance on commit requirements before snapshot operations.
  * Added configuration to manage security advisories for certain dependencies awaiting upstream fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drevops/vortex/pull/2520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->