### PR TITLE
Renamed 'region_map' to 'regions' and nested message selectors in 'behat.yml'.

### DIFF
--- a/.vortex/CLAUDE.md
+++ b/.vortex/CLAUDE.md
@@ -71,6 +71,15 @@ ahoy lint-markdown # Lint markdown files
 
 ## Cross-System Workflow
 
+**HARD RULE — Always use `ahoy update-snapshots` (run from `.vortex/`).
+NEVER invoke `composer update-snapshots` directly in `.vortex/tests/` or
+`.vortex/installer/`.** The ahoy target wraps both composer scripts together
+with the required environment (`XDEBUG_MODE=off`) and parallel job flags.
+Calling the underlying composer scripts directly skips part of the workflow
+and produces partial, inconsistent fixtures. There is no scenario in which
+the direct composer call is correct - if `cd .vortex` is hard, fix the cd,
+do not reach past the abstraction.
+
 **HARD RULE — Always commit before `ahoy update-snapshots`.** Snapshots are
 regenerated from the *committed* baseline. Any uncommitted changes to the
 template (root or `.vortex/`) will not be picked up and the snapshot diff
@@ -130,6 +139,7 @@ Detailed prerequisites and outputs for the video command are documented in
 ### Key Restrictions
 
 - **NEVER** modify `.vortex/installer/tests/Fixtures/` directly
+- **NEVER** run `composer update-snapshots` directly - always use `ahoy update-snapshots` from `.vortex/`
 - American English spelling in documentation
 - Sentence case for doc headings (capitalize proper nouns only)
 

--- a/.vortex/installer/CLAUDE.md
+++ b/.vortex/installer/CLAUDE.md
@@ -40,19 +40,11 @@ tests/Fixtures/install/
 
 ### Updating Fixtures
 
-**CRITICAL**: Never modify fixture files directly. All fixture files
-(including `_baseline/`) are regenerated from the root template files by
-`ahoy update-snapshots`. Only modify the root template files, then run
-`ahoy update-snapshots` to regenerate the fixtures.
+**CRITICAL**: Never modify fixture files directly. Only modify the root
+template files, then regenerate the fixtures.
 
-```bash
-# From .vortex/ directory (recommended)
-ahoy update-snapshots
-
-# Manual (for debugging specific scenarios)
-cd .vortex/installer
-UPDATE_SNAPSHOTS=1 ./vendor/bin/phpunit --filter "testHandlerProcess.*baseline"
-```
+See `.vortex/CLAUDE.md` for the snapshot update process (always
+`ahoy update-snapshots` from `.vortex/`, never composer directly).
 
 ### Updating the Installer Video
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/behat.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/behat.yml
@@ -55,7 +55,7 @@ default:
         drupal_root: web
       drush:
         root: web
-      region_map:
+      regions:
         header: '#header'
         primary_menu: '.header-nav'
         secondary_menu: '.region.region--secondary-menu'
@@ -72,10 +72,11 @@ default:
       selectors:
         login_form_selector: 'form#user-login,form#user-login-form'
         logged_in_selector: 'body.logged-in,body.user-logged-in'
-        message_selector: '.messages'
-        error_message_selector: '.messages.error,.messages.messages--error'
-        success_message_selector: '.messages.status,.messages.messages--status'
-        warning_message_selector: '.messages.warning,.messages.messages--warning'
+        messages:
+          default: '.messages'
+          error: '.messages.error,.messages.messages--error'
+          success: '.messages.status,.messages.messages--status'
+          warning: '.messages.warning,.messages.messages--warning'
 
     # Capture HTML and PNG screenshots on demand and on failure.
     DrevOps\BehatScreenshotExtension:

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/behat.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/behat.yml
@@ -7,6 +7,6 @@
        drush:
 -        root: web
 +        root: docroot
-       region_map:
+       regions:
          header: '#header'
          primary_menu: '.header-nav'

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/behat.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/behat.yml
@@ -7,6 +7,6 @@
        drush:
 -        root: web
 +        root: docroot
-       region_map:
+       regions:
          header: '#header'
          primary_menu: '.header-nav'

--- a/behat.yml
+++ b/behat.yml
@@ -55,7 +55,7 @@ default:
         drupal_root: web
       drush:
         root: web
-      region_map:
+      regions:
         header: '#header'
         primary_menu: '.header-nav'
         secondary_menu: '.region.region--secondary-menu'
@@ -72,10 +72,11 @@ default:
       selectors:
         login_form_selector: 'form#user-login,form#user-login-form'
         logged_in_selector: 'body.logged-in,body.user-logged-in'
-        message_selector: '.messages'
-        error_message_selector: '.messages.error,.messages.messages--error'
-        success_message_selector: '.messages.status,.messages.messages--status'
-        warning_message_selector: '.messages.warning,.messages.messages--warning'
+        messages:
+          default: '.messages'
+          error: '.messages.error,.messages.messages--error'
+          success: '.messages.status,.messages.messages--status'
+          warning: '.messages.warning,.messages.messages--warning'
 
     # Capture HTML and PNG screenshots on demand and on failure.
     DrevOps\BehatScreenshotExtension:


### PR DESCRIPTION
## Summary

Migrated `behat.yml` away from two deprecated config forms in `drupal/drupal-extension` 6.0, and tightened the AI agent documentation around snapshot regeneration to prevent a common workflow mistake.

## Changes

**`behat.yml` - deprecated key migration**

Two breaking deprecations introduced in `drupal/drupal-extension` 6.0 surface as runtime warnings and will be hard-removed in 6.1:

- `region_map:` (under `DrupalExtension`) is renamed to `regions:`
- Flat message selector keys (`message_selector`, `error_message_selector`, `success_message_selector`, `warning_message_selector`) are replaced by a nested `messages:` map with keys `default`, `error`, `success`, `warning`

The same changes are applied to the corresponding fixture files under `.vortex/installer/tests/Fixtures/handler_process/` (`_baseline/`, `hosting_acquia/`, `hosting_project_name___acquia/`).

**`.vortex/CLAUDE.md` - snapshot command HARD RULE**

Added a HARD RULE block in the Cross-System Workflow section and a matching bullet in Key Restrictions that forbids calling `composer update-snapshots` directly. The `ahoy update-snapshots` wrapper (run from `.vortex/`) must always be used - it sets `XDEBUG_MODE=off`, passes the right parallel flags, and runs both composer scripts together. Calling the underlying scripts individually produces partial, inconsistent fixtures.

**`.vortex/installer/CLAUDE.md` - deferred to parent**

Replaced the inline snapshot command block with a pointer to `.vortex/CLAUDE.md`, eliminating duplicate documentation that was drifting out of sync.

## Before / After

### `region_map` -> `regions`

```yaml
# Before
DrupalExtension:
  region_map:
    header: '#header'

# After
DrupalExtension:
  regions:
    header: '#header'
```

### Flat selectors -> `messages:` map

```yaml
# Before
selectors:
  message_selector: '.messages'
  error_message_selector: '.messages.error,.messages.messages--error'
  success_message_selector: '.messages.status,.messages.messages--status'
  warning_message_selector: '.messages.warning,.messages.messages--warning'

# After
selectors:
  messages:
    default: '.messages'
    error: '.messages.error,.messages.messages--error'
    success: '.messages.status,.messages.messages--status'
    warning: '.messages.warning,.messages.messages--warning'
```

## Follow-up

The fixture files under `.vortex/installer/tests/Fixtures/` are auto-generated by `ahoy update-snapshots` (from `.vortex/`). The Acquia hosting fixtures (`hosting_acquia/behat.yml`, `hosting_project_name___acquia/behat.yml`) contain only the `region_map` -> `regions` rename; the nested `messages:` structure is not present in those diff-style fixtures because those files capture only the deltas applied by the hosting handler, not the full file. They are correct as-is - no further regeneration is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified snapshot and fixture update procedures in maintenance guidance.
  * Condensed fixture updating instructions with improved emphasis on proper workflows.

* **Chores**
  * Refactored testing configuration for improved region and message mapping consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drevops/vortex/pull/2523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->