### PR TITLE
[#2518] Removed audit ignore entries for upstream-fixed 'twig/twig' and 'symfony/polyfill-intl-idn' CVEs.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
@@ -96,14 +96,6 @@
             "tbachert/spi": true
         },
         "audit": {
-            "ignore": {
-                "PKSA-1tmc-rt7x-12w6": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
-                "PKSA-dwsq-ppd2-mb1x": "symfony/polyfill-intl-idn __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
-                "PKSA-fbvq-z33h-r2np": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
-                "PKSA-g9zw-qxh8-pq8w": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
-                "PKSA-xx6c-6d96-db2w": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix.",
-                "PKSA-yd6k-t2gh-1m43": "twig/twig __VERSION__ - required by drupal/core-recommended __VERSION__, awaiting upstream fix."
-            },
             "abandoned": "report",
             "block-insecure": true
         },

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -133,38 +133,38 @@
+@@ -125,38 +125,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -133,38 +133,38 @@
+@@ -125,38 +125,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
@@ -38,8 +38,8 @@
 +            "wikimedia/composer-merge-plugin": true
          },
          "audit": {
-             "ignore": {
-@@ -174,7 +181,20 @@
+             "abandoned": "report",
+@@ -166,7 +173,20 @@
          "patchLevel": {
              "drupal/core": "-p2"
          },

--- a/composer.json
+++ b/composer.json
@@ -107,14 +107,6 @@
             "tbachert/spi": true
         },
         "audit": {
-            "ignore": {
-                "PKSA-1tmc-rt7x-12w6": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
-                "PKSA-dwsq-ppd2-mb1x": "symfony/polyfill-intl-idn v1.37.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
-                "PKSA-fbvq-z33h-r2np": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
-                "PKSA-g9zw-qxh8-pq8w": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
-                "PKSA-xx6c-6d96-db2w": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
-                "PKSA-yd6k-t2gh-1m43": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix."
-            },
             "abandoned": "report",
             "block-insecure": true
         },


### PR DESCRIPTION
Closes #2518

## Summary

Removes the six `config.audit.ignore` entries from `composer.json` that were suppressing PKSA advisories for `twig/twig` and `symfony/polyfill-intl-idn`. Those entries were necessary while `drupal/core-recommended ~11.3.10` pinned `twig/twig` at v3.26.0 and `symfony/polyfill-intl-idn` at v1.37.0. With `drupal/core-recommended ~11.3.11` (landed on `main` in #2524), the dependency graph now resolves `twig/twig v3.27.0` and `symfony/polyfill-intl-idn v1.38.1`, both above the fix thresholds. The entire `ignore` map is dropped; `abandoned: report` and `block-insecure: true` are kept. Installer baseline snapshot and three derived fixtures are regenerated to reflect the structural change.

## Changes

- **`composer.json`** - Dropped the `config.audit.ignore` block (6 PKSA advisory suppressions); `audit` section retains `abandoned` and `block-insecure` settings.
- **`.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json`** - Regenerated baseline snapshot; the `ignore` block is removed, matching the updated root `composer.json`.
- **`.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json`** - Diff-header line numbers updated to account for the 8-line removal in the baseline.
- **`.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json`** - Same mechanical line-number cascade as `hosting_acquia`.
- **`.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json`** - Snapshot updated to reflect the absence of the `ignore` block and the cascaded line-number shifts.

## Before / After

```json
// Before
"audit": {
    "ignore": {
        "PKSA-1tmc-rt7x-12w6": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
        "PKSA-dwsq-ppd2-mb1x": "symfony/polyfill-intl-idn v1.37.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
        "PKSA-fbvq-z33h-r2np": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
        "PKSA-g9zw-qxh8-pq8w": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
        "PKSA-xx6c-6d96-db2w": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix.",
        "PKSA-yd6k-t2gh-1m43": "twig/twig v3.26.0 - required by drupal/core-recommended ~11.3.10, awaiting upstream fix."
    },
    "abandoned": "report",
    "block-insecure": true
}

// After
"audit": {
    "abandoned": "report",
    "block-insecure": true
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed security advisory ignore configurations to streamline dependency settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drevops/vortex/pull/2528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->