### PR TITLE
Fixed eight small issues across ahoy commands, installer runners, and CI workflows.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -152,7 +152,7 @@ commands:
     aliases: [fetch-db2, db2-download, db2-fetch]
     cmd: |
       ahoy require-tooling
-      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
+      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB2_FRESH=1 VORTEX_DOWNLOAD_DB2_FORCE=1;; esac
       VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
   #;> MIGRATION
   #;> !PROVISION_TYPE_PROFILE

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -143,7 +143,7 @@ commands:
     aliases: [fetch-db, db-download, db-fetch]
     cmd: |
       ahoy require-tooling
-      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
+      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1 VORTEX_DOWNLOAD_DB_FORCE=1;; esac
       ./vendor/drevops/vortex-tooling/src/download-db
 
   #;< MIGRATION

--- a/.github/workflows/vortex-test-installer.yml
+++ b/.github/workflows/vortex-test-installer.yml
@@ -15,6 +15,10 @@ on:
       - release/**
       - project/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   vortex-test-installer:
     runs-on: ubuntu-latest
@@ -65,6 +69,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
 
       - name: Generate video for installer (not used in the final artifact)
+        if: matrix.php-versions == '8.2'
         run: |
           sudo apt-get update
           sudo apt install expect

--- a/.vortex/.ahoy.yml
+++ b/.vortex/.ahoy.yml
@@ -113,12 +113,6 @@ commands:
   test-common:
     cmd: ./tests/test.common.sh
 
-  test-deployment:
-    cmd: ./tests/test.deployment.sh
-
-  test-workflow:
-    cmd: ./tests/test.workflow.sh
-
   test-docs:
     cmd: |
       [ ! -d ./docs/node_modules ] && yarn --cwd=./docs install --frozen-lockfile

--- a/.vortex/docs/content/contributing/maintenance/installer.mdx
+++ b/.vortex/docs/content/contributing/maintenance/installer.mdx
@@ -208,5 +208,5 @@ To update the video:
 
 ```shell
 cd .vortex
-ahoy update-installer-video
+ahoy update-videos installer
 ```

--- a/.vortex/docs/content/contributing/maintenance/release.mdx
+++ b/.vortex/docs/content/contributing/maintenance/release.mdx
@@ -75,7 +75,7 @@ renovate --schedule= --force-cli=true drevops/vortex
 7. Update minor version of dependencies in theme's `package.json`.
 8. Increment the cache version in `.circleci/config.yml` and `.github/workflows/build-test-deploy.yml`.
 9. Updated documentation with `cd .vortex && ahoy update-docs`.
-10. Update installer video with `cd .vortex && ahoy update-installer-video`.
+10. Update installer video with `cd .vortex && ahoy update-videos installer`.
 11. Create new release notes using release template:
 
 import CodeBlock from '@theme/CodeBlock';

--- a/.vortex/installer/CLAUDE.md
+++ b/.vortex/installer/CLAUDE.md
@@ -54,7 +54,7 @@ documentation goes stale and must be regenerated.
 
 ```bash
 # From .vortex/ directory
-ahoy update-installer-video
+ahoy update-videos installer
 ```
 
 Requires `asciinema`, `expect`, `php`, `composer`, `npx` on PATH. Produces

--- a/.vortex/installer/src/Prompts/Handlers/Services.php
+++ b/.vortex/installer/src/Prompts/Handlers/Services.php
@@ -150,9 +150,6 @@ class Services extends AbstractHandler {
       File::remove($t . DIRECTORY_SEPARATOR . 'tests/behat/features/search.feature');
       File::replaceContentInFile($t . DIRECTORY_SEPARATOR . 'composer.json', '/\s*"drupal\/solr":\s*"[^\"]+",?\n/', "\n");
       File::replaceContentInFile($t . DIRECTORY_SEPARATOR . 'composer.json', '/\s*"drupal\/search_api_solr":\s*"[^\"]+",?\n/', "\n");
-      File::removeLineInFile($t . DIRECTORY_SEPARATOR . '.ahoy.yml', 'VORTEX_HOST_SOLR_PORT=$(docker compose port solr 8983 2>/dev/null | cut -d : -f 2) && \\');
-      // @todo Remove after 25.10.0 release.
-      File::removeLineInFile($t . DIRECTORY_SEPARATOR . '.ahoy.yml', 'VORTEX_HOST_SOLR_PORT=$(docker compose port solr 8983 2>/dev/null | cut -d : -f 2) \\');
     }
 
     if (!in_array(self::REDIS, $v)) {

--- a/.vortex/installer/src/Runner/CommandRunner.php
+++ b/.vortex/installer/src/Runner/CommandRunner.php
@@ -6,7 +6,6 @@ namespace DrevOps\VortexInstaller\Runner;
 
 use DrevOps\VortexInstaller\Logger\LoggerInterface;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -55,13 +54,6 @@ class CommandRunner extends AbstractRunner {
     if ($exit_code < 0 || $exit_code > 255) {
       throw new \RuntimeException('Command exited with invalid exit code: ' . $exit_code);
     }
-
-    match ($exit_code) {
-      Command::SUCCESS => $this->exitCode = self::EXIT_SUCCESS,
-      Command::FAILURE => $this->exitCode = self::EXIT_FAILURE,
-      127 => $this->exitCode = self::EXIT_COMMAND_NOT_FOUND,
-      default => $this->exitCode = self::EXIT_INVALID,
-    };
 
     $this->exitCode = $exit_code;
     $this->output = $buffered_output->fetch();

--- a/.vortex/installer/src/Runner/ProcessRunner.php
+++ b/.vortex/installer/src/Runner/ProcessRunner.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DrevOps\VortexInstaller\Runner;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
@@ -61,13 +60,6 @@ class ProcessRunner extends AbstractRunner implements ExecutableFinderAwareInter
     if ($exit_code < 0 || $exit_code > 255) {
       throw new \RuntimeException('Command exited with invalid exit code: ' . $exit_code);
     }
-
-    match ($exit_code) {
-      Command::SUCCESS => $this->exitCode = self::EXIT_SUCCESS,
-      Command::FAILURE => $this->exitCode = self::EXIT_FAILURE,
-      127 => $this->exitCode = self::EXIT_COMMAND_NOT_FOUND,
-      default => $this->exitCode = self::EXIT_INVALID,
-    };
 
     $this->exitCode = $exit_code;
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
@@ -120,7 +120,7 @@ commands:
     aliases: [fetch-db, db-download, db-fetch]
     cmd: |
       ahoy require-tooling
-      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
+      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1 VORTEX_DOWNLOAD_DB_FORCE=1;; esac
       ./vendor/drevops/vortex-tooling/src/download-db
 
   reload-db:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.ahoy.yml
@@ -30,7 +30,7 @@
 +    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
-+      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
++      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB2_FRESH=1 VORTEX_DOWNLOAD_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
    reload-db:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.ahoy.yml
@@ -22,7 +22,7 @@
    # Container commands.
    # ----------------------------------------------------------------------------
 @@ -123,6 +132,14 @@
-       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
+       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1 VORTEX_DOWNLOAD_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.ahoy.yml
@@ -30,7 +30,7 @@
 +    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
-+      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
++      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB2_FRESH=1 VORTEX_DOWNLOAD_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
    reload-db:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.ahoy.yml
@@ -22,7 +22,7 @@
    # Container commands.
    # ----------------------------------------------------------------------------
 @@ -123,6 +132,14 @@
-       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
+       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1 VORTEX_DOWNLOAD_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.ahoy.yml
@@ -30,7 +30,7 @@
 +    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
-+      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
++      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB2_FRESH=1 VORTEX_DOWNLOAD_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
    reload-db:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.ahoy.yml
@@ -22,7 +22,7 @@
    # Container commands.
    # ----------------------------------------------------------------------------
 @@ -123,6 +132,14 @@
-       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
+       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1 VORTEX_DOWNLOAD_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.ahoy.yml
@@ -30,7 +30,7 @@
 +    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
-+      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
++      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB2_FRESH=1 VORTEX_DOWNLOAD_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
    reload-db:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.ahoy.yml
@@ -22,7 +22,7 @@
    # Container commands.
    # ----------------------------------------------------------------------------
 @@ -123,6 +132,14 @@
-       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
+       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1 VORTEX_DOWNLOAD_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.ahoy.yml
@@ -30,7 +30,7 @@
 +    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
-+      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
++      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB2_FRESH=1 VORTEX_DOWNLOAD_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
    reload-db:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.ahoy.yml
@@ -22,7 +22,7 @@
    # Container commands.
    # ----------------------------------------------------------------------------
 @@ -123,6 +132,14 @@
-       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
+       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1 VORTEX_DOWNLOAD_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.ahoy.yml
@@ -30,7 +30,7 @@
 +    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
-+      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
++      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB2_FRESH=1 VORTEX_DOWNLOAD_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
    reload-db:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.ahoy.yml
@@ -22,7 +22,7 @@
    # Container commands.
    # ----------------------------------------------------------------------------
 @@ -123,6 +132,14 @@
-       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
+       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1 VORTEX_DOWNLOAD_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.ahoy.yml
@@ -30,7 +30,7 @@
 +    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
-+      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
++      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB2_FRESH=1 VORTEX_DOWNLOAD_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
    reload-db:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.ahoy.yml
@@ -22,7 +22,7 @@
    # Container commands.
    # ----------------------------------------------------------------------------
 @@ -123,6 +132,14 @@
-       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
+       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1 VORTEX_DOWNLOAD_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.ahoy.yml
@@ -30,7 +30,7 @@
 +    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
-+      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
++      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB2_FRESH=1 VORTEX_DOWNLOAD_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
    reload-db:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.ahoy.yml
@@ -22,7 +22,7 @@
    # Container commands.
    # ----------------------------------------------------------------------------
 @@ -123,6 +132,14 @@
-       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
+       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1 VORTEX_DOWNLOAD_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.ahoy.yml
@@ -30,7 +30,7 @@
 +    aliases: [fetch-db2, db2-download, db2-fetch]
 +    cmd: |
 +      ahoy require-tooling
-+      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FORCE=1;; esac
++      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB2_FRESH=1 VORTEX_DOWNLOAD_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
    reload-db:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.ahoy.yml
@@ -22,7 +22,7 @@
    # Container commands.
    # ----------------------------------------------------------------------------
 @@ -123,6 +132,14 @@
-       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
+       case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1 VORTEX_DOWNLOAD_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/download-db
  
 +  download-db2:

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.ahoy.yml
@@ -7,7 +7,7 @@
 -    aliases: [fetch-db, db-download, db-fetch]
 -    cmd: |
 -      ahoy require-tooling
--      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1;; esac
+-      case " $* " in *" --fresh "*) export VORTEX_DOWNLOAD_DB_FRESH=1 VORTEX_DOWNLOAD_DB_FORCE=1;; esac
 -      ./vendor/drevops/vortex-tooling/src/download-db
 -
    reload-db:


### PR DESCRIPTION
## Summary

Bundles eight verified findings from an exploratory assessment of the Vortex codebase. Each commit is a focused, independent fix - small enough to review individually but grouped here because they share a theme of cleaning up small bugs, dead code, and CI waste surfaced by the same pass.

## Changes

### Ahoy command bugs and broken doc references

- **`download-db --fresh` no-op on default sources** (`.ahoy.yml`). The `--fresh` flag set `VORTEX_DOWNLOAD_DB_FRESH=1`, but the `download-db` script reads `VORTEX_DOWNLOAD_DB_FORCE`. Only the Acquia and Lagoon downloader variants happen to also read `_FRESH`, so on the default `url`/`ftp`/`s3` paths `--fresh` silently did nothing. Fix: the same `export` statement now also sets `VORTEX_DOWNLOAD_DB_FORCE=1`, keeping both variables for any code that reads either.
- **`download-db2 --fresh` was missing the indexed env vars** (`.ahoy.yml`). Same class of bug as above but for the migration DB. The router resolves env vars with the index suffix (`VORTEX_DOWNLOAD_DB${_db_index}_FORCE`, i.e. `VORTEX_DOWNLOAD_DB2_FORCE` when `VORTEX_DB_INDEX=2`); the Acquia/Lagoon downloaders gate fresh behavior on `VORTEX_DOWNLOAD_DB2_FRESH`. The `download-db2 --fresh` invocation exported the un-indexed `VORTEX_DOWNLOAD_DB_FORCE` instead, so neither the cache-skip nor the fresh dump path was honored. Fix: export `VORTEX_DOWNLOAD_DB2_FRESH=1 VORTEX_DOWNLOAD_DB2_FORCE=1`.
- **Dead `ahoy test-workflow` and `ahoy test-deployment`** (`.vortex/.ahoy.yml`). Both pointed at shell scripts that no longer exist - the work moved to PHPUnit tests under `.vortex/tests/phpunit/Functional/` and neither command is referenced anywhere in CI. Removed.
- **Phantom `ahoy update-installer-video` references** (`.vortex/installer/CLAUDE.md`, `.vortex/docs/content/contributing/maintenance/installer.mdx`, `.vortex/docs/content/contributing/maintenance/release.mdx`). Three files instructed maintainers to run a command that does not exist. Replaced with the actual command, `ahoy update-videos installer`.

### Dead code in the installer

- **Overwritten `match` block in runners** (`.vortex/installer/src/Runner/ProcessRunner.php`, `.vortex/installer/src/Runner/CommandRunner.php`). Both runners had a `match ($exit_code) { ... }` writing an aliased value into `$this->exitCode`, immediately followed by `$this->exitCode = $exit_code;`. The match was 100% no-op. Removed both blocks and the now-unused `use Symfony\Component\Console\Command\Command;` import in each file. The `RunnerInterface::EXIT_*` constants are kept - they are public API surface referenced by mock callbacks in `BuildCommandTest` and `CheckRequirementsCommandTest`.
- **Stale Solr port removal** (`.vortex/installer/src/Prompts/Handlers/Services.php`). Two `File::removeLineInFile()` calls targeted backslash-continuation forms of the Solr port line in `.ahoy.yml` (one had `// @todo Remove after 25.10.0 release.`). The current template line has no `\\` continuation, so neither pattern matches anything. Also, that whole line is already wrapped in `#;< SERVICE_SOLR ... #;> SERVICE_SOLR` and gets removed via `File::removeTokenAsync('SERVICE_SOLR')` earlier in the same handler. The two calls were doubly dead. Removed both.

### CI waste in `vortex-test-installer.yml`

- **No `cancel-in-progress` guard**. `vortex-test-common.yml` has a `concurrency` block; `vortex-test-installer.yml` did not. Rapid force-pushes queued multiple ~15 min runs. Copied the same `concurrency` block over.
- **Installer video step running on all PHP matrix legs**. The "Generate video for installer (not used in the final artifact)" step ran on PHP 8.2, 8.3, and 8.4 even though only one leg produces the downstream artifact. Gated with `if: matrix.php-versions == '8.2'`, matching the existing guard already on the PHAR upload step.

### Auto-regenerated fixtures

20 `.ahoy.yml` fixture files under `.vortex/installer/tests/Fixtures/handler_process/` propagate the `download-db` and `download-db2` env-var changes. Generated by `ahoy update-snapshots`.

## Before / After

The `--fresh` env-var flow on the default `url` source for the primary DB:

```
Before
------
ahoy download-db --fresh
   │
   ▼ exports VORTEX_DOWNLOAD_DB_FRESH=1
   │
   ▼ ./vendor/drevops/vortex-tooling/src/download-db
   │     reads VORTEX_DOWNLOAD_DB_FORCE  ──▶ unset, cache reused
   │     reads VORTEX_DOWNLOAD_DB_FRESH  ──▶ ignored on url/ftp/s3
   ▼
cached dump kept (silent no-op)


After
-----
ahoy download-db --fresh
   │
   ▼ exports VORTEX_DOWNLOAD_DB_FRESH=1 VORTEX_DOWNLOAD_DB_FORCE=1
   │
   ▼ ./vendor/drevops/vortex-tooling/src/download-db
   │     reads VORTEX_DOWNLOAD_DB_FORCE  ──▶ 1, cache skipped
   │     reads VORTEX_DOWNLOAD_DB_FRESH  ──▶ 1, honored on acquia/lagoon
   ▼
fresh dump downloaded
```

The same flow for the migration DB, via the indexed lookup (`_db_index="2"`):

```
Before
------
ahoy download-db2 --fresh
   │
   ▼ exports VORTEX_DOWNLOAD_DB_FORCE=1 (un-indexed)
   │
   ▼ VORTEX_DB_INDEX=2 ./vendor/.../download-db
   │     reads VORTEX_DOWNLOAD_DB2_FORCE  ──▶ unset, cache reused
   │     reads VORTEX_DOWNLOAD_DB2_FRESH  ──▶ unset (Acquia/Lagoon ignore)
   ▼
cached migration dump kept (silent no-op)


After
-----
ahoy download-db2 --fresh
   │
   ▼ exports VORTEX_DOWNLOAD_DB2_FRESH=1 VORTEX_DOWNLOAD_DB2_FORCE=1
   │
   ▼ VORTEX_DB_INDEX=2 ./vendor/.../download-db
   │     reads VORTEX_DOWNLOAD_DB2_FORCE  ──▶ 1, cache skipped
   │     reads VORTEX_DOWNLOAD_DB2_FRESH  ──▶ 1, honored on acquia/lagoon
   ▼
fresh migration dump downloaded
```
