### PR TITLE
Added optional HTTP basic auth credentials to Diffy visual regression workflow.

### DIFF
--- a/.github/workflows/test-vr.yml
+++ b/.github/workflows/test-vr.yml
@@ -170,16 +170,34 @@ jobs:
         if: steps.gate.outputs.skipped != 'true'
         env:
           DIFFY_PROJECT_ID: ${{ vars.VR_DIFFY_PROJECT_ID }}
+          SOURCE_HTTP_USER: ${{ secrets.VR_SOURCE_HTTP_USER }}
+          SOURCE_HTTP_PASS: ${{ secrets.VR_SOURCE_HTTP_PASS }}
+          TARGET_HTTP_USER: ${{ secrets.VR_TARGET_HTTP_USER }}
+          TARGET_HTTP_PASS: ${{ secrets.VR_TARGET_HTTP_PASS }}
         run: |
           set -euo pipefail
           echo "Starting Diffy comparison: source=${SOURCE_ENV} target=${TARGET_URL} label=${LABEL}"
+
+          # HTTP basic auth credentials are passed conditionally. The Diffy CLI
+          # forwards user/pass options as-is to the API, and the SDK gates on
+          # PHP isset() - an empty string still triggers basic-auth mode with
+          # empty credentials, which then fails against the upstream server.
+          # Only pass the flags when both user and pass are non-empty.
+          auth_args=()
+          if [ -n "${SOURCE_HTTP_USER}" ] && [ -n "${SOURCE_HTTP_PASS}" ]; then
+            auth_args+=(--env1User="${SOURCE_HTTP_USER}" --env1Pass="${SOURCE_HTTP_PASS}")
+          fi
+          if [ -n "${TARGET_HTTP_USER}" ] && [ -n "${TARGET_HTTP_PASS}" ]; then
+            auth_args+=(--env2User="${TARGET_HTTP_USER}" --env2Pass="${TARGET_HTTP_PASS}")
+          fi
 
           diff_id="$(/tmp/diffy.phar project:compare \
             "${DIFFY_PROJECT_ID}" \
             "${SOURCE_ENV}" \
             custom \
             --env2Url="${TARGET_URL}" \
-            --name="${LABEL}")"
+            --name="${LABEL}" \
+            ${auth_args[@]+"${auth_args[@]}"})"
 
           if [ -z "${diff_id}" ]; then
             echo "::error::Diffy did not return a diff ID."

--- a/.github/workflows/test-vr.yml
+++ b/.github/workflows/test-vr.yml
@@ -170,10 +170,10 @@ jobs:
         if: steps.gate.outputs.skipped != 'true'
         env:
           DIFFY_PROJECT_ID: ${{ vars.VR_DIFFY_PROJECT_ID }}
-          SOURCE_HTTP_USER: ${{ secrets.VR_SOURCE_HTTP_USER }}
-          SOURCE_HTTP_PASS: ${{ secrets.VR_SOURCE_HTTP_PASS }}
-          TARGET_HTTP_USER: ${{ secrets.VR_TARGET_HTTP_USER }}
-          TARGET_HTTP_PASS: ${{ secrets.VR_TARGET_HTTP_PASS }}
+          VR_SOURCE_HTTP_USER: ${{ secrets.VR_SOURCE_HTTP_USER }}
+          VR_SOURCE_HTTP_PASS: ${{ secrets.VR_SOURCE_HTTP_PASS }}
+          VR_TARGET_HTTP_USER: ${{ secrets.VR_TARGET_HTTP_USER }}
+          VR_TARGET_HTTP_PASS: ${{ secrets.VR_TARGET_HTTP_PASS }}
         run: |
           set -euo pipefail
           echo "Starting Diffy comparison: source=${SOURCE_ENV} target=${TARGET_URL} label=${LABEL}"
@@ -184,11 +184,11 @@ jobs:
           # empty credentials, which then fails against the upstream server.
           # Only pass the flags when both user and pass are non-empty.
           auth_args=()
-          if [ -n "${SOURCE_HTTP_USER}" ] && [ -n "${SOURCE_HTTP_PASS}" ]; then
-            auth_args+=(--env1User="${SOURCE_HTTP_USER}" --env1Pass="${SOURCE_HTTP_PASS}")
+          if [ -n "${VR_SOURCE_HTTP_USER}" ] && [ -n "${VR_SOURCE_HTTP_PASS}" ]; then
+            auth_args+=(--env1User="${VR_SOURCE_HTTP_USER}" --env1Pass="${VR_SOURCE_HTTP_PASS}")
           fi
-          if [ -n "${TARGET_HTTP_USER}" ] && [ -n "${TARGET_HTTP_PASS}" ]; then
-            auth_args+=(--env2User="${TARGET_HTTP_USER}" --env2Pass="${TARGET_HTTP_PASS}")
+          if [ -n "${VR_TARGET_HTTP_USER}" ] && [ -n "${VR_TARGET_HTTP_PASS}" ]; then
+            auth_args+=(--env2User="${VR_TARGET_HTTP_USER}" --env2Pass="${VR_TARGET_HTTP_PASS}")
           fi
 
           diff_id="$(/tmp/diffy.phar project:compare \

--- a/.vortex/docs/content/development/visual-regression.mdx
+++ b/.vortex/docs/content/development/visual-regression.mdx
@@ -33,9 +33,21 @@ secrets and repository variables.
 | Name | Required | Purpose |
 |---|---|---|
 | `VR_DIFFY_API_KEY` | yes | Diffy API key |
+| `VR_SOURCE_HTTP_USER` | no | HTTP basic auth user for the Diffy source environment (set when protected by Acquia Shield, `htpasswd`, or similar) |
+| `VR_SOURCE_HTTP_PASS` | no | HTTP basic auth password for the Diffy source environment |
+| `VR_TARGET_HTTP_USER` | no | HTTP basic auth user for the deployed target environment (typically the PR environment) |
+| `VR_TARGET_HTTP_PASS` | no | HTTP basic auth password for the deployed target environment |
 
-Add this under *Settings > Secrets and variables > Actions > Repository
+Add these under *Settings > Secrets and variables > Actions > Repository
 secrets*.
+
+The `_HTTP_USER` / `_HTTP_PASS` pairs are optional. Leave them unset when
+the environment is publicly reachable. When set, the workflow forwards
+them to Diffy on every comparison so its workers can clear the basic-auth
+gate. Source-side credentials may alternatively be stored in the Diffy
+project settings - the CLI flags act as an override for cases where
+hosting is provisioned with rotating credentials and storing them in
+Diffy is impractical.
 
 ### Variables
 

--- a/.vortex/docs/cspell.json
+++ b/.vortex/docs/cspell.json
@@ -45,6 +45,7 @@
         "gherkinlint",
         "hadolint",
         "hotfixes",
+        "htpasswd",
         "initialise",
         "lagooncli",
         "lando",

--- a/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
@@ -170,16 +170,34 @@ jobs:
         if: steps.gate.outputs.skipped != 'true'
         env:
           DIFFY_PROJECT_ID: ${{ vars.VR_DIFFY_PROJECT_ID }}
+          SOURCE_HTTP_USER: ${{ secrets.VR_SOURCE_HTTP_USER }}
+          SOURCE_HTTP_PASS: ${{ secrets.VR_SOURCE_HTTP_PASS }}
+          TARGET_HTTP_USER: ${{ secrets.VR_TARGET_HTTP_USER }}
+          TARGET_HTTP_PASS: ${{ secrets.VR_TARGET_HTTP_PASS }}
         run: |
           set -euo pipefail
           echo "Starting Diffy comparison: source=${SOURCE_ENV} target=${TARGET_URL} label=${LABEL}"
+
+          # HTTP basic auth credentials are passed conditionally. The Diffy CLI
+          # forwards user/pass options as-is to the API, and the SDK gates on
+          # PHP isset() - an empty string still triggers basic-auth mode with
+          # empty credentials, which then fails against the upstream server.
+          # Only pass the flags when both user and pass are non-empty.
+          auth_args=()
+          if [ -n "${SOURCE_HTTP_USER}" ] && [ -n "${SOURCE_HTTP_PASS}" ]; then
+            auth_args+=(--env1User="${SOURCE_HTTP_USER}" --env1Pass="${SOURCE_HTTP_PASS}")
+          fi
+          if [ -n "${TARGET_HTTP_USER}" ] && [ -n "${TARGET_HTTP_PASS}" ]; then
+            auth_args+=(--env2User="${TARGET_HTTP_USER}" --env2Pass="${TARGET_HTTP_PASS}")
+          fi
 
           diff_id="$(/tmp/diffy.phar project:compare \
             "${DIFFY_PROJECT_ID}" \
             "${SOURCE_ENV}" \
             custom \
             --env2Url="${TARGET_URL}" \
-            --name="${LABEL}")"
+            --name="${LABEL}" \
+            ${auth_args[@]+"${auth_args[@]}"})"
 
           if [ -z "${diff_id}" ]; then
             echo "::error::Diffy did not return a diff ID."

--- a/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
@@ -170,10 +170,10 @@ jobs:
         if: steps.gate.outputs.skipped != 'true'
         env:
           DIFFY_PROJECT_ID: ${{ vars.VR_DIFFY_PROJECT_ID }}
-          SOURCE_HTTP_USER: ${{ secrets.VR_SOURCE_HTTP_USER }}
-          SOURCE_HTTP_PASS: ${{ secrets.VR_SOURCE_HTTP_PASS }}
-          TARGET_HTTP_USER: ${{ secrets.VR_TARGET_HTTP_USER }}
-          TARGET_HTTP_PASS: ${{ secrets.VR_TARGET_HTTP_PASS }}
+          VR_SOURCE_HTTP_USER: ${{ secrets.VR_SOURCE_HTTP_USER }}
+          VR_SOURCE_HTTP_PASS: ${{ secrets.VR_SOURCE_HTTP_PASS }}
+          VR_TARGET_HTTP_USER: ${{ secrets.VR_TARGET_HTTP_USER }}
+          VR_TARGET_HTTP_PASS: ${{ secrets.VR_TARGET_HTTP_PASS }}
         run: |
           set -euo pipefail
           echo "Starting Diffy comparison: source=${SOURCE_ENV} target=${TARGET_URL} label=${LABEL}"
@@ -184,11 +184,11 @@ jobs:
           # empty credentials, which then fails against the upstream server.
           # Only pass the flags when both user and pass are non-empty.
           auth_args=()
-          if [ -n "${SOURCE_HTTP_USER}" ] && [ -n "${SOURCE_HTTP_PASS}" ]; then
-            auth_args+=(--env1User="${SOURCE_HTTP_USER}" --env1Pass="${SOURCE_HTTP_PASS}")
+          if [ -n "${VR_SOURCE_HTTP_USER}" ] && [ -n "${VR_SOURCE_HTTP_PASS}" ]; then
+            auth_args+=(--env1User="${VR_SOURCE_HTTP_USER}" --env1Pass="${VR_SOURCE_HTTP_PASS}")
           fi
-          if [ -n "${TARGET_HTTP_USER}" ] && [ -n "${TARGET_HTTP_PASS}" ]; then
-            auth_args+=(--env2User="${TARGET_HTTP_USER}" --env2Pass="${TARGET_HTTP_PASS}")
+          if [ -n "${VR_TARGET_HTTP_USER}" ] && [ -n "${VR_TARGET_HTTP_PASS}" ]; then
+            auth_args+=(--env2User="${VR_TARGET_HTTP_USER}" --env2Pass="${VR_TARGET_HTTP_PASS}")
           fi
 
           diff_id="$(/tmp/diffy.phar project:compare \


### PR DESCRIPTION
## Summary

The Diffy `project:compare` CLI command supports `--env1User`/`--env1Pass` and `--env2User`/`--env2Pass` flags for HTTP basic auth, but they must only be passed when both the user and password are non-empty. The upstream PHP SDK uses `isset()` to check for presence - an empty string passes that check and causes Diffy to attempt basic-auth with empty credentials, which then fails against servers protected by Acquia Shield or `htpasswd`. This change conditionally builds an `auth_args` bash array and splices it into the `diffy.phar project:compare` call only when both halves of a credential pair are present.

Four optional GitHub Actions secrets (`VR_SOURCE_HTTP_USER`, `VR_SOURCE_HTTP_PASS`, `VR_TARGET_HTTP_USER`, `VR_TARGET_HTTP_PASS`) are wired into the comparison step. When unset (the common case for public environments) the `auth_args` array stays empty and the call is identical to the previous behaviour. The docs and installer fixture are updated to match.

## Changes

- **`.github/workflows/test-vr.yml`** - Added four optional `env` bindings for the new secrets; introduced an `auth_args=()` bash array that is populated only when both halves of a credential pair are non-empty; merged the array into the `diffy.phar project:compare` call using the `${arr[@]+"${arr[@]}"}` safe-expansion idiom (no-op when the array is empty, safe under `set -u`).
- **`.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml`** - Regenerated fixture to match the template above.
- **`.vortex/docs/content/development/visual-regression.mdx`** - Documented the four new optional secrets in the credentials table and added a paragraph explaining the conditional-passing behaviour and when the secrets are needed.
- **`.vortex/docs/cspell.json`** - Added `htpasswd` to the spell-check dictionary.

## Before / After

```
# BEFORE - credentials not supported; call is always unconditional
diffy.phar project:compare \
  "${PROJECT_ID}" "${SOURCE_ENV}" custom \
  --env2Url="${TARGET_URL}" \
  --name="${LABEL}"

# AFTER - auth_args array built conditionally; empty array expands to nothing
auth_args=()
if [ -n "${SOURCE_HTTP_USER}" ] && [ -n "${SOURCE_HTTP_PASS}" ]; then
  auth_args+=(--env1User="${SOURCE_HTTP_USER}" --env1Pass="${SOURCE_HTTP_PASS}")
fi
if [ -n "${TARGET_HTTP_USER}" ] && [ -n "${TARGET_HTTP_PASS}" ]; then
  auth_args+=(--env2User="${TARGET_HTTP_USER}" --env2Pass="${TARGET_HTTP_PASS}")
fi

#  secrets unset (public env) --> auth_args is empty
diffy.phar project:compare \
  "${PROJECT_ID}" "${SOURCE_ENV}" custom \
  --env2Url="${TARGET_URL}" \
  --name="${LABEL}"
  # (no auth flags)

#  secrets set (Shield / htpasswd env) --> auth_args carries the flags
diffy.phar project:compare \
  "${PROJECT_ID}" "${SOURCE_ENV}" custom \
  --env2Url="${TARGET_URL}" \
  --name="${LABEL}" \
  --env1User="alice" --env1Pass="s3cr3t" \
  --env2User="alice" --env2Pass="s3cr3t"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual regression testing now supports optional HTTP basic authentication for protected source and target environments.

* **Documentation**
  * Added guidance on configuring authentication secrets for visual regression, noting they can be left unset for public environments and that project settings may alternatively provide credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->