### PR TITLE
Replaced visual regression PR comment with hide-and-recreate behavior.

### DIFF
--- a/.github/workflows/test-vr.yml
+++ b/.github/workflows/test-vr.yml
@@ -282,3 +282,4 @@ jobs:
             - **Source environment**: ${{ env.SOURCE_ENV }}
 
             [View full Diffy report](${{ needs.vr-compare.outputs.shared_url }})
+          hide_and_recreate: true

--- a/.vortex/CLAUDE.md
+++ b/.vortex/CLAUDE.md
@@ -80,6 +80,16 @@ and produces partial, inconsistent fixtures. There is no scenario in which
 the direct composer call is correct - if `cd .vortex` is hard, fix the cd,
 do not reach past the abstraction.
 
+**HARD RULE — NEVER wrap `ahoy update-snapshots` in a helper script,
+heredoc, temp file, or any other indirection to work around a `cd`
+restriction or a "one simple bash command" constraint.** No
+`.artifacts/tmp/update-snapshots.sh`, no `bash -c "cd .vortex && ahoy ..."`,
+no inline wrappers of any kind. If your environment forbids chaining and
+`cd` does not persist between calls, use the ahoy pointer flag directly:
+`ahoy --file .vortex/.ahoy.yml update-snapshots`. The ahoyfile is the only
+acceptable indirection; everything else hides the abstraction and makes
+future debugging harder.
+
 **HARD RULE — Always commit before `ahoy update-snapshots`.** Snapshots are
 regenerated from the *committed* baseline. Any uncommitted changes to the
 template (root or `.vortex/`) will not be picked up and the snapshot diff

--- a/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
@@ -282,3 +282,4 @@ jobs:
             - **Source environment**: ${{ env.SOURCE_ENV }}
 
             [View full Diffy report](${{ needs.vr-compare.outputs.shared_url }})
+          hide_and_recreate: true


### PR DESCRIPTION
## Summary

Added `hide_and_recreate: true` to the `marocchino/sticky-pull-request-comment` step in the `vr-report` job of the visual regression workflow. This ensures every new VR comparison posts a fresh PR comment rather than silently editing the existing one - making it immediately visible when a new comparison run has occurred. Hardened the `.vortex/CLAUDE.md` snapshot update rules to prevent wrapper-script workarounds, and refreshed the installer fixture to match the updated template.

## Changes

**`.github/workflows/test-vr.yml`** - Added `hide_and_recreate: true` to the sticky PR comment step so each VR comparison run hides the previous comment and creates a new one, mirroring the behavior already used by the coverage comment in `build-test-deploy.yml`.

**`.vortex/CLAUDE.md`** - Added a `HARD RULE` block forbidding any indirection (wrapper scripts, heredocs, temp files, `bash -c` strings) around `ahoy update-snapshots`. The only accepted alternative when `cd` cannot persist is `ahoy --file .vortex/.ahoy.yml update-snapshots` using the ahoy pointer flag directly.

**`.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml`** - Refreshed installer fixture to reflect the `hide_and_recreate: true` addition in the template workflow.

## Before / After

```
BEFORE
──────
vr-report job
  └─ marocchino/sticky-pull-request-comment
       message: "..."
       (no hide_and_recreate)
       → edits the same comment in-place on every run
         (edit is invisible to reviewers watching the PR)

AFTER
─────
vr-report job
  └─ marocchino/sticky-pull-request-comment
       message: "..."
       hide_and_recreate: true
       → hides the old comment, posts a fresh one on every run
         (fresh comment triggers a notification / appears at top)
```
