### PR TITLE
[#2555] Fixed tmate timeout comment to match the 120-minute value.

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -561,7 +561,7 @@ jobs:
       - name: Setup tmate session
         if: ${{ !cancelled() && github.event.inputs.enable_terminal }}
         uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3
-        timeout-minutes: 120 # Cancel the action after 15 minutes, regardless of whether a connection has been established.
+        timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
         with:
           detached: true
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -493,7 +493,7 @@ jobs:
       - name: Setup tmate session
         if: ${{ !cancelled() && github.event.inputs.enable_terminal }}
         uses: mxschmitt/action-tmate@__HASH__ # __VERSION__
-        timeout-minutes: 120 # Cancel the action after 15 minutes, regardless of whether a connection has been established.
+        timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
         with:
           detached: true
 

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,5 +1,5 @@
 @@ -496,98 +496,3 @@
-         timeout-minutes: 120 # Cancel the action after 15 minutes, regardless of whether a connection has been established.
+         timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
          with:
            detached: true
 -


### PR DESCRIPTION
Closes #2555

## Summary

The inline comment on the `Setup tmate session` step in `.github/workflows/build-test-deploy.yml` incorrectly stated "Cancel the action after 15 minutes" while the actual `timeout-minutes` value has always been `120`. The `15` was a copy-paste artifact from the `mxschmitt/action-tmate` documentation boilerplate, which uses 15 minutes in its example. The fix aligns the comment text with the established 2-hour timeout value; the `timeout-minutes: 120` setting itself is unchanged. Two installer test fixture files that mirror this workflow line were regenerated to stay consistent with the template source.

## Changes

- `.github/workflows/build-test-deploy.yml` - corrected trailing comment on `timeout-minutes: 120` from "15 minutes" to "120 minutes"
- `.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml` - fixture regenerated to reflect the corrected comment
- `.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml` - fixture regenerated to reflect the corrected comment

## Before / After

```yaml
# Before
timeout-minutes: 120 # Cancel the action after 15 minutes, regardless of whether a connection has been established.

# After
timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment pipeline configuration.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->