### PR TITLE
[#2554] Grouped 'find' name predicates in CI Dockerfile lint step.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Lint Dockerfiles with Hadolint
         run: |
-          find .docker -name 'Dockerfile' -o -name '*.dockerfile' | while read -r file; do
+          find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \) | while read -r file; do
             echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint
           done
         continue-on-error: ${{ vars.VORTEX_CI_HADOLINT_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Lint Dockerfiles with Hadolint
         run: |
-          find .docker -name 'Dockerfile' -o -name '*.dockerfile' | while read -r file; do
+          find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \) | while read -r file; do
             echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint
           done
         continue-on-error: ${{ vars.VORTEX_CI_HADOLINT_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Lint Dockerfiles with Hadolint
           command: |
-            for file in $(find .docker -name 'Dockerfile' -o -name '*.dockerfile'); do
+            for file in $(find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)); do
               echo "Linting ${file}" && cat "${file}" | docker run --rm -i hadolint/hadolint || [ "${VORTEX_CI_HADOLINT_IGNORE_FAILURE:-0}" -eq 1 ]
             done
 


### PR DESCRIPTION
Closes #2554

## Summary

The Hadolint lint step in both CI providers discovers Dockerfiles with `find .docker -name 'Dockerfile' -o -name '*.dockerfile'`. This groups the two `-name` predicates with `\( ... \)` so the boundary of the `-o` alternation is explicit. The change is behaviour-preserving today; it is a guard against a latent `find` footgun and a readability improvement, not a fix for a currently-broken path.

## Why this is safe today and still worth doing

The current commands rely on `find`'s implicit `-print`. POSIX applies the implicit action to the entire expression (as `( expr ) -print`), and both consumers read that full output: the GitHub Actions `find ... | while read` pipe and the CircleCI `for file in $(find ...)` command substitution. So a file named exactly `Dockerfile` is already linted today. This was verified empirically against GNU findutils (the Debian/Ubuntu CI environment), busybox (Alpine), and bfs - all three print both `Dockerfile` and `*.dockerfile` with the ungrouped form.

The footgun appears only if an explicit action is later appended after the last clause, for example `find .docker -name 'Dockerfile' -o -name '*.dockerfile' -print` (or `-exec` / `-delete`). Operator precedence then binds that action to just the `*.dockerfile` clause and silently drops the bare `Dockerfile`. Grouping the predicates makes such a future edit safe, states the intent explicitly, and matches POSIX best practice for `-o` alternations.

## Changes

- `.github/workflows/build-test-deploy.yml`: grouped the `-name` predicates in the Hadolint step (pipe form).
- `.circleci/config.yml`: the same grouping in the Hadolint step (command-substitution form).
- `.vortex/installer/tests/Fixtures/handler_process/`: regenerated 22 installer snapshot fixtures (1 GitHub Actions baseline plus 21 CircleCI variants) so they match the updated source. Fixtures are generated by `ahoy update-snapshots`, never hand-edited.

## Before / After

```
Before (ungrouped):

  find .docker -name 'Dockerfile' -o -name '*.dockerfile'
                \___ clause A ___/    \____ clause B ____/

  implicit -print:   ( A -o B ) -print     -> both A and B printed   OK
  explicit action:     A -o ( B -action )  -> only B handled         footgun

After (grouped):

  find .docker \( -name 'Dockerfile' -o -name '*.dockerfile' \)
               \___________ grouped ( A -o B ) ___________/

  implicit -print:   ( A -o B ) -print     -> both A and B printed   OK
  explicit action:   ( A -o B ) -action    -> both A and B handled   OK
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal CI/CD pipeline efficiency by updating Dockerfile discovery patterns in build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->