### PR TITLE
[#2552] Cleaned up 'vendor-temp' on failure in 'vortex-tooling.sh'.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
@@ -27,6 +27,10 @@ fi
 
 mkdir -p vendor-temp vendor/drevops
 
+# Always remove the throwaway project on exit - including when an intermediate
+# step fails under 'set -e' - so a re-run never starts from a dirty state.
+trap 'rm -rf vendor-temp' EXIT
+
 # Authenticate Composer with GitHub if a token is available, to avoid hitting
 # the anonymous API rate limit when downloading packages from GitHub.
 if [ -n "${PACKAGE_TOKEN:-}" ]; then
@@ -65,4 +69,3 @@ fi
 composer --working-dir=vendor-temp install --no-dev --no-interaction
 
 mv vendor-temp/vendor/drevops/vortex-tooling vendor/drevops/
-rm -rf vendor-temp

--- a/scripts/vortex-tooling.sh
+++ b/scripts/vortex-tooling.sh
@@ -27,6 +27,10 @@ fi
 
 mkdir -p vendor-temp vendor/drevops
 
+# Always remove the throwaway project on exit - including when an intermediate
+# step fails under 'set -e' - so a re-run never starts from a dirty state.
+trap 'rm -rf vendor-temp' EXIT
+
 # Authenticate Composer with GitHub if a token is available, to avoid hitting
 # the anonymous API rate limit when downloading packages from GitHub.
 if [ -n "${PACKAGE_TOKEN:-}" ]; then
@@ -72,4 +76,3 @@ fi
 composer --working-dir=vendor-temp install --no-dev --no-interaction
 
 mv vendor-temp/vendor/drevops/vortex-tooling vendor/drevops/
-rm -rf vendor-temp


### PR DESCRIPTION
Closes #2552

## Summary

`scripts/vortex-tooling.sh` builds a throwaway Composer project inside `vendor-temp/` and previously only removed it on the script's final line. Any earlier failure under `set -eu` - most commonly `composer install` hitting a network or auth error - left `vendor-temp/` on disk, causing subsequent runs to start from a dirty state. This fix registers an `EXIT` trap immediately after `vendor-temp/` is created so cleanup runs on every exit path: success, failure, or interrupt. The trailing `rm -rf vendor-temp` line is removed because the trap now owns cleanup unconditionally. The generated installer baseline fixture (`.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh`) was regenerated via `ahoy update-snapshots` to mirror the source change.

## Changes

- `scripts/vortex-tooling.sh`: added `trap 'rm -rf vendor-temp' EXIT` right after `mkdir -p vendor-temp vendor/drevops`; removed the now-redundant trailing `rm -rf vendor-temp` line since the trap handles cleanup on every exit path including success. The trap intentionally targets only `vendor-temp` (the throwaway build directory); `vendor/drevops` is the keep destination and is left untouched.
- `.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh`: regenerated installer baseline fixture (with `VORTEX_DEV`-specific content stripped) reflecting the same structural change, produced via `ahoy update-snapshots` (132/132 datasets pass).

## Before / After

```
BEFORE
┌─────────────────────────────────────────────────────────────────┐
│  mkdir -p vendor-temp vendor/drevops                            │
│  ...                                                            │
│  composer install   ← fails here under set -eu                 │
│  mv vendor-temp/... vendor/drevops/                            │
│  rm -rf vendor-temp ← never reached; vendor-temp stays on disk │
└─────────────────────────────────────────────────────────────────┘

AFTER
┌─────────────────────────────────────────────────────────────────┐
│  mkdir -p vendor-temp vendor/drevops                            │
│  trap 'rm -rf vendor-temp' EXIT  ← registered immediately      │
│  ...                                                            │
│  composer install   ← fails here under set -eu                 │
│  EXIT trap fires → vendor-temp removed automatically            │
└─────────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the vortex tooling script with improved temporary file cleanup that automatically triggers on script exit, ensuring better reliability and consistency across repeated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->