### PR TITLE
[#2550] Scoped the 'php:eval' rule to ad-hoc agent use in 'AGENTS.md'.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/AGENTS.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/AGENTS.md
@@ -76,8 +76,8 @@ ahoy test-bdd -- --tags=@tagname  # Run Behat tests with specific tag
 ## Critical Rules
 
 - **Never modify** shipped scripts at `vendor/drevops/vortex-tooling/src/` - use patches via `cweagans/composer-patches`, or add your own scripts under `scripts/`
-- **Never use** `ahoy drush php:eval` - use `ahoy drush php:script` instead
-- **Never pass inline code to commands** via stdin, heredocs, or `/dev/stdin` - always write code to a temporary file first, then pass the file path to the command (e.g. `ahoy drush php:script path/to/fix.php`)
+- **Never use** `ahoy drush php:eval` for ad-hoc commands - write the code to a file and run `ahoy drush php:script path/to/file.php` instead. This targets ad-hoc agent use; committed, vetted scripts may use `drush php:eval` for static, non-dynamic operations.
+- **When running ad-hoc code, never pass it inline** via stdin, heredocs, or `/dev/stdin` - write it to a temporary file first, then pass the file path to the command (e.g. `ahoy drush php:script path/to/fix.php`)
 - **Always export config** after admin UI changes: `ahoy drush cex`
 - **Never use compound Bash commands.** See the highest priority rule at the top.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,8 @@ ahoy test-bdd -- --tags=@tagname  # Run Behat tests with specific tag
 ## Critical Rules
 
 - **Never modify** shipped scripts at `vendor/drevops/vortex-tooling/src/` - use patches via `cweagans/composer-patches`, or add your own scripts under `scripts/`
-- **Never use** `ahoy drush php:eval` - use `ahoy drush php:script` instead
-- **Never pass inline code to commands** via stdin, heredocs, or `/dev/stdin` - always write code to a temporary file first, then pass the file path to the command (e.g. `ahoy drush php:script path/to/fix.php`)
+- **Never use** `ahoy drush php:eval` for ad-hoc commands - write the code to a file and run `ahoy drush php:script path/to/file.php` instead. This targets ad-hoc agent use; committed, vetted scripts may use `drush php:eval` for static, non-dynamic operations.
+- **When running ad-hoc code, never pass it inline** via stdin, heredocs, or `/dev/stdin` - write it to a temporary file first, then pass the file path to the command (e.g. `ahoy drush php:script path/to/fix.php`)
 - **Always export config** after admin UI changes: `ahoy drush cex`
 - **Never use compound Bash commands.** See the highest priority rule at the top.
 


### PR DESCRIPTION
Closes #2550

## Summary

Clarifies the scope of the `drush php:eval` rule in `AGENTS.md` so it targets ad-hoc agent use rather than all tooling. The two affected bullets now explicitly state that committed, vetted scripts may use `drush php:eval` for static, non-dynamic operations - the prohibition applies only when agents would generate and run dynamic inline code. No script behavior changed; all five existing `php:eval` usages in the template remain untouched. The embedded copy of `AGENTS.md` in the installer snapshot fixture was regenerated to match.

## Changes

### `AGENTS.md` - Critical Rules section wording

The `php:eval` bullet previously said "Never use `ahoy drush php:eval` - use `ahoy drush php:script` instead." It now reads: "Never use `ahoy drush php:eval` for ad-hoc commands - write the code to a file and run `ahoy drush php:script path/to/file.php` instead. This targets ad-hoc agent use; committed, vetted scripts may use `drush php:eval` for static, non-dynamic operations."

The inline-code-passing bullet previously said "Never pass inline code to commands via stdin, heredocs, or `/dev/stdin`..." It now leads with "When running ad-hoc code, never pass it inline..." to make explicit that the restriction applies to ad-hoc agent execution, not to committed scripts.

### Installer snapshot fixture regenerated

`.vortex/installer/tests/Fixtures/handler_process/_baseline/AGENTS.md` carries the static Critical Rules section and is the only fixture file that holds this content (individual scenario fixtures inherit via the baseline delta model). The baseline was regenerated via `ahoy update-snapshots` and all 131 installer scenarios pass.

## Before / After

```
BEFORE
  Never use `ahoy drush php:eval` - use `ahoy drush php:script` instead
  Never pass inline code to commands via stdin, heredocs, or /dev/stdin ...

AFTER
  Never use `ahoy drush php:eval` for ad-hoc commands - write the code to a
  file and run `ahoy drush php:script path/to/file.php` instead.
  This targets ad-hoc agent use; committed, vetted scripts may use
  `drush php:eval` for static, non-dynamic operations.

  When running ad-hoc code, never pass it inline via stdin, heredocs,
  or /dev/stdin ...
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on script evaluation practices to enhance consistency and code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->