### PR TITLE
[#2551] Guarded VORTEX_NOTIFY_BRANCH under set -u in notify branch filters.

### DIFF
--- a/.vortex/tooling/src/notify-email
+++ b/.vortex/tooling/src/notify-email
@@ -66,8 +66,8 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 # @formatter:on
 
 if [ -n "${VORTEX_NOTIFY_EMAIL_BRANCHES}" ]; then
-  if ! echo ",${VORTEX_NOTIFY_EMAIL_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH},"; then
-    pass "Skipping email notification for branch '${VORTEX_NOTIFY_BRANCH}'."
+  if ! echo ",${VORTEX_NOTIFY_EMAIL_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
+    pass "Skipping email notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
     exit 0
   fi
 fi

--- a/.vortex/tooling/src/notify-github
+++ b/.vortex/tooling/src/notify-github
@@ -62,8 +62,8 @@ for cmd in php curl; do command -v "${cmd}" >/dev/null || {
 }; done
 
 if [ -n "${VORTEX_NOTIFY_GITHUB_BRANCHES}" ]; then
-  if ! echo ",${VORTEX_NOTIFY_GITHUB_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH},"; then
-    pass "Skipping GitHub notification for branch '${VORTEX_NOTIFY_BRANCH}'."
+  if ! echo ",${VORTEX_NOTIFY_GITHUB_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
+    pass "Skipping GitHub notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
     exit 0
   fi
 fi

--- a/.vortex/tooling/src/notify-jira
+++ b/.vortex/tooling/src/notify-jira
@@ -82,8 +82,8 @@ for cmd in php curl; do command -v "${cmd}" >/dev/null || {
 }; done
 
 if [ -n "${VORTEX_NOTIFY_JIRA_BRANCHES}" ]; then
-  if ! echo ",${VORTEX_NOTIFY_JIRA_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH},"; then
-    pass "Skipping JIRA notification for branch '${VORTEX_NOTIFY_BRANCH}'."
+  if ! echo ",${VORTEX_NOTIFY_JIRA_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
+    pass "Skipping JIRA notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
     exit 0
   fi
 fi

--- a/.vortex/tooling/src/notify-newrelic
+++ b/.vortex/tooling/src/notify-newrelic
@@ -93,8 +93,8 @@ if [ -z "${VORTEX_NOTIFY_NEWRELIC_ENABLED}" ]; then
 fi
 
 if [ -n "${VORTEX_NOTIFY_NEWRELIC_BRANCHES}" ]; then
-  if ! echo ",${VORTEX_NOTIFY_NEWRELIC_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH},"; then
-    pass "Skipping New Relic notification for branch '${VORTEX_NOTIFY_BRANCH}'."
+  if ! echo ",${VORTEX_NOTIFY_NEWRELIC_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
+    pass "Skipping New Relic notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
     exit 0
   fi
 fi

--- a/.vortex/tooling/src/notify-slack
+++ b/.vortex/tooling/src/notify-slack
@@ -68,8 +68,8 @@ for cmd in php curl; do command -v "${cmd}" >/dev/null || {
 }; done
 
 if [ -n "${VORTEX_NOTIFY_SLACK_BRANCHES}" ]; then
-  if ! echo ",${VORTEX_NOTIFY_SLACK_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH},"; then
-    pass "Skipping Slack notification for branch '${VORTEX_NOTIFY_BRANCH}'."
+  if ! echo ",${VORTEX_NOTIFY_SLACK_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
+    pass "Skipping Slack notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
     exit 0
   fi
 fi

--- a/.vortex/tooling/src/notify-webhook
+++ b/.vortex/tooling/src/notify-webhook
@@ -65,8 +65,8 @@ for cmd in php curl; do command -v "${cmd}" >/dev/null || {
 }; done
 
 if [ -n "${VORTEX_NOTIFY_WEBHOOK_BRANCHES}" ]; then
-  if ! echo ",${VORTEX_NOTIFY_WEBHOOK_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH},"; then
-    pass "Skipping Webhook notification for branch '${VORTEX_NOTIFY_BRANCH}'."
+  if ! echo ",${VORTEX_NOTIFY_WEBHOOK_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
+    pass "Skipping Webhook notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
     exit 0
   fi
 fi

--- a/.vortex/tooling/tests/unit/notify-email.bats
+++ b/.vortex/tooling/tests/unit/notify-email.bats
@@ -113,6 +113,24 @@ load ../_helper.bash
   popd >/dev/null || exit 1
 }
 
+@test "Notify: email, branch filter with unset branch skips gracefully" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Direct invocation with branch filtering on but VORTEX_NOTIFY_BRANCH unset
+  # must not trip 'set -u'. The empty branch is not in the allowlist, so the
+  # notification is skipped gracefully instead of aborting.
+  unset VORTEX_NOTIFY_BRANCH
+  export VORTEX_NOTIFY_EMAIL_BRANCHES="main,develop"
+
+  run ./.vortex/tooling/src/notify-email
+  assert_success
+
+  assert_output_contains "Skipping email notification for branch ''."
+  assert_output_not_contains "unbound variable"
+
+  popd >/dev/null || exit 1
+}
+
 @test "Notify: email, shell injection protection" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 

--- a/.vortex/tooling/tests/unit/notify-github.bats
+++ b/.vortex/tooling/tests/unit/notify-github.bats
@@ -254,6 +254,24 @@ load ../_helper.bash
   popd >/dev/null || exit 1
 }
 
+@test "Notify: github, branch filter with unset branch skips gracefully" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Direct invocation with branch filtering on but VORTEX_NOTIFY_BRANCH unset
+  # must not trip 'set -u'. The empty branch is not in the allowlist, so the
+  # notification is skipped gracefully instead of aborting.
+  unset VORTEX_NOTIFY_BRANCH
+  export VORTEX_NOTIFY_GITHUB_BRANCHES="main,develop"
+
+  run ./.vortex/tooling/src/notify-github
+  assert_success
+
+  assert_output_contains "Skipping GitHub notification for branch ''."
+  assert_output_not_contains "unbound variable"
+
+  popd >/dev/null || exit 1
+}
+
 @test "Notify: github, post_deployment, failure to set status" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 

--- a/.vortex/tooling/tests/unit/notify-jira.bats
+++ b/.vortex/tooling/tests/unit/notify-jira.bats
@@ -106,6 +106,24 @@ load ../_helper.bash
   popd >/dev/null || exit 1
 }
 
+@test "Notify: jira, branch filter with unset branch skips gracefully" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Direct invocation with branch filtering on but VORTEX_NOTIFY_BRANCH unset
+  # must not trip 'set -u'. The empty branch is not in the allowlist, so the
+  # notification is skipped gracefully instead of aborting.
+  unset VORTEX_NOTIFY_BRANCH
+  export VORTEX_NOTIFY_JIRA_BRANCHES="main,develop"
+
+  run ./.vortex/tooling/src/notify-jira
+  assert_success
+
+  assert_output_contains "Skipping JIRA notification for branch ''."
+  assert_output_not_contains "unbound variable"
+
+  popd >/dev/null || exit 1
+}
+
 @test "Notify: jira, shell injection protection" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 

--- a/.vortex/tooling/tests/unit/notify-newrelic.bats
+++ b/.vortex/tooling/tests/unit/notify-newrelic.bats
@@ -126,6 +126,25 @@ load ../_helper.bash
   popd >/dev/null || exit 1
 }
 
+@test "Notify: newrelic, branch filter with unset branch skips gracefully" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Direct invocation with branch filtering on but VORTEX_NOTIFY_BRANCH unset
+  # must not trip 'set -u'. The empty branch is not in the allowlist, so the
+  # notification is skipped gracefully instead of aborting.
+  unset VORTEX_NOTIFY_BRANCH
+  export VORTEX_NOTIFY_NEWRELIC_ENABLED=true
+  export VORTEX_NOTIFY_NEWRELIC_BRANCHES="main,develop"
+
+  run ./.vortex/tooling/src/notify-newrelic
+  assert_success
+
+  assert_output_contains "Skipping New Relic notification for branch ''."
+  assert_output_not_contains "unbound variable"
+
+  popd >/dev/null || exit 1
+}
+
 @test "Notify: newrelic, branch filter custom" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 

--- a/.vortex/tooling/tests/unit/notify-slack.bats
+++ b/.vortex/tooling/tests/unit/notify-slack.bats
@@ -295,6 +295,24 @@ load ../_helper.bash
   popd >/dev/null || exit 1
 }
 
+@test "Notify: slack, branch filter with unset branch skips gracefully" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Direct invocation with branch filtering on but VORTEX_NOTIFY_BRANCH unset
+  # must not trip 'set -u'. The empty branch is not in the allowlist, so the
+  # notification is skipped gracefully instead of aborting.
+  unset VORTEX_NOTIFY_BRANCH
+  export VORTEX_NOTIFY_SLACK_BRANCHES="main,develop"
+
+  run ./.vortex/tooling/src/notify-slack
+  assert_success
+
+  assert_output_contains "Skipping Slack notification for branch ''."
+  assert_output_not_contains "unbound variable"
+
+  popd >/dev/null || exit 1
+}
+
 @test "Notify: slack, shell injection protection" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 

--- a/.vortex/tooling/tests/unit/notify-webhook.bats
+++ b/.vortex/tooling/tests/unit/notify-webhook.bats
@@ -112,6 +112,24 @@ load ../_helper.bash
   popd >/dev/null || exit 1
 }
 
+@test "Notify: webhook, branch filter with unset branch skips gracefully" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Direct invocation with branch filtering on but VORTEX_NOTIFY_BRANCH unset
+  # must not trip 'set -u'. The empty branch is not in the allowlist, so the
+  # notification is skipped gracefully instead of aborting.
+  unset VORTEX_NOTIFY_BRANCH
+  export VORTEX_NOTIFY_WEBHOOK_BRANCHES="main,develop"
+
+  run ./.vortex/tooling/src/notify-webhook
+  assert_success
+
+  assert_output_contains "Skipping Webhook notification for branch ''."
+  assert_output_not_contains "unbound variable"
+
+  popd >/dev/null || exit 1
+}
+
 @test "Notify: webhook, shell injection protection" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 


### PR DESCRIPTION
Closes #2551

## Summary

Six notify scripts (`notify-slack`, `notify-email`, `notify-webhook`, `notify-github`, `notify-jira`, `notify-newrelic`) referenced `${VORTEX_NOTIFY_BRANCH}` directly inside their branch-filter blocks. Under `set -eu`, invoking any of these scripts directly with a `*_BRANCHES` filter set but `VORTEX_NOTIFY_BRANCH` unset caused an immediate abort with an opaque "unbound variable" error. The fix replaces every bare reference with the dash-default form `${VORTEX_NOTIFY_BRANCH-}`, so an unset branch is treated as an empty string, the grep check finds no match, and the script exits 0 with a "Skipping ... for branch ''." message instead of crashing. `notify-newrelic` is the most exposed script because its `VORTEX_NOTIFY_NEWRELIC_BRANCHES` defaults to `main,master,develop`, meaning its filter block always executes. A regression BATS test was added for each of the six affected scripts.

## Changes

**Six notify scripts** (`.vortex/tooling/src/`): replaced the two bare `${VORTEX_NOTIFY_BRANCH}` references in each script's branch-filter block with `${VORTEX_NOTIFY_BRANCH-}`. The grep match and the "Skipping" log message both now use the guarded form so neither expansion can trigger `set -u`.

**Six BATS test files** (`.vortex/tooling/tests/unit/`): added one regression test per script. Each test calls the script directly with its `*_BRANCHES` variable set and `VORTEX_NOTIFY_BRANCH` unset, then asserts `assert_success`, that the output contains the graceful-skip message, and that it does not contain "unbound variable".

## Before / After

```
Before (set -u, VORTEX_NOTIFY_BRANCH unset, *_BRANCHES set)
┌───────────────────────────────────────────────────────────┐
│  if [ -n "${VORTEX_NOTIFY_*_BRANCHES}" ]; then            │
│    if ! echo "..." | grep -qF ",${VORTEX_NOTIFY_BRANCH}," │  ← unbound variable
│      ...                                                   │
│    fi                                                      │
│  fi                                                        │
│                                                            │
│  Result: script aborts, exit 1, "unbound variable" error  │
└───────────────────────────────────────────────────────────┘

After (set -u, VORTEX_NOTIFY_BRANCH unset, *_BRANCHES set)
┌────────────────────────────────────────────────────────────┐
│  if [ -n "${VORTEX_NOTIFY_*_BRANCHES}" ]; then             │
│    if ! echo "..." | grep -qF ",${VORTEX_NOTIFY_BRANCH-}," │  ← expands to ''
│      pass "Skipping ... for branch ''."                    │
│      exit 0                                                │  ← graceful skip
│    fi                                                      │
│  fi                                                        │
│                                                            │
│  Result: script exits 0, skip message logged, no crash     │
└────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of notification scripts (email, GitHub, JIRA, New Relic, Slack, webhook) to gracefully handle missing branch configuration, preventing script failures during deployments.

* **Tests**
  * Added unit tests to verify notification scripts properly skip notifications and handle missing branch configuration without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->