### PR TITLE
[#2566] Published PHPUnit and Behat test results to the GitHub Checks UI.

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -319,6 +319,11 @@ jobs:
     if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
     #;> !PROVISION_TYPE_PROFILE
 
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+
     strategy:
       # A matrix to run multiple jobs in parallel.
       matrix:
@@ -547,6 +552,18 @@ jobs:
           path: .logs
           include-hidden-files: true
           if-no-files-found: error
+
+      #;< TOOL_PHPUNIT_BEHAT
+      - name: Publish test results to GitHub Checks
+        if: ${{ !cancelled() && vars.VORTEX_CI_TEST_RESULTS_SKIP != '1' }}
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        with:
+          check_name: Test results (${{ matrix.instance }})
+          comment_mode: "off"
+          test_file_prefix: "-/app/"
+          files: |
+            .logs/test_results/**/*.xml
+      #;> TOOL_PHPUNIT_BEHAT
 
       - name: Upload exported codebase as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -320,9 +320,9 @@ jobs:
     #;> !PROVISION_TYPE_PROFILE
 
     permissions:
-      contents: read
-      checks: write
-      pull-requests: write
+      contents: read # Check out the repository.
+      checks: write # Publish test results to the Checks tab.
+      pull-requests: write # Comment on the pull request.
 
     strategy:
       # A matrix to run multiple jobs in parallel.

--- a/.vortex/docs/content/continuous-integration/github-actions.mdx
+++ b/.vortex/docs/content/continuous-integration/github-actions.mdx
@@ -222,3 +222,16 @@ Coverage reports are automatically posted as PR comments. Each new report
 replaces the previous one — older comments are minimized to keep the PR
 timeline clean. To disable this, set `VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP`
 to `1`.
+
+### Test results
+
+PHPUnit and Behat results are published to the **Checks** tab of each run, so a
+failed check links directly to the failing tests and their messages instead of
+requiring you to download artifacts or search through logs. Results are read
+from the JUnit reports the test tools already generate, so no extra setup is
+required.
+
+Tests run across parallel build instances, so a separate check is created for
+each instance (for example, `Test results (0)` and `Test results (1)`). To
+disable publishing, set `VORTEX_CI_TEST_RESULTS_SKIP` to `1` in **Settings →
+Secrets and variables → Actions → Variables**.

--- a/.vortex/installer/src/Prompts/Handlers/Tools.php
+++ b/.vortex/installer/src/Prompts/Handlers/Tools.php
@@ -479,6 +479,7 @@ class Tools extends AbstractHandler {
           '/^\h*test:\R\h*usage:\h*Run all tests\.\R\h*cmd:\h*\|$/um',
           '/^\h*lint-tests:\R\h*usage:\h*Lint tests code\.\R\h*cmd:\h*\|\h*\R^\h*$/um',
         ],
+        'token' => 'TOOL_PHPUNIT_BEHAT',
       ],
       'frontend_linting' => [
         'tools' => [self::ESLINT, self::STYLELINT],

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -283,9 +283,9 @@ jobs:
     if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 
     permissions:
-      contents: read
-      checks: write
-      pull-requests: write
+      contents: read # Check out the repository.
+      checks: write # Publish test results to the Checks tab.
+      pull-requests: write # Comment on the pull request.
 
     strategy:
       # A matrix to run multiple jobs in parallel.

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -282,6 +282,11 @@ jobs:
     needs: database
     if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+
     strategy:
       # A matrix to run multiple jobs in parallel.
       matrix:
@@ -479,6 +484,16 @@ jobs:
           path: .logs
           include-hidden-files: true
           if-no-files-found: error
+
+      - name: Publish test results to GitHub Checks
+        if: ${{ !cancelled() && vars.VORTEX_CI_TEST_RESULTS_SKIP != '1' }}
+        uses: EnricoMi/publish-unit-test-result-action@__HASH__ # __VERSION__
+        with:
+          check_name: Test results (${{ matrix.instance }})
+          comment_mode: "off"
+          test_file_prefix: "-/app/"
+          files: |
+            .logs/test_results/**/*.xml
 
       - name: Upload exported codebase as an artifact
         uses: actions/upload-artifact@__HASH__ # __VERSION__

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -441,6 +441,17 @@
+@@ -446,6 +446,17 @@
              </details>
            hide_and_recreate: true
  

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -496,98 +496,3 @@
+@@ -511,98 +511,3 @@
          timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
          with:
            detached: true

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -382,6 +385,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -382,6 +385,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -382,6 +385,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -382,6 +385,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -382,6 +385,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -382,6 +385,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -382,6 +385,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -382,6 +385,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -132,7 +132,7 @@
 -    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
  
      permissions:
-       contents: read
+       contents: read # Check out the repository.
 @@ -306,14 +194,6 @@
          VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"
          VORTEX_SSH_REMOVE_ALL_KEYS: "1"

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -131,9 +131,9 @@
 -    needs: database
 -    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
  
-     strategy:
-       # A matrix to run multiple jobs in parallel.
-@@ -301,14 +189,6 @@
+     permissions:
+       contents: read
+@@ -306,14 +194,6 @@
          VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"
          VORTEX_SSH_REMOVE_ALL_KEYS: "1"
          VORTEX_DEBUG: ${{ vars.VORTEX_DEBUG }}
@@ -148,7 +148,7 @@
  
      steps:
        - name: Preserve $HOME set in the container
-@@ -333,29 +213,6 @@
+@@ -338,29 +218,6 @@
        - name: Install Vortex tooling
          run: ./scripts/vortex-tooling.sh
  
@@ -178,7 +178,7 @@
        - name: Login to container registry
          run: ./vendor/drevops/vortex-tooling/src/login-container-registry
  
-@@ -500,7 +357,6 @@
+@@ -515,7 +372,6 @@
    deploy:
      runs-on: ubuntu-latest
      needs: [build, lint]

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -9,11 +9,10 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -390,78 +386,6 @@
-         if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+@@ -396,78 +392,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
--
+ 
 -      - name: Test with PHPUnit
 -        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: docker compose exec -T cli vendor/bin/phpunit
@@ -85,6 +84,24 @@
 -          VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
 -        continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
 -        timeout-minutes: 30
- 
+-
        - name: Process test logs and artifacts
          if: always()
+         run: |
+@@ -484,16 +408,6 @@
+           path: .logs
+           include-hidden-files: true
+           if-no-files-found: error
+-
+-      - name: Publish test results to GitHub Checks
+-        if: ${{ !cancelled() && vars.VORTEX_CI_TEST_RESULTS_SKIP != '1' }}
+-        uses: EnricoMi/publish-unit-test-result-action@__HASH__ # __VERSION__
+-        with:
+-          check_name: Test results (${{ matrix.instance }})
+-          comment_mode: "off"
+-          test_file_prefix: "-/app/"
+-          files: |
+-            .logs/test_results/**/*.xml
+ 
+       - name: Upload exported codebase as an artifact
+         uses: actions/upload-artifact@__HASH__ # __VERSION__

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
@@ -17,7 +17,7 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -375,7 +370,6 @@
+@@ -380,7 +375,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -25,7 +25,7 @@
  
        - name: Provision site
          run: |
-@@ -385,11 +379,6 @@
+@@ -390,11 +384,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
@@ -22,7 +22,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -375,7 +365,6 @@
+@@ -380,7 +370,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -30,7 +30,7 @@
  
        - name: Provision site
          run: |
-@@ -385,11 +374,6 @@
+@@ -390,11 +379,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -9,7 +9,7 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -450,18 +446,6 @@
+@@ -455,18 +451,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -375,7 +375,6 @@
+@@ -380,7 +380,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Provision site
          run: |
-@@ -385,11 +384,6 @@
+@@ -390,11 +389,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -391,66 +391,6 @@
+@@ -396,66 +396,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -65,3 +65,20 @@
        - name: Test with Behat
          run: |
            # shellcheck disable=SC2170
+@@ -484,16 +424,6 @@
+           path: .logs
+           include-hidden-files: true
+           if-no-files-found: error
+-
+-      - name: Publish test results to GitHub Checks
+-        if: ${{ !cancelled() && vars.VORTEX_CI_TEST_RESULTS_SKIP != '1' }}
+-        uses: EnricoMi/publish-unit-test-result-action@__HASH__ # __VERSION__
+-        with:
+-          check_name: Test results (${{ matrix.instance }})
+-          comment_mode: "off"
+-          test_file_prefix: "-/app/"
+-          files: |
+-            .logs/test_results/**/*.xml
+ 
+       - name: Upload exported codebase as an artifact
+         uses: actions/upload-artifact@__HASH__ # __VERSION__

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -41,7 +41,7 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -375,7 +350,6 @@
+@@ -380,7 +355,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -49,12 +49,10 @@
  
        - name: Provision site
          run: |
-@@ -384,83 +358,6 @@
-             docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-           fi
+@@ -391,83 +365,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
--        timeout-minutes: 30
--
+         timeout-minutes: 30
+ 
 -      - name: Test with Jest
 -        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: docker compose exec -T cli bash -c "yarn test"
@@ -130,6 +128,25 @@
 -        env:
 -          VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
 -        continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
-         timeout-minutes: 30
- 
+-        timeout-minutes: 30
+-
        - name: Process test logs and artifacts
+         if: always()
+         run: |
+@@ -484,16 +381,6 @@
+           path: .logs
+           include-hidden-files: true
+           if-no-files-found: error
+-
+-      - name: Publish test results to GitHub Checks
+-        if: ${{ !cancelled() && vars.VORTEX_CI_TEST_RESULTS_SKIP != '1' }}
+-        uses: EnricoMi/publish-unit-test-result-action@__HASH__ # __VERSION__
+-        with:
+-          check_name: Test results (${{ matrix.instance }})
+-          comment_mode: "off"
+-          test_file_prefix: "-/app/"
+-          files: |
+-            .logs/test_results/**/*.xml
+ 
+       - name: Upload exported codebase as an artifact
+         uses: actions/upload-artifact@__HASH__ # __VERSION__

--- a/.vortex/installer/tests/Functional/Handlers/ToolsHandlerProcessTest.php
+++ b/.vortex/installer/tests/Functional/Handlers/ToolsHandlerProcessTest.php
@@ -416,6 +416,7 @@ class ToolsHandlerProcessTest extends AbstractHandlerProcessTestCase {
         'gherkinlint',
         'gherkin-lint',
         'gherkin',
+        'publish-unit-test-result-action',
       ])),
     ];
     yield 'tools_groups_no_be_tests_circleci' => [
@@ -436,6 +437,7 @@ class ToolsHandlerProcessTest extends AbstractHandlerProcessTestCase {
         'gherkinlint',
         'gherkin-lint',
         'gherkin',
+        'publish-unit-test-result-action',
       ])),
     ];
     yield 'tools_groups_no_fe_lint_no_theme' => [


### PR DESCRIPTION
Closes #2566

## Summary

Vortex already generates JUnit XML for PHPUnit and Behat and stores it as a CI artifact, but a failed check meant downloading the artifact or digging through logs to find which test failed. This surfaces those existing JUnit reports in the GitHub **Checks** tab on GitHub Actions runs, so a red check links straight to the failing tests and their messages. GitHub Actions only; CircleCI keeps its native test-results UI via `store_test_results` and is out of scope.

## Changes

### CI workflow (`.github/workflows/build-test-deploy.yml`)

- Added a `Publish test results to GitHub Checks` step inside the existing `build` job, using `EnricoMi/publish-unit-test-result-action` to read the JUnit XML already written to `.logs/test_results/` and publish it to the Checks tab. No new job is introduced.
- The step runs on `!cancelled()` so results are surfaced even when tests fail, and can be opted out with the `VORTEX_CI_TEST_RESULTS_SKIP` repository variable.
- Because `build` runs a parallel matrix, each instance publishes its own results under a per-instance check name (`Test results (0)`, `Test results (1)`), which avoids same-name check collisions.
- `test_file_prefix: "-/app/"` strips the in-container path prefix so PHPUnit failure annotations map onto the repository's source files.
- Added a scoped `permissions:` block to the `build` job: `checks: write` to publish the check, `pull-requests: write` to preserve the existing coverage PR comment once an explicit block is present, and `contents: read` for checkout. This also makes the job work on repositories whose default `GITHUB_TOKEN` is read-only.

### Installer (`.vortex/installer/`)

- Added a `TOOL_PHPUNIT_BEHAT` conditional token to the `test` tool group in `Tools.php`. The publish step is wrapped in this token so it is kept when PHPUnit or Behat is selected and removed only when both are deselected.
- Extended the `tools_groups_no_be_tests` assertions in `ToolsHandlerProcessTest.php` to confirm the publish step is absent when no backend test tools are selected.
- Regenerated installer snapshots to reflect the new step across all affected scenario fixtures.

### Documentation (`.vortex/docs/`)

- Documented Checks-tab publishing and the `VORTEX_CI_TEST_RESULTS_SKIP` opt-out under the GitHub Actions maintenance section.

## Before / After

Build job step flow (per matrix instance):

```
Before                                  After
------                                  -----
... run tests (PHPUnit / Behat)         ... run tests (PHPUnit / Behat)
Process test logs and artifacts         Process test logs and artifacts
Upload test artifacts                   Upload test artifacts
                                        Publish test results to Checks  <-- new
Upload exported codebase                Upload exported codebase
```

Developer experience on a failed run:

```
Before:  red check -> open Actions -> download .logs artifact -> read JUnit XML
After:   red check -> Checks tab shows failing test name + message inline
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PHPUnit and Behat test results are published to GitHub Checks with per-instance checks for parallel runs
  * Publishing of test results can be disabled via environment configuration

* **Documentation**
  * Added guidance on configuring GitHub Checks for test results and how to disable publishing

* **Chores**
  * Installer updated to support removing an associated token for the test tool group

* **Tests**
  * Functional tests tightened to ensure test-result publishing action is not injected in certain setups
<!-- end of auto-generated comment: release notes by coderabbit.ai -->