### PR TITLE
[#2549] Hardened fragile site UUID extraction in the provision script.

### DIFF
--- a/.vortex/tooling/src/provision
+++ b/.vortex/tooling/src/provision
@@ -322,7 +322,7 @@ fi
 # Set site UUID from configuration if config files are present.
 if [ "${site_has_config_files}" = "1" ]; then
   if [ -f "${config_path}/system.site.yml" ]; then
-    config_uuid="$(cat "${config_path}/system.site.yml" | grep uuid | tail -c +7 | head -c 36)"
+    config_uuid="$(awk '/^uuid:/ {print $2; exit}' "${config_path}/system.site.yml")"
     drush config-set system.site uuid "${config_uuid}"
     pass "Updated site UUID from the configuration with ${config_uuid}."
     echo

--- a/.vortex/tooling/src/provision
+++ b/.vortex/tooling/src/provision
@@ -323,6 +323,12 @@ fi
 if [ "${site_has_config_files}" = "1" ]; then
   if [ -f "${config_path}/system.site.yml" ]; then
     config_uuid="$(awk '/^uuid:/ {print $2; exit}' "${config_path}/system.site.yml")"
+
+    if [ -z "${config_uuid}" ]; then
+      fail "Could not read site UUID from ${config_path}/system.site.yml."
+      exit 1
+    fi
+
     drush config-set system.site uuid "${config_uuid}"
     pass "Updated site UUID from the configuration with ${config_uuid}."
     echo

--- a/.vortex/tooling/tests/unit/provision.bats
+++ b/.vortex/tooling/tests/unit/provision.bats
@@ -632,6 +632,71 @@ assert_provision_info() {
   popd >/dev/null || exit 1
 }
 
+@test "Provision: DB; no site; configs; missing UUID" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Remove .env file to test in isolation.
+  rm ./.env && touch ./.env
+  rm -f ./scripts/provision-20-migration.sh
+
+  export VORTEX_PROVISION_SANITIZE_DB_PASSWORD="MOCK_DB_SANITIZE_PASSWORD"
+  export CI=1
+
+  mkdir "./.data"
+  touch "./.data/db.sql"
+
+  # Config file present but with no top-level "uuid" key: the extraction must
+  # fail loudly instead of passing an empty value to drush.
+  echo "# This file stores the site name only." >"./config/default/system.site.yml"
+  echo "name: 'SUT'" >>"./config/default/system.site.yml"
+
+  create_global_command_wrapper "vendor/bin/drush"
+
+  declare -a STEPS=(
+    # Drush status calls.
+    "@drush -y --version # Drush Commandline Tool mocked_drush_version"
+    "@drush -y status --field=drupal-version # mocked_core_version"
+    "@drush -y status --fields=bootstrap # fail"
+    "@drush -y php:eval print realpath(\Drupal\Core\Site\Settings::get(\"config_sync_directory\")); # $(pwd)/config/default"
+
+    # Site provisioning information.
+    "Provisioning site from the database dump file."
+    "Dump file path: $(pwd)/.data/db.sql"
+    "Existing site was not found."
+    "Fresh site content will be imported from the database dump file."
+    "@drush -y sql:drop"
+    "@drush -y sql:connect"
+    "Imported database from the dump file."
+
+    # Drupal environment information.
+    "Current Drupal environment: ci"
+    "@drush -y php:eval print \Drupal\core\Site\Settings::get('environment'); # ci"
+
+    # Maintenance mode.
+    "Enabling maintenance mode."
+    "@drush -y maint:set 1"
+    "Enabled maintenance mode."
+
+    # UUID extraction failure - hard stop before any UUID is applied.
+    "Could not read site UUID from $(pwd)/config/default/system.site.yml."
+
+    # These should NOT appear (script exits at the UUID guard).
+    "- Updated site UUID from the configuration with"
+    "- Running database updates."
+    "- Importing configuration."
+    "- Finished site provisioning"
+  )
+
+  mocks="$(run_steps "setup")"
+
+  run ./.vortex/tooling/src/provision
+  assert_failure
+
+  run_steps "assert" "${mocks[@]}"
+
+  popd >/dev/null || exit 1
+}
+
 @test "Provision: profile; no site" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 

--- a/.vortex/tooling/tests/unit/provision.bats
+++ b/.vortex/tooling/tests/unit/provision.bats
@@ -486,8 +486,11 @@ assert_provision_info() {
   touch "./.data/db.sql"
 
   mocked_uuid="c9360453-e1ea-4292-b074-ea375f97d72b"
-  echo "uuid: ${mocked_uuid}" >"./config/default/system.site.yml"
+  # Adversarial layout: a comment containing "uuid" and the "uuid" key placed
+  # after another key must not confuse the extraction in the provision script.
+  echo "# This file stores the site uuid and name." >"./config/default/system.site.yml"
   echo "name: 'SUT'" >>"./config/default/system.site.yml"
+  echo "uuid: ${mocked_uuid}" >>"./config/default/system.site.yml"
 
   create_global_command_wrapper "vendor/bin/drush"
 


### PR DESCRIPTION
Closes #2549

## Summary

Hardened the site UUID extraction in the `provision` script. The old pipeline `cat ... | grep uuid | tail -c +7 | head -c 36` matched any line containing the substring `uuid` (a comment, or a key such as `default_uuid:`) and then byte-sliced from a fixed column, assuming the value always sat at byte 7 and was exactly 36 bytes long - so it broke as soon as the file layout shifted. It is now a single `awk '/^uuid:/ {print $2; exit}'` that anchors on the top-level `uuid:` key, reads the value field, and stops at the first match - immune to key ordering, comments, and preamble. An empty-result guard was added so that a `system.site.yml` without a top-level `uuid:` key fails fast with a clear message instead of passing an empty value to `drush config-set`. This UUID is seeded as the active site UUID before `drush config:import` runs, so Drush does not abort on a source/target UUID mismatch.

## Changes

**`provision` script (`.vortex/tooling/src/provision`)**
- Replaced the `cat | grep uuid | tail -c +7 | head -c 36` pipeline with `awk '/^uuid:/ {print $2; exit}' "${config_path}/system.site.yml"`.
- Added a guard: when the extracted UUID is empty, fail with `Could not read site UUID from <path>` and exit non-zero, rather than calling `drush config-set` with an empty value.

**`provision` BATS tests (`.vortex/tooling/tests/unit/provision.bats`)**
- Converted the `system.site.yml` fixture in the `Provision: DB; no site; configs` scenario to an adversarial layout: a comment line containing the word "uuid" appears first, then the `name:` key, with the `uuid:` key placed last. This fixture fails against the old byte-slice code and passes with the new `awk` extraction, locking in both reported failure modes. The other three UUID scenarios retain the canonical single-line layout.
- Added a `Provision: DB; no site; configs; missing UUID` scenario that drives provisioning to the UUID step with a `uuid`-less config file and asserts the script aborts with the guard message.

## Before / After

```
OLD (fragile) pipeline
─────────────────────────────────────────────────────────────────
system.site.yml content           Pipeline step        Result
─────────────────────────────────────────────────────────────────
# This file stores the site       grep uuid        ← matches THIS
  uuid and name.                                     comment line!
uuid: c9360453-...                                 ← also matches
                                  tail -c +7       byte-slice from
                                                   byte 7 of the
                                                   comment line →
                                                   WRONG value
─────────────────────────────────────────────────────────────────

NEW (robust) awk command
─────────────────────────────────────────────────────────────────
system.site.yml content           awk '/^uuid:/'   Result
─────────────────────────────────────────────────────────────────
# This file stores the site       no match         skipped
  uuid and name.
name: 'SUT'                       no match         skipped
uuid: c9360453-...                MATCH → $2       c9360453-...  ✓
                                  exit             stops here
─────────────────────────────────────────────────────────────────

NEW guard - missing / empty uuid
─────────────────────────────────────────────────────────────────
system.site.yml content           awk '/^uuid:/'   Result
─────────────────────────────────────────────────────────────────
# This file stores the site       no match         (empty result)
name: 'SUT'                       no match
                                  guard fires →    fail + exit 1
                                                   "Could not read
                                                    site UUID ..."
─────────────────────────────────────────────────────────────────
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site UUID extraction during provisioning to handle varied YAML layouts and comments; provisioning now fails with a clear error if no UUID is found.

* **Tests**
  * Updated unit test to cover adversarial YAML ordering/comments and added a test asserting provisioning aborts when the site UUID is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
