### PR TITLE
[#2548] Added SSH host key pinning as a secure alternative to disabling strict checking.

### DIFF
--- a/.vortex/docs/content/continuous-integration/circleci.mdx
+++ b/.vortex/docs/content/continuous-integration/circleci.mdx
@@ -90,6 +90,42 @@ file:
 - `db_ssh_fingerprint` - your database download SSH key fingerprint
 - `deploy_ssh_fingerprint` - your deployment SSH key fingerprint
 
+### Pin SSH host keys
+
+By default, the runner disables SSH strict host key checking
+(`VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"`) so that database downloads
+and deployments connect without prompting. This also removes protection against
+a man-in-the-middle that impersonates the hosting SSH endpoint to read or tamper
+with the database dump or the deployed code.
+
+To keep host key verification on, pin the hosting host keys with
+`VORTEX_SSH_KNOWN_HOSTS`. When set, **Vortex** writes its entries to the runner's
+`known_hosts` file and leaves strict checking enabled, so a mismatched host key
+aborts the connection. It takes precedence over
+`VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING`.
+
+1. Get the host key for each SSH endpoint (database download and deployment).
+   Prefer the fingerprint published by your hosting provider, then confirm it
+   with `ssh-keyscan` (use `-p` for a non-standard port):
+
+   ```shell
+   ssh-keyscan -p 22 ssh.example.com
+   ```
+
+   Verify the returned key against the provider's published fingerprint before
+   trusting it - a key scanned over a compromised network offers no protection.
+2. Add the verified entries as a `VORTEX_SSH_KNOWN_HOSTS` environment variable in
+   **Project Settings → Environment Variables**. CircleCI variables are
+   single-line, so join multiple entries with `\n`.
+
+:::note
+
+Host keys are public, so they are safe to store in plain configuration. If the
+provider rotates a host key, the connection fails until you refresh the pinned
+entry.
+
+:::
+
 ### 5. Configure environment variables
 
 Add the following variables in **Project Settings → Environment Variables**:

--- a/.vortex/docs/content/continuous-integration/github-actions.mdx
+++ b/.vortex/docs/content/continuous-integration/github-actions.mdx
@@ -81,6 +81,48 @@ same provider, you can use a single key for both operations.
 3. Add the private key as a secret named `VORTEX_DEPLOY_SSH_KEY` in your
    repository under **Settings → Secrets and variables → Actions**
 
+### Pin SSH host keys
+
+By default, the runner disables SSH strict host key checking
+(`VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"`) so that database downloads
+and deployments connect without prompting. This also removes protection against
+a man-in-the-middle that impersonates the hosting SSH endpoint to read or tamper
+with the database dump or the deployed code.
+
+To keep host key verification on, pin the hosting host keys with
+`VORTEX_SSH_KNOWN_HOSTS`. When set, **Vortex** writes its entries to the runner's
+`known_hosts` file and leaves strict checking enabled, so a mismatched host key
+aborts the connection. It takes precedence over
+`VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING`.
+
+1. Get the host key for each SSH endpoint (database download and deployment).
+   Prefer the fingerprint published by your hosting provider, then confirm it
+   with `ssh-keyscan` (use `-p` for a non-standard port):
+
+   ```shell
+   ssh-keyscan -p 22 ssh.example.com
+   ```
+
+   Verify the returned key against the provider's published fingerprint before
+   trusting it - a key scanned over a compromised network offers no protection.
+2. Add the verified entries (newline-separated) as a `VORTEX_SSH_KNOWN_HOSTS`
+   repository variable under **Settings → Secrets and variables → Actions**.
+3. Map the variable into the workflow `env` block in
+   `.github/workflows/build-test-deploy.yml`, alongside the existing SSH
+   variables:
+
+   ```yaml
+   VORTEX_SSH_KNOWN_HOSTS: ${{ vars.VORTEX_SSH_KNOWN_HOSTS }}
+   ```
+
+:::note
+
+Host keys are public, so they are safe to store as a plain variable. If the
+provider rotates a host key, the connection fails until you refresh the pinned
+entry.
+
+:::
+
 ### 4. Configure secrets
 
 Add the following secrets in **Settings → Secrets and variables → Actions**:

--- a/.vortex/tooling/src/setup-ssh
+++ b/.vortex/tooling/src/setup-ssh
@@ -126,6 +126,16 @@ if [ -n "${VORTEX_SSH_KNOWN_HOSTS-}" ]; then
 
   task "Pinning SSH host keys to known_hosts."
   mkdir -p "${HOME}/.ssh/"
+
+  # Strip insecure directives that an earlier run with strict checking disabled
+  # may have left in the SSH config, so the pinned host keys are actually
+  # enforced rather than bypassed by a stale "UserKnownHostsFile /dev/null".
+  if [ -f "${HOME}/.ssh/config" ]; then
+    grep -v -E '^[[:space:]]*(StrictHostKeyChecking[[:space:]]+no|UserKnownHostsFile[[:space:]]+/dev/null)[[:space:]]*$' "${HOME}/.ssh/config" >"${HOME}/.ssh/config.tmp" || true
+    mv "${HOME}/.ssh/config.tmp" "${HOME}/.ssh/config"
+    chmod 600 "${HOME}/.ssh/config"
+  fi
+
   printf '%b\n' "${VORTEX_SSH_KNOWN_HOSTS}" >>"${HOME}/.ssh/known_hosts"
   chmod 600 "${HOME}/.ssh/known_hosts"
 elif [ "${VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING-}" = "1" ]; then

--- a/.vortex/tooling/src/setup-ssh
+++ b/.vortex/tooling/src/setup-ssh
@@ -6,7 +6,8 @@
 #   key file. Export the key file path.
 # - Start SSH agent if not running. Export SSH_AGENT_PID and SSH_AUTH_SOCK.
 # - Load SSH key to the SSH agent.
-# - Disable strict host key checking in CI.
+# - Pin host keys to 'known_hosts' when provided, or disable strict host key
+#   checking in CI as an opt-out.
 #
 # IMPORTANT! This script runs outside the container on the host system.
 #
@@ -29,6 +30,12 @@ VORTEX_SSH_REMOVE_ALL_KEYS="${VORTEX_SSH_REMOVE_ALL_KEYS:-0}"
 
 # Disable strict host key checking in SSH.
 VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING="${VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING:-0}"
+
+# Pinned SSH host keys as 'known_hosts' entries (newline-separated). When set,
+# the entries are written to the SSH 'known_hosts' file and strict host key
+# checking is kept enabled. This is the secure alternative to disabling strict
+# checking and takes precedence over VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING.
+VORTEX_SSH_KNOWN_HOSTS="${VORTEX_SSH_KNOWN_HOSTS:-}"
 
 # ------------------------------------------------------------------------------
 
@@ -112,7 +119,16 @@ else
   ssh-add -l
 fi
 
-if [ "${VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING-}" = "1" ]; then
+if [ -n "${VORTEX_SSH_KNOWN_HOSTS-}" ]; then
+  if [ "${VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING-}" = "1" ]; then
+    note "Both pinned host keys and disabled strict checking are set; pinning takes precedence and strict host key checking remains enabled."
+  fi
+
+  task "Pinning SSH host keys to known_hosts."
+  mkdir -p "${HOME}/.ssh/"
+  printf '%b\n' "${VORTEX_SSH_KNOWN_HOSTS}" >>"${HOME}/.ssh/known_hosts"
+  chmod 600 "${HOME}/.ssh/known_hosts"
+elif [ "${VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING-}" = "1" ]; then
   task "Disabling strict host key checking."
   mkdir -p "${HOME}/.ssh/"
   echo -e "\nHost *\n\tStrictHostKeyChecking no\n\tUserKnownHostsFile /dev/null\n" >>"${HOME}/.ssh/config"

--- a/.vortex/tooling/tests/unit/setup-ssh.bats
+++ b/.vortex/tooling/tests/unit/setup-ssh.bats
@@ -290,6 +290,51 @@ load ../_helper.bash
   popd >/dev/null
 }
 
+@test "Loading SSH key to SSH Agent, Key exists, Pin host keys clears stale insecure config => success" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_DEBUG=1
+
+  fixture_ssh_key_prepare
+  fixture_ssh_key
+  # The script appends to "${HOME}/.ssh/known_hosts". Force HOME into the test
+  # sandbox before running it so it can never touch the real "~/.ssh/known_hosts".
+  export HOME="${BUILD_DIR}"
+  export VORTEX_SSH_PREFIX="TEST"
+  local file=${HOME}/.ssh/id_rsa
+
+  # Simulate a previous run that disabled strict host key checking, leaving an
+  # insecure config behind on a reused runner.
+  mkdir -p "${HOME}/.ssh"
+  printf '\nHost *\n\tStrictHostKeyChecking no\n\tUserKnownHostsFile /dev/null\n' >"${HOME}/.ssh/config"
+
+  # Override the values that could be coming from the environment with defaults.
+  export VORTEX_SSH_REMOVE_ALL_KEYS="0"
+  export VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING="0"
+  export VORTEX_SSH_KNOWN_HOSTS="example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY"
+
+  declare -a STEPS=(
+    "@ssh-add -l # ${file}"
+    "SSH agent already has ${file} key loaded."
+    "Pinning SSH host keys to known_hosts."
+    "- Disabling strict host key checking."
+  )
+  mocks="$(run_steps "setup")"
+
+  run .vortex/tooling/src/setup-ssh
+  assert_success
+  run_steps "assert" "${mocks[@]}"
+
+  run cat "${HOME}/.ssh/known_hosts"
+  assert_output_contains "example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY"
+
+  run cat "${HOME}/.ssh/config"
+  assert_output_not_contains "StrictHostKeyChecking no"
+  assert_output_not_contains "UserKnownHostsFile /dev/null"
+
+  popd >/dev/null
+}
+
 @test "Loading SSH key to SSH Agent, Key exists, Remove existing keys => success" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 

--- a/.vortex/tooling/tests/unit/setup-ssh.bats
+++ b/.vortex/tooling/tests/unit/setup-ssh.bats
@@ -218,6 +218,78 @@ load ../_helper.bash
   popd >/dev/null
 }
 
+@test "Loading SSH key to SSH Agent, Key exists, Pin host keys => success" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_DEBUG=1
+
+  fixture_ssh_key_prepare
+  fixture_ssh_key
+  # The script appends to "${HOME}/.ssh/known_hosts". Force HOME into the test
+  # sandbox before running it so it can never touch the real "~/.ssh/known_hosts".
+  export HOME="${BUILD_DIR}"
+  export VORTEX_SSH_PREFIX="TEST"
+  local file=${HOME}/.ssh/id_rsa
+
+  # Override the values that could be coming from the environment with defaults.
+  export VORTEX_SSH_REMOVE_ALL_KEYS="0"
+  export VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING="0"
+  # Pin host keys instead of disabling strict host key checking.
+  export VORTEX_SSH_KNOWN_HOSTS="example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY"
+
+  declare -a STEPS=(
+    "@ssh-add -l # ${file}"
+    "SSH agent already has ${file} key loaded."
+    "Pinning SSH host keys to known_hosts."
+    "- Disabling strict host key checking."
+  )
+  mocks="$(run_steps "setup")"
+
+  run .vortex/tooling/src/setup-ssh
+  assert_success
+  run_steps "assert" "${mocks[@]}"
+
+  run cat "${HOME}/.ssh/known_hosts"
+  assert_output_contains "example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY"
+
+  popd >/dev/null
+}
+
+@test "Loading SSH key to SSH Agent, Key exists, Pin host keys takes precedence over disable => success" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_DEBUG=1
+
+  fixture_ssh_key_prepare
+  fixture_ssh_key
+  # The script appends to "${HOME}/.ssh/known_hosts". Force HOME into the test
+  # sandbox before running it so it can never touch the real "~/.ssh/known_hosts".
+  export HOME="${BUILD_DIR}"
+  export VORTEX_SSH_PREFIX="TEST"
+  local file=${HOME}/.ssh/id_rsa
+
+  # Override the values that could be coming from the environment with defaults.
+  export VORTEX_SSH_REMOVE_ALL_KEYS="0"
+  # Both pinning and the disable flag are set; pinning must take precedence.
+  export VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING="1"
+  export VORTEX_SSH_KNOWN_HOSTS="example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY"
+
+  declare -a STEPS=(
+    "@ssh-add -l # ${file}"
+    "SSH agent already has ${file} key loaded."
+    "pinning takes precedence"
+    "Pinning SSH host keys to known_hosts."
+    "- Disabling strict host key checking."
+  )
+  mocks="$(run_steps "setup")"
+
+  run .vortex/tooling/src/setup-ssh
+  assert_success
+  run_steps "assert" "${mocks[@]}"
+
+  popd >/dev/null
+}
+
 @test "Loading SSH key to SSH Agent, Key exists, Remove existing keys => success" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 


### PR DESCRIPTION
Closes #2548

## Summary

The `setup-ssh` script previously offered only one way to handle SSH host identity on CI runners: set `VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING=1` to write a global `StrictHostKeyChecking no` block, which disables MITM protection on every database-download and deployment SSH connection. This PR adds a secure alternative: `VORTEX_SSH_KNOWN_HOSTS`. When set to one or more `known_hosts` entries, the script writes those entries to `~/.ssh/known_hosts` and leaves strict checking enabled, so a mismatched key aborts the connection rather than silently proceeding. Pinning takes precedence over the disable flag when both are set, and it also clears any stale insecure directives a previous disable-run left in `~/.ssh/config` so the pins are actually enforced on reused runners.

Note: this PR deliberately does not flip the CI default away from `VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING`. Changing the default would break consumer deploys that have not yet supplied pinned host keys, because the template cannot universally know every hosting provider's SSH host keys. The secure path is now fully documented; whether to eventually change the default is left as a separate maintainer decision.

## Changes

**`setup-ssh` mechanism**
- Added `VORTEX_SSH_KNOWN_HOSTS` variable (newline-separated `known_hosts` entries).
- When set, entries are written to `~/.ssh/known_hosts` with `printf '%b\n'` to expand `\n` separators, permissions set to `600`, and strict checking is left enabled.
- When pinning, any stale `StrictHostKeyChecking no` / `UserKnownHostsFile /dev/null` lines left in `~/.ssh/config` by an earlier disable-run are stripped, so a reused runner cannot silently bypass the pins.
- When both `VORTEX_SSH_KNOWN_HOSTS` and `VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING=1` are set, pinning wins and a runtime note is emitted.
- The original disable path (`Host * / StrictHostKeyChecking no / UserKnownHostsFile /dev/null`) is unchanged.

**BATS tests (`tooling/tests/unit/setup-ssh.bats`)**
- Added test: pin-only path writes the entry to `known_hosts` and does not run the disable block.
- Added test: pin-takes-precedence path confirms the note fires and `known_hosts` is written when both flags are set.
- Added test: pinning over a pre-seeded insecure config strips the `StrictHostKeyChecking no` / `UserKnownHostsFile /dev/null` directives.
- All three tests redirect `HOME` into the test sandbox before running the script to prevent any write to the real `~/.ssh/known_hosts`.
- Full suite is 14/14 green.

**CI setup docs (`circleci.mdx`, `github-actions.mdx`)**
- New "Pin SSH host keys" section in each guide explains the security rationale, how to obtain a host key via `ssh-keyscan`, how to verify it against the provider's published fingerprint, and where to set `VORTEX_SSH_KNOWN_HOSTS` (CircleCI: env var with `\n`-joined entries; GitHub Actions: repository variable mapped into the workflow `env` block).
- Both sections include a note that host keys are public (safe for plain config) and that a provider key rotation will fail the connection until the pinned entry is refreshed.

## Before / After

```
BEFORE (single opt-out path)
─────────────────────────────────────────────────────
setup-ssh
 └─ VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING=1?
     ├─ yes → ~/.ssh/config: Host * / StrictHostKeyChecking no
     │         (MITM protection removed on all SSH connections)
     └─ no  → (nothing - strict checking applies but no known_hosts)


AFTER (pin first, disable as fallback)
─────────────────────────────────────────────────────
setup-ssh
 └─ VORTEX_SSH_KNOWN_HOSTS set?
     ├─ yes → strip stale insecure directives from ~/.ssh/config
     │         write entries to ~/.ssh/known_hosts (chmod 600)
     │         strict checking stays ON
     │         (if disable flag also set: emit note, still pin)
     └─ no  → VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING=1?
               ├─ yes → ~/.ssh/config: Host * / StrictHostKeyChecking no
               │         (opt-out, unchanged behavior)
               └─ no  → (nothing)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for pinning SSH host keys in CI, enabling strict host key verification (pins take precedence over the opt-out).

* **Documentation**
  * Added guides for configuring pinned host keys in CircleCI and GitHub Actions, including how to obtain/verify keys and note on breakage if providers rotate keys.

* **Tests**
  * Added unit tests covering pinning behavior, precedence, and cleanup of prior insecure SSH configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
