### PR TITLE
[#2557] Included 'scripts' directory in PHPCS and PHPStan analysis paths.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/phpcs.xml
@@ -7,6 +7,7 @@
     <file>web/sites/default/settings.php</file>
     <file>web/sites/default/includes</file>
     <file>tests</file>
+    <file>scripts</file>
 
     <rule ref="Drupal"/>
     <rule ref="DrupalPractice"/>

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/phpstan.neon
@@ -19,6 +19,7 @@ parameters:
     - web/sites/default/settings.php
     - web/sites/default/includes
     - tests
+    - scripts
 
   excludePaths:
     - vendor/*

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/phpcs.xml
@@ -11,9 +11,9 @@
 +    <file>docroot/sites/default/settings.php</file>
 +    <file>docroot/sites/default/includes</file>
      <file>tests</file>
+     <file>scripts</file>
  
-     <rule ref="Drupal"/>
-@@ -30,10 +30,10 @@
+@@ -31,10 +31,10 @@
      <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/phpstan.neon
@@ -11,9 +11,9 @@
 +    - docroot/sites/default/settings.php
 +    - docroot/sites/default/includes
      - tests
+     - scripts
  
-   excludePaths:
-@@ -34,12 +34,12 @@
+@@ -35,12 +35,12 @@
        # parameters or return values in iterable type arrays.
        message: '#.*no value type specified in iterable type array#'
        paths:
@@ -29,7 +29,7 @@
        reportUnmatched: false
      - # Since tests and data providers do not have to have parameter docblocks,
        # it is not possible to specify the type of the parameter, so we ignore
-@@ -46,7 +46,7 @@
+@@ -47,7 +47,7 @@
        # this error.
        message: '#.*no value type specified in iterable type array.#'
        paths:

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/phpcs.xml
@@ -11,9 +11,9 @@
 +    <file>docroot/sites/default/settings.php</file>
 +    <file>docroot/sites/default/includes</file>
      <file>tests</file>
+     <file>scripts</file>
  
-     <rule ref="Drupal"/>
-@@ -30,10 +30,10 @@
+@@ -31,10 +31,10 @@
      <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/phpstan.neon
@@ -11,9 +11,9 @@
 +    - docroot/sites/default/settings.php
 +    - docroot/sites/default/includes
      - tests
+     - scripts
  
-   excludePaths:
-@@ -34,12 +34,12 @@
+@@ -35,12 +35,12 @@
        # parameters or return values in iterable type arrays.
        message: '#.*no value type specified in iterable type array#'
        paths:
@@ -29,7 +29,7 @@
        reportUnmatched: false
      - # Since tests and data providers do not have to have parameter docblocks,
        # it is not possible to specify the type of the parameter, so we ignore
-@@ -46,7 +46,7 @@
+@@ -47,7 +47,7 @@
        # this error.
        message: '#.*no value type specified in iterable type array.#'
        paths:

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/phpcs.xml
@@ -6,7 +6,7 @@
      <file>web/sites/default/settings.php</file>
      <file>web/sites/default/includes</file>
      <file>tests</file>
-@@ -30,10 +29,6 @@
+@@ -31,10 +30,6 @@
      <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/phpstan.neon
@@ -6,7 +6,7 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -35,7 +34,6 @@
+@@ -36,7 +35,6 @@
        message: '#.*no value type specified in iterable type array#'
        paths:
          - web/modules/custom/*
@@ -14,7 +14,7 @@
      - # Included settings files are not aware about global variables.
        message: '#Variable .* might not be defined.#'
        paths:
-@@ -47,6 +45,5 @@
+@@ -48,6 +46,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/phpcs.xml
@@ -6,7 +6,7 @@
      <file>web/sites/default/settings.php</file>
      <file>web/sites/default/includes</file>
      <file>tests</file>
-@@ -30,10 +29,6 @@
+@@ -31,10 +30,6 @@
      <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/phpstan.neon
@@ -6,7 +6,7 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -35,7 +34,6 @@
+@@ -36,7 +35,6 @@
        message: '#.*no value type specified in iterable type array#'
        paths:
          - web/modules/custom/*
@@ -14,7 +14,7 @@
      - # Included settings files are not aware about global variables.
        message: '#Variable .* might not be defined.#'
        paths:
-@@ -47,6 +45,5 @@
+@@ -48,6 +46,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/phpcs.xml
@@ -6,7 +6,7 @@
      <file>web/sites/default/settings.php</file>
      <file>web/sites/default/includes</file>
      <file>tests</file>
-@@ -30,10 +29,6 @@
+@@ -31,10 +30,6 @@
      <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/phpstan.neon
@@ -6,7 +6,7 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -35,7 +34,6 @@
+@@ -36,7 +35,6 @@
        message: '#.*no value type specified in iterable type array#'
        paths:
          - web/modules/custom/*
@@ -14,7 +14,7 @@
      - # Included settings files are not aware about global variables.
        message: '#Variable .* might not be defined.#'
        paths:
-@@ -47,6 +45,5 @@
+@@ -48,6 +46,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/phpcs.xml
@@ -1,4 +1,4 @@
-@@ -58,8 +58,4 @@
+@@ -59,8 +59,4 @@
          <exclude-pattern>*.test</exclude-pattern>
      </rule>
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/phpstan.neon
@@ -1,4 +1,4 @@
-@@ -48,5 +48,4 @@
+@@ -49,5 +49,4 @@
        paths:
          - web/modules/custom/*/tests/*
          - web/themes/custom/*/tests/*

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/phpcs.xml
@@ -1,4 +1,4 @@
-@@ -58,8 +58,4 @@
+@@ -59,8 +59,4 @@
          <exclude-pattern>*.test</exclude-pattern>
      </rule>
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/phpstan.neon
@@ -1,4 +1,4 @@
-@@ -48,5 +48,4 @@
+@@ -49,5 +49,4 @@
        paths:
          - web/modules/custom/*/tests/*
          - web/themes/custom/*/tests/*

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/phpcs.xml
@@ -6,7 +6,7 @@
      <file>web/sites/default/settings.php</file>
      <file>web/sites/default/includes</file>
      <file>tests</file>
-@@ -30,10 +29,6 @@
+@@ -31,10 +30,6 @@
      <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/phpstan.neon
@@ -6,7 +6,7 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -35,7 +34,6 @@
+@@ -36,7 +35,6 @@
        message: '#.*no value type specified in iterable type array#'
        paths:
          - web/modules/custom/*
@@ -14,7 +14,7 @@
      - # Included settings files are not aware about global variables.
        message: '#Variable .* might not be defined.#'
        paths:
-@@ -47,6 +45,5 @@
+@@ -48,6 +46,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/phpcs.xml
@@ -6,7 +6,7 @@
      <file>web/sites/default/settings.php</file>
      <file>web/sites/default/includes</file>
      <file>tests</file>
-@@ -30,10 +29,6 @@
+@@ -31,10 +30,6 @@
      <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/phpstan.neon
@@ -6,7 +6,7 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -35,7 +34,6 @@
+@@ -36,7 +35,6 @@
        message: '#.*no value type specified in iterable type array#'
        paths:
          - web/modules/custom/*
@@ -14,7 +14,7 @@
      - # Included settings files are not aware about global variables.
        message: '#Variable .* might not be defined.#'
        paths:
-@@ -47,6 +45,5 @@
+@@ -48,6 +46,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/phpcs.xml
@@ -1,4 +1,4 @@
-@@ -58,8 +58,4 @@
+@@ -59,8 +59,4 @@
          <exclude-pattern>*.test</exclude-pattern>
      </rule>
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/phpcs.xml
@@ -1,4 +1,4 @@
-@@ -58,8 +58,4 @@
+@@ -59,8 +59,4 @@
          <exclude-pattern>*.test</exclude-pattern>
      </rule>
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/phpcs.xml
@@ -6,7 +6,7 @@
      <file>web/sites/default/settings.php</file>
      <file>web/sites/default/includes</file>
      <file>tests</file>
-@@ -30,10 +29,6 @@
+@@ -31,10 +30,6 @@
      <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/phpstan.neon
@@ -6,7 +6,7 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -35,7 +34,6 @@
+@@ -36,7 +35,6 @@
        message: '#.*no value type specified in iterable type array#'
        paths:
          - web/modules/custom/*
@@ -14,7 +14,7 @@
      - # Included settings files are not aware about global variables.
        message: '#Variable .* might not be defined.#'
        paths:
-@@ -47,6 +45,5 @@
+@@ -48,6 +46,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/phpstan.neon
@@ -1,4 +1,4 @@
-@@ -48,5 +48,4 @@
+@@ -49,5 +49,4 @@
        paths:
          - web/modules/custom/*/tests/*
          - web/themes/custom/*/tests/*

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/phpstan.neon
@@ -1,4 +1,4 @@
-@@ -48,5 +48,4 @@
+@@ -49,5 +49,4 @@
        paths:
          - web/modules/custom/*/tests/*
          - web/themes/custom/*/tests/*

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/phpcs.xml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/phpcs.xml
@@ -6,7 +6,7 @@
      <file>web/sites/default/settings.php</file>
      <file>web/sites/default/includes</file>
      <file>tests</file>
-@@ -30,10 +29,6 @@
+@@ -31,10 +30,6 @@
      <config name="testVersion" value="8.4"/>
  
      <!-- Exclude theme assets. -->

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/phpstan.neon
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/phpstan.neon
@@ -6,7 +6,7 @@
      - web/sites/default/settings.php
      - web/sites/default/includes
      - tests
-@@ -35,7 +34,6 @@
+@@ -36,7 +35,6 @@
        message: '#.*no value type specified in iterable type array#'
        paths:
          - web/modules/custom/*
@@ -14,7 +14,7 @@
      - # Included settings files are not aware about global variables.
        message: '#Variable .* might not be defined.#'
        paths:
-@@ -47,6 +45,5 @@
+@@ -48,6 +46,5 @@
        message: '#.*no value type specified in iterable type array.#'
        paths:
          - web/modules/custom/*/tests/*

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,6 +7,7 @@
     <file>web/sites/default/settings.php</file>
     <file>web/sites/default/includes</file>
     <file>tests</file>
+    <file>scripts</file>
 
     <rule ref="Drupal"/>
     <rule ref="DrupalPractice"/>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,6 +19,7 @@ parameters:
     - web/sites/default/settings.php
     - web/sites/default/includes
     - tests
+    - scripts
 
   excludePaths:
     - vendor/*


### PR DESCRIPTION
Closes #2557

## Summary

Added `scripts` to the analyzed paths in both `phpcs.xml` and `phpstan.neon`. The issue originally cited `scripts/composer/ScriptHandler.php` as an unanalyzed file, but that file was removed by #2545 (already merged), so `find scripts -name '*.php'` now returns nothing. This change is therefore a forward-looking safety net: any PHP added to `scripts/` later will be automatically covered by PHPCS and PHPStan without requiring a separate config update. It is a no-op for the current analysis - PHPCS filters by extension (shell scripts in `scripts/` are skipped) and PHPStan tolerates a path that contains no PHP files when other paths still yield files.

## Changes

- **`phpcs.xml`**: added `<file>scripts</file>` to the analyzed `<file>` list.
- **`phpstan.neon`**: added `- scripts` to the `paths` list.
- **`.vortex/installer/tests/Fixtures/handler_process/**`**: regenerated ~28 `phpcs.xml`/`phpstan.neon` fixture files and the `_baseline` entries so generated consumer projects carry the same `scripts/` path going forward.

## Before / After

```
BEFORE                              AFTER
─────────────────────────────────── ────────────────────────────────────
phpcs.xml paths:                    phpcs.xml paths:
  web/modules/custom/                 web/modules/custom/
  web/themes/custom/                  web/themes/custom/
  web/sites/default/settings.php      web/sites/default/settings.php
  web/sites/default/includes          web/sites/default/includes
  tests                               tests
                                      scripts   ← added

phpstan.neon paths:                 phpstan.neon paths:
  web/modules/custom/                 web/modules/custom/
  web/themes/custom/                  web/themes/custom/
  web/sites/default/settings.php      web/sites/default/settings.php
  web/sites/default/includes          web/sites/default/includes
  tests                               tests
                                      scripts   ← added
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended code analysis tooling configuration to include the scripts directory in automated code quality and static analysis scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->