### PR TITLE
[#2563] Added GitHub Actions security analysis with Zizmor.

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -95,6 +95,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Fix Git ownership permissions
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -364,6 +366,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Fix Git ownership permissions
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -530,12 +534,14 @@ jobs:
       - name: Test with Behat
         run: |
           # shellcheck disable=SC2170
-          if [ ${{ strategy.job-total }} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${{ strategy.job-index }}}"; fi
+          if [ ${STRATEGY_JOB_TOTAL} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
           echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
           docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
             docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
         env:
           VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
+          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
+          STRATEGY_JOB_INDEX: ${{ strategy.job-index }}
         continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
         timeout-minutes: 30
       #;> TOOL_BEHAT

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -70,6 +70,9 @@ defaults:
 env:
   DOCKER_CONFIG: /tmp/.docker
 
+permissions:
+  contents: read # Minimal default for all jobs; jobs that need more override below.
+
 jobs:
 
   lint:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -537,7 +537,7 @@ jobs:
       - name: Test with Behat
         run: |
           # shellcheck disable=SC2170
-          if [ ${STRATEGY_JOB_TOTAL} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
+          if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
           echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
           docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
             docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"

--- a/.github/workflows/close-pull-request.yml
+++ b/.github/workflows/close-pull-request.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   remove_lagoon_environment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Remove environment after a PR is closed
         run: |

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Load environment variables from .env
         run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"

--- a/.github/workflows/label-merge-conflict.yml
+++ b/.github/workflows/label-merge-conflict.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Check if PRs have conflicts
         uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0

--- a/.github/workflows/test-vr.yml
+++ b/.github/workflows/test-vr.yml
@@ -211,7 +211,7 @@ jobs:
         if: steps.gate.outputs.skipped != 'true'
         run: |
           set -euo pipefail
-          diff_id="${{ steps.compare.outputs.diff_id }}"
+          diff_id="${STEPS_COMPARE_OUTPUTS_DIFF_ID}"
           start=$(date +%s)
           attempt=0
 
@@ -234,13 +234,15 @@ jobs:
             echo "[poll #${attempt} | ${elapsed}s] Comparison in progress, sleeping ${DIFFY_POLL_INTERVAL}s..."
             sleep "${DIFFY_POLL_INTERVAL}"
           done
+        env:
+          STEPS_COMPARE_OUTPUTS_DIFF_ID: ${{ steps.compare.outputs.diff_id }}
 
       - name: Fetch comparison result
         id: result
         if: steps.gate.outputs.skipped != 'true'
         run: |
           set -euo pipefail
-          diff_id="${{ steps.compare.outputs.diff_id }}"
+          diff_id="${STEPS_COMPARE_OUTPUTS_DIFF_ID}"
 
           changes_percent="$(/tmp/diffy.phar diff:get-changes-percent "${diff_id}")"
           result_json="$(/tmp/diffy.phar diff:get-result "${diff_id}" --format=json)"
@@ -258,6 +260,8 @@ jobs:
 
           echo "Diff summary: ${pages_changed} of ${pages_total} pages changed (${changes_percent}% total)."
           echo "Report URL: ${shared_url}"
+        env:
+          STEPS_COMPARE_OUTPUTS_DIFF_ID: ${{ steps.compare.outputs.diff_id }}
 
   vr-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-vr.yml
+++ b/.github/workflows/test-vr.yml
@@ -53,6 +53,9 @@ jobs:
 
   vr-compare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Read repository contents.
+      pull-requests: read # 'gh pr view' reads PR labels and head branch.
     outputs:
       diff_id: ${{ steps.compare.outputs.diff_id }}
       pr_number: ${{ steps.resolve_pr.outputs.pr_number }}
@@ -86,12 +89,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.resolve_pr.outputs.pr_number }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
           # Manual workflow_dispatch always proceeds - the operator
           # explicitly asked for a comparison.
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             echo "Manual dispatch, proceeding."
             echo "skipped=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -105,7 +110,7 @@ jobs:
           fi
 
           # PR resolved - fetch labels and head branch in one call.
-          pr_data="$(gh pr view "${PR_NUMBER}" --repo "${{ github.repository }}" --json labels,headRefName)"
+          pr_data="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels,headRefName)"
           head_ref="$(printf '%s' "${pr_data}" | jq -r '.headRefName')"
           labels_lower="$(printf '%s' "${pr_data}" | jq -r '.labels[].name' | tr '[:upper:]' '[:lower:]')"
 

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -22,15 +22,22 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read # Default least-privilege baseline; jobs widen as needed.
+
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # Renovate creates branches and pushes commits.
+      pull-requests: write # Renovate opens and updates dependency PRs.
 
     steps:
       - name: Check requirements
         id: check-requirements
         run: |
-          if [ -z "${{ secrets.RENOVATE_TOKEN }}" ]; then
+          if [ -z "${RENOVATE_TOKEN}" ]; then
             echo "Renovate token is not set. Skipping job."
             exit 0
           fi
@@ -42,6 +49,7 @@ jobs:
 
           echo "should_run=true" >> "$GITHUB_OUTPUT"
         env:
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
           VARS_RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR }}
 
       - name: Checkout

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -35,15 +35,19 @@ jobs:
             exit 0
           fi
 
-          if [ -z "${{ vars.RENOVATE_GIT_AUTHOR }}" ]; then
+          if [ -z "${VARS_RENOVATE_GIT_AUTHOR}" ]; then
             echo "Renovate git author is not set. Skipping job."
             exit 0
           fi
 
           echo "should_run=true" >> "$GITHUB_OUTPUT"
+        env:
+          VARS_RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR }}
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/vortex-publish-tooling.yml
+++ b/.github/workflows/vortex-publish-tooling.yml
@@ -21,6 +21,9 @@ concurrency:
   group: vortex-publish-tooling-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   vortex-publish-tooling:
     runs-on: ubuntu-latest

--- a/.github/workflows/vortex-release.yml
+++ b/.github/workflows/vortex-release.yml
@@ -15,11 +15,6 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: pages
   cancel-in-progress: true
@@ -28,6 +23,9 @@ jobs:
 
   vortex-release-installer:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # Checkout the repository; only builds and uploads the PHAR artifact.
 
     outputs:
       release-version: ${{ steps.version.outputs.value }}
@@ -59,8 +57,10 @@ jobs:
           if [ -n "${INPUTS_VERSION}" ]; then
             version="${INPUTS_VERSION}"
           else
-            TAG=${{ github.ref_type == 'tag' && github.ref_name || '' }}
-            SHA=${{ github.ref_type == 'branch' && github.sha || '' }}
+            TAG=""
+            SHA=""
+            if [ "${REF_TYPE}" = "tag" ]; then TAG="${REF_NAME}"; fi
+            if [ "${REF_TYPE}" = "branch" ]; then SHA="${REF_SHA}"; fi
             version="${TAG:-${SHA}}"
           fi
           echo "RELEASE_VERSION=$version" >> "$GITHUB_ENV"
@@ -69,6 +69,9 @@ jobs:
         working-directory: .vortex/installer
         env:
           INPUTS_VERSION: ${{ inputs.version }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_SHA: ${{ github.sha }}
 
       - name: Build PHAR
         run: |
@@ -91,6 +94,11 @@ jobs:
 
   vortex-release-docs:
     needs: vortex-release-installer
+
+    permissions:
+      contents: read # Checkout the repository and build the documentation site.
+      pages: write # Deploy the built site via 'actions/deploy-pages'.
+      id-token: write # OIDC token required by 'actions/deploy-pages' to publish to GitHub Pages.
 
     environment:
       name: github-pages

--- a/.github/workflows/vortex-release.yml
+++ b/.github/workflows/vortex-release.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Set release version
         id: version
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            version="${{ inputs.version }}"
+          if [ -n "${INPUTS_VERSION}" ]; then
+            version="${INPUTS_VERSION}"
           else
             TAG=${{ github.ref_type == 'tag' && github.ref_name || '' }}
             SHA=${{ github.ref_type == 'branch' && github.sha || '' }}
@@ -67,6 +67,8 @@ jobs:
           echo "value=$version" >> "$GITHUB_OUTPUT"
           echo "Release version: $version"
         working-directory: .vortex/installer
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: Build PHAR
         run: |
@@ -104,12 +106,15 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set version
         run: |
-          version="${{ needs.vortex-release-installer.outputs.release-version }}"
+          version="${NEEDS_VORTEX_RELEASE_INSTALLER_OUTPUTS_RELEASE_VERSION}"
           echo "RELEASE_VERSION=$version" >> "$GITHUB_ENV"
           echo "Release version: $version"
+        env:
+          NEEDS_VORTEX_RELEASE_INSTALLER_OUTPUTS_RELEASE_VERSION: ${{ needs.vortex-release-installer.outputs.release-version }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/vortex-test-common.yml
+++ b/.github/workflows/vortex-test-common.yml
@@ -23,6 +23,9 @@ jobs:
   vortex-test-common:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read # Read repository contents; coverage is uploaded to external Codecov.
+
     container:
       image: drevops/ci-runner:26.6.0@sha256:190027056cac7b7ce28c29a1e5494779ebadc4ee8e95d468b75bc56e7be5aabd
       env:
@@ -122,6 +125,9 @@ jobs:
 
   vortex-test-workflow:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # Read repository contents; coverage is uploaded to external Codecov.
 
     strategy:
       fail-fast: false
@@ -230,6 +236,11 @@ jobs:
   vortex-test-actions:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read # Read workflows for the GitHub Actions linters.
+      security-events: write # Upload zizmor SARIF results to code scanning.
+      actions: read # Required by code scanning SARIF upload on private repositories.
+
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -252,3 +263,9 @@ jobs:
       - name: Check coding standards with actionlint
         run: docker run --rm -v "${GITHUB_WORKSPACE:-.}":/app --workdir /app rhysd/actionlint:1.7.10 -ignore 'SC2002:' -ignore 'SC2155:' -ignore 'SC2015:' -ignore 'SC2046:' -ignore 'SC1090:'
         continue-on-error: ${{ vars.VORTEX_CI_ACTIONLINT_IGNORE_FAILURE == '1' }}
+
+      - name: Check GitHub Actions security with Zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          config: .vortex/tests/zizmor.yml
+        continue-on-error: ${{ vars.VORTEX_CI_ZIZMOR_IGNORE_FAILURE == '1' }}

--- a/.github/workflows/vortex-test-common.yml
+++ b/.github/workflows/vortex-test-common.yml
@@ -233,6 +233,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Install Vortex tooling
         run: ./scripts/vortex-tooling.sh

--- a/.github/workflows/vortex-test-docs.yml
+++ b/.github/workflows/vortex-test-docs.yml
@@ -19,19 +19,21 @@ jobs:
       # on the triggering PR, so we need to do it manually.
       - name: Set pending commit status
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }} \
+          gh api repos/${{ github.repository }}/statuses/${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA} \
             -f state=pending \
             -f context="Vortex - Test docs" \
             -f description="Running documentation tests..." \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -120,10 +122,11 @@ jobs:
         run: |
           state=${{ job.status == 'success' && 'success' || 'failure' }}
           description=${{ job.status == 'success' && '"Documentation tests passed"' || '"Documentation tests failed"' }}
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }} \
+          gh api repos/${{ github.repository }}/statuses/${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA} \
             -f state="${state}" \
             -f context="Vortex - Test docs" \
             -f description="${description}" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/vortex-test-docs.yml
+++ b/.github/workflows/vortex-test-docs.yml
@@ -23,11 +23,11 @@ jobs:
       # on the triggering PR, so we need to do it manually.
       - name: Set pending commit status
         run: |
-          gh api repos/${{ github.repository }}/statuses/${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA} \
+          gh api repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA} \
             -f state=pending \
             -f context="Vortex - Test docs" \
             -f description="Running documentation tests..." \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -126,11 +126,11 @@ jobs:
         run: |
           state=${{ job.status == 'success' && 'success' || 'failure' }}
           description=${{ job.status == 'success' && '"Documentation tests passed"' || '"Documentation tests failed"' }}
-          gh api repos/${{ github.repository }}/statuses/${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA} \
+          gh api repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA} \
             -f state="${state}" \
             -f context="Vortex - Test docs" \
             -f description="${description}" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/vortex-test-docs.yml
+++ b/.github/workflows/vortex-test-docs.yml
@@ -15,6 +15,7 @@ jobs:
 
     permissions:
       contents: read # Checkout the repository at the triggering commit.
+      actions: read # Download the installer artifact from the test-installer workflow run.
       statuses: write # Post pending/final commit statuses via 'gh api repos/.../statuses/...'.
 
     steps:

--- a/.github/workflows/vortex-test-docs.yml
+++ b/.github/workflows/vortex-test-docs.yml
@@ -13,6 +13,10 @@ jobs:
     # Only run if installer workflow succeeded
     if: github.event.workflow_run.conclusion == 'success'
 
+    permissions:
+      contents: read # Checkout the repository at the triggering commit.
+      statuses: write # Post pending/final commit statuses via 'gh api repos/.../statuses/...'.
+
     steps:
       # Post pending status to the PR commit.
       # Workflows triggered by workflow_run don't automatically report status

--- a/.github/workflows/vortex-test-docs.yml
+++ b/.github/workflows/vortex-test-docs.yml
@@ -23,7 +23,7 @@ jobs:
       # on the triggering PR, so we need to do it manually.
       - name: Set pending commit status
         run: |
-          gh api repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA} \
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA}" \
             -f state=pending \
             -f context="Vortex - Test docs" \
             -f description="Running documentation tests..." \
@@ -126,7 +126,7 @@ jobs:
         run: |
           state=${{ job.status == 'success' && 'success' || 'failure' }}
           description=${{ job.status == 'success' && '"Documentation tests passed"' || '"Documentation tests failed"' }}
-          gh api repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA} \
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA}" \
             -f state="${state}" \
             -f context="Vortex - Test docs" \
             -f description="${description}" \

--- a/.github/workflows/vortex-test-installer.yml
+++ b/.github/workflows/vortex-test-installer.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2

--- a/.github/workflows/vortex-test-installer.yml
+++ b/.github/workflows/vortex-test-installer.yml
@@ -23,6 +23,9 @@ jobs:
   vortex-test-installer:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read # Checkout the repository; no GITHUB_TOKEN writes are performed.
+
     env:
       GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
       COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.TEST_GITHUB_TOKEN }}"}}'

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -65,6 +65,9 @@ defaults:
 env:
   DOCKER_CONFIG: /tmp/.docker
 
+permissions:
+  contents: read # Minimal default for all jobs; jobs that need more override below.
+
 jobs:
 
   lint:
@@ -88,6 +91,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@__HASH__ # __VERSION__
+        with:
+          persist-credentials: false
 
       - name: Fix Git ownership permissions
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -325,6 +330,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@__HASH__ # __VERSION__
+        with:
+          persist-credentials: false
 
       - name: Fix Git ownership permissions
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -463,12 +470,14 @@ jobs:
       - name: Test with Behat
         run: |
           # shellcheck disable=SC2170
-          if [ ${{ strategy.job-total }} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${{ strategy.job-index }}}"; fi
+          if [ ${STRATEGY_JOB_TOTAL} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
           echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
           docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
             docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
         env:
           VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
+          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
+          STRATEGY_JOB_INDEX: ${{ strategy.job-index }}
         continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
         timeout-minutes: 30
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -470,7 +470,7 @@ jobs:
       - name: Test with Behat
         run: |
           # shellcheck disable=SC2170
-          if [ ${STRATEGY_JOB_TOTAL} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
+          if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
           echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
           docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
             docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/draft-release-notes.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/draft-release-notes.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@__HASH__ # __VERSION__
+        with:
+          persist-credentials: false
 
       - name: Load environment variables from .env
         run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/label-merge-conflict.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/label-merge-conflict.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Check if PRs have conflicts
         uses: eps1lon/actions-label-merge-conflict@__HASH__ # __VERSION__

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -450,6 +450,17 @@
+@@ -457,6 +457,17 @@
              </details>
            hide_and_recreate: true
  

--- a/.vortex/installer/tests/Fixtures/handler_process/db_download_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/db_download_source_acquia/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -259,6 +259,9 @@
+@@ -264,6 +264,9 @@
            VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -522,100 +522,3 @@
+@@ -531,100 +531,3 @@
          timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
          with:
            detached: true

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.github/workflows/update-dependencies.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.github/workflows/update-dependencies.yml
@@ -22,28 +22,40 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read # Default least-privilege baseline; jobs widen as needed.
+
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # Renovate creates branches and pushes commits.
+      pull-requests: write # Renovate opens and updates dependency PRs.
 
     steps:
       - name: Check requirements
         id: check-requirements
         run: |
-          if [ -z "${{ secrets.RENOVATE_TOKEN }}" ]; then
+          if [ -z "${RENOVATE_TOKEN}" ]; then
             echo "Renovate token is not set. Skipping job."
             exit 0
           fi
 
-          if [ -z "${{ vars.RENOVATE_GIT_AUTHOR }}" ]; then
+          if [ -z "${VARS_RENOVATE_GIT_AUTHOR}" ]; then
             echo "Renovate git author is not set. Skipping job."
             exit 0
           fi
 
           echo "should_run=true" >> "$GITHUB_OUTPUT"
+        env:
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+          VARS_RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR }}
 
       - name: Checkout
         uses: actions/checkout@__HASH__ # __VERSION__
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@__HASH__ # __VERSION__
         with:

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_gha/.github/workflows/update-dependencies.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_gha/.github/workflows/update-dependencies.yml
@@ -22,28 +22,40 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read # Default least-privilege baseline; jobs widen as needed.
+
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # Renovate creates branches and pushes commits.
+      pull-requests: write # Renovate opens and updates dependency PRs.
 
     steps:
       - name: Check requirements
         id: check-requirements
         run: |
-          if [ -z "${{ secrets.RENOVATE_TOKEN }}" ]; then
+          if [ -z "${RENOVATE_TOKEN}" ]; then
             echo "Renovate token is not set. Skipping job."
             exit 0
           fi
 
-          if [ -z "${{ vars.RENOVATE_GIT_AUTHOR }}" ]; then
+          if [ -z "${VARS_RENOVATE_GIT_AUTHOR}" ]; then
             echo "Renovate git author is not set. Skipping job."
             exit 0
           fi
 
           echo "should_run=true" >> "$GITHUB_OUTPUT"
+        env:
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+          VARS_RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR }}
 
       - name: Checkout
         uses: actions/checkout@__HASH__ # __VERSION__
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@__HASH__ # __VERSION__
         with:

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_none/.github/workflows/update-dependencies.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_none/.github/workflows/update-dependencies.yml
@@ -22,28 +22,40 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read # Default least-privilege baseline; jobs widen as needed.
+
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # Renovate creates branches and pushes commits.
+      pull-requests: write # Renovate opens and updates dependency PRs.
 
     steps:
       - name: Check requirements
         id: check-requirements
         run: |
-          if [ -z "${{ secrets.RENOVATE_TOKEN }}" ]; then
+          if [ -z "${RENOVATE_TOKEN}" ]; then
             echo "Renovate token is not set. Skipping job."
             exit 0
           fi
 
-          if [ -z "${{ vars.RENOVATE_GIT_AUTHOR }}" ]; then
+          if [ -z "${VARS_RENOVATE_GIT_AUTHOR}" ]; then
             echo "Renovate git author is not set. Skipping job."
             exit 0
           fi
 
           echo "should_run=true" >> "$GITHUB_OUTPUT"
+        env:
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+          VARS_RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR }}
 
       - name: Checkout
         uses: actions/checkout@__HASH__ # __VERSION__
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@__HASH__ # __VERSION__
         with:

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -259,6 +259,9 @@
+@@ -264,6 +264,9 @@
            VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_lagoon/.github/workflows/close-pull-request.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_lagoon/.github/workflows/close-pull-request.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   remove_lagoon_environment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Remove environment after a PR is closed
         run: |

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -259,6 +259,9 @@
+@@ -264,6 +264,9 @@
            VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___lagoon/.github/workflows/close-pull-request.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___lagoon/.github/workflows/close-pull-request.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   remove_lagoon_environment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Remove environment after a PR is closed
         run: |

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_lagoon/.github/workflows/close-pull-request.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_lagoon/.github/workflows/close-pull-request.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   remove_lagoon_environment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Remove environment after a PR is closed
         run: |

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -260,6 +260,9 @@
+@@ -265,6 +265,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -391,6 +394,10 @@
+@@ -398,6 +401,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -260,6 +260,9 @@
+@@ -265,6 +265,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -391,6 +394,10 @@
+@@ -398,6 +401,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -260,6 +260,9 @@
+@@ -265,6 +265,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -391,6 +394,10 @@
+@@ -398,6 +401,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -260,6 +260,9 @@
+@@ -265,6 +265,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -391,6 +394,10 @@
+@@ -398,6 +401,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -260,6 +260,9 @@
+@@ -265,6 +265,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -391,6 +394,10 @@
+@@ -398,6 +401,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -260,6 +260,9 @@
+@@ -265,6 +265,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -391,6 +394,10 @@
+@@ -398,6 +401,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -260,6 +260,9 @@
+@@ -265,6 +265,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -391,6 +394,10 @@
+@@ -398,6 +401,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -260,6 +260,9 @@
+@@ -265,6 +265,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -391,6 +394,10 @@
+@@ -398,6 +401,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/close-pull-request.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/close-pull-request.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   remove_lagoon_environment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Remove environment after a PR is closed
         run: |

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_database_lagoon/.github/workflows/close-pull-request.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_database_lagoon/.github/workflows/close-pull-request.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   remove_lagoon_environment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Remove environment after a PR is closed
         run: |

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -7,7 +7,7 @@
  
  defaults:
    run:
-@@ -69,7 +67,6 @@
+@@ -72,7 +70,6 @@
  
    lint:
      runs-on: ubuntu-latest
@@ -15,7 +15,7 @@
  
      container:
        # https://hub.docker.com/r/drevops/ci-runner
-@@ -174,117 +171,8 @@
+@@ -179,117 +176,8 @@
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  
@@ -133,7 +133,7 @@
  
      permissions:
        contents: read # Check out the repository.
-@@ -310,14 +198,6 @@
+@@ -315,14 +203,6 @@
          VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"
          VORTEX_SSH_REMOVE_ALL_KEYS: "1"
          VORTEX_DEBUG: ${{ vars.VORTEX_DEBUG }}
@@ -148,7 +148,7 @@
  
      steps:
        - name: Preserve $HOME set in the container
-@@ -342,29 +222,6 @@
+@@ -349,29 +229,6 @@
        - name: Install Vortex tooling
          run: ./scripts/vortex-tooling.sh
  
@@ -178,7 +178,7 @@
        - name: Login to container registry
          run: ./vendor/drevops/vortex-tooling/src/login-container-registry
  
-@@ -526,7 +383,6 @@
+@@ -535,7 +392,6 @@
    deploy:
      runs-on: ubuntu-latest
      needs: [build, lint]

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -169,11 +169,6 @@
+@@ -174,11 +174,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -169,11 +169,6 @@
+@@ -174,11 +174,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -169,11 +169,6 @@
+@@ -174,11 +174,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -141,22 +141,6 @@
+@@ -146,22 +146,6 @@
          run: docker compose exec -T cli composer normalize --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_NORMALIZE_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -161,10 +161,6 @@
+@@ -166,10 +166,6 @@
          run: docker compose exec -T cli vendor/bin/twig-cs-fixer
          continue-on-error: ${{ vars.VORTEX_CI_TWIG_CS_FIXER_IGNORE_FAILURE == '1' }}
  
@@ -9,7 +9,7 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -400,78 +396,6 @@
+@@ -407,80 +403,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -76,19 +76,21 @@
 -      - name: Test with Behat
 -        run: |
 -          # shellcheck disable=SC2170
--          if [ ${{ strategy.job-total }} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${{ strategy.job-index }}}"; fi
+-          if [ ${STRATEGY_JOB_TOTAL} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
 -          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
 -          docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
 -            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
 -        env:
 -          VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
+-          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
+-          STRATEGY_JOB_INDEX: ${{ strategy.job-index }}
 -        continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
 -        timeout-minutes: 30
 -
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -488,16 +412,6 @@
+@@ -497,16 +419,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -76,7 +76,7 @@
 -      - name: Test with Behat
 -        run: |
 -          # shellcheck disable=SC2170
--          if [ ${STRATEGY_JOB_TOTAL} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
+-          if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
 -          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
 -          docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
 -            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -131,7 +131,6 @@
+@@ -136,7 +136,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -165,10 +164,6 @@
+@@ -170,10 +169,6 @@
          run: docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features
          continue-on-error: ${{ vars.VORTEX_CI_GHERKIN_LINT_IGNORE_FAILURE == '1' }}
  
@@ -17,7 +17,7 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -384,7 +379,6 @@
+@@ -391,7 +386,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -25,7 +25,7 @@
  
        - name: Provision site
          run: |
-@@ -394,11 +388,6 @@
+@@ -401,11 +395,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -131,7 +131,6 @@
+@@ -136,7 +136,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -165,15 +164,6 @@
+@@ -170,15 +169,6 @@
          run: docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features
          continue-on-error: ${{ vars.VORTEX_CI_GHERKIN_LINT_IGNORE_FAILURE == '1' }}
  
@@ -22,7 +22,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -384,7 +374,6 @@
+@@ -391,7 +381,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -30,7 +30,7 @@
  
        - name: Provision site
          run: |
-@@ -394,11 +383,6 @@
+@@ -401,11 +390,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -17,7 +17,7 @@
 -      - name: Test with Behat
 -        run: |
 -          # shellcheck disable=SC2170
--          if [ ${STRATEGY_JOB_TOTAL} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
+-          if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
 -          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
 -          docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
 -            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -161,10 +161,6 @@
+@@ -166,10 +166,6 @@
          run: docker compose exec -T cli vendor/bin/twig-cs-fixer
          continue-on-error: ${{ vars.VORTEX_CI_TWIG_CS_FIXER_IGNORE_FAILURE == '1' }}
  
@@ -9,7 +9,7 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -459,18 +455,6 @@
+@@ -466,20 +462,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
@@ -17,12 +17,14 @@
 -      - name: Test with Behat
 -        run: |
 -          # shellcheck disable=SC2170
--          if [ ${{ strategy.job-total }} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${{ strategy.job-index }}}"; fi
+-          if [ ${STRATEGY_JOB_TOTAL} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
 -          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
 -          docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
 -            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
 -        env:
 -          VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
+-          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
+-          STRATEGY_JOB_INDEX: ${{ strategy.job-index }}
 -        continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
 -        timeout-minutes: 30
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -131,7 +131,6 @@
+@@ -136,7 +136,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -164,10 +163,6 @@
+@@ -169,10 +168,6 @@
        - name: Lint code with Gherkin Lint
          run: docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features
          continue-on-error: ${{ vars.VORTEX_CI_GHERKIN_LINT_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -131,7 +131,6 @@
+@@ -136,7 +136,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -164,15 +163,6 @@
+@@ -169,15 +168,6 @@
        - name: Lint code with Gherkin Lint
          run: docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features
          continue-on-error: ${{ vars.VORTEX_CI_GHERKIN_LINT_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -384,7 +384,6 @@
+@@ -391,7 +391,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Provision site
          run: |
-@@ -394,11 +393,6 @@
+@@ -401,11 +400,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -141,10 +141,6 @@
+@@ -146,10 +146,6 @@
          run: docker compose exec -T cli composer normalize --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_NORMALIZE_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpmd/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -153,10 +153,6 @@
+@@ -158,10 +158,6 @@
          run: docker compose exec -T cli vendor/bin/rector --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_RECTOR_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -145,10 +145,6 @@
+@@ -150,10 +150,6 @@
          run: docker compose exec -T cli vendor/bin/phpcs
          continue-on-error: ${{ vars.VORTEX_CI_PHPCS_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -400,66 +400,6 @@
+@@ -407,66 +407,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -65,7 +65,7 @@
        - name: Test with Behat
          run: |
            # shellcheck disable=SC2170
-@@ -488,16 +428,6 @@
+@@ -497,16 +437,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -149,10 +149,6 @@
+@@ -154,10 +154,6 @@
          run: docker compose exec -T cli vendor/bin/phpstan
          continue-on-error: ${{ vars.VORTEX_CI_PHPSTAN_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -169,11 +169,6 @@
+@@ -174,11 +174,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -121,7 +121,7 @@
 -      - name: Test with Behat
 -        run: |
 -          # shellcheck disable=SC2170
--          if [ ${STRATEGY_JOB_TOTAL} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
+-          if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
 -          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
 -          docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
 -            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -131,7 +131,6 @@
+@@ -136,7 +136,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -141,34 +140,10 @@
+@@ -146,34 +145,10 @@
          run: docker compose exec -T cli composer normalize --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_NORMALIZE_IGNORE_FAILURE == '1' }}
  
@@ -41,7 +41,7 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -384,7 +359,6 @@
+@@ -391,7 +366,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -49,7 +49,7 @@
  
        - name: Provision site
          run: |
-@@ -395,83 +369,6 @@
+@@ -402,85 +376,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30
  
@@ -121,19 +121,21 @@
 -      - name: Test with Behat
 -        run: |
 -          # shellcheck disable=SC2170
--          if [ ${{ strategy.job-total }} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${{ strategy.job-index }}}"; fi
+-          if [ ${STRATEGY_JOB_TOTAL} -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
 -          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
 -          docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
 -            docker compose exec -T cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
 -        env:
 -          VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
+-          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
+-          STRATEGY_JOB_INDEX: ${{ strategy.job-index }}
 -        continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
 -        timeout-minutes: 30
 -
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -488,16 +385,6 @@
+@@ -497,16 +392,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
@@ -53,6 +53,9 @@ jobs:
 
   vr-compare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Read repository contents.
+      pull-requests: read # 'gh pr view' reads PR labels and head branch.
     outputs:
       diff_id: ${{ steps.compare.outputs.diff_id }}
       pr_number: ${{ steps.resolve_pr.outputs.pr_number }}
@@ -86,12 +89,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.resolve_pr.outputs.pr_number }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
           # Manual workflow_dispatch always proceeds - the operator
           # explicitly asked for a comparison.
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             echo "Manual dispatch, proceeding."
             echo "skipped=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -105,7 +110,7 @@ jobs:
           fi
 
           # PR resolved - fetch labels and head branch in one call.
-          pr_data="$(gh pr view "${PR_NUMBER}" --repo "${{ github.repository }}" --json labels,headRefName)"
+          pr_data="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels,headRefName)"
           head_ref="$(printf '%s' "${pr_data}" | jq -r '.headRefName')"
           labels_lower="$(printf '%s' "${pr_data}" | jq -r '.labels[].name' | tr '[:upper:]' '[:lower:]')"
 
@@ -211,7 +216,7 @@ jobs:
         if: steps.gate.outputs.skipped != 'true'
         run: |
           set -euo pipefail
-          diff_id="${{ steps.compare.outputs.diff_id }}"
+          diff_id="${STEPS_COMPARE_OUTPUTS_DIFF_ID}"
           start=$(date +%s)
           attempt=0
 
@@ -234,13 +239,15 @@ jobs:
             echo "[poll #${attempt} | ${elapsed}s] Comparison in progress, sleeping ${DIFFY_POLL_INTERVAL}s..."
             sleep "${DIFFY_POLL_INTERVAL}"
           done
+        env:
+          STEPS_COMPARE_OUTPUTS_DIFF_ID: ${{ steps.compare.outputs.diff_id }}
 
       - name: Fetch comparison result
         id: result
         if: steps.gate.outputs.skipped != 'true'
         run: |
           set -euo pipefail
-          diff_id="${{ steps.compare.outputs.diff_id }}"
+          diff_id="${STEPS_COMPARE_OUTPUTS_DIFF_ID}"
 
           changes_percent="$(/tmp/diffy.phar diff:get-changes-percent "${diff_id}")"
           result_json="$(/tmp/diffy.phar diff:get-result "${diff_id}" --format=json)"
@@ -258,6 +265,8 @@ jobs:
 
           echo "Diff summary: ${pages_changed} of ${pages_total} pages changed (${changes_percent}% total)."
           echo "Report URL: ${shared_url}"
+        env:
+          STEPS_COMPARE_OUTPUTS_DIFF_ID: ${{ steps.compare.outputs.diff_id }}
 
   vr-report:
     runs-on: ubuntu-latest

--- a/.vortex/tests/zizmor.yml
+++ b/.vortex/tests/zizmor.yml
@@ -32,9 +32,10 @@ rules:
       - vortex-test-common.yml
       - vortex-test-installer.yml
   ref-version-mismatch:
-    # The actions are pinned by commit SHA, which is the security control. The
+    # Actions are pinned by commit SHA, which is the security control. The
     # trailing version comment is informational and managed by Renovate, which
-    # may lag the moving major tag; suppressed to avoid churn against Renovate.
-    ignore:
-      - build-test-deploy.yml
-      - test-vr.yml
+    # may lag the moving major tag. This is also an online audit that resolves
+    # inconsistently across runs, so it is disabled entirely to keep a stable
+    # baseline against Renovate. SHA pinning itself stays enforced by the
+    # 'unpinned-uses' audit.
+    disable: true

--- a/.vortex/tests/zizmor.yml
+++ b/.vortex/tests/zizmor.yml
@@ -1,0 +1,40 @@
+# Zizmor configuration for auditing the Vortex template's own GitHub Actions
+# workflows. Consumed by the 'vortex-test-actions' job in
+# '.github/workflows/vortex-test-common.yml' (a maintenance-only workflow that
+# is not shipped to scaffolded projects).
+#
+# Every entry below documents an intentional, accepted finding. Genuine issues
+# are fixed in the workflows themselves rather than ignored here.
+#
+# https://docs.zizmor.sh/configuration/
+rules:
+  dangerous-triggers:
+    # These triggers are required and do not execute attacker-supplied code:
+    # - assign-author: assigns the PR author via 'toshimaru/auto-author-assign';
+    #   needs a write token on fork PRs and never checks out PR code.
+    # - label-merge-conflict: labels PRs with merge-conflict status via
+    #   'eps1lon/actions-label-merge-conflict'; never checks out PR code.
+    # - vortex-test-docs: chained run after 'Vortex - Test installer'; the
+    #   'head_sha' interpolation has been moved into 'env:' to remove the
+    #   injection surface.
+    ignore:
+      - assign-author.yml
+      - label-merge-conflict.yml
+      - vortex-test-docs.yml
+  cache-poisoning:
+    # Low-confidence findings on trusted, maintenance-only workflows that run
+    # in the Vortex repository and are never shipped to consumer sites. The
+    # default 'actions/cache' and 'actions/setup-node' caching is keyed on lock
+    # files; the poisoning surface on these internal release/test jobs is
+    # accepted.
+    ignore:
+      - vortex-release.yml
+      - vortex-test-common.yml
+      - vortex-test-installer.yml
+  ref-version-mismatch:
+    # The actions are pinned by commit SHA, which is the security control. The
+    # trailing version comment is informational and managed by Renovate, which
+    # may lag the moving major tag; suppressed to avoid churn against Renovate.
+    ignore:
+      - build-test-deploy.yml
+      - test-vr.yml


### PR DESCRIPTION
Closes #2563

## Summary

Adds `zizmor` GitHub Actions static analysis to Vortex's own maintenance CI (`vortex-test-actions` job), uploading results as SARIF to GitHub code scanning. All workflows - both the template's own maintenance workflows and the consumer-project workflows shipped via the installer - have been hardened to least-privilege: explicit `permissions:` blocks on every job, `persist-credentials: false` on checkouts that do not write back, and `${{ ... }}` context expressions moved out of `run:` blocks into `env:` variables to eliminate template-injection surface. Consumer projects inherit the hardened workflows automatically through the installer.

## Changes

### Zizmor integration (template-only)
- New `Check GitHub Actions security with Zizmor` step in the `vortex-test-actions` job of `.github/workflows/vortex-test-common.yml`, placed after actionlint, using the official `zizmorcore/zizmor-action` (SHA-pinned at `5f14fd08f7cf1cb1609c1e344975f152c7ee938d` / v0.5.6) with SARIF upload to GitHub code scanning.
- Suppressions config at `.vortex/tests/zizmor.yml` documenting the few intentional, accepted findings with per-entry rationale.
- Not shipped to consumer projects (lives in the `vortex-test-actions` job and `.vortex/tests/`, both stripped on install).

### Workflow hardening (inherited by consumers)
- Top-level `permissions: contents: read` baseline added to `build-test-deploy.yml`, `update-dependencies.yml`, `vortex-publish-tooling.yml`, and `vortex-release.yml`; per-job overrides widen only where needed (e.g. `contents: write` + `pull-requests: write` for the Renovate job).
- Explicit per-job `permissions:` blocks added to every job that was missing them across all workflows. Where a job needs more than the read baseline it is granted narrowly - for example `statuses: write` and `actions: read` on `vortex-test-docs` so its `gh api` status updates and its cross-workflow `dawidd6/action-download-artifact` download keep working under the explicit block.
- `persist-credentials: false` added to every `actions/checkout` step that does not push or create commits.
- `${{ ... }}` interpolations moved out of `run:` blocks and into `env:` variables (or replaced with the equivalent built-in `GITHUB_*` env vars) across `build-test-deploy.yml`, `test-vr.yml`, `update-dependencies.yml`, `vortex-release.yml`, `vortex-test-docs.yml`, and `vortex-test-installer.yml`, with the resulting shell variables quoted to satisfy shellcheck.

### Documented suppressions
- `dangerous-triggers` on `pull_request_target` / `workflow_run` triggers that do not execute attacker-supplied code (`assign-author.yml`, `label-merge-conflict.yml`, `vortex-test-docs.yml`).
- `cache-poisoning` (low-confidence) on trusted, maintenance-only workflows never shipped to consumer sites (`vortex-release.yml`, `vortex-test-common.yml`, `vortex-test-installer.yml`).
- `ref-version-mismatch` disabled globally: it is an online audit that resolves inconsistently across runs and only flags Renovate-managed version comments on already SHA-pinned actions. SHA pinning itself stays enforced by the `unpinned-uses` audit.

### Fixtures
- Regenerated installer fixtures so generated consumer projects inherit all hardened workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced least-privilege permissions across CI workflows to reduce token scope.
  * Disabled credential persistence during repository checkout to improve workspace security.
  * Moved workflow script lookups to controlled environment variables for more reliable CI behavior.

* **Tests**
  * Added automated security scanning of CI configuration with documented, intentional exceptions for specific maintenance workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
