### PR TITLE
[#2595] Added path-based documentation versioning with v1/v2 CI aggregation.

### DIFF
--- a/.github/workflows/vortex-release.yml
+++ b/.github/workflows/vortex-release.yml
@@ -154,6 +154,19 @@ jobs:
         run: yarn install --frozen-lockfile
         working-directory: .vortex/docs
 
+      # Assemble the multi-version site for production: snapshot the released
+      # docs as v1 (served at the bare '/docs') and pull the 'project/2.x'
+      # docs in as v2 (at '/docs/v2'). Mirrors the same step in
+      # 'vortex-test-docs.yml' (development / Netlify).
+      - name: Assemble versioned docs
+        run: |
+          yarn docusaurus docs:version 1.x
+          git -C "${{ github.workspace }}" fetch origin project/2.x --depth=1 || { echo "Failed to fetch the project/2.x branch."; exit 1; }
+          git -C "${{ github.workspace }}" rev-parse --verify origin/project/2.x || { echo "The project/2.x branch does not exist."; exit 1; }
+          rm -rf content
+          git -C "${{ github.workspace }}" checkout origin/project/2.x -- .vortex/docs/content || { echo "Failed to check out content from project/2.x."; exit 1; }
+        working-directory: .vortex/docs
+
       - name: Build documentation site
         run: yarn run build
         working-directory: .vortex/docs

--- a/.github/workflows/vortex-test-docs.yml
+++ b/.github/workflows/vortex-test-docs.yml
@@ -87,6 +87,21 @@ jobs:
         run: yarn run spellcheck
         working-directory: '${{ github.workspace }}/.vortex/docs'
 
+      # On the main (development) deploy, assemble the multi-version site:
+      # snapshot main's docs as v1 (served at the bare '/docs') and pull the
+      # 'project/2.x' docs in as v2 (at '/docs/v2'). Skipped on PR/branch
+      # builds, which stay single-version previews. Mirrors the same step in
+      # 'vortex-release.yml' (production / GitHub Pages).
+      - name: Assemble versioned docs
+        if: github.event.workflow_run.head_branch == 'main'
+        run: |
+          yarn docusaurus docs:version 1.x
+          git -C "${{ github.workspace }}" fetch origin project/2.x --depth=1 || { echo "Failed to fetch the project/2.x branch."; exit 1; }
+          git -C "${{ github.workspace }}" rev-parse --verify origin/project/2.x || { echo "The project/2.x branch does not exist."; exit 1; }
+          rm -rf content
+          git -C "${{ github.workspace }}" checkout origin/project/2.x -- .vortex/docs/content || { echo "Failed to check out content from project/2.x."; exit 1; }
+        working-directory: '${{ github.workspace }}/.vortex/docs'
+
       - name: Build documentation site
         run: yarn run build
         working-directory: '${{ github.workspace }}/.vortex/docs'

--- a/.vortex/docs/.gitignore
+++ b/.vortex/docs/.gitignore
@@ -8,6 +8,13 @@
 .docusaurus
 .cache-loader
 
+# Assembled docs versions - created by the CI publish step (or a local
+# `docusaurus docs:version` to preview the multi-version site) and never
+# committed; the build auto-detects `versioned_docs/` to switch to multi-version.
+/versioned_docs
+/versioned_sidebars
+/versions.json
+
 # Test outputs
 .logs
 

--- a/.vortex/docs/content/contributing/code-of-conduct.mdx
+++ b/.vortex/docs/content/contributing/code-of-conduct.mdx
@@ -4,6 +4,6 @@ sidebar_position: 3
 hide_title: true
 ---
 
-import CodeOfConduct from '../../../../CODE_OF_CONDUCT.md'
+import CodeOfConduct from '@site/../../CODE_OF_CONDUCT.md'
 
 <CodeOfConduct />

--- a/.vortex/docs/content/drupal/composer-json.mdx
+++ b/.vortex/docs/content/drupal/composer-json.mdx
@@ -28,7 +28,7 @@ explaining its role and how it contributes to your project's setup and
 management.
 
 import CodeBlock from '@theme/CodeBlock';
-import ComposerJsonSource from '!!raw-loader!./../../../../composer.json';
+import ComposerJsonSource from '!!raw-loader!@site/../../composer.json';
 
 <details>
   <summary>Click here to see the contents of the `composer.json` file</summary>

--- a/.vortex/docs/content/drupal/settings.mdx
+++ b/.vortex/docs/content/drupal/settings.mdx
@@ -87,7 +87,7 @@ This allows for environment-specific configuration without cluttering the main
 `settings.php` file.<br/>
 Use the `$settings['environment']` variable to check the current _environment type_.
 
-import EnvironmentIndicatorModuleSettingsExample from '!!raw-loader!./../../../../web/sites/default/includes/modules/settings.environment_indicator.php';
+import EnvironmentIndicatorModuleSettingsExample from '!!raw-loader!@site/../../web/sites/default/includes/modules/settings.environment_indicator.php';
 
 <details>
   <summary>Example of the `Environment indicator` module `settings.environment_indicator.php` file</summary>
@@ -108,7 +108,7 @@ file is organized into the following sections:
 - [Local overrides](#local-overrides)
 
 import CodeBlock from '@theme/CodeBlock';
-import SettingsExample from '!!raw-loader!./../../../../web/sites/default/settings.php';
+import SettingsExample from '!!raw-loader!@site/../../web/sites/default/settings.php';
 
 <details>
   <summary>Click here to see the contents of the `settings.php` file</summary>
@@ -309,7 +309,7 @@ in an environment where it would otherwise be enabled. This is useful for
 temporary access during debugging or when an environment does not require
 protection.
 
-import ShieldModuleSettingsExample from '!!raw-loader!./../../../../web/sites/default/includes/modules/settings.shield.php';
+import ShieldModuleSettingsExample from '!!raw-loader!@site/../../web/sites/default/includes/modules/settings.shield.php';
 
 <details>
   <summary>Example of the `Shield` module `settings.shield.php` file</summary>
@@ -351,7 +351,7 @@ that do not match the standard environment types listed above.
 Set `DRUPAL_REROUTE_EMAIL_DISABLED` to any non-empty value to completely disable
 email rerouting in an environment where it would otherwise be enabled.
 
-import RerouteEmailModuleSettingsExample from '!!raw-loader!./../../../../web/sites/default/includes/modules/settings.reroute_email.php';
+import RerouteEmailModuleSettingsExample from '!!raw-loader!@site/../../web/sites/default/includes/modules/settings.reroute_email.php';
 
 <details>
   <summary>Example of the `Reroute Email` module `settings.reroute_email.php` file</summary>
@@ -369,7 +369,7 @@ copy `example.settings.local.php` and `example.services.local.yml`
 to `settings.local.php` and `services.local.yml`, respectively, to utilize this
 functionality.
 
-import LocalSettingsExample from '!!raw-loader!./../../../../web/sites/default/example.settings.local.php';
+import LocalSettingsExample from '!!raw-loader!@site/../../web/sites/default/example.settings.local.php';
 
 <details>
   <summary>Click here to see the contents of the `example.settings.local.php` file</summary>
@@ -378,7 +378,7 @@ import LocalSettingsExample from '!!raw-loader!./../../../../web/sites/default/e
 
 </details>
 
-import LocalServicesExample from '!!raw-loader!./../../../../web/sites/default/example.services.local.yml';
+import LocalServicesExample from '!!raw-loader!@site/../../web/sites/default/example.services.local.yml';
 
 <details>
   <summary>Click here to see the contents of the `example.services.local.yml` file</summary>

--- a/.vortex/docs/docusaurus.config.js
+++ b/.vortex/docs/docusaurus.config.js
@@ -4,7 +4,19 @@
 // There are various equivalent ways to declare your Docusaurus config.
 // @see https://docusaurus.io/docs/api/docusaurus-config
 
+import fs from 'node:fs';
+
 import {themes as prismThemes} from 'prism-react-renderer';
+
+// Multi-version mode turns on automatically when a 'versioned_docs/' snapshot
+// is present: 'versioned_docs/version-1.x' is v1 (the default, served at the
+// bare '/docs') and the current 'content/' is v2 (served at '/docs/v2'). With
+// no snapshot - local development, per-branch preview builds, and the
+// 'docusaurus docs:version' run that creates the snapshot - the site builds
+// 'content/' as a single unversioned set, so the config never references a
+// version that does not exist yet. The publish jobs assemble the snapshot in
+// CI; it is never committed to a branch.
+const versioned = fs.existsSync('versioned_docs');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -46,6 +58,25 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl: 'https://github.com/drevops/vortex/tree/main/.vortex/docs/',
+          // In versioned (aggregate) builds, v1 is the snapshot in
+          // 'versioned_docs/' served at the bare '/docs' (the default), and
+          // the current 'content/' is v2 at '/docs/v2'. To flip the default
+          // when 2.x is ready: set `lastVersion: 'current'`, give '1.x' a
+          // `path: 'v1'`, drop the v2 `path` so 'current' serves at the bare
+          // '/docs', and swap the '/docs/v1' redirect below for '/docs/v2'.
+          ...(versioned ? {
+            lastVersion: '1.x',
+            versions: {
+              '1.x': {
+                label: 'v1',
+              },
+              current: {
+                label: 'v2',
+                path: 'v2',
+                banner: 'unreleased',
+              },
+            },
+          } : {}),
         },
         blog: false,
         theme: {
@@ -125,6 +156,10 @@ const config = {
             position: 'right',
             title: 'Join us on Slack',
           },
+          ...(versioned ? [{
+            type: 'docsVersionDropdown',
+            position: 'right',
+          }] : []),
           {
             type: 'search',
             position: 'right',
@@ -198,6 +233,13 @@ const config = {
       '@docusaurus/plugin-client-redirects',
       {
         redirects: [
+          // In versioned builds, 'v1' is the default at the bare '/docs', so
+          // its explicit path redirects there. When the default flips to
+          // 'v2', change this to redirect '/docs/v2' instead.
+          ...(versioned ? [{
+            from: '/docs/v1',
+            to: '/docs',
+          }] : []),
           {
             from: ['/quickstart'],
             to: '/docs',


### PR DESCRIPTION
Closes #2595

## Summary

Added path-based documentation versioning to the Docusaurus site. Multi-version mode turns on automatically when a `versioned_docs/` snapshot is present: v1 (a snapshot of the building branch's docs) is served at the bare `/docs` as the default, and v2 (pulled from `project/2.x`) is served at `/docs/v2` with an `unreleased` banner and a navbar version dropdown. A `/docs/v1 -> /docs` redirect keeps the explicit v1 path valid. With no snapshot - local development, per-branch preview builds, and the `docusaurus docs:version` run that creates the snapshot - the site builds `content/` as a single unversioned set, so the config never references a version that does not exist yet.

Three `.mdx` files that import repo-root files were switched from depth-relative `../../../../` paths to the depth-independent `@site/../..` alias, so they still resolve when `content/` is relocated into `versioned_docs/` during the CI assembly step.

Both publish workflows gain a matching "Assemble versioned docs" step that snapshots the building branch's docs as `1.x`, then fetches and swaps in `project/2.x`'s content as the current (v2) version before building. `vortex-release.yml` (production / GitHub Pages) runs it unconditionally; `vortex-test-docs.yml` (development / Netlify) runs it only on `main`, so PR and feature-branch previews stay single-version. The step guards each git operation and verifies the branch exists before removing content, so a missing or failed `project/2.x` fetch can never publish an empty docs site. The assembled `versioned_docs/` is gitignored and never committed.

## Changes

**`.vortex/docs/docusaurus.config.js`** - The multi-version config (the `versions` block with v1 as `lastVersion` at the bare `/docs`, v2 at path `v2` with an `unreleased` banner, the `docsVersionDropdown` navbar item, and a `/docs/v1 -> /docs` client redirect) is gated on `fs.existsSync('versioned_docs')`, so it applies only when the snapshot exists and produces no output otherwise.

**`.vortex/docs/content/contributing/code-of-conduct.mdx`**, **`.vortex/docs/content/drupal/composer-json.mdx`**, **`.vortex/docs/content/drupal/settings.mdx`** - Replaced depth-relative imports (`../../../../`) with the `@site/../..` alias so they remain valid when the file is copied into `versioned_docs/version-1.x/` during CI assembly.

**`.github/workflows/vortex-release.yml`** and **`.github/workflows/vortex-test-docs.yml`** - Added a guarded "Assemble versioned docs" step before the build (`docusaurus docs:version 1.x`, then fetch + verify `origin/project/2.x` and swap its docs into `content/`). The release workflow runs it always; the test-docs workflow runs it only on `main`. The build then auto-detects the assembled snapshot - no environment flag.

**`.vortex/docs/.gitignore`** - Ignore `versioned_docs/`, `versioned_sidebars/`, and `versions.json` (assembled in CI for the published site, or locally to preview the multi-version build; never committed).

## Before / After

```
BEFORE (single-version, always)
───────────────────────────────
/docs            → current content (one version, no dropdown)

CI publish flow:
  yarn build
  → single-version GitHub Pages / Netlify site
```

```
AFTER (single-version on PRs/branches, multi-version on main/release)
──────────────────────────────────────────────────────────────────────
Local dev / PR preview  (no versioned_docs/ snapshot):
  /docs            → current content (unchanged, no dropdown)

main / release build  (snapshot assembled in CI, auto-detected):
  /docs            → versioned_docs/version-1.x  (v1, default)
  /docs/v2         → content/ from project/2.x   (v2, "unreleased" banner)
  /docs/v1         → redirect to /docs

CI publish flow (vortex-release.yml always; vortex-test-docs.yml on main):
  yarn docusaurus docs:version 1.x     # snapshot building-branch docs as v1
  git fetch origin project/2.x         # guarded fetch + branch verification
  rm -rf content && checkout 2.x docs  # swap in v2 content
  yarn build                           # auto-detects versioned_docs/ -> multi-version
  → versioned GitHub Pages / Netlify site with dropdown
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Multi-version docs: preserved v1 snapshot while serving v2 alongside, with version chooser and redirects for discoverability.
  * Fixed embedded examples and policy asset references so code samples and conduct docs render reliably.

* **Chores**
  * CI now assembles the versioned documentation site automatically and ignores generated version artifacts in the docs tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->