### PR TITLE
Added '*.x' version branch CI support behind VORTEX_DEV fences.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -649,7 +649,7 @@ workflows:
               # - release/2023-04-17, release/2023-04-17.123 (date-based)
               # - hotfix/123.456.789, hotfix/123.456.789-rc.1213 (per https://semver.org/)
               # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$|^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -18,6 +18,9 @@ on:
       - release/**
       - hotfix/**
       - project/**
+      #;< VORTEX_DEV
+      - '*.x'
+      #;> VORTEX_DEV
     # Pushes of tags will also trigger the workflow.
     tags:
       - '*'
@@ -37,6 +40,9 @@ on:
       - feature/**
       - bugfix/**
       - project/**
+      #;< VORTEX_DEV
+      - '*.x'
+      #;> VORTEX_DEV
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/vortex-release.yml
+++ b/.github/workflows/vortex-release.yml
@@ -155,16 +155,16 @@ jobs:
         working-directory: .vortex/docs
 
       # Assemble the multi-version site for production: snapshot the released
-      # docs as v1 (served at the bare '/docs') and pull the 'project/2.x'
+      # docs as v1 (served at the bare '/docs') and pull the '2.x'
       # docs in as v2 (at '/docs/v2'). Mirrors the same step in
       # 'vortex-test-docs.yml' (development / Netlify).
       - name: Assemble versioned docs
         run: |
           yarn docusaurus docs:version 1.x
-          git -C "${{ github.workspace }}" fetch origin project/2.x --depth=1 || { echo "Failed to fetch the project/2.x branch."; exit 1; }
-          git -C "${{ github.workspace }}" rev-parse --verify origin/project/2.x || { echo "The project/2.x branch does not exist."; exit 1; }
+          git -C "${{ github.workspace }}" fetch origin 2.x --depth=1 || { echo "Failed to fetch the 2.x branch."; exit 1; }
+          git -C "${{ github.workspace }}" rev-parse --verify origin/2.x || { echo "The 2.x branch does not exist."; exit 1; }
           rm -rf content
-          git -C "${{ github.workspace }}" checkout origin/project/2.x -- .vortex/docs/content || { echo "Failed to check out content from project/2.x."; exit 1; }
+          git -C "${{ github.workspace }}" checkout origin/2.x -- .vortex/docs/content || { echo "Failed to check out content from 2.x."; exit 1; }
         working-directory: .vortex/docs
 
       - name: Build documentation site

--- a/.github/workflows/vortex-test-common.yml
+++ b/.github/workflows/vortex-test-common.yml
@@ -7,6 +7,7 @@ on:
       - main
       - release/**
       - project/**
+      - '*.x'
   pull_request:
     branches:
       - main
@@ -14,6 +15,7 @@ on:
       - bugfix/**
       - release/**
       - project/**
+      - '*.x'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/vortex-test-docs.yml
+++ b/.github/workflows/vortex-test-docs.yml
@@ -89,17 +89,17 @@ jobs:
 
       # On the main (development) deploy, assemble the multi-version site:
       # snapshot main's docs as v1 (served at the bare '/docs') and pull the
-      # 'project/2.x' docs in as v2 (at '/docs/v2'). Skipped on PR/branch
+      # '2.x' docs in as v2 (at '/docs/v2'). Skipped on PR/branch
       # builds, which stay single-version previews. Mirrors the same step in
       # 'vortex-release.yml' (production / GitHub Pages).
       - name: Assemble versioned docs
         if: github.event.workflow_run.head_branch == 'main'
         run: |
           yarn docusaurus docs:version 1.x
-          git -C "${{ github.workspace }}" fetch origin project/2.x --depth=1 || { echo "Failed to fetch the project/2.x branch."; exit 1; }
-          git -C "${{ github.workspace }}" rev-parse --verify origin/project/2.x || { echo "The project/2.x branch does not exist."; exit 1; }
+          git -C "${{ github.workspace }}" fetch origin 2.x --depth=1 || { echo "Failed to fetch the 2.x branch."; exit 1; }
+          git -C "${{ github.workspace }}" rev-parse --verify origin/2.x || { echo "The 2.x branch does not exist."; exit 1; }
           rm -rf content
-          git -C "${{ github.workspace }}" checkout origin/project/2.x -- .vortex/docs/content || { echo "Failed to check out content from project/2.x."; exit 1; }
+          git -C "${{ github.workspace }}" checkout origin/2.x -- .vortex/docs/content || { echo "Failed to check out content from 2.x."; exit 1; }
         working-directory: '${{ github.workspace }}/.vortex/docs'
 
       - name: Build documentation site

--- a/.github/workflows/vortex-test-installer.yml
+++ b/.github/workflows/vortex-test-installer.yml
@@ -7,6 +7,7 @@ on:
       - main
       - release/**
       - project/**
+      - '*.x'
   pull_request:
     branches:
       - main
@@ -14,6 +15,7 @@ on:
       - bugfix/**
       - release/**
       - project/**
+      - '*.x'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.vortex/installer/src/Prompts/Handlers/Internal.php
+++ b/.vortex/installer/src/Prompts/Handlers/Internal.php
@@ -41,6 +41,11 @@ class Internal extends AbstractHandler {
     // Remove code required for Vortex maintenance.
     File::removeTokenAsync('VORTEX_DEV');
 
+    // The CircleCI deploy filter is a single-line regex, so the Vortex-only
+    // '*.x' branch deploy target cannot be wrapped in a line-based VORTEX_DEV
+    // fence. Strip the inline alternative here instead.
+    File::replaceContentAsync('|^[0-9]+\.x$', '');
+
     // Enable commented out code and process complex content transformations.
     File::replaceContentAsync(function (string $content, ContentFile $file) use ($t): string {
       // Remove all other comments.

--- a/tests/phpunit/CircleCiConfigTest.php
+++ b/tests/phpunit/CircleCiConfigTest.php
@@ -130,7 +130,6 @@ class CircleCiConfigTest extends TestCase {
     yield ['3.x'];
     yield ['10.x'];
     // #;> VORTEX_DEV.
-
     // Negative branches.
     yield ['something', FALSE];
     yield ['premain', FALSE];

--- a/tests/phpunit/CircleCiConfigTest.php
+++ b/tests/phpunit/CircleCiConfigTest.php
@@ -129,7 +129,7 @@ class CircleCiConfigTest extends TestCase {
     yield ['2.x'];
     yield ['3.x'];
     yield ['10.x'];
-    // phpcs:ignore #;> VORTEX_DEV
+    // #;> VORTEX_DEV.
 
     // Negative branches.
     yield ['something', FALSE];

--- a/tests/phpunit/CircleCiConfigTest.php
+++ b/tests/phpunit/CircleCiConfigTest.php
@@ -124,6 +124,13 @@ class CircleCiConfigTest extends TestCase {
     yield ['project/0.1.x-description'];
     yield ['project/0.1.2.x-description'];
 
+    // #;< VORTEX_DEV
+    // Vortex version-development branches.
+    yield ['2.x'];
+    yield ['3.x'];
+    yield ['10.x'];
+    // phpcs:ignore #;> VORTEX_DEV
+
     // Negative branches.
     yield ['something', FALSE];
     yield ['premain', FALSE];


### PR DESCRIPTION
## Summary

Vortex version development moved from a `project/2.x` branch to a bare `2.x` branch, so CI must build and test `*.x` branches. The `*.x` push and PR triggers are added to `build-test-deploy.yml` inside `VORTEX_DEV` fences so the installer strips them from consumer projects - consumer output is byte-identical to before. The Vortex-internal workflows (`vortex-test-common.yml`, `vortex-test-installer.yml`) receive the trigger unfenced since those files are deleted wholesale on install. CircleCI's deploy-job branch filter gains an `|^[0-9]+\.x$` inline alternative, which the installer's `Internal.php` strips via `File::replaceContentAsync` because the single-line regex cannot be wrapped in a block fence. The v2 docs aggregation in `vortex-release.yml` and `vortex-test-docs.yml` is updated from `project/2.x` to `2.x` to track the branch rename.

## Changes

**GitHub Actions - `build-test-deploy.yml`**
- Added `- '*.x'` to the `push.branches` and `pull_request.branches` trigger lists, wrapped in `#;< VORTEX_DEV` / `#;> VORTEX_DEV` fences so the installer removes them from consumer projects.

**GitHub Actions - Vortex-internal workflows**
- `vortex-test-common.yml` and `vortex-test-installer.yml`: added `- '*.x'` to both push and PR branch trigger lists (unfenced - these files are dropped by the installer).

**CircleCI - `.circleci/config.yml`**
- Extended the `deploy` job's `branches.only` filter regex with `|^[0-9]+\.x$` to allow `2.x`, `3.x`, etc.

**Installer - `Internal.php`**
- Added a `File::replaceContentAsync('|^[0-9]+\.x$', '')` call to strip the inline CircleCI alternative from consumer projects, maintaining byte-identical consumer output.

**Docs - `vortex-release.yml` and `vortex-test-docs.yml`**
- Updated the v2 docs-content checkout target from `project/2.x` to `2.x` in the "Assemble versioned docs" step.

**Tests - `CircleCiConfigTest.php`**
- Added `VORTEX_DEV`-fenced positive test cases for `2.x`, `3.x`, and `10.x` in the deploy-branch regex data provider.

## Before / After

```
BEFORE - Vortex repo push to '2.x':
  GitHub Actions build-test-deploy  →  not triggered (no *.x rule)
  CircleCI deploy job               →  not triggered (regex lacks *.x)
  Docs v2 aggregation               →  fetches 'project/2.x'

AFTER - Vortex repo push to '2.x':
  GitHub Actions build-test-deploy  →  triggered (*.x rule, VORTEX_DEV-fenced)
  CircleCI deploy job               →  triggered (regex now includes ^[0-9]+\.x$)
  Docs v2 aggregation               →  fetches '2.x'

Consumer project (after install):
  build-test-deploy.yml             →  *.x lines stripped by installer (unchanged)
  .circleci/config.yml              →  |^[0-9]+\.x$ stripped by Internal.php (unchanged)
  vortex-test-*.yml                 →  files deleted by installer (unchanged)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD and workflow triggers to accept numeric version branch patterns (e.g., "12.x") and broadened branch globs for builds, tests, and releases.
  * Adjusted documentation assembly steps to source from the updated versioned docs branch.
* **Tests**
  * Expanded CI-related tests to include additional versioned-branch cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->