### PR TITLE
[#2609] Removed deprecated 'sid_length' and 'sid_bits_per_character' from 'services.yml'.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/sites/default/services.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/sites/default/services.yml
@@ -43,23 +43,6 @@ parameters:
     # information.
     # @default no value
     cookie_samesite: Lax
-    #
-    # Set the session ID string length. The length can be between 22 to 256. The
-    # PHP recommended value is 48. See
-    # https://www.php.net/manual/session.security.ini.php for more information.
-    # This value should be kept in sync with
-    # \Drupal\Core\Session\SessionConfiguration::__construct()
-    # @default 48
-    sid_length: 48
-    #
-    # Set the number of bits in encoded session ID character. The possible
-    # values are '4' (0-9, a-f), '5' (0-9, a-v), and '6' (0-9, a-z, A-Z, "-",
-    # ","). The PHP recommended value is 6. See
-    # https://www.php.net/manual/session.security.ini.php for more information.
-    # This value should be kept in sync with
-    # \Drupal\Core\Session\SessionConfiguration::__construct()
-    # @default 6
-    sid_bits_per_character: 6
   twig.config:
     # Twig debugging:
     #

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/sites/default/services.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/sites/default/services.yml
@@ -43,23 +43,6 @@ parameters:
     # information.
     # @default no value
     cookie_samesite: Lax
-    #
-    # Set the session ID string length. The length can be between 22 to 256. The
-    # PHP recommended value is 48. See
-    # https://www.php.net/manual/session.security.ini.php for more information.
-    # This value should be kept in sync with
-    # \Drupal\Core\Session\SessionConfiguration::__construct()
-    # @default 48
-    sid_length: 48
-    #
-    # Set the number of bits in encoded session ID character. The possible
-    # values are '4' (0-9, a-f), '5' (0-9, a-v), and '6' (0-9, a-z, A-Z, "-",
-    # ","). The PHP recommended value is 6. See
-    # https://www.php.net/manual/session.security.ini.php for more information.
-    # This value should be kept in sync with
-    # \Drupal\Core\Session\SessionConfiguration::__construct()
-    # @default 6
-    sid_bits_per_character: 6
   twig.config:
     # Twig debugging:
     #

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/sites/default/services.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/sites/default/services.yml
@@ -43,23 +43,6 @@ parameters:
     # information.
     # @default no value
     cookie_samesite: Lax
-    #
-    # Set the session ID string length. The length can be between 22 to 256. The
-    # PHP recommended value is 48. See
-    # https://www.php.net/manual/session.security.ini.php for more information.
-    # This value should be kept in sync with
-    # \Drupal\Core\Session\SessionConfiguration::__construct()
-    # @default 48
-    sid_length: 48
-    #
-    # Set the number of bits in encoded session ID character. The possible
-    # values are '4' (0-9, a-f), '5' (0-9, a-v), and '6' (0-9, a-z, A-Z, "-",
-    # ","). The PHP recommended value is 6. See
-    # https://www.php.net/manual/session.security.ini.php for more information.
-    # This value should be kept in sync with
-    # \Drupal\Core\Session\SessionConfiguration::__construct()
-    # @default 6
-    sid_bits_per_character: 6
   twig.config:
     # Twig debugging:
     #

--- a/web/sites/default/services.yml
+++ b/web/sites/default/services.yml
@@ -43,23 +43,6 @@ parameters:
     # information.
     # @default no value
     cookie_samesite: Lax
-    #
-    # Set the session ID string length. The length can be between 22 to 256. The
-    # PHP recommended value is 48. See
-    # https://www.php.net/manual/session.security.ini.php for more information.
-    # This value should be kept in sync with
-    # \Drupal\Core\Session\SessionConfiguration::__construct()
-    # @default 48
-    sid_length: 48
-    #
-    # Set the number of bits in encoded session ID character. The possible
-    # values are '4' (0-9, a-f), '5' (0-9, a-v), and '6' (0-9, a-z, A-Z, "-",
-    # ","). The PHP recommended value is 6. See
-    # https://www.php.net/manual/session.security.ini.php for more information.
-    # This value should be kept in sync with
-    # \Drupal\Core\Session\SessionConfiguration::__construct()
-    # @default 6
-    sid_bits_per_character: 6
   twig.config:
     # Twig debugging:
     #


### PR DESCRIPTION
Closes #2609

## Summary

PHP 8.4 deprecated the `session.sid_length` and `session.sid_bits_per_character` INI settings, making them no-ops (see [Drupal change record 3469305](https://www.drupal.org/node/3469305)). The values Vortex carried (`48` and `6`) were already identical to the PHP defaults, so they were redundant even before 8.4. Drupal core's own scaffold `default.services.yml` has already dropped both settings, and since Vortex requires `php >=8.4`, removal is safe and realigns with upstream.

## Changes

- Removed `sid_length: 48` and `sid_bits_per_character: 6` along with their multi-line comment blocks from `web/sites/default/services.yml`.
- Regenerated the 3 affected installer fixtures via `ahoy update-snapshots`: `_baseline/web/sites/default/services.yml`, `hosting_acquia/docroot/sites/default/services.yml`, and `hosting_project_name___acquia/docroot/sites/default/services.yml`.

## Before / After

```
BEFORE
┌─────────────────────────────────────────────────────────────┐
│     cookie_samesite: Lax                                    │
│     #                                                       │
│     # Set the session ID string length. ...                 │
│     # @default 48                                           │
│     sid_length: 48                                          │
│     #                                                       │
│     # Set the number of bits in encoded session ID ...      │
│     # @default 6                                            │
│     sid_bits_per_character: 6                               │
│   twig.config:                                              │
└─────────────────────────────────────────────────────────────┘

AFTER
┌─────────────────────────────────────────────────────────────┐
│     cookie_samesite: Lax                                    │
│   twig.config:                                              │
└─────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified session storage configuration by removing session ID length and character encoding settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->