### PR TITLE
[#2611] Ignored 'guzzlehttp/psr7' advisories pulled transitively via 'drupal/core-recommended'.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
@@ -90,6 +90,10 @@
             "tbachert/spi": true
         },
         "audit": {
+            "ignore": {
+                "GHSA-34xg-wgjx-8xph": "guzzlehttp/psr7: transitive via drupal/core-recommended (__VERSION__). Ignore until an upstream core/psr7 release moves off the affected __VERSION__/__VERSION__.",
+                "GHSA-hq7v-mx3g-29hw": "guzzlehttp/psr7: transitive via drupal/core-recommended (__VERSION__). Ignore until an upstream core/psr7 release moves off the affected __VERSION__/__VERSION__."
+            },
             "abandoned": "report",
             "block-insecure": true
         },

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -119,38 +119,38 @@
+@@ -123,38 +123,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -119,38 +119,38 @@
+@@ -123,38 +123,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
@@ -38,8 +38,8 @@
 +            "wikimedia/composer-merge-plugin": true
          },
          "audit": {
-             "abandoned": "report",
-@@ -160,6 +167,19 @@
+             "ignore": {
+@@ -164,6 +171,19 @@
          "patchLevel": {
              "drupal/core": "-p2"
          },

--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,10 @@
             "tbachert/spi": true
         },
         "audit": {
+            "ignore": {
+                "GHSA-34xg-wgjx-8xph": "guzzlehttp/psr7: transitive via drupal/core-recommended (~2.8.0). Ignore until an upstream core/psr7 release moves off the affected 2.8.0/2.8.1.",
+                "GHSA-hq7v-mx3g-29hw": "guzzlehttp/psr7: transitive via drupal/core-recommended (~2.8.0). Ignore until an upstream core/psr7 release moves off the affected 2.8.0/2.8.1."
+            },
             "abandoned": "report",
             "block-insecure": true
         },


### PR DESCRIPTION
Removal tracked in #2611.

## Summary

Added a `config.audit.ignore` block to `composer.json` for two `guzzlehttp/psr7` security advisories (`GHSA-34xg-wgjx-8xph` and `GHSA-hq7v-mx3g-29hw`). These advisories target `guzzlehttp/psr7` `2.8.0`/`2.8.1`, which is pulled transitively by `drupal/core-recommended` (`~2.8.0`); no fixed release exists within that constraint yet. With `config.audit.block-insecure` enabled, the unresolvable advisories were blocking `composer audit` and automated dependency updates. Composer treats string-value ignore entries as `apply: all`, silencing both the audit report and the version-block.

## Changes

### Root `composer.json`

- Added `config.audit.ignore` with string-value entries for `GHSA-34xg-wgjx-8xph` and `GHSA-hq7v-mx3g-29hw`, each describing the transitive path and the condition for future removal.

### Installer snapshot fixtures (regenerated)

- `_baseline/composer.json` - baseline fixture gained the same `config.audit.ignore` block as the root file.
- `hosting_acquia/composer.json` and `hosting_project_name___acquia/composer.json` - unified-diff hunk headers re-based from line `119` to `123` to reflect the four new lines inserted earlier in the file.
- `starter_drupal_cms_profile/composer.json` - unified-diff hunk headers re-based from `160` to `164` and `167` to `171` for the same reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security audit configurations to address advisories related to project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->