### PR TITLE
[#2614] Fixed inline 'extra.patches' for 'drevops/vortex-tooling' failing in the bootstrap install.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
@@ -64,6 +64,10 @@ fi
 if [ -n "${patches}" ] || [ -n "${patches_file}" ]; then
   composer --working-dir=vendor-temp require --no-update cweagans/composer-patches:^2
   composer --working-dir=vendor-temp config allow-plugins.cweagans/composer-patches true
+  # Inline 'extra.patches' paths (and paths inside a 'patches-file') are
+  # relative to the project root. Copy the project 'patches/' directory into
+  # the throwaway project so those paths resolve from inside 'vendor-temp/'.
+  [ -d patches ] && cp -R patches vendor-temp/
 fi
 
 composer --working-dir=vendor-temp install --no-dev --no-interaction

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
@@ -67,7 +67,9 @@ if [ -n "${patches}" ] || [ -n "${patches_file}" ]; then
   # Inline 'extra.patches' paths (and paths inside a 'patches-file') are
   # relative to the project root. Copy the project 'patches/' directory into
   # the throwaway project so those paths resolve from inside 'vendor-temp/'.
-  [ -d patches ] && cp -R patches vendor-temp/
+  if [ -d patches ]; then
+    cp -R patches vendor-temp/
+  fi
 fi
 
 composer --working-dir=vendor-temp install --no-dev --no-interaction

--- a/scripts/vortex-tooling.sh
+++ b/scripts/vortex-tooling.sh
@@ -71,6 +71,10 @@ fi
 if [ -n "${patches}" ] || [ -n "${patches_file}" ]; then
   composer --working-dir=vendor-temp require --no-update cweagans/composer-patches:^2
   composer --working-dir=vendor-temp config allow-plugins.cweagans/composer-patches true
+  # Inline 'extra.patches' paths (and paths inside a 'patches-file') are
+  # relative to the project root. Copy the project 'patches/' directory into
+  # the throwaway project so those paths resolve from inside 'vendor-temp/'.
+  [ -d patches ] && cp -R patches vendor-temp/
 fi
 
 composer --working-dir=vendor-temp install --no-dev --no-interaction

--- a/scripts/vortex-tooling.sh
+++ b/scripts/vortex-tooling.sh
@@ -74,7 +74,9 @@ if [ -n "${patches}" ] || [ -n "${patches_file}" ]; then
   # Inline 'extra.patches' paths (and paths inside a 'patches-file') are
   # relative to the project root. Copy the project 'patches/' directory into
   # the throwaway project so those paths resolve from inside 'vendor-temp/'.
-  [ -d patches ] && cp -R patches vendor-temp/
+  if [ -d patches ]; then
+    cp -R patches vendor-temp/
+  fi
 fi
 
 composer --working-dir=vendor-temp install --no-dev --no-interaction


### PR DESCRIPTION
Closes #2614

## Summary

When consumers use `extra.patches` in `composer.json` to patch the `drevops/vortex-tooling` package itself, `cweagans/composer-patches` resolves patch file paths relative to the project root. The tooling bootstrap script performs a throwaway `composer install` inside `vendor-temp/`, but the project `patches/` directory was not present there, so relative paths like `patches/vortex-tooling.patch` could not be resolved and the install failed with "file could not be downloaded". This fix copies the project `patches/` directory into `vendor-temp/` before the install runs, so inline patch paths resolve correctly. Only consumers patching `drevops/vortex-tooling` itself were affected; patches targeting Drupal core or contributed modules were unaffected.

## Changes

**`scripts/vortex-tooling.sh`** - After enabling `cweagans/composer-patches` in the throwaway install, copy the project-root `patches/` directory into `vendor-temp/` (if it exists) so that relative patch paths declared in `extra.patches` or a `patches-file` resolve from inside the throwaway project directory.

**`.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh`** - Regenerated installer baseline fixture to mirror the updated root script (the baseline tracks the shipped script minus the dev-only path-repo block).

## Before / After

```
BEFORE
──────────────────────────────────────────────────────────────────
project root/
├── patches/
│   └── vortex-tooling.patch    ← patch file lives here
├── composer.json               ← extra.patches path: "patches/vortex-tooling.patch"
└── vendor-temp/                ← throwaway install (no patches/ dir)
    └── composer.json           ← resolves paths from vendor-temp/ → FAILS
                                   "file could not be downloaded: patches/vortex-tooling.patch"

AFTER
──────────────────────────────────────────────────────────────────
project root/
├── patches/
│   └── vortex-tooling.patch    ← patch file lives here
├── composer.json               ← extra.patches path: "patches/vortex-tooling.patch"
└── vendor-temp/
    ├── patches/                ← copied from project root before install
    │   └── vortex-tooling.patch
    └── composer.json           ← resolves paths from vendor-temp/patches/ → OK
```
