### PR TITLE
[#2613] Fixed 'download-db-acquia' to read backup URL from JSON response.

### DIFF
--- a/.vortex/tooling/src/download-db-acquia
+++ b/.vortex/tooling/src/download-db-acquia
@@ -255,13 +255,16 @@ else
     [ ! -d "${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR:-}" ] && note "Creating dump directory ${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR}" && mkdir -p "${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR}"
 
     task "Discovering backup URL."
-    # The Acquia API responds with a 302 redirect to the final S3 download URL.
-    # Capture the redirect URL without following it to avoid sending the
-    # Authorization header to S3 - the auth header is required only to query
-    # the Acquia API.
-    backup_url=$(curl -s -o /dev/null -w "%{redirect_url}" -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/environments/${env_id}/databases/${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}/backups/${backup_id}/actions/download")
+    # The Acquia API responds with a 200 and a JSON body containing the
+    # temporary, pre-signed S3 download URL under the "url" key. Fetch the
+    # body and extract that URL. The Authorization header is required only to
+    # query the Acquia API; the returned S3 URL is pre-signed and is fetched
+    # later without it.
+    backup_url_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/environments/${env_id}/databases/${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}/backups/${backup_id}/actions/download")
+    [ "${VORTEX_DEBUG-}" = "1" ] && note "Download action API response: ${backup_url_json}"
+    backup_url=$(echo "${backup_url_json}" | extract_json_value "url")
     [ "${VORTEX_DEBUG-}" = "1" ] && note "Extracted backup URL: ${backup_url}"
-    [ -z "${backup_url}" ] && fail "Unable to discover backup URL for backup ID '${backup_id}'." && exit 1
+    [ -z "${backup_url}" ] && fail "Unable to discover backup URL for backup ID '${backup_id}'. API response: ${backup_url_json}" && exit 1
 
     task "Downloading DB dump into file ${file_name_compressed}."
     curl --progress-bar -L "${backup_url}" -o "${file_name_compressed}"

--- a/.vortex/tooling/tests/unit/download-db-acquia.bats
+++ b/.vortex/tooling/tests/unit/download-db-acquia.bats
@@ -35,7 +35,7 @@ load ../_helper.bash
 
     # Mock backup URL curl call with its message
     "Discovering backup URL."
-    '@curl -s -o /dev/null -w %{redirect_url} -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # https://backup.example.com/db.sql.gz'
+    '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # {"url":"https://backup.example.com/db.sql.gz"}'
 
     # Mock file download curl call with its message and side effect to create zipped archive
     "Downloading DB dump into file .data/testdb_backup_backup-id-789.sql.gz."
@@ -224,7 +224,7 @@ load ../_helper.bash
 
     # Mock backup URL curl call with its message
     "Discovering backup URL."
-    '@curl -s -o /dev/null -w %{redirect_url} -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # https://backup.example.com/db.sql.gz'
+    '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # {"url":"https://backup.example.com/db.sql.gz"}'
 
     # Mock file download curl call with its message and side effect to create zipped archive
     "Downloading DB dump into file ./.data/testdb_backup_backup-id-789.sql.gz."
@@ -491,7 +491,7 @@ load ../_helper.bash
 
     # Rest of download steps...
     "[TASK] Discovering backup URL."
-    '@curl -s -o /dev/null -w %{redirect_url} -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-new-123/actions/download # https://backup.example.com/db-fresh.sql.gz'
+    '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-new-123/actions/download # {"url":"https://backup.example.com/db-fresh.sql.gz"}'
 
     "[TASK] Downloading DB dump into file .data/testdb_backup_backup-id-new-123.sql.gz."
     '@curl --progress-bar -L https://backup.example.com/db-fresh.sql.gz -o .data/testdb_backup_backup-id-new-123.sql.gz # 0 #  # echo "CREATE TABLE fresh (id INT);" | gzip > .data/testdb_backup_backup-id-new-123.sql.gz'
@@ -718,6 +718,61 @@ load ../_helper.bash
   run_steps "assert" "${mocks}"
 
   assert_failure
+
+  popd >/dev/null
+}
+
+@test "download-db-acquia: Backup URL discovery fails when response has no URL" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Clean up any existing test files first to force full download workflow
+  rm -rf .data
+  mkdir -p .data
+
+  declare -a STEPS=(
+    # Assert initial message
+    "[INFO] Started database dump download from Acquia."
+
+    # Mock authentication token curl call with its message
+    "Retrieving authentication token."
+    '@curl -s -L https://accounts.acquia.com/api/auth/oauth/token --data-urlencode client_id=test-key --data-urlencode client_secret=test-secret --data-urlencode grant_type=client_credentials # {"access_token":"test-token", "expires_in":3600}'
+
+    # Mock application UUID curl call with its message
+    "Retrieving testapp application UUID."
+    '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications?filter=name%3Dtestapp # {"_embedded":{"items":[{"uuid":"app-uuid-123","name":"testapp"}]}}'
+
+    # Mock environment ID curl call with its message
+    "Retrieving prod environment ID."
+    '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod # {"_embedded":{"items":[{"id":"env-id-456","name":"prod"}]}}'
+
+    # Mock backups curl call with its message
+    "Discovering latest backup ID for DB testdb."
+    '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups?sort=created # {"_embedded":{"items":[{"id":"backup-id-789","completed":"2024-01-01T00:00:00+00:00"}]}}'
+
+    # Mock backup URL curl call returning a JSON body without a usable URL
+    "Discovering backup URL."
+    '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # {"url":""}'
+
+    # Assert failure message includes the raw API response for diagnosis
+    "[FAIL] Unable to discover backup URL for backup ID 'backup-id-789'. API response: {\"url\":\"\"}"
+  )
+
+  export VORTEX_DOWNLOAD_DB_ACQUIA_KEY="test-key"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_SECRET="test-secret"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_APP_NAME="testapp"
+  export VORTEX_DOWNLOAD_DB_ENVIRONMENT="prod"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME="testdb"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR=".data"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_DB_FILE="db.sql"
+
+  mocks="$(run_steps "setup")"
+  run .vortex/tooling/src/download-db-acquia
+  run_steps "assert" "${mocks}"
+
+  assert_failure
+
+  # Clean up
+  rm -rf .data
 
   popd >/dev/null
 }

--- a/.vortex/tooling/tests/unit/download-db-acquia.bats
+++ b/.vortex/tooling/tests/unit/download-db-acquia.bats
@@ -776,3 +776,107 @@ load ../_helper.bash
 
   popd >/dev/null
 }
+
+@test "download-db-acquia: Backup URL discovery fails when response is missing the URL field" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Clean up any existing test files first to force full download workflow
+  rm -rf .data
+  mkdir -p .data
+
+  declare -a STEPS=(
+    # Assert initial message
+    "[INFO] Started database dump download from Acquia."
+
+    # Mock authentication token curl call with its message
+    "Retrieving authentication token."
+    '@curl -s -L https://accounts.acquia.com/api/auth/oauth/token --data-urlencode client_id=test-key --data-urlencode client_secret=test-secret --data-urlencode grant_type=client_credentials # {"access_token":"test-token", "expires_in":3600}'
+
+    # Mock application UUID curl call with its message
+    "Retrieving testapp application UUID."
+    '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications?filter=name%3Dtestapp # {"_embedded":{"items":[{"uuid":"app-uuid-123","name":"testapp"}]}}'
+
+    # Mock environment ID curl call with its message
+    "Retrieving prod environment ID."
+    '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod # {"_embedded":{"items":[{"id":"env-id-456","name":"prod"}]}}'
+
+    # Mock backups curl call with its message
+    "Discovering latest backup ID for DB testdb."
+    '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups?sort=created # {"_embedded":{"items":[{"id":"backup-id-789","completed":"2024-01-01T00:00:00+00:00"}]}}'
+
+    # Mock backup URL curl call returning a JSON error body without a url key
+    "Discovering backup URL."
+    '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # {"message":"Resource not found"}'
+  )
+
+  export VORTEX_DOWNLOAD_DB_ACQUIA_KEY="test-key"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_SECRET="test-secret"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_APP_NAME="testapp"
+  export VORTEX_DOWNLOAD_DB_ENVIRONMENT="prod"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME="testdb"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR=".data"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_DB_FILE="db.sql"
+
+  mocks="$(run_steps "setup")"
+  run .vortex/tooling/src/download-db-acquia
+  run_steps "assert" "${mocks}"
+
+  assert_failure
+
+  # Clean up
+  rm -rf .data
+
+  popd >/dev/null
+}
+
+@test "download-db-acquia: Backup URL discovery fails with malformed JSON response" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Clean up any existing test files first to force full download workflow
+  rm -rf .data
+  mkdir -p .data
+
+  declare -a STEPS=(
+    # Assert initial message
+    "[INFO] Started database dump download from Acquia."
+
+    # Mock authentication token curl call with its message
+    "Retrieving authentication token."
+    '@curl -s -L https://accounts.acquia.com/api/auth/oauth/token --data-urlencode client_id=test-key --data-urlencode client_secret=test-secret --data-urlencode grant_type=client_credentials # {"access_token":"test-token", "expires_in":3600}'
+
+    # Mock application UUID curl call with its message
+    "Retrieving testapp application UUID."
+    '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications?filter=name%3Dtestapp # {"_embedded":{"items":[{"uuid":"app-uuid-123","name":"testapp"}]}}'
+
+    # Mock environment ID curl call with its message
+    "Retrieving prod environment ID."
+    '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod # {"_embedded":{"items":[{"id":"env-id-456","name":"prod"}]}}'
+
+    # Mock backups curl call with its message
+    "Discovering latest backup ID for DB testdb."
+    '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups?sort=created # {"_embedded":{"items":[{"id":"backup-id-789","completed":"2024-01-01T00:00:00+00:00"}]}}'
+
+    # Mock backup URL curl call returning a non-JSON body
+    "Discovering backup URL."
+    '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # Internal Server Error'
+  )
+
+  export VORTEX_DOWNLOAD_DB_ACQUIA_KEY="test-key"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_SECRET="test-secret"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_APP_NAME="testapp"
+  export VORTEX_DOWNLOAD_DB_ENVIRONMENT="prod"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME="testdb"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR=".data"
+  export VORTEX_DOWNLOAD_DB_ACQUIA_DB_FILE="db.sql"
+
+  mocks="$(run_steps "setup")"
+  run .vortex/tooling/src/download-db-acquia
+  run_steps "assert" "${mocks}"
+
+  assert_failure
+
+  # Clean up
+  rm -rf .data
+
+  popd >/dev/null
+}


### PR DESCRIPTION
Closes #2613

## Summary

The `download-db-acquia` tooling script was using `curl`'s `%{redirect_url}` to capture the Acquia Cloud API backup download URL, expecting a 3xx redirect. The Acquia Cloud API v2 endpoint `backups/{id}/actions/download` already returns `200 OK` with a JSON body containing a pre-signed S3 URL under the `url` key when the `Accept: application/json, version=2` header is present. As a result, `%{redirect_url}` was always empty, and `ahoy download-db` always failed with "Unable to discover backup URL" for every Acquia consumer. The fix reads the JSON response body and extracts the `url` value via the existing `extract_json_value` helper, and includes the raw API response in the failure message to aid diagnosis.

## Changes

**Script fix (`.vortex/tooling/src/download-db-acquia`)**
- Replaced the `-o /dev/null -w "%{redirect_url}"` `curl` flags with `-L` and direct body capture into `backup_url_json`.
- Extracted the download URL from the JSON body using `extract_json_value "url"` instead of relying on a redirect.
- Added the raw API response (`backup_url_json`) to the failure message so operators can diagnose unexpected responses.
- Added a `VORTEX_DEBUG` trace line that prints the full API response before extraction.

**Test updates (`.vortex/tooling/tests/unit/download-db-acquia.bats`)**
- Updated 3 existing happy-path mock entries to return `{"url":"https://..."}` JSON bodies instead of a bare redirect URL string, matching the new `curl` invocation signature.
- Added 3 new failure-path tests:
  - Empty `url` value in the JSON response (`{"url":""}`) - asserts failure with the raw response in the message.
  - Missing `url` field in the JSON response (`{"message":"Resource not found"}`) - asserts failure.
  - Malformed/non-JSON response (`Internal Server Error`) - asserts failure.

## Before / After

```
BEFORE (broken)
┌─────────────────────────────────────────────────────────────────────┐
│ curl -s -o /dev/null -w "%{redirect_url}"                           │
│      -H 'Accept: application/json, version=2'                       │
│      -H 'Authorization: Bearer <token>'                             │
│      .../backups/{id}/actions/download                              │
│                                                                     │
│ API returns: 200 OK + {"url":"https://s3.example.com/..."}          │
│ %{redirect_url} captures: (empty - no redirect occurred)            │
│                                                                     │
│ Result: backup_url="" → FAIL "Unable to discover backup URL"        │
└─────────────────────────────────────────────────────────────────────┘

AFTER (fixed)
┌─────────────────────────────────────────────────────────────────────┐
│ curl -s -L                                                          │
│      -H 'Accept: application/json, version=2'                       │
│      -H 'Authorization: Bearer <token>'                             │
│      .../backups/{id}/actions/download                              │
│                                                                     │
│ API returns: 200 OK + {"url":"https://s3.example.com/..."}          │
│ backup_url_json = '{"url":"https://s3.example.com/..."}'            │
│ backup_url = extract_json_value "url" → "https://s3.example.com/…" │
│                                                                     │
│ Result: backup_url set → S3 download proceeds (no Auth header)      │
└─────────────────────────────────────────────────────────────────────┘
```
