### PR TITLE
Updated deps.

### DIFF
--- a/.vortex/CLAUDE.md
+++ b/.vortex/CLAUDE.md
@@ -80,7 +80,7 @@ note() { printf "      %s\n" "${1}"; }
 
 **Publishing**: the version is injected at publish time - never hardcode
 `version` in the package `composer.json`. The path repository in the template's
-root `composer.json` declares `"versions": {"drevops/vortex-tooling": "1.1.0"}`
+root `composer.json` declares `"versions": {"drevops/vortex-tooling": "1.2.0"}`
 so the in-repo copy resolves during development; the installer strips that entry
 from consumer sites so they resolve from Packagist.
 

--- a/.vortex/tests/phpunit/Traits/SutTrait.php
+++ b/.vortex/tests/phpunit/Traits/SutTrait.php
@@ -120,7 +120,7 @@ trait SutTrait {
           'options' => [
             'symlink' => FALSE,
             'versions' => [
-              'drevops/vortex-tooling' => '1.1.0',
+              'drevops/vortex-tooling' => '1.2.0',
             ],
           ],
         ];

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^1.2.1",
         "drevops/behat-format-progress-fail": "^1.4",
         "drevops/behat-screenshot": "^2.3.0",
-        "drevops/behat-steps": "^3.9.0",
+        "drevops/behat-steps": "^3.10.0",
         "drevops/phpcs-standard": "^0.7.0",
         "drupal/coder": "^9@alpha",
         "drupal/drupal-extension": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.4",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^2.0",
-        "drevops/vortex-tooling": "^1.1.0",
+        "drevops/vortex-tooling": "^1.2.0",
         "drupal/admin_toolbar": "^3.6.3",
         "drupal/clamav": "^2.1",
         "drupal/coffee": "^2.0.1",
@@ -74,7 +74,7 @@
             "url": ".vortex/tooling",
             "options": {
                 "versions": {
-                    "drevops/vortex-tooling": "1.1.0"
+                    "drevops/vortex-tooling": "1.2.0"
                 }
             }
         }

--- a/scripts/vortex-tooling.sh
+++ b/scripts/vortex-tooling.sh
@@ -50,7 +50,7 @@ echo "{\"require\":{\"drevops/vortex-tooling\":\"${version}\"}}" >vendor-temp/co
 # In dev mode the package is not yet on Packagist, so add a path repository
 # pointing at the in-tree copy. The installer strips this VORTEX_DEV-fenced
 # block from consumer sites.
-composer --working-dir=vendor-temp config repositories.vortex-tooling --json '{"type":"path","url":"../.vortex/tooling","options":{"symlink":false,"versions":{"drevops/vortex-tooling":"1.1.0"}}}'
+composer --working-dir=vendor-temp config repositories.vortex-tooling --json '{"type":"path","url":"../.vortex/tooling","options":{"symlink":false,"versions":{"drevops/vortex-tooling":"1.2.0"}}}'
 #;> VORTEX_DEV
 
 # Carry over inline patches declared for our package, if any.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Composer dependency constraints for `drevops/vortex-tooling` and related tooling to the latest minor versions.
  * Adjusted the local published/version mapping and test/dev Composer setup to use `drevops/vortex-tooling` `1.2.0`.
  * Refreshed internal version documentation for the new tooling release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->