### PR TITLE
Removed remaining PHPMD traces and regenerated installer fixtures.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -454,6 +454,17 @@
+@@ -446,6 +446,17 @@
              </details>
            hide_and_recreate: true
  

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -556,6 +556,24 @@
+@@ -553,6 +553,24 @@
        - name: Build stack
          run: docker compose up --detach && docker builder prune --all --force
  

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_artifact/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_artifact/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -556,6 +556,24 @@
+@@ -553,6 +553,24 @@
        - name: Build stack
          run: docker compose up --detach && docker builder prune --all --force
  

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,11 +1,60 @@
-@@ -521,100 +521,3 @@
+@@ -503,149 +503,3 @@
          timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
          with:
            detached: true
 -
+-  # Build the deployable in parallel with the lint and test jobs. For artifact
+-  # deployments, it exports the built codebase for the deploy job; for
+-  # image-based hosting, a successful build validates that the production images
+-  # are deployable.
+-  build:
+-    runs-on: ubuntu-latest
+-    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+-
+-    container:
+-      # https://hub.docker.com/r/drevops/ci-runner
+-      image: drevops/ci-runner:__VERSION__
+-      env:
+-        PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+-        VORTEX_CONTAINER_REGISTRY_USER: ${{ secrets.VORTEX_CONTAINER_REGISTRY_USER }}
+-        VORTEX_CONTAINER_REGISTRY_PASS: ${{ secrets.VORTEX_CONTAINER_REGISTRY_PASS }}
+-        TZ: ${{ vars.TZ || 'UTC' }}
+-        TERM: xterm-256color
+-        # Disable strict host key checking for SSH connections.
+-        VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"
+-        VORTEX_SSH_REMOVE_ALL_KEYS: "1"
+-        VORTEX_DEBUG: ${{ vars.VORTEX_DEBUG }}
+-
+-    steps:
+-      - name: Preserve $HOME set in the container
+-        run: echo HOME=/root >> "$GITHUB_ENV" # https://github.com/actions/runner/issues/863
+-
+-      - name: Check out code
+-        uses: actions/checkout@__HASH__ # __VERSION__
+-        with:
+-          persist-credentials: false
+-
+-      - name: Fix Git ownership permissions
+-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+-
+-      - name: Process the codebase to run in CI
+-        run: find . -name "docker-compose.yml" -print0 | xargs -0 -I {} sh -c "sed -i -e '/###/d' {} && sed -i -e 's/##//' {}"
+-
+-      - name: Load environment variables from .env
+-        run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"
+-
+-      - name: Install Vortex tooling
+-        run: ./scripts/vortex-tooling.sh
+-
+-      - name: Login to container registry
+-        run: ./vendor/drevops/vortex-tooling/src/login-container-registry
+-
+-      - name: Build stack
+-        run: docker compose up --detach && docker builder prune --all --force
+-
 -  deploy:
 -    runs-on: ubuntu-latest
--    needs: [build, lint]
+-    needs: [test, lint, build]
 -    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
 -
 -    container:

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
  
        - name: Export DB
          run: |
-@@ -555,6 +558,24 @@
+@@ -552,6 +555,24 @@
  
        - name: Build stack
          run: docker compose up --detach && docker builder prune --all --force

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -122,38 +122,38 @@
+@@ -123,38 +123,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
  
        - name: Export DB
          run: |
-@@ -555,6 +558,24 @@
+@@ -552,6 +555,24 @@
  
        - name: Build stack
          run: docker compose up --detach && docker builder prune --all --force

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -122,38 +122,38 @@
+@@ -123,38 +123,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
@@ -154,8 +154,6 @@ final class MigrateContentDeployStep extends DeployStepBase {
    *
    * @return bool
    *   TRUE when the probe table is queryable.
-   *
-   * @SuppressWarnings("PHPMD.StaticAccess")
    */
   protected function sourceDatabaseIntact(): bool {
     try {

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
@@ -154,8 +154,6 @@ final class MigrateContentDeployStep extends DeployStepBase {
    *
    * @return bool
    *   TRUE when the probe table is queryable.
-   *
-   * @SuppressWarnings("PHPMD.StaticAccess")
    */
   protected function sourceDatabaseIntact(): bool {
     try {

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
@@ -154,8 +154,6 @@ final class MigrateContentDeployStep extends DeployStepBase {
    *
    * @return bool
    *   TRUE when the probe table is queryable.
-   *
-   * @SuppressWarnings("PHPMD.StaticAccess")
    */
   protected function sourceDatabaseIntact(): bool {
     try {

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
@@ -154,8 +154,6 @@ final class MigrateContentDeployStep extends DeployStepBase {
    *
    * @return bool
    *   TRUE when the probe table is queryable.
-   *
-   * @SuppressWarnings("PHPMD.StaticAccess")
    */
   protected function sourceDatabaseIntact(): bool {
     try {

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
@@ -154,8 +154,6 @@ final class MigrateContentDeployStep extends DeployStepBase {
    *
    * @return bool
    *   TRUE when the probe table is queryable.
-   *
-   * @SuppressWarnings("PHPMD.StaticAccess")
    */
   protected function sourceDatabaseIntact(): bool {
     try {

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
@@ -154,8 +154,6 @@ final class MigrateContentDeployStep extends DeployStepBase {
    *
    * @return bool
    *   TRUE when the probe table is queryable.
-   *
-   * @SuppressWarnings("PHPMD.StaticAccess")
    */
   protected function sourceDatabaseIntact(): bool {
     try {

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
@@ -154,8 +154,6 @@ final class MigrateContentDeployStep extends DeployStepBase {
    *
    * @return bool
    *   TRUE when the probe table is queryable.
-   *
-   * @SuppressWarnings("PHPMD.StaticAccess")
    */
   protected function sourceDatabaseIntact(): bool {
     try {

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
@@ -154,8 +154,6 @@ final class MigrateContentDeployStep extends DeployStepBase {
    *
    * @return bool
    *   TRUE when the probe table is queryable.
-   *
-   * @SuppressWarnings("PHPMD.StaticAccess")
    */
   protected function sourceDatabaseIntact(): bool {
     try {

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
+@@ -387,6 +390,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
@@ -154,8 +154,6 @@ final class MigrateContentDeployStep extends DeployStepBase {
    *
    * @return bool
    *   TRUE when the probe table is queryable.
-   *
-   * @SuppressWarnings("PHPMD.StaticAccess")
    */
   protected function sourceDatabaseIntact(): bool {
     try {

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -127,7 +127,7 @@
 -          path: .data
 -          key: __VERSION__${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
 -
-   build:
+   test:
      runs-on: ubuntu-latest
 -    needs: database
 -    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
@@ -179,10 +179,10 @@
        - name: Login to container registry
          run: ./vendor/drevops/vortex-tooling/src/login-container-registry
  
-@@ -525,7 +381,6 @@
+@@ -556,7 +412,6 @@
    deploy:
      runs-on: ubuntu-latest
-     needs: [build, lint]
+     needs: [test, lint, build]
 -    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
  
      container:

--- a/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
@@ -6,7 +6,7 @@
          "drupal/coffee": "__VERSION__",
          "drupal/config_split": "__VERSION__",
          "drupal/config_update": "__VERSION__",
-@@ -32,7 +33,9 @@
+@@ -33,7 +34,9 @@
          "drupal/xmlsitemap": "__VERSION__",
          "drush/drush": "__VERSION__",
          "oomphinc/composer-installers-extender": "__VERSION__",
@@ -17,7 +17,7 @@
      },
      "require-dev": {
          "behat/behat": "__VERSION__",
-@@ -68,7 +71,7 @@
+@@ -69,7 +72,7 @@
              "url": "https://packages.drupal.org/8"
          }
      ],
@@ -26,7 +26,7 @@
      "prefer-stable": true,
      "autoload-dev": {
          "classmap": [
-@@ -86,7 +89,11 @@
+@@ -87,7 +90,11 @@
              "php-http/discovery": true,
              "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,
@@ -39,7 +39,7 @@
          },
          "audit": {
              "ignore": {
-@@ -163,6 +170,19 @@
+@@ -164,6 +171,19 @@
          "patchLevel": {
              "drupal/core": "-p2"
          },

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/composer.json
@@ -1,4 +1,4 @@
-@@ -37,26 +37,17 @@
+@@ -38,26 +38,17 @@
      "require-dev": {
          "behat/behat": "__VERSION__",
          "dantleech/gherkin-lint": "__VERSION__",
@@ -25,7 +25,7 @@
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
      },
      "conflict": {
-@@ -79,12 +70,10 @@
+@@ -80,12 +71,10 @@
          "allow-plugins": {
              "composer/installers": true,
              "cweagans/composer-patches": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -37,26 +37,17 @@
+@@ -38,26 +38,17 @@
      "require-dev": {
          "behat/behat": "__VERSION__",
          "dantleech/gherkin-lint": "__VERSION__",
@@ -25,7 +25,7 @@
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
      },
      "conflict": {
-@@ -79,12 +70,10 @@
+@@ -80,12 +71,10 @@
          "allow-plugins": {
              "composer/installers": true,
              "cweagans/composer-patches": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -9,7 +9,7 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -404,80 +400,6 @@
+@@ -396,80 +392,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -90,7 +90,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -494,16 +416,6 @@
+@@ -486,16 +408,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error
@@ -105,5 +105,5 @@
 -          files: |
 -            .logs/test_results/**/*.xml
  
-       - name: Upload exported codebase as an artifact
-         uses: actions/upload-artifact@__HASH__ # __VERSION__
+       - name: Setup tmate session
+         if: ${{ !cancelled() && github.event.inputs.enable_terminal }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/composer.json
@@ -1,4 +1,4 @@
-@@ -35,15 +35,9 @@
+@@ -36,15 +36,9 @@
          "webflo/drupal-finder": "__VERSION__"
      },
      "require-dev": {
@@ -14,7 +14,7 @@
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
          "lullabot/php-webdriver": "__VERSION__",
-@@ -51,10 +45,8 @@
+@@ -52,10 +46,8 @@
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
          "phpcompatibility/php-compatibility": "__VERSION__",
@@ -25,7 +25,7 @@
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
-@@ -70,11 +62,6 @@
+@@ -71,11 +63,6 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -35,15 +35,9 @@
+@@ -36,15 +36,9 @@
          "webflo/drupal-finder": "__VERSION__"
      },
      "require-dev": {
@@ -14,7 +14,7 @@
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
          "lullabot/php-webdriver": "__VERSION__",
-@@ -51,10 +45,8 @@
+@@ -52,10 +46,8 @@
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
          "phpcompatibility/php-compatibility": "__VERSION__",
@@ -25,7 +25,7 @@
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
-@@ -70,11 +62,6 @@
+@@ -71,11 +63,6 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
@@ -17,7 +17,7 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -388,7 +383,6 @@
+@@ -380,7 +375,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -25,7 +25,7 @@
  
        - name: Provision site
          run: |
-@@ -398,11 +392,6 @@
+@@ -390,11 +384,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
@@ -22,7 +22,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -388,7 +378,6 @@
+@@ -380,7 +370,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -30,7 +30,7 @@
  
        - name: Provision site
          run: |
-@@ -398,11 +387,6 @@
+@@ -390,11 +379,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -9,7 +9,7 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -463,20 +459,6 @@
+@@ -455,20 +451,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -388,7 +388,6 @@
+@@ -380,7 +380,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Provision site
          run: |
-@@ -398,11 +397,6 @@
+@@ -390,11 +389,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/composer.json
@@ -1,4 +1,4 @@
-@@ -37,12 +37,9 @@
+@@ -38,12 +38,9 @@
      "require-dev": {
          "behat/behat": "__VERSION__",
          "dantleech/gherkin-lint": "__VERSION__",
@@ -11,7 +11,7 @@
          "drupal/drupal-extension": "__VERSION__",
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
-@@ -50,7 +47,6 @@
+@@ -51,7 +48,6 @@
          "mglaman/phpstan-drupal": "__VERSION__",
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
@@ -19,7 +19,7 @@
          "phpspec/prophecy-phpunit": "__VERSION__",
          "phpstan/extension-installer": "__VERSION__",
          "phpstan/phpstan": "__VERSION__",
-@@ -79,7 +75,6 @@
+@@ -80,7 +76,6 @@
          "allow-plugins": {
              "composer/installers": true,
              "cweagans/composer-patches": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -37,12 +37,9 @@
+@@ -38,12 +38,9 @@
      "require-dev": {
          "behat/behat": "__VERSION__",
          "dantleech/gherkin-lint": "__VERSION__",
@@ -11,7 +11,7 @@
          "drupal/drupal-extension": "__VERSION__",
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
-@@ -50,7 +47,6 @@
+@@ -51,7 +48,6 @@
          "mglaman/phpstan-drupal": "__VERSION__",
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
@@ -19,7 +19,7 @@
          "phpspec/prophecy-phpunit": "__VERSION__",
          "phpstan/extension-installer": "__VERSION__",
          "phpstan/phpstan": "__VERSION__",
-@@ -79,7 +75,6 @@
+@@ -80,7 +76,6 @@
          "allow-plugins": {
              "composer/installers": true,
              "cweagans/composer-patches": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/composer.json
@@ -1,4 +1,4 @@
-@@ -47,13 +47,10 @@
+@@ -48,13 +48,10 @@
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
          "lullabot/php-webdriver": "__VERSION__",
@@ -12,7 +12,7 @@
          "phpunit/phpunit": "__VERSION__",
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
-@@ -84,7 +81,6 @@
+@@ -85,7 +82,6 @@
              "ergebnis/composer-normalize": true,
              "oomphinc/composer-installers-extender": true,
              "php-http/discovery": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -47,13 +47,10 @@
+@@ -48,13 +48,10 @@
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
          "lullabot/php-webdriver": "__VERSION__",
@@ -12,7 +12,7 @@
          "phpunit/phpunit": "__VERSION__",
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
-@@ -84,7 +81,6 @@
+@@ -85,7 +82,6 @@
              "ergebnis/composer-normalize": true,
              "oomphinc/composer-installers-extender": true,
              "php-http/discovery": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -404,66 +404,6 @@
+@@ -396,66 +396,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -65,7 +65,7 @@
        - name: Test with Behat
          run: |
            # shellcheck disable=SC2170
-@@ -494,16 +434,6 @@
+@@ -486,16 +426,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error
@@ -80,5 +80,5 @@
 -          files: |
 -            .logs/test_results/**/*.xml
  
-       - name: Upload exported codebase as an artifact
-         uses: actions/upload-artifact@__HASH__ # __VERSION__
+       - name: Setup tmate session
+         if: ${{ !cancelled() && github.event.inputs.enable_terminal }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/composer.json
@@ -1,4 +1,4 @@
-@@ -51,10 +51,8 @@
+@@ -52,10 +52,8 @@
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
          "phpcompatibility/php-compatibility": "__VERSION__",
@@ -9,7 +9,7 @@
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
-@@ -70,11 +68,6 @@
+@@ -71,11 +69,6 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -51,10 +51,8 @@
+@@ -52,10 +52,8 @@
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
          "phpcompatibility/php-compatibility": "__VERSION__",
@@ -9,7 +9,7 @@
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
-@@ -70,11 +68,6 @@
+@@ -71,11 +69,6 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/composer.json
@@ -1,4 +1,4 @@
-@@ -49,7 +49,6 @@
+@@ -50,7 +50,6 @@
          "lullabot/php-webdriver": "__VERSION__",
          "mglaman/phpstan-drupal": "__VERSION__",
          "mikey179/vfsstream": "__VERSION__",
@@ -6,7 +6,7 @@
          "phpcompatibility/php-compatibility": "__VERSION__",
          "phpspec/prophecy-phpunit": "__VERSION__",
          "phpstan/extension-installer": "__VERSION__",
-@@ -56,7 +55,6 @@
+@@ -57,7 +56,6 @@
          "phpstan/phpstan": "__VERSION__",
          "phpunit/phpunit": "__VERSION__",
          "pyrech/composer-changelogs": "__VERSION__",

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -49,7 +49,6 @@
+@@ -50,7 +50,6 @@
          "lullabot/php-webdriver": "__VERSION__",
          "mglaman/phpstan-drupal": "__VERSION__",
          "mikey179/vfsstream": "__VERSION__",
@@ -6,7 +6,7 @@
          "phpcompatibility/php-compatibility": "__VERSION__",
          "phpspec/prophecy-phpunit": "__VERSION__",
          "phpstan/extension-installer": "__VERSION__",
-@@ -56,7 +55,6 @@
+@@ -57,7 +56,6 @@
          "phpstan/phpstan": "__VERSION__",
          "phpunit/phpunit": "__VERSION__",
          "pyrech/composer-changelogs": "__VERSION__",

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -37,7 +37,7 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -388,7 +367,6 @@
+@@ -380,7 +359,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -45,7 +45,7 @@
  
        - name: Provision site
          run: |
-@@ -399,85 +377,6 @@
+@@ -391,85 +369,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30
  
@@ -131,7 +131,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -494,16 +393,6 @@
+@@ -486,16 +385,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error
@@ -146,5 +146,5 @@
 -          files: |
 -            .logs/test_results/**/*.xml
  
-       - name: Upload exported codebase as an artifact
-         uses: actions/upload-artifact@__HASH__ # __VERSION__
+       - name: Setup tmate session
+         if: ${{ !cancelled() && github.event.inputs.enable_terminal }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/composer.json
@@ -1,4 +1,4 @@
-@@ -35,28 +35,11 @@
+@@ -36,28 +36,11 @@
          "webflo/drupal-finder": "__VERSION__"
      },
      "require-dev": {
@@ -27,7 +27,7 @@
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
      },
      "conflict": {
-@@ -70,21 +53,14 @@
+@@ -71,21 +54,14 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,

--- a/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
+++ b/web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php
@@ -154,8 +154,6 @@ final class MigrateContentDeployStep extends DeployStepBase {
    *
    * @return bool
    *   TRUE when the probe table is queryable.
-   *
-   * @SuppressWarnings("PHPMD.StaticAccess")
    */
   protected function sourceDatabaseIntact(): bool {
     try {


### PR DESCRIPTION
## Summary

After `2.x` was rebased onto `main`, the `MigrateContentDeployStep.php` file introduced by the `deploy_steps` work on `2.x` retained a `@SuppressWarnings("PHPMD.StaticAccess")` annotation - the last surviving PHPMD trace in the codebase after `main` removed PHPMD repo-wide. This PR removes that orphaned annotation from both the live source file and from all 9 installer test fixtures that include it. The same rebase also left installer fixture snapshots in a stale state (the `drupal/deploy_steps` additions in `composer.json` fixtures and the `build` sidecar job in `build-test-deploy.yml` fixtures had drift introduced by rebase conflict resolution); the fixtures are regenerated here to make the 130 installer snapshot scenarios pass cleanly.

## Changes

### PHPMD annotation removal (`web/modules/custom/ys_migrate/src/Plugin/DeployStep/MigrateContentDeployStep.php`)

- Removed the blank `*` line and `@SuppressWarnings("PHPMD.StaticAccess")` annotation from the `sourceDatabaseIntact()` method docblock in the live source file.
- The same removal is reflected across 9 installer test fixture copies of `MigrateContentDeployStep.php` under `.vortex/installer/tests/Fixtures/handler_process/` (all `migration_*` and `migration_enabled*` scenarios).

### Installer fixture regeneration (`.vortex/installer/tests/Fixtures/handler_process/`)

- Updated line-number anchors in `build-test-deploy.yml` fixture snippets across ~30 fixture directories - anchors shifted because the `build` sidecar job added in `2.x` changed the surrounding line counts.
- Updated line-number anchors in `composer.json` fixture snippets for scenarios that include `drupal/deploy_steps` (`hosting_acquia`, `hosting_project_name___acquia`, `starter_drupal_cms_profile`, and the various `tools_*` fixtures) - anchors shifted due to the same `drupal/deploy_steps` addition.
- One fixture (`deploy_types_none_gha`) required a larger `build-test-deploy.yml` fixture update: this scenario omits the `build` sidecar job entirely, so the fixture now correctly captures the full block removal (including the `deploy` job's updated `needs` list changing from `[build, lint]` to `[test, lint, build]`).

## Before / After

Docblock of `sourceDatabaseIntact()` in `MigrateContentDeployStep.php`:

```
Before:
   *
   * @return bool
   *   TRUE when the probe table is queryable.
   *
   * @SuppressWarnings("PHPMD.StaticAccess")
   */
  protected function sourceDatabaseIntact(): bool {

After:
   *
   * @return bool
   *   TRUE when the probe table is queryable.
   */
  protected function sourceDatabaseIntact(): bool {
```
