### PR TITLE
Folded database caching into the 'test' CI job and removed the nightly database job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,6 +303,7 @@ jobs:
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
       #;> !PROVISION_TYPE_PROFILE
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  #;< !PROVISION_TYPE_PROFILE
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-  #;> !PROVISION_TYPE_PROFILE
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -210,110 +205,6 @@ jobs:
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
       #;> DRUPAL_THEME
 
-  #;< !PROVISION_TYPE_PROFILE
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - v26.6.0-db11-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - v26.6.0-db11-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      #;< MIGRATION
-      - run:
-          name: Download migration DB
-          command: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-      #;> MIGRATION
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: v26.6.0-db11-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:26.1.0
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-  #;> !PROVISION_TYPE_PROFILE
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -323,6 +214,12 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      #;< !PROVISION_TYPE_PROFILE
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
+      #;> !PROVISION_TYPE_PROFILE
 
       - checkout
       - *step_process_codebase_for_ci
@@ -358,6 +255,23 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      #;< !PROVISION_TYPE_PROFILE
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
+      #;< MIGRATION
+      - run:
+          name: Download migration DB
+          command: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+      #;> MIGRATION
+      #;> !PROVISION_TYPE_PROFILE
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -371,6 +285,26 @@ jobs:
             #;< TOOL_JEST
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
             #;> TOOL_JEST
+
+      #;< !PROVISION_TYPE_PROFILE
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+          no_output_timeout: 30m
+      #;> !PROVISION_TYPE_PROFILE
 
       - run:
           name: Provision site
@@ -387,6 +321,29 @@ jobs:
             #;> MIGRATION
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      #;< !PROVISION_TYPE_PROFILE
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: v26.6.0-db11-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
+      #;> !PROVISION_TYPE_PROFILE
 
       #;< TOOL_JEST
       - run:
@@ -637,21 +594,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      #;< !PROVISION_TYPE_PROFILE
-      - database:
-          filters:
-            tags:
-              only: /.*/
-      #;> !PROVISION_TYPE_PROFILE
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          #;< !PROVISION_TYPE_PROFILE
-          requires:
-            - database
-          #;> !PROVISION_TYPE_PROFILE
           filters:
             tags:
               only: /.*/
@@ -712,17 +659,3 @@ workflows:
               only: /.*/
   #=============================================================================
   #;> VORTEX_DEV
-
-  #;< !PROVISION_TYPE_PROFILE
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly
-  #;> !PROVISION_TYPE_PROFILE

--- a/.circleci/vortex-test-common.yml
+++ b/.circleci/vortex-test-common.yml
@@ -190,6 +190,7 @@ jobs:
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
       #;> !PROVISION_TYPE_PROFILE
 
@@ -366,6 +367,7 @@ jobs:
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
   vortex-dev-didi-build-fi:
@@ -422,6 +424,7 @@ jobs:
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
   vortex-dev-didi-build-ii:

--- a/.circleci/vortex-test-common.yml
+++ b/.circleci/vortex-test-common.yml
@@ -14,11 +14,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  #;< !PROVISION_TYPE_PROFILE
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-  #;> !PROVISION_TYPE_PROFILE
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -99,93 +94,19 @@ aliases:
 ################################################################################
 
 jobs:
-  # Base jobs as anchor sources (not referenced in any workflow).
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - v26.6.0-db11-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - v26.6.0-db11-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      #;< MIGRATION
-      - run:
-          name: Download migration DB
-          command: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-      #;> MIGRATION
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: v26.6.0-db11-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
+  # Base job as an anchor source (not referenced in any workflow).
   test: &job_test
     <<: *runner_config
     parallelism: 2
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      #;< !PROVISION_TYPE_PROFILE
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
+      #;> !PROVISION_TYPE_PROFILE
 
       - checkout
       - *step_process_codebase_for_ci
@@ -221,6 +142,23 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      #;< !PROVISION_TYPE_PROFILE
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
+      #;< MIGRATION
+      - run:
+          name: Download migration DB
+          command: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+      #;> MIGRATION
+      #;> !PROVISION_TYPE_PROFILE
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -234,6 +172,26 @@ jobs:
             #;< TOOL_JEST
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
             #;> TOOL_JEST
+
+      #;< !PROVISION_TYPE_PROFILE
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+          no_output_timeout: 30m
+      #;> !PROVISION_TYPE_PROFILE
 
       - run:
           name: Provision site
@@ -250,6 +208,29 @@ jobs:
             #;> MIGRATION
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      #;< !PROVISION_TYPE_PROFILE
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: v26.6.0-db11-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
+      #;> !PROVISION_TYPE_PROFILE
 
       #;< TOOL_JEST
       - run:
@@ -341,7 +322,7 @@ jobs:
 
   # DIDI-FI variant jobs
   vortex-dev-didi-database-fi:
-    <<: *job-database
+    <<: *runner_config
     environment:
       VORTEX_DOWNLOAD_DB_SOURCE: url
       VORTEX_DOWNLOAD_DB_FORCE: 1
@@ -349,17 +330,55 @@ jobs:
       VORTEX_DEPLOY_CONTAINER_REGISTRY_IMAGE_TAG: vortex-dev-didi-database-fi
       VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
       VORTEX_CI_DB_CACHE_BRANCH: vortex-dev-didi-fi
+    steps:
+      - checkout
+      - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
+
+      - run:
+          name: Install Vortex tooling
+          command: ./scripts/vortex-tooling.sh
+
+      - *step_setup_remote_docker
+
+      - run:
+          name: Login to container registry
+          command: ./vendor/drevops/vortex-tooling/src/login-container-registry
+
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
+      - run:
+          name: Build stack
+          command: docker compose up --detach && docker builder prune --all --force
+
+      # Import the downloaded dump and export it as a database container image,
+      # then push it for the matching build job to pull. Configuration changes
+      # and database updates are not applied, so the image stays in the same
+      # state as downloaded.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+          no_output_timeout: 30m
 
   vortex-dev-didi-build-fi:
     <<: *job_test
     environment:
       VORTEX_DB_IMAGE: drevops/vortex-dev-mariadb-drupal-data-demo-destination-11.x:vortex-dev-didi-database-fi
       VORTEX_CI_DB_CACHE_BRANCH: vortex-dev-didi-fi
+      VORTEX_DOWNLOAD_DB_PROCEED: 0
       DRUPAL_MIGRATION_SKIP: 1
 
   # DIDI-II variant jobs
   vortex-dev-database-ii:
-    <<: *job-database
+    <<: *runner_config
     environment:
       VORTEX_DOWNLOAD_DB_SOURCE: VORTEX_CONTAINER_REGISTRY
       VORTEX_DOWNLOAD_DB_FORCE: 1
@@ -367,12 +386,50 @@ jobs:
       VORTEX_DEPLOY_CONTAINER_REGISTRY_IMAGE_TAG: vortex-dev-database-ii
       VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
       VORTEX_CI_DB_CACHE_BRANCH: vortex-dev-didi-ii
+    steps:
+      - checkout
+      - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
+
+      - run:
+          name: Install Vortex tooling
+          command: ./scripts/vortex-tooling.sh
+
+      - *step_setup_remote_docker
+
+      - run:
+          name: Login to container registry
+          command: ./vendor/drevops/vortex-tooling/src/login-container-registry
+
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
+      - run:
+          name: Build stack
+          command: docker compose up --detach && docker builder prune --all --force
+
+      # Import the downloaded dump and export it as a database container image,
+      # then push it for the matching build job to pull. Configuration changes
+      # and database updates are not applied, so the image stays in the same
+      # state as downloaded.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+          no_output_timeout: 30m
 
   vortex-dev-didi-build-ii:
     <<: *job_test
     environment:
       VORTEX_DB_IMAGE: drevops/vortex-dev-mariadb-drupal-data-demo-destination-11.x:vortex-dev-database-ii
       VORTEX_CI_DB_CACHE_BRANCH: vortex-dev-didi-ii
+      VORTEX_DOWNLOAD_DB_PROCEED: 0
       DRUPAL_MIGRATION_SKIP: 1
 
 ################################################################################

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -345,7 +345,7 @@ jobs:
         run: |
           if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
           if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ] && [ "${STRATEGY_JOB_INDEX}" -ne 0 ]; then export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0; fi
-          docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+          docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
           docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
           ./vendor/drevops/vortex-tooling/src/export-db db.sql
         timeout-minutes: 30

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -5,7 +5,7 @@
 #;
 #; Comments starting with '#;<' and '#;>' are internal Vortex comments
 #; and will be removed during installation or update of Vortex.
-name: Database, Build, Test and Deploy
+name: Build, Test and Deploy
 
 on:
   push:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -348,6 +348,7 @@ jobs:
           docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
           docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
           ./vendor/drevops/vortex-tooling/src/export-db db.sql
+          docker compose cp -L cli:/app/.data/db.sql .data/db.sql
         timeout-minutes: 30
         env:
           STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -61,10 +61,6 @@ on:
         description: 'Enable terminal session for CI jobs'
         required: false
         default: false
-  #;< !PROVISION_TYPE_PROFILE
-  schedule:
-    - cron: '0 18 * * *'
-  #;> !PROVISION_TYPE_PROFILE
 
 defaults:
   run:
@@ -84,7 +80,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     #;< !PROVISION_TYPE_PROFILE
-    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+    if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
     #;> !PROVISION_TYPE_PROFILE
 
     container:
@@ -202,131 +198,10 @@ jobs:
         continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
       #;> DRUPAL_THEME
 
-  #;< !PROVISION_TYPE_PROFILE
-  database:
-    runs-on: ubuntu-latest
-    if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-
-    container:
-      # https://hub.docker.com/r/drevops/ci-runner
-      image: drevops/ci-runner:26.6.0@sha256:190027056cac7b7ce28c29a1e5494779ebadc4ee8e95d468b75bc56e7be5aabd
-      env:
-        PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
-        VORTEX_CONTAINER_REGISTRY_USER: ${{ secrets.VORTEX_CONTAINER_REGISTRY_USER }}
-        VORTEX_CONTAINER_REGISTRY_PASS: ${{ secrets.VORTEX_CONTAINER_REGISTRY_PASS }}
-        TZ: ${{ vars.TZ || 'UTC' }}
-        TERM: xterm-256color
-        VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"
-        VORTEX_SSH_REMOVE_ALL_KEYS: "1"
-        VORTEX_DEBUG: ${{ vars.VORTEX_DEBUG }}
-        # How often to refresh the cache of the DB dump. Refer to `date` command.
-        VORTEX_CI_DB_CACHE_TIMESTAMP: +%Y%m%d
-        # Use previous database caches on this branch as a fallback if the above cache
-        # does not match (for example, the cache is available only from the previous
-        # day). If "no" is set, the cache will be rebuilt from scratch.
-        VORTEX_CI_DB_CACHE_FALLBACK: "yes"
-        # Which branch to use as a source of DB caches.
-        VORTEX_CI_DB_CACHE_BRANCH: "develop"
-
-    steps:
-      - name: Preserve $HOME set in the container
-        run: echo HOME=/root >> "$GITHUB_ENV" # https://github.com/actions/runner/issues/863
-
-      - name: Check out code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          # Do not keep SSH credentials after checkout to allow adding custom SSH keys.
-          persist-credentials: false
-
-      - name: Fix Git ownership permissions
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Add SSH private key used to download database
-        if: ${{ env.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY != '' }}
-        uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 # v2.8.1
-        with:
-          key: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
-          known_hosts: unnecessary
-        env:
-          VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
-
-      - name: Process the codebase to run in CI
-        run: find . -name "docker-compose.yml" -print0 | xargs -0 -I {} sh -c "sed -i -e '/###/d' {} && sed -i -e 's/##//' {}"
-
-      - name: Install Vortex tooling
-        run: ./scripts/vortex-tooling.sh
-
-      - name: Adjust variables for a scheduled run
-        if: github.event_name == 'schedule'
-        run: |
-          echo "VORTEX_CI_DB_CACHE_FALLBACK=no" >> "$GITHUB_ENV"
-          echo "VORTEX_FRONTEND_BUILD_SKIP=1" >> "$GITHUB_ENV"
-
-      - name: Create cache keys files for database caching
-        run: |
-          echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee db_cache_branch
-          echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/"${GITHUB_RUN_NUMBER}"}" | tee db_cache_fallback
-          date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee db_cache_timestamp
-          echo "yes" | tee db_cache_fallback_yes
-
-      # Restore DB cache based on the cache strategy set by the cache keys below.
-      # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-      # Lookup cache based on the default branch and a timestamp. Allows
-      # to use cache from the very first build on the day (sanitized database dump, for example).
-      - name: Restore DB cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: .data
-          key: v26.6.0-db11-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback') }}-${{ hashFiles('db_cache_timestamp') }}
-          # Fallback to caching by default branch name only. Allows to use
-          # cache from the branch build on the previous day.
-          restore-keys: |
-            v26.6.0-db11-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback') }}-
-
-      - name: Download DB
-        run: |
-          VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
-        timeout-minutes: 30
-        #;< DB_DOWNLOAD_SOURCE_ACQUIA
-        env:
-          VORTEX_ACQUIA_KEY: ${{ secrets.VORTEX_ACQUIA_KEY }}
-          VORTEX_ACQUIA_SECRET: ${{ secrets.VORTEX_ACQUIA_SECRET }}
-        #;> DB_DOWNLOAD_SOURCE_ACQUIA
-
-      #;< MIGRATION
-      - name: Download migration DB
-        run: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
-      #;> MIGRATION
-
-      - name: Export DB
-        run: |
-          if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-          ./vendor/drevops/vortex-tooling/src/login-container-registry
-          docker compose up --detach && sleep 15
-          docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-          docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-          ./vendor/drevops/vortex-tooling/src/export-db db.sql
-          docker compose cp -L cli:/app/.data/db.sql .data/db.sql
-        timeout-minutes: 30
-
-      # Save cache per default branch and the timestamp.
-      # The cache will not be saved if it already exists.
-      # Note that the cache fallback flag is enabled for this case in order
-      # to save cache even if the fallback is not used when restoring it.
-      - name: Save DB cache
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        if: env.db_hash != hashFiles('.data')
-        with:
-          path: .data
-          key: v26.6.0-db11-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
-  #;> !PROVISION_TYPE_PROFILE
-
   test:
     runs-on: ubuntu-latest
     #;< !PROVISION_TYPE_PROFILE
-    needs: database
-    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+    if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
     #;> !PROVISION_TYPE_PROFILE
 
     permissions:
@@ -407,7 +282,6 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .data
-          fail-on-cache-miss: true
           # Use cached database from previous builds of this branch.
           key: v26.6.0-db11-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
           restore-keys: |
@@ -416,6 +290,36 @@ jobs:
 
       - name: Login to container registry
         run: ./vendor/drevops/vortex-tooling/src/login-container-registry
+
+      #;< !PROVISION_TYPE_PROFILE
+      - name: Add SSH private key used to download database
+        if: ${{ env.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY != '' }}
+        uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 # v2.8.1
+        with:
+          key: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
+          known_hosts: unnecessary
+        env:
+          VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
+
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - name: Download DB
+        run: |
+          VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
+        timeout-minutes: 30
+        #;< DB_DOWNLOAD_SOURCE_ACQUIA
+        env:
+          VORTEX_ACQUIA_KEY: ${{ secrets.VORTEX_ACQUIA_KEY }}
+          VORTEX_ACQUIA_SECRET: ${{ secrets.VORTEX_ACQUIA_SECRET }}
+        #;> DB_DOWNLOAD_SOURCE_ACQUIA
+
+      #;< MIGRATION
+      - name: Download migration DB
+        run: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
+      #;> MIGRATION
+      #;> !PROVISION_TYPE_PROFILE
 
       - name: Build stack
         run: docker compose up --detach && docker builder prune --all --force
@@ -428,6 +332,36 @@ jobs:
           #;< TOOL_JEST
           docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
           #;> TOOL_JEST
+
+      #;< !PROVISION_TYPE_PROFILE
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - name: Export DB after download
+        run: |
+          if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
+          if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ] && [ "${STRATEGY_JOB_INDEX}" -ne 0 ]; then export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0; fi
+          docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+          docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+          ./vendor/drevops/vortex-tooling/src/export-db db.sql
+        timeout-minutes: 30
+        env:
+          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
+          STRATEGY_JOB_INDEX: ${{ strategy.job-index }}
+
+      # Save the clean DB dump to cache from the primary parallel runner only,
+      # and only when a fresh dump was downloaded this run (db_hash changed).
+      - name: Save DB cache
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        if: ${{ (matrix.instance == 0 || strategy.job-total == 1) && env.db_hash != hashFiles('.data') }}
+        with:
+          path: .data
+          key: v26.6.0-db11-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
+      #;> !PROVISION_TYPE_PROFILE
 
       - name: Provision site
         run: |
@@ -585,7 +519,7 @@ jobs:
   # are deployable.
   build:
     runs-on: ubuntu-latest
-    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+    if: ${{ !inputs.deploy_target && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 
     container:
       # https://hub.docker.com/r/drevops/ci-runner
@@ -652,7 +586,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, lint, build]
     #;< !PROVISION_TYPE_PROFILE
-    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
+    if: ${{ !cancelled() && (inputs.deploy_target || (success() && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
     #;> !PROVISION_TYPE_PROFILE
 
     container:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -348,7 +348,7 @@ jobs:
           docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
           docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
           ./vendor/drevops/vortex-tooling/src/export-db db.sql
-          docker compose cp -L cli:/app/.data/db.sql .data/db.sql
+          docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
         timeout-minutes: 30
         env:
           STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}

--- a/.vortex/docs/content/_code-lifecycle.mdx
+++ b/.vortex/docs/content/_code-lifecycle.mdx
@@ -15,7 +15,7 @@
 │                                                                                           │
 │  Lint Job                                                                                 │
 │    Build CLI container ──► Composer validate / audit / normalize ──► Hadolint ──►         │
-│    DCLint ──► PHPCS ──► PHPStan ──► Rector ──► PHPMD ──► Twig CS Fixer ──►                │
+│    DCLint ──► PHPCS ──► PHPStan ──► Rector ──► Twig CS Fixer ──►                          │
 │    Gherkin Lint ──► ESLint / Stylelint                                                    │
 │                                                                                           │
 │  Test Job                                                                                 │

--- a/.vortex/docs/content/_code-lifecycle.mdx
+++ b/.vortex/docs/content/_code-lifecycle.mdx
@@ -9,57 +9,33 @@
                    Push to remote branch ──► Open/Update Pull Request
                                             │
                                             ▼
-┌─ CI Pipeline ────────────────────────────────────────────────────────────────────────────┐
-│                                                                                          │
-│  ┌─ Database Job (Nightly) ───────────────────────────────────────────────────────────┐  │
-│  │                                                                                    │  │
-│  │  Scheduled ──► Download production ──► Sanitize database ──► Store database cache  │  │
-│  │  trigger       database                Remove sensitive data                       │  │
-│  │                                                                                    │  │
-│  └─────────────────────────────────────┬──────────────────────────────────────────────┘  │
-│                                        │ Provides cached database                        │
-│                                        ▼                                                 │
-│  ┌─ Lint Job ────────────┐  ┌─ Database Job ──────────────────────────────────────────┐  │
-│  │                       │  │                                                         │  │
-│  │  Build CLI container  │  │  ◆ Nightly cache ──Yes──► Pipeline Success              │  │
-│  │          ▼            │  │    exists?                                              │  │
-│  │  Composer validate    │  │       │ No                                              │  │
-│  │          ▼            │  │       ▼                                                 │  │
-│  │   Composer audit      │  │  Download    ──►   Sanitize    ──►    Store database    │  │
-│  │          ▼            │  │  production        database           cache             │  │
-│  │  Composer normalize   │  │  database          Remove                               │  │
-│  │          ▼            │  │                    sensitive data                       │  │
-│  │      Hadolint         │  │                                                         │  │
-│  │          ▼            │  └───────────────────────────┬─────────────────────────────┘  │
-│  │       DCLint          │                              │                                │
-│  │          ▼            │                              ▼                                │
-│  │       PHPCS           │  ┌─ Test Job ─────────────────────────────────────────────┐   │
-│  │          ▼            │  │                                                        │   │
-│  │      PHPStan          │  │  Code assembly                                         │   │
-│  │          ▼            │  │  Build Docker ──► Composer deps ──► NPM deps ──► Assets│   │
-│  │       Rector          │  │                          │                             │   │
-│  │          ▼            │  │                          ▼                             │   │
-│  │    Twig CS Fixer      │  │  Website setup                                         │   │
-│  │          ▼            │  │  Import cached DB ──► drush deploy ──► Custom scripts  │   │
-│  │    Gherkin Lint       │  │                          │                             │   │
-│  │          ▼            │  │                          ▼                             │   │
-│  │  ESLint / Stylelint   │  │  Testing                                               │   │
-│  │                       │  │  PHPUnit tests ──► Behat tests                         │   │
-│  │                       │  │                                                        │   │
-│  │                       │  └────────────────────────────┬───────────────────────────┘   │
-│  └──────────┬────────────┘                               │                               │
-│             │                                            │                               │
-│             │                                            │                               │
-│             │                                            │                               │
-│             ▼                                            ▼                               │
-│  ┌─ Deployment Job ─────────────────────────────────────────────────────────────────┐    │
-│  │                                                                                  │    │
-│  │  Webhook     Artifact            Lagoon              Docker                      │    │
-│  │  Call URL    Package artifact    Call Lagoon webhook  Create container image     │    │
-│  │                                                                                  │    │
-│  └──────────────────────────────────────────────────────────────────────────────────┘    │
-│                                                                                          │
-└──────────────────────────────────────────────────────────────────────────────────────────┘
+┌─ CI Pipeline ─────────────────────────────────────────────────────────────────────────────┐
+│                                                                                           │
+│  The Lint, Test and Build jobs run in parallel. Deployment runs after all three pass.     │
+│                                                                                           │
+│  Lint Job                                                                                 │
+│    Build CLI container ──► Composer validate / audit / normalize ──► Hadolint ──►         │
+│    DCLint ──► PHPCS ──► PHPStan ──► Rector ──► PHPMD ──► Twig CS Fixer ──►                │
+│    Gherkin Lint ──► ESLint / Stylelint                                                    │
+│                                                                                           │
+│  Test Job                                                                                 │
+│    Restore the database cache. On the first build of the day (cache miss), one runner     │
+│    downloads the production database, exports a clean pre-provision dump and stores it    │
+│    in the cache for the rest of the day's builds (one runner only when parallel).         │
+│      ▼                                                                                    │
+│    Build Docker ──► Composer deps ──► NPM deps ──► Assets                                 │
+│      ▼                                                                                    │
+│    Import cached database ──► drush deploy ──► custom deploy steps                        │
+│      ▼                                                                                    │
+│    PHPUnit tests ──► Behat tests                                                          │
+│                                                                                           │
+│  Build Job                                                                                │
+│    Assemble and validate the deployable artifact                                          │
+│                                                                                           │
+│  Deployment Job (after Lint, Test and Build pass)                                         │
+│    Webhook URL ──► artifact package ──► Lagoon webhook ──► Docker container image         │
+│                                                                                           │
+└───────────────────────────────────────────────────────────────────────────────────────────┘
                                             │
                                             ▼
                                      Hosting Platform

--- a/.vortex/docs/content/_code-lifecycle.mdx
+++ b/.vortex/docs/content/_code-lifecycle.mdx
@@ -9,33 +9,33 @@
                    Push to remote branch ──► Open/Update Pull Request
                                             │
                                             ▼
-┌─ CI Pipeline ─────────────────────────────────────────────────────────────────────────────┐
-│                                                                                           │
-│  The Lint, Test and Build jobs run in parallel. Deployment runs after all three pass.     │
-│                                                                                           │
-│  Lint Job                                                                                 │
-│    Build CLI container ──► Composer validate / audit / normalize ──► Hadolint ──►         │
-│    DCLint ──► PHPCS ──► PHPStan ──► Rector ──► Twig CS Fixer ──►                          │
-│    Gherkin Lint ──► ESLint / Stylelint                                                    │
-│                                                                                           │
-│  Test Job                                                                                 │
-│    Restore the database cache. On the first build of the day (cache miss), one runner     │
-│    downloads the production database, exports a clean pre-provision dump and stores it    │
-│    in the cache for the rest of the day's builds (one runner only when parallel).         │
-│      ▼                                                                                    │
-│    Build Docker ──► Composer deps ──► NPM deps ──► Assets                                 │
-│      ▼                                                                                    │
-│    Import cached database ──► drush deploy ──► custom deploy steps                        │
-│      ▼                                                                                    │
-│    PHPUnit tests ──► Behat tests                                                          │
-│                                                                                           │
-│  Build Job                                                                                │
-│    Assemble and validate the deployable artifact                                          │
-│                                                                                           │
-│  Deployment Job (after Lint, Test and Build pass)                                         │
-│    Webhook URL ──► artifact package ──► Lagoon webhook ──► Docker container image         │
-│                                                                                           │
-└───────────────────────────────────────────────────────────────────────────────────────────┘
+┌─ CI Pipeline ──────────────────────────────────────────────────────────────────────────────┐
+│                                                                                            │
+│  The Lint, Test and Build jobs run in parallel. Deployment runs after all three pass.      │
+│                                                                                            │
+│  Lint Job                                                                                  │
+│    Build CLI container ──► Composer validate / audit / normalize ──► Hadolint ──►          │
+│    DCLint ──► PHPCS ──► PHPStan ──► Rector ──► Twig CS Fixer ──►                           │
+│    Gherkin Lint ──► ESLint / Stylelint                                                     │
+│                                                                                            │
+│  Test Job                                                                                  │
+│    Restore the database cache. On the first build of the day (cache miss), each runner     │
+│    downloads the production database and exports a clean pre-provision dump; only the      │
+│    primary runner stores it in the cache for the rest of the day's builds.                 │
+│      ▼                                                                                     │
+│    Build Docker ──► Composer deps ──► NPM deps ──► Assets                                  │
+│      ▼                                                                                     │
+│    Import cached database ──► drush deploy ──► custom deploy steps                         │
+│      ▼                                                                                     │
+│    PHPUnit tests ──► Behat tests                                                           │
+│                                                                                            │
+│  Build Job                                                                                 │
+│    Assemble and validate the deployable artifact                                           │
+│                                                                                            │
+│  Deployment Job (after Lint, Test and Build pass)                                          │
+│    Webhook URL ──► artifact package ──► Lagoon webhook ──► Docker container image          │
+│                                                                                            │
+└────────────────────────────────────────────────────────────────────────────────────────────┘
                                             │
                                             ▼
                                      Hosting Platform

--- a/.vortex/docs/content/continuous-integration/README.mdx
+++ b/.vortex/docs/content/continuous-integration/README.mdx
@@ -33,14 +33,10 @@ import CodeLifecycle from '../_code-lifecycle.mdx';
 - Runs all code linters: PHPCS, PHPStan, Rector, Twig CS Fixer, Gherkin Lint, ESLint, Stylelint
 - Audits and normalizes Composer packages
 
-### 2. Database
+### 2. Test
 
-- Downloads the latest DB version based on a caching strategy
-- Caches database dumps to speed up the follow-up runs
-
-### 3. Test
-
-- Runs after the `database` job, in parallel with the `build` job
+- Runs in parallel with the `lint` and `build` jobs
+- Downloads the database on the first build of the day and caches it for the rest of the day's builds (only one runner stores the cache when running in parallel)
 - Uses Docker Compose to set up the full environment
 - Validates Composer configuration
 - Assembles the codebase by installing dependencies
@@ -50,14 +46,14 @@ import CodeLifecycle from '../_code-lifecycle.mdx';
 - Runs BDD tests (distributed across all instances)
 - Collects and stores test results and artifacts
 
-### 4. Build
+### 3. Build
 
 - Runs in parallel with the `lint` and `test` jobs (no dependencies)
 - Uses Docker Compose to build the production stack
 - For artifact-based hosting (e.g. Acquia), exports the built codebase for the deployment job
 - For image-based hosting (e.g. Lagoon), a successful build confirms that the production images are deployable
 
-### 5. Deployment
+### 4. Deployment
 
 - Runs after successful completion of the `lint`, `test`, and `build` jobs
 - Uses the built codebase without development dependencies from the `build` job
@@ -66,8 +62,8 @@ import CodeLifecycle from '../_code-lifecycle.mdx';
 
 ## Caching strategy
 
-Database is downloaded overnight and cached so that the next continuous integration run on the same
-day uses the cached database dump.
+The database is downloaded on the first continuous integration run of the day and cached so that
+the remaining runs on the same day reuse the cached database dump.
 
 By default, the database is cached per-branch for 24 hours. If cache is not
 available, the fallback default branch is used.
@@ -79,7 +75,7 @@ continuous integration runs on large projects with a lot of data.
 
 In case of a project with a large database >1GB, the database import itself may
 take a long time, so it may be worth looking into either packaging the database
-dump into a container image (overnight) or using a sanitized database dump with
+dump into a container image or using a sanitized database dump with
 only the required data for the tests.
 
 **Vortex** supports both creating and using a database container image with embedded
@@ -94,8 +90,8 @@ export command without the need for an intermediate database import step.
 
 ### Reset the cache
 
-If you need to force a fresh cache (e.g., to pull the new database dump outside
-of the regular schedule), increment the version tag in the cache keys:
+If you need to force a fresh cache (e.g., to pull a new database dump before the
+daily cache refreshes), increment the version tag in the cache keys:
 
 ```yaml
 # Before
@@ -116,7 +112,6 @@ The continuous integration pipeline is triggered by:
   - `ci*`
 - **Pull requests** to these branches
 - **Tags** matching semantic version (`1.2.3`, `1.2.3-rc.1`) or date-based (`2023-04-17`) patterns
-- **Scheduled runs** for automatic database caching
 
 ## Test parallelism
 

--- a/.vortex/docs/content/continuous-integration/circleci.mdx
+++ b/.vortex/docs/content/continuous-integration/circleci.mdx
@@ -46,16 +46,20 @@ only runs for specific branch patterns, controlled by a regex filter in the
 To modify which branches trigger deployments, update the `only` filter regex
 in the `deploy` job.
 
-### Update nightly database schedule
+### Configure database caching
 
-The nightly database job caches a fresh database dump for faster builds the next
-day. To change when this runs, update the `nightly_db_schedule` YAML anchor
-in `.circleci/config.yml`
-([cron format](https://crontab.guru/#0_18_*_*_*), UTC timezone):
+The `test` job downloads a fresh database dump on the first build of the day and
+caches it for the rest of that day's builds; later builds reuse the cached dump
+instead of downloading it again. The cache key includes a daily timestamp, so
+the cache refreshes automatically each day. To change the cache window, update
+the `VORTEX_CI_DB_CACHE_TIMESTAMP` value (a `date` format string) in the
+`runner_config` environment in `.circleci/config.yml`:
 
 ```yaml
-- &nightly_db_schedule "0 18 * * *"  # 6 PM UTC daily
+VORTEX_CI_DB_CACHE_TIMESTAMP: +%Y%m%d  # New cache each day
 ```
+
+When the `test` job runs in parallel, only the first runner stores the cache.
 
 ### Change runner resource class
 

--- a/.vortex/docs/content/continuous-integration/circleci.mdx
+++ b/.vortex/docs/content/continuous-integration/circleci.mdx
@@ -27,7 +27,7 @@ in the Installation guide and select **CircleCI**.
 
 ### Update deployment branches
 
-All CI jobs (`database`, `lint`, `test`, `build`) run on every branch. The `deploy` job
+All CI jobs (`lint`, `test`, `build`) run on every branch. The `deploy` job
 only runs for specific branch patterns, controlled by a regex filter in the
 `workflows` section of `.circleci/config.yml`:
 

--- a/.vortex/docs/content/continuous-integration/github-actions.mdx
+++ b/.vortex/docs/content/continuous-integration/github-actions.mdx
@@ -57,16 +57,21 @@ pull requests, not on direct pushes.
 To add or remove branches, update the `push` and `pull_request` sections
 in the workflow file.
 
-### Update nightly database schedule
+### Configure database caching
 
-The nightly database job caches a fresh database dump for faster builds the next
-day. To change when this runs, update the `schedule.cron` value (
-[cron format](https://crontab.guru/#0_18_*_*_*), UTC timezone):
+The `test` job downloads a fresh database dump on the first build of the day and
+caches it for the rest of that day's builds; later builds reuse the cached dump
+instead of downloading it again. The cache key includes a daily timestamp, so
+the cache refreshes automatically each day. To change the cache window, update
+the `VORTEX_CI_DB_CACHE_TIMESTAMP` value (a `date` format string) in the `test`
+job environment in `.github/workflows/build-test-deploy.yml`:
 
 ```yaml
-schedule:
-  - cron: '0 18 * * *'  # 6 PM UTC daily
+VORTEX_CI_DB_CACHE_TIMESTAMP: +%Y%m%d  # New cache each day
 ```
+
+When the `test` job runs as a parallel matrix, only the first instance stores
+the cache.
 
 ### Change runner size
 

--- a/.vortex/docs/content/continuous-integration/github-actions.mdx
+++ b/.vortex/docs/content/continuous-integration/github-actions.mdx
@@ -105,8 +105,8 @@ on how tests are distributed across containers.
 ### Manual deployment
 
 The workflow supports triggering deployments directly from the GitHub UI without
-running the `lint`, `test`, and `build` jobs. Navigate to **Actions → Database, Build,
-Test and Deploy → Run workflow** and provide:
+running the `lint`, `test`, and `build` jobs. Navigate to **Actions → Build, Test and
+Deploy → Run workflow** and provide:
 
 | Input           | Description                                                                      |
 |-----------------|----------------------------------------------------------------------------------|

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -2,7 +2,7 @@
 #
 # This configuration file uses a custom "container" executor to run the
 # Docker stack to speed up the build process.
-name: Database, Build, Test and Deploy
+name: Build, Test and Deploy
 
 on:
   push:

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -302,7 +302,7 @@ jobs:
           docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
           docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
           ./vendor/drevops/vortex-tooling/src/export-db db.sql
-          docker compose cp -L cli:/app/.data/db.sql .data/db.sql
+          docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
         timeout-minutes: 30
         env:
           STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -52,8 +52,6 @@ on:
         description: 'Enable terminal session for CI jobs'
         required: false
         default: false
-  schedule:
-    - cron: '0 18 * * *'
 
 defaults:
   run:
@@ -72,7 +70,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+    if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 
     container:
       # https://hub.docker.com/r/drevops/ci-runner
@@ -175,118 +173,9 @@ jobs:
         run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
         continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
 
-  database:
-    runs-on: ubuntu-latest
-    if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-
-    container:
-      # https://hub.docker.com/r/drevops/ci-runner
-      image: drevops/ci-runner:__VERSION__
-      env:
-        PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
-        VORTEX_CONTAINER_REGISTRY_USER: ${{ secrets.VORTEX_CONTAINER_REGISTRY_USER }}
-        VORTEX_CONTAINER_REGISTRY_PASS: ${{ secrets.VORTEX_CONTAINER_REGISTRY_PASS }}
-        TZ: ${{ vars.TZ || 'UTC' }}
-        TERM: xterm-256color
-        VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"
-        VORTEX_SSH_REMOVE_ALL_KEYS: "1"
-        VORTEX_DEBUG: ${{ vars.VORTEX_DEBUG }}
-        # How often to refresh the cache of the DB dump. Refer to `date` command.
-        VORTEX_CI_DB_CACHE_TIMESTAMP: +%Y%m%d
-        # Use previous database caches on this branch as a fallback if the above cache
-        # does not match (for example, the cache is available only from the previous
-        # day). If "no" is set, the cache will be rebuilt from scratch.
-        VORTEX_CI_DB_CACHE_FALLBACK: "yes"
-        # Which branch to use as a source of DB caches.
-        VORTEX_CI_DB_CACHE_BRANCH: "develop"
-
-    steps:
-      - name: Preserve $HOME set in the container
-        run: echo HOME=/root >> "$GITHUB_ENV" # https://github.com/actions/runner/issues/863
-
-      - name: Check out code
-        uses: actions/checkout@__HASH__ # __VERSION__
-        with:
-          # Do not keep SSH credentials after checkout to allow adding custom SSH keys.
-          persist-credentials: false
-
-      - name: Fix Git ownership permissions
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Add SSH private key used to download database
-        if: ${{ env.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY != '' }}
-        uses: shimataro/ssh-key-action@__HASH__ # __VERSION__
-        with:
-          key: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
-          known_hosts: unnecessary
-        env:
-          VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
-
-      - name: Process the codebase to run in CI
-        run: find . -name "docker-compose.yml" -print0 | xargs -0 -I {} sh -c "sed -i -e '/###/d' {} && sed -i -e 's/##//' {}"
-
-      - name: Install Vortex tooling
-        run: ./scripts/vortex-tooling.sh
-
-      - name: Adjust variables for a scheduled run
-        if: github.event_name == 'schedule'
-        run: |
-          echo "VORTEX_CI_DB_CACHE_FALLBACK=no" >> "$GITHUB_ENV"
-          echo "VORTEX_FRONTEND_BUILD_SKIP=1" >> "$GITHUB_ENV"
-
-      - name: Create cache keys files for database caching
-        run: |
-          echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee db_cache_branch
-          echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/"${GITHUB_RUN_NUMBER}"}" | tee db_cache_fallback
-          date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee db_cache_timestamp
-          echo "yes" | tee db_cache_fallback_yes
-
-      # Restore DB cache based on the cache strategy set by the cache keys below.
-      # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-      # Lookup cache based on the default branch and a timestamp. Allows
-      # to use cache from the very first build on the day (sanitized database dump, for example).
-      - name: Restore DB cache
-        uses: actions/cache/restore@__HASH__ # __VERSION__
-        with:
-          path: .data
-          key: __VERSION__${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback') }}-${{ hashFiles('db_cache_timestamp') }}
-          # Fallback to caching by default branch name only. Allows to use
-          # cache from the branch build on the previous day.
-          restore-keys: |
-            __VERSION__${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback') }}-
-
-      - name: Download DB
-        run: |
-          VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
-        timeout-minutes: 30
-
-      - name: Export DB
-        run: |
-          if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-          ./vendor/drevops/vortex-tooling/src/login-container-registry
-          docker compose up --detach && sleep 15
-          docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-          docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-          ./vendor/drevops/vortex-tooling/src/export-db db.sql
-          docker compose cp -L cli:/app/.data/db.sql .data/db.sql
-        timeout-minutes: 30
-
-      # Save cache per default branch and the timestamp.
-      # The cache will not be saved if it already exists.
-      # Note that the cache fallback flag is enabled for this case in order
-      # to save cache even if the fallback is not used when restoring it.
-      - name: Save DB cache
-        uses: actions/cache/save@__HASH__ # __VERSION__
-        if: env.db_hash != hashFiles('.data')
-        with:
-          path: .data
-          key: __VERSION__${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
-
   test:
     runs-on: ubuntu-latest
-    needs: database
-    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+    if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 
     permissions:
       contents: read # Check out the repository.
@@ -363,7 +252,6 @@ jobs:
         uses: actions/cache/restore@__HASH__ # __VERSION__
         with:
           path: .data
-          fail-on-cache-miss: true
           # Use cached database from previous builds of this branch.
           key: __VERSION__${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
           restore-keys: |
@@ -371,6 +259,24 @@ jobs:
 
       - name: Login to container registry
         run: ./vendor/drevops/vortex-tooling/src/login-container-registry
+
+      - name: Add SSH private key used to download database
+        if: ${{ env.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY != '' }}
+        uses: shimataro/ssh-key-action@__HASH__ # __VERSION__
+        with:
+          key: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
+          known_hosts: unnecessary
+        env:
+          VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
+
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - name: Download DB
+        run: |
+          VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
+        timeout-minutes: 30
 
       - name: Build stack
         run: docker compose up --detach && docker builder prune --all --force
@@ -381,6 +287,35 @@ jobs:
             if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
             COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
           docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - name: Export DB after download
+        run: |
+          if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
+          if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ] && [ "${STRATEGY_JOB_INDEX}" -ne 0 ]; then export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0; fi
+          docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+          docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+          ./vendor/drevops/vortex-tooling/src/export-db db.sql
+          docker compose cp -L cli:/app/.data/db.sql .data/db.sql
+        timeout-minutes: 30
+        env:
+          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
+          STRATEGY_JOB_INDEX: ${{ strategy.job-index }}
+
+      # Save the clean DB dump to cache from the primary parallel runner only,
+      # and only when a fresh dump was downloaded this run (db_hash changed).
+      - name: Save DB cache
+        uses: actions/cache/save@__HASH__ # __VERSION__
+        if: ${{ (matrix.instance == 0 || strategy.job-total == 1) && env.db_hash != hashFiles('.data') }}
+        with:
+          path: .data
+          key: __VERSION__${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
 
       - name: Provision site
         run: |
@@ -510,7 +445,7 @@ jobs:
   # are deployable.
   build:
     runs-on: ubuntu-latest
-    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+    if: ${{ !inputs.deploy_target && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 
     container:
       # https://hub.docker.com/r/drevops/ci-runner
@@ -556,7 +491,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [test, lint, build]
-    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
+    if: ${{ !cancelled() && (inputs.deploy_target || (success() && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
 
     container:
       # https://hub.docker.com/r/drevops/ci-runner

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/README.md
@@ -9,7 +9,7 @@
 
 Drupal 11 implementation of star wars for star wars Org
 
-[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 
 ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
 

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -185,101 +182,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -289,6 +191,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -322,6 +228,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -334,6 +248,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -343,6 +276,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -520,17 +474,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -571,15 +519,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -446,6 +446,17 @@
+@@ -381,6 +381,17 @@
              </details>
            hide_and_recreate: true
  

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -185,101 +182,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -289,6 +191,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -322,6 +228,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -334,6 +248,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -343,6 +276,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -528,17 +482,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -579,15 +527,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/db_download_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/db_download_source_acquia/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -260,6 +260,9 @@
+@@ -277,6 +277,9 @@
            VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
@@ -6,5 +6,5 @@
 +          VORTEX_ACQUIA_KEY: ${{ secrets.VORTEX_ACQUIA_KEY }}
 +          VORTEX_ACQUIA_SECRET: ${{ secrets.VORTEX_ACQUIA_SECRET }}
  
-       - name: Export DB
-         run: |
+       - name: Build stack
+         run: docker compose up --detach && docker builder prune --all --force

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -185,101 +182,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -289,6 +191,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -322,6 +228,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -334,6 +248,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -343,6 +276,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -528,17 +482,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -579,15 +527,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -553,6 +553,24 @@
+@@ -488,6 +488,24 @@
        - name: Build stack
          run: docker compose up --detach && docker builder prune --all --force
  

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_artifact/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_artifact/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -553,6 +553,24 @@
+@@ -488,6 +488,24 @@
        - name: Build stack
          run: docker compose up --detach && docker builder prune --all --force
  

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -185,101 +182,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -289,6 +191,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -322,6 +228,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -334,6 +248,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -343,6 +276,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -424,29 +378,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -503,149 +503,3 @@
+@@ -438,149 +438,3 @@
          timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
          with:
            detached: true
@@ -9,7 +9,7 @@
 -  # are deployable.
 -  build:
 -    runs-on: ubuntu-latest
--    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+-    if: ${{ !inputs.deploy_target && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 -
 -    container:
 -      # https://hub.docker.com/r/drevops/ci-runner
@@ -55,7 +55,7 @@
 -  deploy:
 -    runs-on: ubuntu-latest
 -    needs: [test, lint, build]
--    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
+-    if: ${{ !cancelled() && (inputs.deploy_target || (success() && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
 -
 -    container:
 -      # https://hub.docker.com/r/drevops/ci-runner

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -185,101 +182,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -289,6 +191,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -322,6 +228,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -334,6 +248,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -343,6 +276,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -520,17 +474,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -571,15 +519,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -260,6 +260,9 @@
+@@ -277,6 +277,9 @@
            VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
@@ -6,9 +6,9 @@
 +          VORTEX_ACQUIA_KEY: ${{ secrets.VORTEX_ACQUIA_KEY }}
 +          VORTEX_ACQUIA_SECRET: ${{ secrets.VORTEX_ACQUIA_SECRET }}
  
-       - name: Export DB
-         run: |
-@@ -552,6 +555,24 @@
+       - name: Build stack
+         run: docker compose up --detach && docker builder prune --all --force
+@@ -487,6 +490,24 @@
  
        - name: Build stack
          run: docker compose up --detach && docker builder prune --all --force

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -260,6 +260,9 @@
+@@ -277,6 +277,9 @@
            VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
@@ -6,9 +6,9 @@
 +          VORTEX_ACQUIA_KEY: ${{ secrets.VORTEX_ACQUIA_KEY }}
 +          VORTEX_ACQUIA_SECRET: ${{ secrets.VORTEX_ACQUIA_SECRET }}
  
-       - name: Export DB
-         run: |
-@@ -552,6 +555,24 @@
+       - name: Build stack
+         run: docker compose up --detach && docker builder prune --all --force
+@@ -487,6 +490,24 @@
  
        - name: Build stack
          run: docker compose up --detach && docker builder prune --all --force

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -185,101 +182,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -289,6 +191,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -322,6 +228,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -334,6 +248,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -343,6 +276,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -520,17 +474,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -571,15 +519,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/.github/workflows/build-test-deploy.yml
@@ -1,14 +1,14 @@
-@@ -261,6 +261,9 @@
+@@ -278,6 +278,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
 +      - name: Download migration DB
 +        run: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
-       - name: Export DB
-         run: |
-           if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -387,6 +390,10 @@
+       - name: Build stack
+         run: docker compose up --detach && docker builder prune --all --force
+ 
+@@ -322,6 +325,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/.github/workflows/build-test-deploy.yml
@@ -1,14 +1,14 @@
-@@ -261,6 +261,9 @@
+@@ -278,6 +278,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
 +      - name: Download migration DB
 +        run: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
-       - name: Export DB
-         run: |
-           if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -387,6 +390,10 @@
+       - name: Build stack
+         run: docker compose up --detach && docker builder prune --all --force
+ 
+@@ -322,6 +325,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/.github/workflows/build-test-deploy.yml
@@ -1,14 +1,14 @@
-@@ -261,6 +261,9 @@
+@@ -278,6 +278,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
 +      - name: Download migration DB
 +        run: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
-       - name: Export DB
-         run: |
-           if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -387,6 +390,10 @@
+       - name: Build stack
+         run: docker compose up --detach && docker builder prune --all --force
+ 
+@@ -322,6 +325,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/.github/workflows/build-test-deploy.yml
@@ -1,14 +1,14 @@
-@@ -261,6 +261,9 @@
+@@ -278,6 +278,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
 +      - name: Download migration DB
 +        run: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
-       - name: Export DB
-         run: |
-           if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -387,6 +390,10 @@
+       - name: Build stack
+         run: docker compose up --detach && docker builder prune --all --force
+ 
+@@ -322,6 +325,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/.github/workflows/build-test-deploy.yml
@@ -1,14 +1,14 @@
-@@ -261,6 +261,9 @@
+@@ -278,6 +278,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
 +      - name: Download migration DB
 +        run: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
-       - name: Export DB
-         run: |
-           if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -387,6 +390,10 @@
+       - name: Build stack
+         run: docker compose up --detach && docker builder prune --all --force
+ 
+@@ -322,6 +325,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/.github/workflows/build-test-deploy.yml
@@ -1,14 +1,14 @@
-@@ -261,6 +261,9 @@
+@@ -278,6 +278,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
 +      - name: Download migration DB
 +        run: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
-       - name: Export DB
-         run: |
-           if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -387,6 +390,10 @@
+       - name: Build stack
+         run: docker compose up --detach && docker builder prune --all --force
+ 
+@@ -322,6 +325,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
@@ -1,14 +1,14 @@
-@@ -261,6 +261,9 @@
+@@ -278,6 +278,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
 +      - name: Download migration DB
 +        run: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
-       - name: Export DB
-         run: |
-           if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -387,6 +390,10 @@
+       - name: Build stack
+         run: docker compose up --detach && docker builder prune --all --force
+ 
+@@ -322,6 +325,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -185,106 +182,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      - run:
-          name: Download migration DB
-          command: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -294,6 +191,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -327,6 +228,19 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
+      - run:
+          name: Download migration DB
+          command: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -338,6 +252,25 @@ jobs:
               if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
 
       - run:
           name: Provision site
@@ -352,6 +285,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -529,17 +483,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -580,15 +528,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
@@ -1,14 +1,14 @@
-@@ -261,6 +261,9 @@
+@@ -278,6 +278,9 @@
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
  
 +      - name: Download migration DB
 +        run: VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/download-db
 +
-       - name: Export DB
-         run: |
-           if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -387,6 +390,10 @@
+       - name: Build stack
+         run: docker compose up --detach && docker builder prune --all --force
+ 
+@@ -322,6 +325,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/names/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/names/README.md
@@ -13,8 +13,8 @@
 -Drupal 11 implementation of star wars for star wars Org
 +Drupal 11 implementation of New hope for Jedi Order
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
-+[![Database, Build, Test and Deploy](https://github.com/the_jedi_order/the_new_hope/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/the_jedi_order/the_new_hope/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
++[![Build, Test and Deploy](https://github.com/the_jedi_order/the_new_hope/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/the_jedi_order/the_new_hope/actions/workflows/build-test-deploy.yml)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/non_interactive_config_file/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/non_interactive_config_file/README.md
@@ -5,8 +5,8 @@
 -Drupal 11 implementation of star wars for star wars Org
 +Drupal 11 implementation of star wars for My custom org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
-+[![Database, Build, Test and Deploy](https://github.com/my_custom_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/my_custom_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
++[![Build, Test and Deploy](https://github.com/my_custom_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/my_custom_org/star_wars/actions/workflows/build-test-deploy.yml)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/non_interactive_config_string/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/non_interactive_config_string/README.md
@@ -5,8 +5,8 @@
 -Drupal 11 implementation of star wars for star wars Org
 +Drupal 11 implementation of star wars for My other custom org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
-+[![Database, Build, Test and Deploy](https://github.com/my_other_custom_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/my_other_custom_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
++[![Build, Test and Deploy](https://github.com/my_other_custom_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/my_other_custom_org/star_wars/actions/workflows/build-test-deploy.yml)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -97,7 +97,7 @@
 -          docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
 -          docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
 -          ./vendor/drevops/vortex-tooling/src/export-db db.sql
--          docker compose cp -L cli:/app/.data/db.sql .data/db.sql
+-          docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
 -        timeout-minutes: 30
 -        env:
 -          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -1,140 +1,20 @@
-@@ -52,8 +52,6 @@
-         description: 'Enable terminal session for CI jobs'
-         required: false
-         default: false
--  schedule:
--    - cron: '0 18 * * *'
- 
- defaults:
-   run:
-@@ -72,7 +70,6 @@
+@@ -70,7 +70,6 @@
  
    lint:
      runs-on: ubuntu-latest
--    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+-    if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
  
      container:
        # https://hub.docker.com/r/drevops/ci-runner
-@@ -175,118 +172,8 @@
-         run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-         continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
+@@ -175,7 +174,6 @@
  
--  database:
--    runs-on: ubuntu-latest
--    if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
--
--    container:
--      # https://hub.docker.com/r/drevops/ci-runner
--      image: drevops/ci-runner:__VERSION__
--      env:
--        PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
--        VORTEX_CONTAINER_REGISTRY_USER: ${{ secrets.VORTEX_CONTAINER_REGISTRY_USER }}
--        VORTEX_CONTAINER_REGISTRY_PASS: ${{ secrets.VORTEX_CONTAINER_REGISTRY_PASS }}
--        TZ: ${{ vars.TZ || 'UTC' }}
--        TERM: xterm-256color
--        VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"
--        VORTEX_SSH_REMOVE_ALL_KEYS: "1"
--        VORTEX_DEBUG: ${{ vars.VORTEX_DEBUG }}
--        # How often to refresh the cache of the DB dump. Refer to `date` command.
--        VORTEX_CI_DB_CACHE_TIMESTAMP: +%Y%m%d
--        # Use previous database caches on this branch as a fallback if the above cache
--        # does not match (for example, the cache is available only from the previous
--        # day). If "no" is set, the cache will be rebuilt from scratch.
--        VORTEX_CI_DB_CACHE_FALLBACK: "yes"
--        # Which branch to use as a source of DB caches.
--        VORTEX_CI_DB_CACHE_BRANCH: "develop"
--
--    steps:
--      - name: Preserve $HOME set in the container
--        run: echo HOME=/root >> "$GITHUB_ENV" # https://github.com/actions/runner/issues/863
--
--      - name: Check out code
--        uses: actions/checkout@__HASH__ # __VERSION__
--        with:
--          # Do not keep SSH credentials after checkout to allow adding custom SSH keys.
--          persist-credentials: false
--
--      - name: Fix Git ownership permissions
--        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
--
--      - name: Add SSH private key used to download database
--        if: ${{ env.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY != '' }}
--        uses: shimataro/ssh-key-action@__HASH__ # __VERSION__
--        with:
--          key: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
--          known_hosts: unnecessary
--        env:
--          VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
--
--      - name: Process the codebase to run in CI
--        run: find . -name "docker-compose.yml" -print0 | xargs -0 -I {} sh -c "sed -i -e '/###/d' {} && sed -i -e 's/##//' {}"
--
--      - name: Install Vortex tooling
--        run: ./scripts/vortex-tooling.sh
--
--      - name: Adjust variables for a scheduled run
--        if: github.event_name == 'schedule'
--        run: |
--          echo "VORTEX_CI_DB_CACHE_FALLBACK=no" >> "$GITHUB_ENV"
--          echo "VORTEX_FRONTEND_BUILD_SKIP=1" >> "$GITHUB_ENV"
--
--      - name: Create cache keys files for database caching
--        run: |
--          echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee db_cache_branch
--          echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/"${GITHUB_RUN_NUMBER}"}" | tee db_cache_fallback
--          date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee db_cache_timestamp
--          echo "yes" | tee db_cache_fallback_yes
--
--      # Restore DB cache based on the cache strategy set by the cache keys below.
--      # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
--      # Lookup cache based on the default branch and a timestamp. Allows
--      # to use cache from the very first build on the day (sanitized database dump, for example).
--      - name: Restore DB cache
--        uses: actions/cache/restore@__HASH__ # __VERSION__
--        with:
--          path: .data
--          key: __VERSION__${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback') }}-${{ hashFiles('db_cache_timestamp') }}
--          # Fallback to caching by default branch name only. Allows to use
--          # cache from the branch build on the previous day.
--          restore-keys: |
--            __VERSION__${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback') }}-
--
--      - name: Download DB
--        run: |
--          VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
--          echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
--        timeout-minutes: 30
--
--      - name: Export DB
--        run: |
--          if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
--          ./vendor/drevops/vortex-tooling/src/login-container-registry
--          docker compose up --detach && sleep 15
--          docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql
--          docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
--          ./vendor/drevops/vortex-tooling/src/export-db db.sql
--          docker compose cp -L cli:/app/.data/db.sql .data/db.sql
--        timeout-minutes: 30
--
--      # Save cache per default branch and the timestamp.
--      # The cache will not be saved if it already exists.
--      # Note that the cache fallback flag is enabled for this case in order
--      # to save cache even if the fallback is not used when restoring it.
--      - name: Save DB cache
--        uses: actions/cache/save@__HASH__ # __VERSION__
--        if: env.db_hash != hashFiles('.data')
--        with:
--          path: .data
--          key: __VERSION__${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
--
    test:
      runs-on: ubuntu-latest
--    needs: database
--    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
+-    if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
  
      permissions:
        contents: read # Check out the repository.
-@@ -312,14 +199,6 @@
+@@ -201,14 +199,6 @@
          VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"
          VORTEX_SSH_REMOVE_ALL_KEYS: "1"
          VORTEX_DEBUG: ${{ vars.VORTEX_DEBUG }}
@@ -149,7 +29,7 @@
  
      steps:
        - name: Preserve $HOME set in the container
-@@ -346,29 +225,6 @@
+@@ -235,49 +225,9 @@
        - name: Install Vortex tooling
          run: ./scripts/vortex-tooling.sh
  
@@ -170,7 +50,6 @@
 -        uses: actions/cache/restore@__HASH__ # __VERSION__
 -        with:
 -          path: .data
--          fail-on-cache-miss: true
 -          # Use cached database from previous builds of this branch.
 -          key: __VERSION__${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
 -          restore-keys: |
@@ -179,11 +58,68 @@
        - name: Login to container registry
          run: ./vendor/drevops/vortex-tooling/src/login-container-registry
  
-@@ -556,7 +412,6 @@
+-      - name: Add SSH private key used to download database
+-        if: ${{ env.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY != '' }}
+-        uses: shimataro/ssh-key-action@__HASH__ # __VERSION__
+-        with:
+-          key: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
+-          known_hosts: unnecessary
+-        env:
+-          VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
+-
+-      # On the first build of the day (cache miss), download a fresh DB dump.
+-      # On subsequent builds, the restored cache already contains the dump and
+-      # the download script skips itself, leaving no semaphore file behind.
+-      - name: Download DB
+-        run: |
+-          VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+-          echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
+-        timeout-minutes: 30
+-
+       - name: Build stack
+         run: docker compose up --detach && docker builder prune --all --force
+ 
+@@ -288,35 +238,6 @@
+             COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+           docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+ 
+-      # Execute commands after the database download finished: if a fresh DB
+-      # dump was downloaded (cache miss), import it and export it back to
+-      # produce a clean dump cached for the rest of the day's builds. This also
+-      # validates the dump and supports "file-to-image" / "image-to-file"
+-      # conversions. Configuration changes and DB updates are not applied, so
+-      # the cached database stays in the same state as downloaded. Only the
+-      # primary parallel runner pushes a refreshed database container image.
+-      - name: Export DB after download
+-        run: |
+-          if [ ! -f /tmp/download-db-success ]; then echo "==> Database download semaphore file is missing. DB export will not proceed."; exit 0; fi
+-          if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ] && [ "${STRATEGY_JOB_INDEX}" -ne 0 ]; then export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0; fi
+-          docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+-          docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+-          ./vendor/drevops/vortex-tooling/src/export-db db.sql
+-          docker compose cp -L cli:/app/.data/db.sql .data/db.sql
+-        timeout-minutes: 30
+-        env:
+-          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
+-          STRATEGY_JOB_INDEX: ${{ strategy.job-index }}
+-
+-      # Save the clean DB dump to cache from the primary parallel runner only,
+-      # and only when a fresh dump was downloaded this run (db_hash changed).
+-      - name: Save DB cache
+-        uses: actions/cache/save@__HASH__ # __VERSION__
+-        if: ${{ (matrix.instance == 0 || strategy.job-total == 1) && env.db_hash != hashFiles('.data') }}
+-        with:
+-          path: .data
+-          key: __VERSION__${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
+-
+       - name: Provision site
+         run: |
+           if [ -f .data/db.sql ]; then
+@@ -491,7 +412,6 @@
    deploy:
      runs-on: ubuntu-latest
      needs: [test, lint, build]
--    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
+-    if: ${{ !cancelled() && (inputs.deploy_target || (success() && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
  
      container:
        # https://hub.docker.com/r/drevops/ci-runner

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -170,11 +170,6 @@
+@@ -168,11 +168,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  
@@ -7,6 +7,6 @@
 -        run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
 -        continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
 -
-   database:
+   test:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -170,11 +170,6 @@
+@@ -168,11 +168,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  
@@ -7,6 +7,6 @@
 -        run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
 -        continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
 -
-   database:
+   test:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -170,11 +170,6 @@
+@@ -168,11 +168,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  
@@ -7,6 +7,6 @@
 -        run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
 -        continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
 -
-   database:
+   test:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -185,101 +182,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -289,6 +191,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -322,6 +228,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -334,6 +248,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -343,6 +276,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -520,17 +474,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -571,15 +519,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -146,18 +146,6 @@
+@@ -144,18 +144,6 @@
          run: docker compose exec -T cli composer normalize --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_NORMALIZE_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -173,101 +170,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -277,6 +179,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -310,6 +216,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -322,6 +236,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -331,6 +264,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -508,17 +462,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -559,15 +507,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -162,10 +162,6 @@
+@@ -160,10 +160,6 @@
          run: docker compose exec -T cli vendor/bin/twig-cs-fixer
          continue-on-error: ${{ vars.VORTEX_CI_TWIG_CS_FIXER_IGNORE_FAILURE == '1' }}
  
@@ -9,7 +9,7 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -396,80 +392,6 @@
+@@ -331,80 +327,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -90,7 +90,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -486,16 +408,6 @@
+@@ -421,16 +343,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -181,101 +178,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -285,6 +187,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -318,6 +224,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -330,6 +244,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -339,6 +272,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -466,17 +420,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -517,15 +465,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -136,7 +136,6 @@
+@@ -134,7 +134,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -166,10 +165,6 @@
+@@ -164,10 +163,6 @@
          run: docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features
          continue-on-error: ${{ vars.VORTEX_CI_GHERKIN_LINT_IGNORE_FAILURE == '1' }}
  
@@ -17,15 +17,15 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -380,7 +375,6 @@
+@@ -286,7 +281,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       - name: Provision site
-         run: |
-@@ -390,11 +384,6 @@
+       # Execute commands after the database download finished: if a fresh DB
+       # dump was downloaded (cache miss), import it and export it back to
+@@ -325,11 +319,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -180,101 +177,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -284,6 +186,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -317,6 +223,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -328,6 +242,25 @@ jobs:
               if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -337,6 +270,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with PHPUnit
@@ -510,17 +464,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -561,15 +509,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -136,7 +136,6 @@
+@@ -134,7 +134,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -166,15 +165,6 @@
+@@ -164,15 +163,6 @@
          run: docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features
          continue-on-error: ${{ vars.VORTEX_CI_GHERKIN_LINT_IGNORE_FAILURE == '1' }}
  
@@ -19,18 +19,18 @@
 -        run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
 -        continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
 -
-   database:
+   test:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -380,7 +370,6 @@
+@@ -286,7 +276,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       - name: Provision site
-         run: |
-@@ -390,11 +379,6 @@
+       # Execute commands after the database download finished: if a fresh DB
+       # dump was downloaded (cache miss), import it and export it back to
+@@ -325,11 +314,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -174,101 +171,6 @@ jobs:
           name: Lint code with Gherkin Lint
           command: docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features || [ "${VORTEX_CI_GHERKIN_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -278,6 +180,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -311,6 +217,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -322,6 +236,25 @@ jobs:
               if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -331,6 +264,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with PHPUnit
@@ -504,17 +458,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -555,15 +503,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/README.md
@@ -11,7 +11,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -162,10 +162,6 @@
+@@ -160,10 +160,6 @@
          run: docker compose exec -T cli vendor/bin/twig-cs-fixer
          continue-on-error: ${{ vars.VORTEX_CI_TWIG_CS_FIXER_IGNORE_FAILURE == '1' }}
  
@@ -9,7 +9,7 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -455,20 +451,6 @@
+@@ -390,20 +386,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -181,101 +178,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -285,6 +187,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -318,6 +224,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -330,6 +244,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -339,6 +272,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -506,17 +460,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -557,15 +505,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -136,7 +136,6 @@
+@@ -134,7 +134,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -165,10 +164,6 @@
+@@ -163,10 +162,6 @@
        - name: Lint code with Gherkin Lint
          run: docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features
          continue-on-error: ${{ vars.VORTEX_CI_GHERKIN_LINT_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -180,101 +177,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -284,6 +186,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -317,6 +223,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -329,6 +243,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -338,6 +271,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -515,17 +469,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -566,15 +514,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -136,7 +136,6 @@
+@@ -134,7 +134,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -165,15 +164,6 @@
+@@ -163,15 +162,6 @@
        - name: Lint code with Gherkin Lint
          run: docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features
          continue-on-error: ${{ vars.VORTEX_CI_GHERKIN_LINT_IGNORE_FAILURE == '1' }}
@@ -20,5 +20,5 @@
 -        run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
 -        continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  
-   database:
+   test:
      runs-on: ubuntu-latest

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
@@ -1,12 +1,12 @@
-@@ -380,7 +380,6 @@
+@@ -286,7 +286,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       - name: Provision site
-         run: |
-@@ -390,11 +389,6 @@
+       # Execute commands after the database download finished: if a fresh DB
+       # dump was downloaded (cache miss), import it and export it back to
+@@ -325,11 +324,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -185,101 +182,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -289,6 +191,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -322,6 +228,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -333,6 +247,25 @@ jobs:
               if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -342,6 +275,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with PHPUnit
@@ -515,17 +469,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -566,15 +514,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -146,10 +146,6 @@
+@@ -144,10 +144,6 @@
          run: docker compose exec -T cli composer normalize --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_NORMALIZE_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -181,101 +178,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -285,6 +187,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -318,6 +224,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -330,6 +244,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -339,6 +272,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -516,17 +470,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -567,15 +515,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -150,10 +150,6 @@
+@@ -148,10 +148,6 @@
          run: docker compose exec -T cli vendor/bin/phpcs
          continue-on-error: ${{ vars.VORTEX_CI_PHPCS_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -181,101 +178,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -285,6 +187,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -318,6 +224,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -330,6 +244,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -339,6 +272,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -516,17 +470,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -567,15 +515,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -396,66 +396,6 @@
+@@ -331,66 +331,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -65,7 +65,7 @@
        - name: Test with Behat
          run: |
            # shellcheck disable=SC2170
-@@ -486,16 +426,6 @@
+@@ -421,16 +361,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -185,101 +182,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -289,6 +191,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -322,6 +228,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -334,6 +248,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -343,6 +276,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -480,17 +434,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -531,15 +479,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -154,10 +154,6 @@
+@@ -152,10 +152,6 @@
          run: docker compose exec -T cli vendor/bin/phpstan
          continue-on-error: ${{ vars.VORTEX_CI_PHPSTAN_IGNORE_FAILURE == '1' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -181,101 +178,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -285,6 +187,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -318,6 +224,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -330,6 +244,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -339,6 +272,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -516,17 +470,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -567,15 +515,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
@@ -18,9 +18,6 @@ aliases:
   # Replace this key fingerprint with your own and remove this comment.
   - &deploy_ssh_fingerprint "SHA256:6d+U5QubT0eAWz+4N2wt+WM2qx6o4cvyvQ6xILETJ84"
 
-  # Schedule to run nightly database build (to cache the database for the next day).
-  - &nightly_db_schedule "0 18 * * *"
-
   # Shared runner container configuration applied to each job.
   - &runner_config
     working_directory: &working_directory ~/project
@@ -185,101 +182,6 @@ jobs:
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint" || [ "${VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE:-0}" -eq 1 ]
 
-  # Database handling is a first step of the build.
-  # - $VORTEX_CI_DB_CACHE_TIMESTAMP is used to determine if a fresh DB dump
-  #   should be downloaded for the current build. Usually, a daily database dump
-  #   is sufficient for development activities.
-  # - $VORTEX_CI_DB_CACHE_FALLBACK is used if the cache did not match $VORTEX_CI_DB_CACHE_TIMESTAMP.
-  #   This allows to rely on the cache from the previous days within the same branch.
-  database: &job-database
-    <<: *runner_config
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - add_ssh_keys:
-          fingerprints:
-            - *db_ssh_fingerprint
-
-      - checkout
-      - *step_process_codebase_for_ci
-      - *load_variables_from_dotenv
-
-      - run:
-          name: Install Vortex tooling
-          command: ./scripts/vortex-tooling.sh
-
-      - *step_setup_remote_docker
-
-      - run:
-          name: Create cache keys for database caching as files
-          command: |
-            echo "${VORTEX_CI_DB_CACHE_BRANCH}" | tee /tmp/db_cache_branch
-            echo "${VORTEX_CI_DB_CACHE_FALLBACK/no/${CIRCLE_BUILD_NUM}}" | tee /tmp/db_cache_fallback
-            date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee /tmp/db_cache_timestamp
-            echo "yes" | tee /tmp/db_cache_fallback_yes
-
-      - restore_cache:
-          keys:
-            # Restore DB cache based on the cache strategy set by the cache keys below.
-            # https://circleci.com/docs/2.0/caching/#restoring-cache
-            # Change 'v1' to 'v2', 'v3' etc., commit and push to force cache reset.
-            # Lookup cache based on the default branch and a timestamp. Allows
-            # to use cache from the very first build on the day (sanitized database dump, for example).
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            # Fallback to caching by default branch name only. Allows to use
-            # cache from the branch build on the previous day.
-            - __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
-
-      - run:
-          name: Download DB
-          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
-          no_output_timeout: 30m
-
-      # Execute commands after database download script finished: if the
-      # DB dump was downloaded - build the site (to ensure that the DB dump
-      # is valid) and export the DB using selected method (to support
-      # "file-to-image" or "image-to-file" conversions).
-      # Note that configuration changes and the DB updates are not applied, so
-      # the database will be cached in the same state as downloaded.
-      - run:
-          name: Export DB after download
-          command: |
-            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
-            ./vendor/drevops/vortex-tooling/src/login-container-registry
-            docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
-            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
-            ./vendor/drevops/vortex-tooling/src/export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
-          no_output_timeout: 30m
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-
-  # Nightly database job. Same as above, but with additional variables set.
-  # Triggered by the "nightly-db" schedule configured in CircleCI UI.
-  database-nightly:
-    <<: *job-database
-    environment:
-      VORTEX_DOWNLOAD_DB_SSH_FINGERPRINT: *db_ssh_fingerprint
-      VORTEX_DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
-      # Enforce fresh DB build (do not rely on fallback caches).
-      VORTEX_CI_DB_CACHE_FALLBACK: 'no'
-      # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:__VERSION__
-      # Deploy container image (if database-in-image storage is used).
-      VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
-      # Do not build the Drupal front-end.
-      VORTEX_FRONTEND_BUILD_SKIP: 1
-
   # Test the provisioned site. Runs in parallel with the lint and build jobs.
   # Provisioning and testing happen within the same job to save time on
   # re-provisioning.
@@ -289,6 +191,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - *db_ssh_fingerprint
 
       - checkout
       - *step_process_codebase_for_ci
@@ -322,6 +228,14 @@ jobs:
           name: Login to container registry
           command: ./vendor/drevops/vortex-tooling/src/login-container-registry
 
+      # On the first build of the day (cache miss), download a fresh DB dump.
+      # On subsequent builds, the restored cache already contains the dump and
+      # the download script skips itself, leaving no semaphore file behind.
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
       - run:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
@@ -334,6 +248,25 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Execute commands after the database download finished: if a fresh DB
+      # dump was downloaded (cache miss), import it and export it back to
+      # produce a clean dump cached for the rest of the day's builds. This also
+      # validates the dump and supports "file-to-image" / "image-to-file"
+      # conversions. Configuration changes and DB updates are not applied, so
+      # the cached database stays in the same state as downloaded. Only the
+      # primary parallel runner pushes a refreshed database container image.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
       - run:
           name: Provision site
           command: |
@@ -343,6 +276,27 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
+
+      # Save the clean DB dump to cache from the primary parallel runner only.
+      # save_cache has no runtime condition, so drop the cached path on the
+      # non-primary runners to make their save a no-op and let only node 0 store
+      # the cache. The provision step above already consumed the dump.
+      - run:
+          name: Keep DB cache only on the primary parallel runner
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
+              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
+              rm -rf .data
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
 
       - run:
           name: Test with Jest
@@ -520,17 +474,11 @@ workflows:
   # Commit workflow. Runs for every commit push to the remote repository.
   commit:
     jobs:
-      - database:
-          filters:
-            tags:
-              only: /.*/
       - lint:
           filters:
             tags:
               only: /.*/
       - test:
-          requires:
-            - database
           filters:
             tags:
               only: /.*/
@@ -571,15 +519,3 @@ workflows:
               # - __VERSION__, __VERSION__ (per https://semver.org/)
               # - 2023-04-17, 2023-04-17.123 (date-based)
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-
-  # Nightly database workflow runs overnight to capture fresh database and cache it.
-  nightly-db:
-    triggers:
-      - schedule:
-          cron: *nightly_db_schedule
-          filters:
-            branches:
-              only:
-                - develop
-    jobs:
-      - database-nightly

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/README.md
@@ -2,7 +2,7 @@
  
  Drupal 11 implementation of star wars for star wars Org
  
--[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
+-[![Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
  ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -170,11 +170,6 @@
+@@ -168,11 +168,6 @@
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
  
@@ -7,6 +7,6 @@
 -        run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
 -        continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
 -
-   database:
+   test:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -136,7 +136,6 @@
+@@ -134,7 +134,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,7 +6,7 @@
  
        - name: Audit Composer packages
          run: docker compose exec -T cli composer audit
-@@ -146,30 +145,10 @@
+@@ -144,30 +143,10 @@
          run: docker compose exec -T cli composer normalize --dry-run
          continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_NORMALIZE_IGNORE_FAILURE == '1' }}
  
@@ -37,15 +37,15 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -380,7 +359,6 @@
+@@ -286,7 +265,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       - name: Provision site
-         run: |
-@@ -391,85 +369,6 @@
+       # Execute commands after the database download finished: if a fresh DB
+       # dump was downloaded (cache miss), import it and export it back to
+@@ -326,85 +304,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30
  
@@ -131,7 +131,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -486,16 +385,6 @@
+@@ -421,16 +320,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/tests/generate-vortex-dev-circleci
+++ b/.vortex/tests/generate-vortex-dev-circleci
@@ -6,8 +6,11 @@ declare(strict_types=1);
 /**
  * Generate .circleci/vortex-test-common.yml from config.yml.
  *
- * Extracts aliases, database and build jobs from the main CircleCI config
- * and assembles them with DIDI variant jobs into a single test config.
+ * Extracts the aliases and the test job from the main CircleCI config and
+ * assembles them with the DIDI variant jobs into a single test config. The
+ * DIDI database-builder jobs are synthesized here (the main config no longer
+ * carries a standalone database job), while the DIDI build jobs reuse the
+ * test job anchor and skip the database download to consume a pre-built image.
  *
  * Usage:
  *   php .vortex/tests/generate-vortex-dev-circleci         # Generate
@@ -29,7 +32,6 @@ if ($content === FALSE) {
 $lines = explode("\n", $content);
 
 $aliases = extract_aliases($lines);
-$database_job = extract_job($lines, '/^  database: &job-database/');
 $test_job = extract_job($lines, '/^  test: &job_test/');
 
 $output = implode("\n", [
@@ -45,13 +47,11 @@ $output = implode("\n", [
   '################################################################################',
   '',
   'jobs:',
-  '  # Base jobs as anchor sources (not referenced in any workflow).',
-  $database_job,
-  '',
+  '  # Base job as an anchor source (not referenced in any workflow).',
   $test_job,
   '',
   '  # DIDI-FI variant jobs',
-  build_variant_job('vortex-dev-didi-database-fi', '*job-database', [
+  build_database_builder_job('vortex-dev-didi-database-fi', [
     'VORTEX_DOWNLOAD_DB_SOURCE' => 'url',
     'VORTEX_DOWNLOAD_DB_FORCE' => 1,
     'VORTEX_DB_IMAGE' => 'drevops/vortex-dev-mariadb-drupal-data-demo-destination-11.x',
@@ -63,11 +63,12 @@ $output = implode("\n", [
   build_variant_job('vortex-dev-didi-build-fi', '*job_test', [
     'VORTEX_DB_IMAGE' => 'drevops/vortex-dev-mariadb-drupal-data-demo-destination-11.x:vortex-dev-didi-database-fi',
     'VORTEX_CI_DB_CACHE_BRANCH' => 'vortex-dev-didi-fi',
+    'VORTEX_DOWNLOAD_DB_PROCEED' => 0,
     'DRUPAL_MIGRATION_SKIP' => 1,
   ]),
   '',
   '  # DIDI-II variant jobs',
-  build_variant_job('vortex-dev-database-ii', '*job-database', [
+  build_database_builder_job('vortex-dev-database-ii', [
     'VORTEX_DOWNLOAD_DB_SOURCE' => 'VORTEX_CONTAINER_REGISTRY',
     'VORTEX_DOWNLOAD_DB_FORCE' => 1,
     'VORTEX_DB_IMAGE' => 'drevops/vortex-dev-mariadb-drupal-data-demo-destination-11.x',
@@ -79,6 +80,7 @@ $output = implode("\n", [
   build_variant_job('vortex-dev-didi-build-ii', '*job_test', [
     'VORTEX_DB_IMAGE' => 'drevops/vortex-dev-mariadb-drupal-data-demo-destination-11.x:vortex-dev-database-ii',
     'VORTEX_CI_DB_CACHE_BRANCH' => 'vortex-dev-didi-ii',
+    'VORTEX_DOWNLOAD_DB_PROCEED' => 0,
     'DRUPAL_MIGRATION_SKIP' => 1,
   ]),
   '',
@@ -204,7 +206,7 @@ function extract_job(array $lines, string $pattern): string {
 }
 
 /**
- * Build a DIDI variant job YAML block.
+ * Build a DIDI variant job YAML block that reuses an existing job anchor.
  *
  * @param array<string, string|int> $env
  *   Environment variable overrides.
@@ -221,4 +223,63 @@ function build_variant_job(string $name, string $anchor, array $env): string {
   }
 
   return implode("\n", $lines);
+}
+
+/**
+ * Build a DIDI database-builder job YAML block.
+ *
+ * Downloads the database, imports it without applying configuration or database
+ * updates, then exports it as a container image and pushes it for the matching
+ * build job to consume. Mirrors the database-handling steps of the test job.
+ *
+ * @param array<string, string|int> $env
+ *   Environment variable overrides.
+ */
+function build_database_builder_job(string $name, array $env): string {
+  $env_lines = '';
+  foreach ($env as $key => $value) {
+    $env_lines .= sprintf("      %s: %s\n", $key, $value);
+  }
+
+  $steps = <<<'YAML'
+    steps:
+      - checkout
+      - *step_process_codebase_for_ci
+      - *load_variables_from_dotenv
+
+      - run:
+          name: Install Vortex tooling
+          command: ./scripts/vortex-tooling.sh
+
+      - *step_setup_remote_docker
+
+      - run:
+          name: Login to container registry
+          command: ./vendor/drevops/vortex-tooling/src/login-container-registry
+
+      - run:
+          name: Download DB
+          command: VORTEX_DOWNLOAD_DB_SEMAPHORE=/tmp/download-db-success ./vendor/drevops/vortex-tooling/src/download-db
+          no_output_timeout: 30m
+
+      - run:
+          name: Build stack
+          command: docker compose up --detach && docker builder prune --all --force
+
+      # Import the downloaded dump and export it as a database container image,
+      # then push it for the matching build job to pull. Configuration changes
+      # and database updates are not applied, so the image stays in the same
+      # state as downloaded.
+      - run:
+          name: Export DB after download
+          command: |
+            [ ! -f /tmp/download-db-success ] && echo "==> Database download semaphore file is missing. DB export will not proceed." && exit 0
+            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
+            grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
+            ./vendor/drevops/vortex-tooling/src/export-db db.sql
+          no_output_timeout: 30m
+YAML;
+
+  return sprintf("  %s:\n    <<: *runner_config\n    environment:\n%s%s", $name, $env_lines, $steps);
 }

--- a/.vortex/tests/generate-vortex-dev-circleci
+++ b/.vortex/tests/generate-vortex-dev-circleci
@@ -278,6 +278,7 @@ function build_database_builder_job(string $name, array $env): string {
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/drevops/vortex-tooling/src/provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 YAML;
 

--- a/README.dist.md
+++ b/README.dist.md
@@ -21,7 +21,7 @@ Drupal 11 implementation of YOURSITE for YOURORG
 
 [//]: # (#;< CI_PROVIDER_GHA)
 
-[![Database, Build, Test and Deploy](https://github.com/your_org/your_site/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/your_org/your_site/actions/workflows/build-test-deploy.yml)
+[![Build, Test and Deploy](https://github.com/your_org/your_site/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/your_org/your_site/actions/workflows/build-test-deploy.yml)
 
 [//]: # (#;> CI_PROVIDER_GHA)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <div align="center">
 
-[![Database, Build, Test and Deploy](https://github.com/drevops/vortex/actions/workflows/build-test-deploy.yml/badge.svg?branch=project%2F2.x)](https://github.com/drevops/vortex/actions/workflows/build-test-deploy.yml)
+[![Build, Test and Deploy](https://github.com/drevops/vortex/actions/workflows/build-test-deploy.yml/badge.svg?branch=project%2F2.x)](https://github.com/drevops/vortex/actions/workflows/build-test-deploy.yml)
 [![CircleCI](https://circleci.com/gh/drevops/vortex/tree/project%2F2.x.svg?style=shield)](https://circleci.com/gh/drevops/vortex/tree/project%2F2.x)
 [![Test](https://github.com/drevops/vortex/actions/workflows/vortex-test-common.yml/badge.svg?branch=project%2F2.x)](https://github.com/drevops/vortex/actions/workflows/vortex-test-common.yml)
 [![Test docs](https://github.com/drevops/vortex/actions/workflows/vortex-test-docs.yml/badge.svg?branch=project%2F2.x)](https://github.com/drevops/vortex/actions/workflows/vortex-test-docs.yml)


### PR DESCRIPTION
## Summary

Moved database download and caching out of a dedicated `database` CI job (and its paired nightly schedule) and into the `test` job itself. On a cache hit the test runners restore the cached dump and proceed straight to provisioning; on a cache miss (first build of the day) one runner downloads the production database, runs `provision` with `VORTEX_PROVISION_POST_OPERATIONS_SKIP=1` to import and export a clean pre-provision dump, copies that processed dump back to the host, then stores it in the cache so all subsequent builds that day skip the download entirely. Only the primary parallel runner (CircleCI node 0, GHA matrix instance 0) writes to the cache to prevent redundant stores. The nightly scheduled workflow that previously pre-warmed the database cache overnight is eliminated.

## Changes

**CircleCI (`.circleci/config.yml`)**
- Removed the `database` and `database-nightly` jobs, the `nightly-db` scheduled workflow, and the `nightly_db_schedule` alias.
- Added the DB-download SSH key, cache-key creation, `restore_cache`, `Download DB`, `Export DB after download`, `Keep DB cache only on the primary parallel runner`, and `save_cache` steps inside the `test` job.
- The `Export DB after download` step is guarded by a semaphore file (`/tmp/download-db-success`) so it only runs when a fresh dump was actually downloaded, and it copies the processed dump back to the host so the cache stores the clean re-exported dump rather than the raw download.
- Non-primary parallel runners remove `.data` before `save_cache` so only node 0 stores the cache; the image push (`VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED`) is likewise restricted to node 0.

**GitHub Actions (`.github/workflows/build-test-deploy.yml`)**
- Removed the `database` job, the `schedule:` cron trigger, the "Adjust variables for a scheduled run" step, the `needs: database` dependency, and the now-dead `github.event_name != 'schedule'` guards.
- Added the DB-download SSH key, cache-key creation, `Restore DB cache`, `Download DB`, `Export DB after download`, and `Save DB cache` steps inside the `test` job, including the copy-back of the processed dump to the host.
- Cache save is gated on `matrix.instance == 0` and a content-hash check (`db_hash`) so only the first matrix runner stores it; the export step tolerates a missing dump file for parity with CircleCI.

**DIDI dev-test generator (`.vortex/tests/generate-vortex-dev-circleci`)**
- No longer extracts the deleted `database` job.
- Synthesizes a minimal image-builder job for the FI/II database variants (download, clean export, push image), including the same copy-back.
- Build (consumer) variants reuse the `test` anchor and set `VORTEX_DOWNLOAD_DB_PROCEED: 0` to skip the now-built-in download step.
- Regenerated output: `.circleci/vortex-test-common.yml`.

**Documentation**
- `_code-lifecycle.mdx`: lifecycle diagram redrawn to show database caching as part of the Test job; the separate nightly database job is gone.
- `continuous-integration/README.mdx`, `circleci.mdx`, `github-actions.mdx`: updated job descriptions and caching guidance, removed references to the `database` job and nightly schedule.

**Installer fixtures**
- All fixtures under `.vortex/installer/tests/Fixtures/handler_process/**` regenerated to reflect the removed `database` job and the new DB-caching steps inside `test`.

## Before / After

```
BEFORE                                          AFTER
┌──────────────────────────────────────┐        ┌──────────────────────────────────────┐
│  Nightly schedule (cron)             │        │  (no nightly schedule)               │
│    └─► database-nightly job          │        │                                      │
│          Restore cache               │        │  Push / PR trigger                   │
│          Download DB                 │        │    │                                 │
│          Export clean dump           │        │    ▼                                 │
│          Save cache                  │        │  lint job   test job     build job   │
└──────────────────────────────────────┘        │             │                        │
                                                │             Restore DB cache         │
  Push / PR trigger                             │             │                        │
    │                                           │             ├─ cache miss ──►        │
    ▼                                           │             │   Download DB          │
  lint job   database job   test job  build job │             │   Export clean dump    │
               Restore cache                    │             │   Copy dump to host    │
               Download DB                      │             │   Save cache (node 0)  │
               Export clean dump  ──────────►   │             │                        │
               Save cache                       │             └─ cache hit ──►         │
                              test job          │             Build stack              │
                              Restore cache     │             Provision site           │
                              Build stack       │             Run tests                │
                              Provision site    └──────────────────────────────────────┘
                              Run tests
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI pipelines to remove standalone database jobs and move database download, migration download, export, and cache refresh into the test phase.
  * Improved database caching for parallel runs so only the primary runner refreshes and saves the cache.
  * Refined scheduling and event gating for GitHub Actions and reorganized CircleCI job structure accordingly.

* **Documentation**
  * Refreshed CircleCI/GitHub Actions CI documentation and lifecycle diagrams to match the new pipeline and daily cache refresh behavior.
  * Updated CI badge labels in the readme files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->