### PR TITLE
[#2634] Moved AI doc cache to '.artifacts' and git-excluded '.artifacts'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ web/themes/**/node_modules
 web/themes/**/build
 .data
 .logs
+.artifacts
 .phpunit.cache
 .twig-cs-fixer.cache
 

--- a/.gitignore
+++ b/.gitignore
@@ -67,9 +67,9 @@ web/themes/**/node_modules
 
 # Assets.
 web/themes/**/build
+.artifacts
 .data
 .logs
-.artifacts
 .phpunit.cache
 .twig-cs-fixer.cache
 

--- a/.vortex/docs/content/development/ai.mdx
+++ b/.vortex/docs/content/development/ai.mdx
@@ -21,7 +21,7 @@ throughout **Vortex**:
 - **How** to perform operations is sourced from the
   https://www.vortextemplate.com/docs (this site). The
   `AGENTS.md` file instructs agents to fetch operational guides from the
-  website and cache them locally in `.data/ai-artifacts/`.
+  website and cache them locally in `.artifacts/`.
 
 This means AI agents receive the same layered guidance as human developers:
 project-level decisions first, then Vortex-level procedures.

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.gitignore
@@ -53,9 +53,9 @@ web/themes/**/node_modules
 
 # Assets.
 web/themes/**/build
+.artifacts
 .data
 .logs
-.artifacts
 .phpunit.cache
 .twig-cs-fixer.cache
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.gitignore
@@ -55,6 +55,7 @@ web/themes/**/node_modules
 web/themes/**/build
 .data
 .logs
+.artifacts
 .phpunit.cache
 .twig-cs-fixer.cache
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/AGENTS.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/AGENTS.md
@@ -69,9 +69,9 @@ ahoy test-bdd -- --tags=@tagname  # Run Behat tests with specific tag
 
 ## Before Starting Any Task
 
-1. **Check cached docs first.** Before investigating any topic, check `.data/ai-artifacts/docs-[topic].md` for existing cached documentation. Do not search the codebase or fetch from the web if a cached doc already exists.
+1. **Check cached docs first.** Before investigating any topic, check `.artifacts/docs-[topic].md` for existing cached documentation. Do not search the codebase or fetch from the web if a cached doc already exists.
 2. **Check project docs.** Before making implementation decisions, check the relevant file in `docs/` for project-specific conventions.
-3. **Fetch and cache if missing.** If no cached doc exists for the topic, fetch from https://www.vortextemplate.com/docs and save to `.data/ai-artifacts/docs-[topic].md` (see [Documentation](#documentation) for format).
+3. **Fetch and cache if missing.** If no cached doc exists for the topic, fetch from https://www.vortextemplate.com/docs and save to `.artifacts/docs-[topic].md` (see [Documentation](#documentation) for format).
 
 ## Critical Rules
 
@@ -111,6 +111,6 @@ For **how** to perform operations, fetch from https://www.vortextemplate.com/doc
 
 Use the sitemap to discover available pages: https://www.vortextemplate.com/sitemap.xml
 
-**Caching:** Save fetched docs to `.data/ai-artifacts/docs-[topic].md` with header
+**Caching:** Save fetched docs to `.artifacts/docs-[topic].md` with header
 `<!-- Source: [URL] | Cached: [YYYY-MM-DD] -->`.
 Re-fetch if user reports docs are outdated.

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.gitignore
@@ -77,6 +77,6 @@
  # Assets.
 -web/themes/**/build
 +docroot/themes/**/build
+ .artifacts
  .data
  .logs
- .artifacts

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.gitignore
@@ -79,4 +79,4 @@
 +docroot/themes/**/build
  .data
  .logs
- .phpunit.cache
+ .artifacts

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.gitignore
@@ -77,6 +77,6 @@
  # Assets.
 -web/themes/**/build
 +docroot/themes/**/build
+ .artifacts
  .data
  .logs
- .artifacts

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.gitignore
@@ -79,4 +79,4 @@
 +docroot/themes/**/build
  .data
  .logs
- .phpunit.cache
+ .artifacts

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.gitignore
@@ -1,7 +1,7 @@
 @@ -56,7 +56,6 @@
+ .artifacts
  .data
  .logs
- .artifacts
 -.phpunit.cache
  .twig-cs-fixer.cache
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.gitignore
@@ -1,7 +1,7 @@
-@@ -55,7 +55,6 @@
- web/themes/**/build
+@@ -56,7 +56,6 @@
  .data
  .logs
+ .artifacts
 -.phpunit.cache
  .twig-cs-fixer.cache
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.gitignore
@@ -1,7 +1,7 @@
 @@ -56,7 +56,6 @@
+ .artifacts
  .data
  .logs
- .artifacts
 -.phpunit.cache
  .twig-cs-fixer.cache
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.gitignore
@@ -1,7 +1,7 @@
-@@ -55,7 +55,6 @@
- web/themes/**/build
+@@ -56,7 +56,6 @@
  .data
  .logs
+ .artifacts
 -.phpunit.cache
  .twig-cs-fixer.cache
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.gitignore
@@ -1,7 +1,7 @@
 @@ -56,7 +56,6 @@
+ .artifacts
  .data
  .logs
- .artifacts
 -.phpunit.cache
  .twig-cs-fixer.cache
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.gitignore
@@ -1,7 +1,7 @@
-@@ -55,7 +55,6 @@
- web/themes/**/build
+@@ -56,7 +56,6 @@
  .data
  .logs
+ .artifacts
 -.phpunit.cache
  .twig-cs-fixer.cache
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.gitignore
@@ -1,7 +1,7 @@
 @@ -56,7 +56,6 @@
+ .artifacts
  .data
  .logs
- .artifacts
 -.phpunit.cache
  .twig-cs-fixer.cache
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.gitignore
@@ -1,7 +1,7 @@
-@@ -55,7 +55,6 @@
- web/themes/**/build
+@@ -56,7 +56,6 @@
  .data
  .logs
+ .artifacts
 -.phpunit.cache
  .twig-cs-fixer.cache
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.gitignore
@@ -1,7 +1,7 @@
 @@ -56,7 +56,6 @@
+ .artifacts
  .data
  .logs
- .artifacts
 -.phpunit.cache
  .twig-cs-fixer.cache
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.gitignore
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.gitignore
@@ -1,7 +1,7 @@
-@@ -55,7 +55,6 @@
- web/themes/**/build
+@@ -56,7 +56,6 @@
  .data
  .logs
+ .artifacts
 -.phpunit.cache
  .twig-cs-fixer.cache
  

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,9 @@ ahoy test-bdd -- --tags=@tagname  # Run Behat tests with specific tag
 
 ## Before Starting Any Task
 
-1. **Check cached docs first.** Before investigating any topic, check `.data/ai-artifacts/docs-[topic].md` for existing cached documentation. Do not search the codebase or fetch from the web if a cached doc already exists.
+1. **Check cached docs first.** Before investigating any topic, check `.artifacts/docs-[topic].md` for existing cached documentation. Do not search the codebase or fetch from the web if a cached doc already exists.
 2. **Check project docs.** Before making implementation decisions, check the relevant file in `docs/` for project-specific conventions.
-3. **Fetch and cache if missing.** If no cached doc exists for the topic, fetch from https://www.vortextemplate.com/docs and save to `.data/ai-artifacts/docs-[topic].md` (see [Documentation](#documentation) for format).
+3. **Fetch and cache if missing.** If no cached doc exists for the topic, fetch from https://www.vortextemplate.com/docs and save to `.artifacts/docs-[topic].md` (see [Documentation](#documentation) for format).
 
 ## Critical Rules
 
@@ -121,6 +121,6 @@ For **how** to perform operations, fetch from https://www.vortextemplate.com/doc
 
 Use the sitemap to discover available pages: https://www.vortextemplate.com/sitemap.xml
 
-**Caching:** Save fetched docs to `.data/ai-artifacts/docs-[topic].md` with header
+**Caching:** Save fetched docs to `.artifacts/docs-[topic].md` with header
 `<!-- Source: [URL] | Cached: [YYYY-MM-DD] -->`.
 Re-fetch if user reports docs are outdated.


### PR DESCRIPTION
Closes #2634

## Summary

The AI doc cache was previously instructed to live under `.data/ai-artifacts/`, but `.data/` is the conventional home for project data (e.g. database dumps), while `.artifacts/` is the right location for agent scratch and generated output. This moves the three cache-path references in `AGENTS.md` from `.data/ai-artifacts/docs-[topic].md` to `.artifacts/docs-[topic].md`, updates the matching published-docs reference in `.vortex/docs/content/development/ai.mdx`, and adds `.artifacts` to `.gitignore` so the agent scratch directory is never committed by accident. Installer/test fixtures were regenerated via snapshots to keep the baseline and all scenario diffs in sync.

## Changes

- `AGENTS.md` - repointed the three AI-doc-cache references to `.artifacts/docs-[topic].md`.
- `.gitignore` - added `.artifacts` so the agent scratch directory is git-excluded.
- `.vortex/docs/content/development/ai.mdx` - updated the published docs reference to `.artifacts/`.
- Installer/test fixtures - regenerated via snapshots to reflect the templated `AGENTS.md`/`.gitignore` changes (baseline plus seven scenario `.gitignore` diffs).

## Before / After

```
# Cache path (AGENTS.md)
Before: .data/ai-artifacts/docs-[topic].md
After:  .artifacts/docs-[topic].md

# .gitignore (new entry)
Before: .data
        .logs
        .phpunit.cache
After:  .data
        .logs
        .artifacts      ← new
        .phpunit.cache
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude the `.artifacts` directory.
  * Reorganized local AI/development cache storage to use `.artifacts/` instead of the previous cache path.
* **Documentation**
  * Revised AI integration and developer workflow instructions to reference the new `.artifacts/docs-[topic].md` cache location and related caching steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->