### PR TITLE
[#2632] Made GitHub Actions SSH 'known_hosts' configurable via per-step variables.

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -246,7 +246,7 @@ jobs:
         uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 # v2.8.1
         with:
           key: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
-          known_hosts: unnecessary
+          known_hosts: ${{ vars.VORTEX_DOWNLOAD_DB_SSH_KNOWN_HOSTS || 'unnecessary' }}
         env:
           VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
 
@@ -667,7 +667,7 @@ jobs:
         uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 # v2.8.1
         with:
           key: ${{ secrets.VORTEX_DEPLOY_SSH_PRIVATE_KEY }}
-          known_hosts: unnecessary
+          known_hosts: ${{ vars.VORTEX_DEPLOY_SSH_KNOWN_HOSTS || 'unnecessary' }}
         env:
           VORTEX_DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.VORTEX_DEPLOY_SSH_PRIVATE_KEY }}
 

--- a/.vortex/docs/content/installation.mdx
+++ b/.vortex/docs/content/installation.mdx
@@ -165,7 +165,11 @@ ssh-keygen -m PEM -t rsa -b 4096 -C "deployer+myproject-gha@example.com" -f ~/.s
 
 **Pin host keys (optional).** Strict host-key checking is disabled by default. To
 enable it, add the verified host keys as a `VORTEX_SSH_KNOWN_HOSTS` repository
-variable and map it into the workflow `env` block.
+variable and map it into the workflow `env` block. The steps that load the SSH
+keys skip their `known_hosts` file by default; set the
+`VORTEX_DOWNLOAD_DB_SSH_KNOWN_HOSTS` (database download) and
+`VORTEX_DEPLOY_SSH_KNOWN_HOSTS` (deployment) repository variables to pin those
+host keys too.
 
 </TabItem>
 <TabItem value="circleci" label="CircleCI">

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -218,7 +218,7 @@ jobs:
         uses: shimataro/ssh-key-action@__HASH__ # __VERSION__
         with:
           key: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
-          known_hosts: unnecessary
+          known_hosts: ${{ vars.VORTEX_DOWNLOAD_DB_SSH_KNOWN_HOSTS || 'unnecessary' }}
         env:
           VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
 
@@ -590,7 +590,7 @@ jobs:
         uses: shimataro/ssh-key-action@__HASH__ # __VERSION__
         with:
           key: ${{ secrets.VORTEX_DEPLOY_SSH_PRIVATE_KEY }}
-          known_hosts: unnecessary
+          known_hosts: ${{ vars.VORTEX_DEPLOY_SSH_KNOWN_HOSTS || 'unnecessary' }}
         env:
           VORTEX_DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.VORTEX_DEPLOY_SSH_PRIVATE_KEY }}
 

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -71,7 +71,7 @@
 -        uses: shimataro/ssh-key-action@__HASH__ # __VERSION__
 -        with:
 -          key: ${{ secrets.VORTEX_DEPLOY_SSH_PRIVATE_KEY }}
--          known_hosts: unnecessary
+-          known_hosts: ${{ vars.VORTEX_DEPLOY_SSH_KNOWN_HOSTS || 'unnecessary' }}
 -        env:
 -          VORTEX_DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.VORTEX_DEPLOY_SSH_PRIVATE_KEY }}
 -

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -62,7 +62,7 @@
 -        uses: shimataro/ssh-key-action@__HASH__ # __VERSION__
 -        with:
 -          key: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
--          known_hosts: unnecessary
+-          known_hosts: ${{ vars.VORTEX_DOWNLOAD_DB_SSH_KNOWN_HOSTS || 'unnecessary' }}
 -        env:
 -          VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY: ${{ secrets.VORTEX_DOWNLOAD_DB_SSH_PRIVATE_KEY }}
 -


### PR DESCRIPTION
Closes #2632

## Summary

The two `shimataro/ssh-key-action` steps in `.github/workflows/build-test-deploy.yml` had `known_hosts: unnecessary` hardcoded, making it impossible for consumers to pin SSH host keys without forking or patching the workflow. Both steps now read per-step GitHub Actions repository variables (`VORTEX_DOWNLOAD_DB_SSH_KNOWN_HOSTS` and `VORTEX_DEPLOY_SSH_KNOWN_HOSTS`) with `|| 'unnecessary'` as a fallback, matching Vortex's established `vars.X || 'default'` idiom used elsewhere (e.g. `TZ`). Default behavior is unchanged - anyone not setting these variables gets exactly the same `unnecessary` value as before, so this is a backward-compatible opt-in knob for host-key pinning. CircleCI is out of scope: it uses `add_ssh_keys` with fingerprints and has no equivalent `known_hosts` field.

## Changes

**Workflow (`.github/workflows/build-test-deploy.yml`)**
- Database-download `shimataro/ssh-key-action` step: `known_hosts: unnecessary` -> `known_hosts: ${{ vars.VORTEX_DOWNLOAD_DB_SSH_KNOWN_HOSTS || 'unnecessary' }}`
- Deploy `shimataro/ssh-key-action` step: `known_hosts: unnecessary` -> `known_hosts: ${{ vars.VORTEX_DEPLOY_SSH_KNOWN_HOSTS || 'unnecessary' }}`

**Docs (`.vortex/docs/content/installation.mdx`)**
- Extended the "Pin host keys (optional)" section (GitHub Actions tab) to mention `VORTEX_DOWNLOAD_DB_SSH_KNOWN_HOSTS` and `VORTEX_DEPLOY_SSH_KNOWN_HOSTS` as the per-step variables.

**Installer fixtures (`.vortex/installer/tests/Fixtures/handler_process/`)**
- Regenerated `_baseline`, `deploy_types_none_gha`, and `provision_profile` fixtures to reflect the updated `known_hosts` expressions. These are generated files - not hand-edited.

## Before / After

```yaml
# Before
known_hosts: unnecessary

# After (database-download step)
known_hosts: ${{ vars.VORTEX_DOWNLOAD_DB_SSH_KNOWN_HOSTS || 'unnecessary' }}

# After (deploy step)
known_hosts: ${{ vars.VORTEX_DEPLOY_SSH_KNOWN_HOSTS || 'unnecessary' }}
```
