### PR TITLE
Added '2.x' to the tooling publish workflow trigger.

### DIFF
--- a/.github/workflows/vortex-publish-tooling.yml
+++ b/.github/workflows/vortex-publish-tooling.yml
@@ -2,12 +2,12 @@
 #
 # Publishes the contents of '.vortex/tooling/' from this monorepo to the
 # 'drevops/vortex-tooling' repository, mirroring the source branch name.
-# Runs only for 'main' and any branch whose name contains 'vortex-tooling'
-# so feature work that does not touch the tooling does not churn the
-# downstream repository. An empty commit is created when there are no file
-# changes so every source commit is reflected at the target. The published
-# commit subject matches the source commit subject; the body records
-# provenance.
+# Runs only for 'main', '2.x', and any branch whose name contains
+# 'vortex-tooling' so feature work that does not touch the tooling does not
+# churn the downstream repository. An empty commit is created when there are
+# no file changes so every source commit is reflected at the target. The
+# published commit subject matches the source commit subject; the body
+# records provenance.
 
 name: Vortex - Publish tooling
 
@@ -15,6 +15,7 @@ on:
   push:
     branches:
       - main
+      - '2.x'
       - '**vortex-tooling**'
 
 concurrency:


### PR DESCRIPTION
## Summary

The `vortex-publish-tooling` workflow mirrors this monorepo's `.vortex/tooling/` directory to the separate `drevops/vortex-tooling` repository, targeting the branch whose name matches `github.ref_name` - so `main` publishes to `main`, and (now) `2.x` publishes to `2.x`. Previously the trigger allowlist only listed `main` and `**vortex-tooling**`, which meant pushes to the `2.x` long-lived branch were silently skipped and the tooling repo never received `2.x` content. This change adds `'2.x'` to the `on.push.branches` list, enabling an independent `2.x` release line in `drevops/vortex-tooling`. The header comment is rewrapped to mention `2.x` alongside `main`.

## Changes

- `.github/workflows/vortex-publish-tooling.yml` - added `'2.x'` to the `on.push.branches` trigger allowlist and updated the top-of-file descriptive comment to reflect it.

## Before / After

**Trigger allowlist**

```
# Before
on:
  push:
    branches:
      - main
      - '**vortex-tooling**'

# After
on:
  push:
    branches:
      - main
      - '2.x'
      - '**vortex-tooling**'
```

**Branch routing (unchanged - each run publishes to its own `ref_name`)**

```
Push to main   → workflow runs → BRANCH=main   → publishes to drevops/vortex-tooling#main
Push to 2.x    → workflow runs → BRANCH=2.x    → publishes to drevops/vortex-tooling#2.x
Push to main   → can NEVER publish to 2.x (branch env is set from github.ref_name, not chosen by the trigger)
```

The routing is fully decoupled: the trigger allowlist controls which branches may fire the workflow; the destination is always the source branch name. Adding `2.x` to the allowlist does not affect `main` publishing in any way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended automated publishing workflow to cover the `2.x` branch in addition to `main` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->