### PR TITLE
[#2611] Removed 'guzzlehttp/psr7' audit ignore entries and bumped core to '~11.3.12'.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
@@ -89,10 +89,6 @@
             "tbachert/spi": true
         },
         "audit": {
-            "ignore": {
-                "GHSA-34xg-wgjx-8xph": "guzzlehttp/psr7: transitive via drupal/core-recommended (__VERSION__). Ignore until an upstream core/psr7 release moves off the affected __VERSION__/__VERSION__.",
-                "GHSA-hq7v-mx3g-29hw": "guzzlehttp/psr7: transitive via drupal/core-recommended (__VERSION__). Ignore until an upstream core/psr7 release moves off the affected __VERSION__/__VERSION__."
-            },
             "abandoned": "report",
             "block-insecure": true
         },

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/sites/default/default.settings.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/sites/default/default.settings.php
@@ -843,6 +843,23 @@ $settings['migrate_node_migrate_type_classic'] = FALSE;
 # $settings['migrate_file_private_path'] = '';
 
 /**
+ * Media oEmbed discovery trusted host configuration.
+ *
+ * The oEmbed spec allows for provider/resource discovery by fetching a URL. The
+ * patterns here restrict which domains Drupal will make a request to for oEmbed
+ * discovery.
+ *
+ * For example:
+ * @code
+ * $settings['media_oembed_discovery_trusted_host_patterns'] = [
+ *   '^www\.example\.com$',
+ * ];
+ * @endcode
+ * will allow the site to make oEmbed discovery requests to www.example.com.
+ */
+# $settings['media_oembed_discovery_trusted_host_patterns'] = [];
+
+/**
  * Load local development override configuration, if available.
  *
  * Create a settings.local.php file to override variables on secondary (staging,

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -122,38 +122,38 @@
+@@ -118,38 +118,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/sites/default/default.settings.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/sites/default/default.settings.php
@@ -841,6 +841,23 @@ $settings['migrate_node_migrate_type_classic'] = FALSE;
 # $settings['migrate_file_private_path'] = '';
 
 /**
+ * Media oEmbed discovery trusted host configuration.
+ *
+ * The oEmbed spec allows for provider/resource discovery by fetching a URL. The
+ * patterns here restrict which domains Drupal will make a request to for oEmbed
+ * discovery.
+ *
+ * For example:
+ * @code
+ * $settings['media_oembed_discovery_trusted_host_patterns'] = [
+ *   '^www\.example\.com$',
+ * ];
+ * @endcode
+ * will allow the site to make oEmbed discovery requests to www.example.com.
+ */
+# $settings['media_oembed_discovery_trusted_host_patterns'] = [];
+
+/**
  * Load local development override configuration, if available.
  *
  * Create a settings.local.php file to override variables on secondary (staging,

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -122,38 +122,38 @@
+@@ -118,38 +118,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/sites/default/default.settings.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/sites/default/default.settings.php
@@ -841,6 +841,23 @@ $settings['migrate_node_migrate_type_classic'] = FALSE;
 # $settings['migrate_file_private_path'] = '';
 
 /**
+ * Media oEmbed discovery trusted host configuration.
+ *
+ * The oEmbed spec allows for provider/resource discovery by fetching a URL. The
+ * patterns here restrict which domains Drupal will make a request to for oEmbed
+ * discovery.
+ *
+ * For example:
+ * @code
+ * $settings['media_oembed_discovery_trusted_host_patterns'] = [
+ *   '^www\.example\.com$',
+ * ];
+ * @endcode
+ * will allow the site to make oEmbed discovery requests to www.example.com.
+ */
+# $settings['media_oembed_discovery_trusted_host_patterns'] = [];
+
+/**
  * Load local development override configuration, if available.
  *
  * Create a settings.local.php file to override variables on secondary (staging,

--- a/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
@@ -38,8 +38,8 @@
 +            "wikimedia/composer-merge-plugin": true
          },
          "audit": {
-             "ignore": {
-@@ -163,6 +170,19 @@
+             "abandoned": "report",
+@@ -159,6 +166,19 @@
          "patchLevel": {
              "drupal/core": "-p2"
          },

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "drupal/coffee": "^2.0.1",
         "drupal/config_split": "^2.0.2",
         "drupal/config_update": "^2@alpha",
-        "drupal/core-composer-scaffold": "~11.3.11",
-        "drupal/core-recommended": "~11.3.11",
+        "drupal/core-composer-scaffold": "~11.3.12",
+        "drupal/core-recommended": "~11.3.12",
         "drupal/drupal_helpers": "^2.0.1",
         "drupal/environment_indicator": "^4.0.25",
         "drupal/generated_content": "^2.0.1",
@@ -58,7 +58,7 @@
         "phpstan/phpstan": "^2.2.2",
         "phpunit/phpunit": "^11.5.55",
         "pyrech/composer-changelogs": "^2.2",
-        "rector/rector": "^2.4.5",
+        "rector/rector": "^2.4.6",
         "vincentlanglet/twig-cs-fixer": "^3.14"
     },
     "conflict": {
@@ -100,10 +100,6 @@
             "tbachert/spi": true
         },
         "audit": {
-            "ignore": {
-                "GHSA-34xg-wgjx-8xph": "guzzlehttp/psr7: transitive via drupal/core-recommended (~2.8.0). Ignore until an upstream core/psr7 release moves off the affected 2.8.0/2.8.1.",
-                "GHSA-hq7v-mx3g-29hw": "guzzlehttp/psr7: transitive via drupal/core-recommended (~2.8.0). Ignore until an upstream core/psr7 release moves off the affected 2.8.0/2.8.1."
-            },
             "abandoned": "report",
             "block-insecure": true
         },

--- a/web/sites/default/default.settings.php
+++ b/web/sites/default/default.settings.php
@@ -843,6 +843,23 @@ $settings['migrate_node_migrate_type_classic'] = FALSE;
 # $settings['migrate_file_private_path'] = '';
 
 /**
+ * Media oEmbed discovery trusted host configuration.
+ *
+ * The oEmbed spec allows for provider/resource discovery by fetching a URL. The
+ * patterns here restrict which domains Drupal will make a request to for oEmbed
+ * discovery.
+ *
+ * For example:
+ * @code
+ * $settings['media_oembed_discovery_trusted_host_patterns'] = [
+ *   '^www\.example\.com$',
+ * ];
+ * @endcode
+ * will allow the site to make oEmbed discovery requests to www.example.com.
+ */
+# $settings['media_oembed_discovery_trusted_host_patterns'] = [];
+
+/**
  * Load local development override configuration, if available.
  *
  * Create a settings.local.php file to override variables on secondary (staging,


### PR DESCRIPTION
Closes #2611

## Summary

Drupal core 11.3.12 ships `guzzlehttp/psr7` at `~2.10.4`, which includes the fixes for both `GHSA-34xg-wgjx-8xph` (CVE-2026-48998, malformed Host header parsing) and `GHSA-hq7v-mx3g-29hw` (CVE-2026-49214, CRLF injection via URI host) introduced in psr7 2.10.2. Since the advisories are now resolved upstream, both `config.audit.ignore` entries have been removed from the root `composer.json`. The core packages were bumped from `~11.3.11` to `~11.3.12` and `rector/rector` from `^2.4.5` to `^2.4.6`. The Drupal scaffold refresh added a commented `media_oembed_discovery_trusted_host_patterns` block to `web/sites/default/default.settings.php`, and the installer fixtures were regenerated to reflect these changes.

## Changes

**`composer.json`**
- Removed `config.audit.ignore` entries for `GHSA-34xg-wgjx-8xph` and `GHSA-hq7v-mx3g-29hw` (both advisories resolved in psr7 2.10.2+, shipped with core 11.3.12).
- Bumped `drupal/core-composer-scaffold` and `drupal/core-recommended` from `~11.3.11` to `~11.3.12`.
- Bumped `rector/rector` from `^2.4.5` to `^2.4.6`.

**`web/sites/default/default.settings.php`**
- Drupal scaffold refresh added the commented `$settings['media_oembed_discovery_trusted_host_patterns']` block (new in core 11.3.12).

**Installer fixtures**
- Regenerated `_baseline`, `hosting_acquia`, `hosting_project_name___acquia`, and `starter_drupal_cms_profile` fixtures to match the updated `composer.json` and refreshed scaffold settings file.

## Before / After

```diff
-        "audit": {
-            "ignore": {
-                "GHSA-34xg-wgjx-8xph": "guzzlehttp/psr7: transitive via drupal/core-recommended (~2.8.0). ...",
-                "GHSA-hq7v-mx3g-29hw": "guzzlehttp/psr7: transitive via drupal/core-recommended (~2.8.0). ..."
-            },
-            "abandoned": "report",
-            "block-insecure": true
-        },
+        "audit": {
+            "abandoned": "report",
+            "block-insecure": true
+        },
```
