### PR TITLE
[#2649] Isolated 'ssh-add' in BATS tests so they cannot touch the real SSH agent.

### DIFF
--- a/.vortex/tooling/tests/_helper.bash
+++ b/.vortex/tooling/tests/_helper.bash
@@ -44,6 +44,14 @@ setup() {
   # Setup command mocking.
   setup_mock
 
+  # Isolate the SSH agent from tests. Scripts under test call `ssh-add`, which
+  # reaches the agent via the inherited SSH_AUTH_SOCK - a socket the HOME
+  # override does not sandbox. Stub `ssh-add` (the only agent-mutating command)
+  # so a test can never read, pollute or, with VORTEX_SSH_REMOVE_ALL_KEYS=1,
+  # wipe the real agent of the developer running the suite. Tests that assert
+  # specific `ssh-add` calls override this with their own mock via run_steps.
+  mock_command "ssh-add" >/dev/null
+
   ##
   ## Phase 2: Pre-flight checks.
   ##

--- a/.vortex/tooling/tests/unit/deploy-lagoon.bats
+++ b/.vortex/tooling/tests/unit/deploy-lagoon.bats
@@ -70,6 +70,7 @@ load ../_helper.bash
 
   declare -a STEPS=(
     "Started LAGOON deployment."
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for branch deployments."
@@ -103,6 +104,7 @@ load ../_helper.bash
 
   declare -a STEPS=(
     "Started LAGOON deployment."
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for branch deployments."
@@ -140,6 +142,7 @@ load ../_helper.bash
 
   declare -a STEPS=(
     "Started LAGOON deployment."
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for branch deployments."
@@ -184,6 +187,7 @@ load ../_helper.bash
 
   declare -a STEPS=(
     "Started LAGOON deployment."
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for PR deployments."
@@ -222,6 +226,7 @@ load ../_helper.bash
 
   declare -a STEPS=(
     "Started LAGOON deployment."
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for PR deployments."
@@ -264,6 +269,7 @@ load ../_helper.bash
 
   declare -a STEPS=(
     "Started LAGOON deployment."
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for PR deployments."
@@ -305,6 +311,7 @@ load ../_helper.bash
 
   declare -a STEPS=(
     "Started LAGOON deployment."
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Destroying environment: project test_project, branch: test-branch."
@@ -339,6 +346,7 @@ load ../_helper.bash
 
   declare -a STEPS=(
     "Started LAGOON deployment."
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for branch deployments."
@@ -374,6 +382,7 @@ load ../_helper.bash
 
   declare -a STEPS=(
     "Started LAGOON deployment."
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for branch deployments."
@@ -413,6 +422,7 @@ load ../_helper.bash
   # shellcheck disable=SC2034
   declare -a STEPS=(
     "Started LAGOON deployment."
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for PR deployments."


### PR DESCRIPTION
Closes #2649

## Summary

The BATS test harness redirected `HOME` to a per-test sandbox but left `SSH_AUTH_SOCK` inherited, meaning every script under test had a live path to the developer's real SSH agent. `deploy-lagoon.bats` drove the full deploy path through `setup-ssh`, which calls `ssh-add` to list and conditionally remove keys; with `VORTEX_SSH_REMOVE_ALL_KEYS=1` set (the CI default), that path calls `ssh-add -D`, wiping the developer's real agent during a local `ahoy test-bats` run. This PR stubs `ssh-add` globally in the harness `setup()` so no test can reach the real agent, and adds an explicit `@ssh-add -l` mock to the 10 full-deploy tests in `deploy-lagoon.bats` so their step assertions remain accurate. The production `setup-ssh` script design is unchanged and out of scope for this PR.

## Changes

**`.vortex/tooling/tests/_helper.bash`**

- Added a `mock_command "ssh-add"` call in `setup()`, immediately after `setup_mock`, to stub `ssh-add` for every test in the suite. `ssh-add` is the only command that mutates the SSH agent, and `SSH_AUTH_SOCK` inheritance means even a sandboxed `HOME` does not prevent it from reaching the real agent. Tests that need to assert specific `ssh-add` invocations can override the stub by declaring their own mock in the `STEPS` array via `run_steps`.

**`.vortex/tooling/tests/unit/deploy-lagoon.bats`**

- Added `"@ssh-add -l # ${HOME}/.ssh/id_rsa"` as the first step after "Started LAGOON deployment." in each of the 10 tests that exercise the full deploy path through `setup-ssh`. This makes the step sequence in the mocks match what the script actually calls, so `run_steps` intercepts the call instead of letting it fall through to the real binary.

## Before / After

```
BEFORE
──────
ahoy test-bats
  └─ deploy-lagoon.bats (any of 10 full-deploy tests)
       └─ run_steps → deploy-lagoon.sh
            └─ setup-ssh.sh
                 └─ ssh-add -l          ← real agent read
                 └─ ssh-add -D          ← real agent WIPED
                    (via inherited SSH_AUTH_SOCK;
                     HOME override does not protect it)

AFTER
─────
ahoy test-bats
  └─ _helper.bash setup()
       └─ mock_command "ssh-add"        ← stub registered
  └─ deploy-lagoon.bats (any of 10 full-deploy tests)
       └─ STEPS includes "@ssh-add -l" ← explicit mock
       └─ run_steps → deploy-lagoon.sh
            └─ setup-ssh.sh
                 └─ ssh-add -l          ← intercepted by mock
                 └─ ssh-add -D          ← intercepted by stub
                    real agent untouched
```
