### PR TITLE
[#2659] Fixed tooling script messages to read as proper English and aligned wording.

### DIFF
--- a/.vortex/docs/content/contributing/maintenance/script-boilerplate.sh
+++ b/.vortex/docs/content/contributing/maintenance/script-boilerplate.sh
@@ -23,10 +23,10 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 info "Started Vortex operations."
 
-[ -z "${VORTEX_EXAMPLE_URL}" ] && fail "Missing required value for VORTEX_EXAMPLE_URL" && exit 1
+[ -z "${VORTEX_EXAMPLE_URL}" ] && fail "Missing required value for VORTEX_EXAMPLE_URL." && exit 1
 command -v curl >/dev/null || (fail "curl command is not available." && exit 1)
 
 # Example of the script body.
-curl -L -s -o /dev/null -w "%{http_code}" "${VORTEX_EXAMPLE_URL}" | grep -q '200\|403' && note "Requested example page"
+curl -L -s -o /dev/null -w "%{http_code}" "${VORTEX_EXAMPLE_URL}" | grep -q '200\|403' && note "Requested example page."
 
 pass "Finished Vortex operations."

--- a/.vortex/docs/content/contributing/maintenance/template.mdx
+++ b/.vortex/docs/content/contributing/maintenance/template.mdx
@@ -60,7 +60,7 @@ in [this issue](https://github.com/drevops/vortex/issues/1192).
     ```
 7. SHOULD include variable values checks with errors and early exist, i.e.:
     ```shell
-    [ -z "${VORTEX_NOTIFY_REF}" ] && fail "Missing required value for VORTEX_NOTIFY_REF" && exit 1
+    [ -z "${VORTEX_NOTIFY_REF}" ] && fail "Missing required value for VORTEX_NOTIFY_REF." && exit 1
     ```
 8. SHOULD include binaries checks if the script relies on them, i.e.:
     ```shell
@@ -68,11 +68,11 @@ in [this issue](https://github.com/drevops/vortex/issues/1192).
     ```
 9. MUST contain an `info` message about the start of the script body, e.g.:
     ```shell
-    info "Started GitHub notification for operation ${VORTEX_NOTIFY_EVENT}"
+    info "Started GitHub notification for operation ${VORTEX_NOTIFY_EVENT}."
     ```
 10. MUST contain an `pass` message about the finish of the script body, e.g.:
     ```shell
-    pass "Finished GitHub notification for operation ${VORTEX_NOTIFY_EVENT}"
+    pass "Finished GitHub notification for operation ${VORTEX_NOTIFY_EVENT}."
     ```
 11. MUST use uppercase global variables
 12. MUST use lowercase local variables.

--- a/.vortex/docs/content/drupal/provision-example.sh
+++ b/.vortex/docs/content/drupal/provision-example.sh
@@ -48,7 +48,7 @@ if echo "${environment}" | grep -q -e dev -e stage -e ci -e local; then
     note "Existing database detected. Performing additional example operations."
   fi
 else
-  note "Skipping example operations in production environment."
+  note "Skipped example operations in production environment."
 fi
 
 info "Finished example operations."

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-10-example.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-10-example.sh
@@ -80,7 +80,7 @@ if echo "${environment}" | grep -q -e dev -e stage -e ci -e local; then
     note "Existing database detected. Performing additional example operations."
   fi
 else
-  note "Skipping example operations in production environment."
+  note "Skipped example operations in production environment."
 fi
 
 info "Finished example operations."

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_acquia/scripts/provision-20-migration.sh
@@ -70,7 +70,7 @@ note "Source DB import:        ${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}"
 echo
 
 if [ "${DRUPAL_MIGRATION_SKIP}" = "1" ]; then
-  info "Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1."
+  info "Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1."
   exit 0
 fi
 
@@ -84,7 +84,7 @@ run_migration() {
     exit 1
   }
 
-  task "Running migration: ${migration_name}"
+  task "Running migration: ${migration_name}."
   local opts=()
 
   opts+=("--feedback=${DRUPAL_MIGRATION_FEEDBACK}")
@@ -151,7 +151,7 @@ pass "Enabled migration modules."
 info "Starting migrations."
 
 if [ "${DRUPAL_MIGRATION_ROLLBACK_SKIP}" = "1" ]; then
-  note "Skipping rollback of all migrations."
+  note "Skipped rollback of all migrations."
 else
   task "Rolling back all migrations."
   drush migrate:rollback --all || true

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_container_registry/scripts/provision-20-migration.sh
@@ -70,7 +70,7 @@ note "Source DB import:        ${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}"
 echo
 
 if [ "${DRUPAL_MIGRATION_SKIP}" = "1" ]; then
-  info "Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1."
+  info "Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1."
   exit 0
 fi
 
@@ -84,7 +84,7 @@ run_migration() {
     exit 1
   }
 
-  task "Running migration: ${migration_name}"
+  task "Running migration: ${migration_name}."
   local opts=()
 
   opts+=("--feedback=${DRUPAL_MIGRATION_FEEDBACK}")
@@ -151,7 +151,7 @@ pass "Enabled migration modules."
 info "Starting migrations."
 
 if [ "${DRUPAL_MIGRATION_ROLLBACK_SKIP}" = "1" ]; then
-  note "Skipping rollback of all migrations."
+  note "Skipped rollback of all migrations."
 else
   task "Rolling back all migrations."
   drush migrate:rollback --all || true

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_ftp/scripts/provision-20-migration.sh
@@ -70,7 +70,7 @@ note "Source DB import:        ${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}"
 echo
 
 if [ "${DRUPAL_MIGRATION_SKIP}" = "1" ]; then
-  info "Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1."
+  info "Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1."
   exit 0
 fi
 
@@ -84,7 +84,7 @@ run_migration() {
     exit 1
   }
 
-  task "Running migration: ${migration_name}"
+  task "Running migration: ${migration_name}."
   local opts=()
 
   opts+=("--feedback=${DRUPAL_MIGRATION_FEEDBACK}")
@@ -151,7 +151,7 @@ pass "Enabled migration modules."
 info "Starting migrations."
 
 if [ "${DRUPAL_MIGRATION_ROLLBACK_SKIP}" = "1" ]; then
-  note "Skipping rollback of all migrations."
+  note "Skipped rollback of all migrations."
 else
   task "Rolling back all migrations."
   drush migrate:rollback --all || true

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_lagoon/scripts/provision-20-migration.sh
@@ -70,7 +70,7 @@ note "Source DB import:        ${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}"
 echo
 
 if [ "${DRUPAL_MIGRATION_SKIP}" = "1" ]; then
-  info "Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1."
+  info "Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1."
   exit 0
 fi
 
@@ -84,7 +84,7 @@ run_migration() {
     exit 1
   }
 
-  task "Running migration: ${migration_name}"
+  task "Running migration: ${migration_name}."
   local opts=()
 
   opts+=("--feedback=${DRUPAL_MIGRATION_FEEDBACK}")
@@ -151,7 +151,7 @@ pass "Enabled migration modules."
 info "Starting migrations."
 
 if [ "${DRUPAL_MIGRATION_ROLLBACK_SKIP}" = "1" ]; then
-  note "Skipping rollback of all migrations."
+  note "Skipped rollback of all migrations."
 else
   task "Rolling back all migrations."
   drush migrate:rollback --all || true

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_s3/scripts/provision-20-migration.sh
@@ -70,7 +70,7 @@ note "Source DB import:        ${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}"
 echo
 
 if [ "${DRUPAL_MIGRATION_SKIP}" = "1" ]; then
-  info "Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1."
+  info "Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1."
   exit 0
 fi
 
@@ -84,7 +84,7 @@ run_migration() {
     exit 1
   }
 
-  task "Running migration: ${migration_name}"
+  task "Running migration: ${migration_name}."
   local opts=()
 
   opts+=("--feedback=${DRUPAL_MIGRATION_FEEDBACK}")
@@ -151,7 +151,7 @@ pass "Enabled migration modules."
 info "Starting migrations."
 
 if [ "${DRUPAL_MIGRATION_ROLLBACK_SKIP}" = "1" ]; then
-  note "Skipping rollback of all migrations."
+  note "Skipped rollback of all migrations."
 else
   task "Rolling back all migrations."
   drush migrate:rollback --all || true

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_download_source_url/scripts/provision-20-migration.sh
@@ -70,7 +70,7 @@ note "Source DB import:        ${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}"
 echo
 
 if [ "${DRUPAL_MIGRATION_SKIP}" = "1" ]; then
-  info "Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1."
+  info "Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1."
   exit 0
 fi
 
@@ -84,7 +84,7 @@ run_migration() {
     exit 1
   }
 
-  task "Running migration: ${migration_name}"
+  task "Running migration: ${migration_name}."
   local opts=()
 
   opts+=("--feedback=${DRUPAL_MIGRATION_FEEDBACK}")
@@ -151,7 +151,7 @@ pass "Enabled migration modules."
 info "Starting migrations."
 
 if [ "${DRUPAL_MIGRATION_ROLLBACK_SKIP}" = "1" ]; then
-  note "Skipping rollback of all migrations."
+  note "Skipped rollback of all migrations."
 else
   task "Rolling back all migrations."
   drush migrate:rollback --all || true

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/scripts/provision-20-migration.sh
@@ -70,7 +70,7 @@ note "Source DB import:        ${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}"
 echo
 
 if [ "${DRUPAL_MIGRATION_SKIP}" = "1" ]; then
-  info "Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1."
+  info "Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1."
   exit 0
 fi
 
@@ -84,7 +84,7 @@ run_migration() {
     exit 1
   }
 
-  task "Running migration: ${migration_name}"
+  task "Running migration: ${migration_name}."
   local opts=()
 
   opts+=("--feedback=${DRUPAL_MIGRATION_FEEDBACK}")
@@ -151,7 +151,7 @@ pass "Enabled migration modules."
 info "Starting migrations."
 
 if [ "${DRUPAL_MIGRATION_ROLLBACK_SKIP}" = "1" ]; then
-  note "Skipping rollback of all migrations."
+  note "Skipped rollback of all migrations."
 else
   task "Rolling back all migrations."
   drush migrate:rollback --all || true

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/scripts/provision-20-migration.sh
@@ -70,7 +70,7 @@ note "Source DB import:        ${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}"
 echo
 
 if [ "${DRUPAL_MIGRATION_SKIP}" = "1" ]; then
-  info "Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1."
+  info "Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1."
   exit 0
 fi
 
@@ -84,7 +84,7 @@ run_migration() {
     exit 1
   }
 
-  task "Running migration: ${migration_name}"
+  task "Running migration: ${migration_name}."
   local opts=()
 
   opts+=("--feedback=${DRUPAL_MIGRATION_FEEDBACK}")
@@ -151,7 +151,7 @@ pass "Enabled migration modules."
 info "Starting migrations."
 
 if [ "${DRUPAL_MIGRATION_ROLLBACK_SKIP}" = "1" ]; then
-  note "Skipping rollback of all migrations."
+  note "Skipped rollback of all migrations."
 else
   task "Rolling back all migrations."
   drush migrate:rollback --all || true

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/scripts/provision-20-migration.sh
@@ -70,7 +70,7 @@ note "Source DB import:        ${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}"
 echo
 
 if [ "${DRUPAL_MIGRATION_SKIP}" = "1" ]; then
-  info "Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1."
+  info "Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1."
   exit 0
 fi
 
@@ -84,7 +84,7 @@ run_migration() {
     exit 1
   }
 
-  task "Running migration: ${migration_name}"
+  task "Running migration: ${migration_name}."
   local opts=()
 
   opts+=("--feedback=${DRUPAL_MIGRATION_FEEDBACK}")
@@ -151,7 +151,7 @@ pass "Enabled migration modules."
 info "Starting migrations."
 
 if [ "${DRUPAL_MIGRATION_ROLLBACK_SKIP}" = "1" ]; then
-  note "Skipping rollback of all migrations."
+  note "Skipped rollback of all migrations."
 else
   task "Rolling back all migrations."
   drush migrate:rollback --all || true

--- a/.vortex/tests/phpunit/Functional/DeploymentTest.php
+++ b/.vortex/tests/phpunit/Functional/DeploymentTest.php
@@ -40,10 +40,10 @@ class DeploymentTest extends FunctionalTestCase {
 
     $this->logSubstep('Run webhook deployment');
     $this->cmd('ahoy deploy', [
-      '* Started WEBHOOK deployment.',
+      '* Started webhook deployment.',
       '* Webhook call completed.',
       '! [FAIL] Unable to complete webhook deployment.',
-      '* Finished WEBHOOK deployment.',
+      '* Finished webhook deployment.',
     ], txt: 'Webhook deployment should complete successfully', env: [
       'VORTEX_DEPLOY_TYPES' => 'webhook',
       'VORTEX_DEPLOY_WEBHOOK_URL' => 'https://www.example.com',
@@ -67,9 +67,9 @@ class DeploymentTest extends FunctionalTestCase {
 
     $this->logSubstep('Subtest 1: Run deployment without skip flag set');
     $this->cmd('ahoy deploy', [
-      '* Started WEBHOOK deployment.',
-      '* Finished WEBHOOK deployment.',
-      '! Skipping deployment webhook.',
+      '* Started webhook deployment.',
+      '* Finished webhook deployment.',
+      '! Skipped deployment webhook.',
     ], txt: 'Deployment should proceed without skip flag', env: [
       'VORTEX_DEPLOY_TYPES' => 'webhook',
       'VORTEX_DEPLOY_WEBHOOK_URL' => 'https://www.example.com',
@@ -79,9 +79,9 @@ class DeploymentTest extends FunctionalTestCase {
     $this->logSubstep('Subtest 2: Run deployment with ALLOW_SKIP but no skip lists');
     $this->cmd('ahoy deploy', [
       '* Found flag to skip a deployment.',
-      '* Started WEBHOOK deployment.',
-      '* Finished WEBHOOK deployment.',
-      '! Skipping deployment webhook.',
+      '* Started webhook deployment.',
+      '* Finished webhook deployment.',
+      '! Skipped deployment webhook.',
     ], txt: 'Deployment should proceed with ALLOW_SKIP but no specific skip', env: [
       'VORTEX_DEPLOY_TYPES' => 'webhook',
       'VORTEX_DEPLOY_WEBHOOK_URL' => 'https://www.example.com',
@@ -93,8 +93,8 @@ class DeploymentTest extends FunctionalTestCase {
     $this->cmd('ahoy deploy', [
       '* Found flag to skip a deployment.',
       '* Found PR 123 in skip list.',
-      '* Skipping deployment webhook.',
-      '! Started WEBHOOK deployment.',
+      '* Skipped deployment webhook.',
+      '! Started webhook deployment.',
     ], txt: 'Deployment should be skipped for single PR', env: [
       'VORTEX_DEPLOY_TYPES' => 'webhook',
       'VORTEX_DEPLOY_WEBHOOK_URL' => 'https://www.example.com',
@@ -108,8 +108,8 @@ class DeploymentTest extends FunctionalTestCase {
     $this->cmd('ahoy deploy', [
       '* Found flag to skip a deployment.',
       '* Found PR 123 in skip list.',
-      '* Skipping deployment webhook.',
-      '! Started WEBHOOK deployment.',
+      '* Skipped deployment webhook.',
+      '! Started webhook deployment.',
     ], txt: 'Deployment should be skipped for PR 123 in list', env: [
       'VORTEX_DEPLOY_TYPES' => 'webhook',
       'VORTEX_DEPLOY_WEBHOOK_URL' => 'https://www.example.com',
@@ -122,10 +122,10 @@ class DeploymentTest extends FunctionalTestCase {
     $this->logSubstep('Subtest 5: Allow deployment for PR not in skip list');
     $this->cmd('ahoy deploy', [
       '* Found flag to skip a deployment.',
-      '* Started WEBHOOK deployment.',
-      '* Finished WEBHOOK deployment.',
+      '* Started webhook deployment.',
+      '* Finished webhook deployment.',
       '! Found PR 999 in skip list.',
-      '! Skipping deployment webhook.',
+      '! Skipped deployment webhook.',
     ], txt: 'Deployment should proceed for PR 999 not in skip list', env: [
       'VORTEX_DEPLOY_TYPES' => 'webhook',
       'VORTEX_DEPLOY_WEBHOOK_URL' => 'https://www.example.com',
@@ -139,8 +139,8 @@ class DeploymentTest extends FunctionalTestCase {
     $this->cmd('ahoy deploy', [
       '* Found flag to skip a deployment.',
       '* Found branch feature/test in skip list.',
-      '* Skipping deployment webhook.',
-      '! Started WEBHOOK deployment.',
+      '* Skipped deployment webhook.',
+      '! Started webhook deployment.',
     ], txt: 'Deployment should be skipped for single branch', env: [
       'VORTEX_DEPLOY_TYPES' => 'webhook',
       'VORTEX_DEPLOY_WEBHOOK_URL' => 'https://www.example.com',
@@ -154,8 +154,8 @@ class DeploymentTest extends FunctionalTestCase {
     $this->cmd('ahoy deploy', [
       '* Found flag to skip a deployment.',
       '* Found branch feature/test in skip list.',
-      '* Skipping deployment webhook.',
-      '! Started WEBHOOK deployment.',
+      '* Skipped deployment webhook.',
+      '! Started webhook deployment.',
     ], txt: 'Deployment should be skipped for branch in list', env: [
       'VORTEX_DEPLOY_TYPES' => 'webhook',
       'VORTEX_DEPLOY_WEBHOOK_URL' => 'https://www.example.com',
@@ -168,10 +168,10 @@ class DeploymentTest extends FunctionalTestCase {
     $this->logSubstep('Subtest 8: Allow deployment for branch not in skip list');
     $this->cmd('ahoy deploy', [
       '* Found flag to skip a deployment.',
-      '* Started WEBHOOK deployment.',
-      '* Finished WEBHOOK deployment.',
+      '* Started webhook deployment.',
+      '* Finished webhook deployment.',
       '! Found branch develop in skip list.',
-      '! Skipping deployment webhook.',
+      '! Skipped deployment webhook.',
     ], txt: 'Deployment should proceed for branch not in skip list', env: [
       'VORTEX_DEPLOY_TYPES' => 'webhook',
       'VORTEX_DEPLOY_WEBHOOK_URL' => 'https://www.example.com',
@@ -183,10 +183,10 @@ class DeploymentTest extends FunctionalTestCase {
 
     $this->logSubstep('Subtest 9: Run deployment without ALLOW_SKIP despite skip lists');
     $this->cmd('ahoy deploy', [
-      '* Started WEBHOOK deployment.',
-      '* Finished WEBHOOK deployment.',
+      '* Started webhook deployment.',
+      '* Finished webhook deployment.',
       '! Found flag to skip a deployment.',
-      '! Skipping deployment webhook.',
+      '! Skipped deployment webhook.',
     ], txt: 'Deployment should proceed when ALLOW_SKIP is not set', env: [
       'VORTEX_DEPLOY_TYPES' => 'webhook',
       'VORTEX_DEPLOY_WEBHOOK_URL' => 'https://www.example.com',
@@ -238,12 +238,12 @@ class DeploymentTest extends FunctionalTestCase {
 
     $this->logSubstep('Run artifact deployment');
     $this->cmd('ahoy deploy', [
-      '* Started ARTIFACT deployment.',
+      '* Started artifact deployment.',
       '* Installing artifact builder.',
       '* Copying git repo files meta file to the deploy code repo.',
       '* Copying deployment .gitignore as it may not exist in deploy code source files.',
       '* Running artifact builder.',
-      '* Finished ARTIFACT deployment.',
+      '* Finished artifact deployment.',
     ], txt: 'Artifact deployment should complete successfully', env: [
       'VORTEX_DEPLOY_TYPES' => 'artifact',
       'VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE' => $remote_dir . '/.git',

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -1003,7 +1003,7 @@ trait SubtestAhoyTrait {
     $this->cmd(
       'ahoy provision',
       [
-        '* Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1.',
+        '* Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1.',
         '! Importing migration source database.',
         '! Starting migrations.',
       ],

--- a/.vortex/tooling/src/deploy
+++ b/.vortex/tooling/src/deploy
@@ -80,7 +80,7 @@ SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 if [ "${VORTEX_DEPLOY_SKIP:-}" = "1" ]; then
   note "Found flag to skip all deployments."
-  pass "Skipping deployment ${VORTEX_DEPLOY_TYPES}."
+  pass "Skipped deployment ${VORTEX_DEPLOY_TYPES}."
   exit 0
 fi
 
@@ -98,7 +98,7 @@ if [ "${VORTEX_DEPLOY_ALLOW_SKIP:-}" = "1" ]; then
     # VORTEX_DEPLOY_SKIP_PRS=123,456,789
     if echo ",${VORTEX_DEPLOY_SKIP_PRS}," | grep -q ",${VORTEX_DEPLOY_PR},"; then
       note "Found PR ${VORTEX_DEPLOY_PR} in skip list."
-      note "Skipping deployment ${VORTEX_DEPLOY_TYPES}."
+      note "Skipped deployment ${VORTEX_DEPLOY_TYPES}."
       exit 0
     fi
   fi
@@ -114,7 +114,7 @@ if [ "${VORTEX_DEPLOY_ALLOW_SKIP:-}" = "1" ]; then
     # VORTEX_DEPLOY_SKIP_BRANCHES=feature/test,hotfix/urgent,project/experimental
     if echo ",${VORTEX_DEPLOY_SKIP_BRANCHES}," | grep -qF ",${VORTEX_DEPLOY_BRANCH},"; then
       note "Found branch ${VORTEX_DEPLOY_BRANCH} in skip list."
-      note "Skipping deployment ${VORTEX_DEPLOY_TYPES}."
+      note "Skipped deployment ${VORTEX_DEPLOY_TYPES}."
       exit 0
     fi
   fi
@@ -129,7 +129,7 @@ if [ -n "${VORTEX_DEPLOY_ALLOW_LABEL}" ] && [ -n "${VORTEX_DEPLOY_PR}" ]; then
 
   if ! echo ",${VORTEX_DEPLOY_PR_LABELS}," | grep -qF ",${VORTEX_DEPLOY_ALLOW_LABEL},"; then
     note "PR ${VORTEX_DEPLOY_PR} does not carry the '${VORTEX_DEPLOY_ALLOW_LABEL}' label."
-    note "Skipping deployment ${VORTEX_DEPLOY_TYPES}."
+    note "Skipped deployment ${VORTEX_DEPLOY_TYPES}."
     exit 0
   fi
 

--- a/.vortex/tooling/src/deploy-artifact
+++ b/.vortex/tooling/src/deploy-artifact
@@ -67,7 +67,7 @@ pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START)
 fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
 # @formatter:on
 
-info "Started ARTIFACT deployment."
+info "Started artifact deployment."
 
 # shellcheck disable=SC2043
 for cmd in curl; do command -v "${cmd}" >/dev/null || {
@@ -125,4 +125,4 @@ task "Running artifact builder."
   --log="${VORTEX_DEPLOY_ARTIFACT_LOG}" \
   -vvv
 
-pass "Finished ARTIFACT deployment."
+pass "Finished artifact deployment."

--- a/.vortex/tooling/src/deploy-container-registry
+++ b/.vortex/tooling/src/deploy-container-registry
@@ -44,7 +44,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 #shellcheck disable=SC2043
 for cmd in docker; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
@@ -68,7 +68,7 @@ images=()
 IFS=',' read -r -a values <<<"${VORTEX_DEPLOY_CONTAINER_REGISTRY_MAP}"
 for value in "${values[@]}"; do
   IFS='=' read -r -a parts <<<"${value}"
-  [ "${#parts[@]}" -ne 2 ] && fail "invalid key/value pair \"${value}\" provided." && exit 1
+  [ "${#parts[@]}" -ne 2 ] && fail "Invalid key/value pair \"${value}\" provided." && exit 1
   services+=("${parts[0]}")
   images+=("${parts[1]}")
 done

--- a/.vortex/tooling/src/deploy-lagoon
+++ b/.vortex/tooling/src/deploy-lagoon
@@ -98,12 +98,12 @@ is_lagoon_env_limit_exceeded() {
 # Track exit status to return at the end.
 exit_code=0
 
-info "Started LAGOON deployment."
+info "Started Lagoon deployment."
 
 # Lagoon does not support tag deployments. Exit successfully with a message.
 if [ "${VORTEX_DEPLOY_MODE}" = "tag" ]; then
-  note "Lagoon does not support tag deployments. Skipping."
-  pass "Finished LAGOON deployment."
+  note "Lagoon does not support tag deployments. Skipped."
+  pass "Finished Lagoon deployment."
   exit 0
 fi
 
@@ -130,7 +130,7 @@ if ! command -v lagoon >/dev/null || [ -n "${VORTEX_DEPLOY_LAGOON_LAGOONCLI_FORC
 fi
 
 for cmd in lagoon curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
@@ -143,7 +143,7 @@ lagoon() { command lagoon --force --skip-update-check --ssh-key "${VORTEX_DEPLOY
 # ACTION: 'destroy'
 # Explicitly specifying "destroy" action as a failsafe.
 if [ "${VORTEX_DEPLOY_LAGOON_ACTION}" = "destroy" ]; then
-  task "Destroying environment: project ${VORTEX_DEPLOY_LAGOON_PROJECT}, branch: ${VORTEX_DEPLOY_LAGOON_BRANCH}."
+  task "Destroying environment: project: ${VORTEX_DEPLOY_LAGOON_PROJECT}, branch: ${VORTEX_DEPLOY_LAGOON_BRANCH}."
   lagoon delete environment --environment "${VORTEX_DEPLOY_LAGOON_BRANCH}" || true
 
 # ACTION: 'deploy' OR 'deploy_override_db'
@@ -171,17 +171,17 @@ else
     if [ "${is_redeploy:-}" = "1" ]; then
       # Explicitly set DB overwrite flag to 0 due to a bug in Lagoon.
       # @see https://github.com/uselagoon/lagoon/issues/1922
-      task "Setting a DB overwrite flag to 0."
+      task "Setting a database overwrite flag to 0."
       lagoon update variable --environment "${deploy_pr_full}" --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global || true
 
       # Override DB during re-deployment.
       if [ "${VORTEX_DEPLOY_LAGOON_ACTION}" = "deploy_override_db" ]; then
-        task "Adding a DB import override flag for the current deployment."
+        task "Adding a database import override flag for the current deployment."
         # To update variable value, we need to remove it and add again.
         lagoon update variable --environment "${deploy_pr_full}" --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global || true
       fi
 
-      task "Redeploying environment: project ${VORTEX_DEPLOY_LAGOON_PROJECT}, PR: ${VORTEX_DEPLOY_LAGOON_PR}."
+      task "Redeploying environment: project: ${VORTEX_DEPLOY_LAGOON_PROJECT}, PR: ${VORTEX_DEPLOY_LAGOON_PR}."
       deploy_output=$(lagoon deploy pullrequest --number "${VORTEX_DEPLOY_LAGOON_PR}" --base-branch-name "${VORTEX_DEPLOY_LAGOON_PR_BASE_BRANCH}" --base-branch-ref "origin/${VORTEX_DEPLOY_LAGOON_PR_BASE_BRANCH}" --head-branch-name "${VORTEX_DEPLOY_LAGOON_BRANCH}" --head-branch-ref "${VORTEX_DEPLOY_LAGOON_PR_HEAD}" --title "${deploy_pr_full}" 2>&1) || exit_code=$?
       exit_code=${exit_code:-0}
       if is_lagoon_env_limit_exceeded "${deploy_output}"; then
@@ -193,7 +193,7 @@ else
         task "Waiting for deployment to be queued."
         sleep 10
 
-        task "Removing a DB import override flag for the current deployment."
+        task "Removing a database import override flag for the current deployment."
         # Note that a variable will be read by Lagoon during queuing of the build.
         lagoon update variable --environment "${deploy_pr_full}" --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global || true
       fi
@@ -201,7 +201,7 @@ else
     # Deployment of the fresh environment.
     else
       # If PR deployments are not configured in Lagoon - it will filter it out and will not deploy.
-      task "Deploying environment: project ${VORTEX_DEPLOY_LAGOON_PROJECT}, PR: ${VORTEX_DEPLOY_LAGOON_PR}."
+      task "Deploying environment: project: ${VORTEX_DEPLOY_LAGOON_PROJECT}, PR: ${VORTEX_DEPLOY_LAGOON_PR}."
       deploy_output=$(lagoon deploy pullrequest --number "${VORTEX_DEPLOY_LAGOON_PR}" --base-branch-name "${VORTEX_DEPLOY_LAGOON_PR_BASE_BRANCH}" --base-branch-ref "origin/${VORTEX_DEPLOY_LAGOON_PR_BASE_BRANCH}" --head-branch-name "${VORTEX_DEPLOY_LAGOON_BRANCH}" --head-branch-ref "${VORTEX_DEPLOY_LAGOON_PR_HEAD}" --title "${deploy_pr_full}" 2>&1) || exit_code=$?
       exit_code=${exit_code:-0}
       if is_lagoon_env_limit_exceeded "${deploy_output}"; then
@@ -231,17 +231,17 @@ else
     if [ "${is_redeploy:-}" = "1" ]; then
       # Explicitly set DB overwrite flag to 0 due to a bug in Lagoon.
       # @see https://github.com/uselagoon/lagoon/issues/1922
-      task "Setting a DB overwrite flag to 0."
+      task "Setting a database overwrite flag to 0."
       lagoon update variable --environment "${VORTEX_DEPLOY_LAGOON_BRANCH}" --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global || true
 
       # Override DB during re-deployment.
       if [ "${VORTEX_DEPLOY_LAGOON_ACTION:-}" = "deploy_override_db" ]; then
-        task "Adding a DB import override flag for the current deployment."
+        task "Adding a database import override flag for the current deployment."
         # To update variable value, we need to remove it and add again.
         lagoon update variable --environment "${VORTEX_DEPLOY_LAGOON_BRANCH}" --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global || true
       fi
 
-      task "Redeploying environment: project ${VORTEX_DEPLOY_LAGOON_PROJECT}, branch: ${VORTEX_DEPLOY_LAGOON_BRANCH}."
+      task "Redeploying environment: project: ${VORTEX_DEPLOY_LAGOON_PROJECT}, branch: ${VORTEX_DEPLOY_LAGOON_BRANCH}."
       deploy_output=$(lagoon deploy latest --environment "${VORTEX_DEPLOY_LAGOON_BRANCH}" 2>&1) || exit_code=$?
       exit_code=${exit_code:-0}
       if is_lagoon_env_limit_exceeded "${deploy_output}"; then
@@ -253,7 +253,7 @@ else
         task "Waiting for deployment to be queued."
         sleep 10
 
-        task "Removing a DB import override flag for the current deployment."
+        task "Removing a database import override flag for the current deployment."
         # Note that a variable will be read by Lagoon during queuing of the build.
         lagoon update variable --environment "${VORTEX_DEPLOY_LAGOON_BRANCH}" --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global || true
       fi
@@ -261,7 +261,7 @@ else
     # Deployment of the fresh environment.
     else
       # If current branch deployments does not match a regex in Lagoon - it will filter it out and will not deploy.
-      task "Deploying environment: project ${VORTEX_DEPLOY_LAGOON_PROJECT}, branch: ${VORTEX_DEPLOY_LAGOON_BRANCH}."
+      task "Deploying environment: project: ${VORTEX_DEPLOY_LAGOON_PROJECT}, branch: ${VORTEX_DEPLOY_LAGOON_BRANCH}."
       deploy_output=$(lagoon deploy branch --branch "${VORTEX_DEPLOY_LAGOON_BRANCH}" 2>&1) || exit_code=$?
       exit_code=${exit_code:-0}
       if is_lagoon_env_limit_exceeded "${deploy_output}"; then
@@ -273,9 +273,9 @@ else
 fi
 
 if [ "${exit_code}" = "0" ]; then
-  pass "Finished LAGOON deployment."
+  pass "Finished Lagoon deployment."
 else
-  fail "LAGOON deployment completed with errors."
+  fail "Lagoon deployment completed with errors."
 fi
 
 exit "${exit_code}"

--- a/.vortex/tooling/src/deploy-webhook
+++ b/.vortex/tooling/src/deploy-webhook
@@ -32,11 +32,11 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 #shellcheck disable=SC2043
 for cmd in curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
-info "Started WEBHOOK deployment."
+info "Started webhook deployment."
 
 # Check all required values.
 [ -z "${VORTEX_DEPLOY_WEBHOOK_URL}" ] && fail "Missing required value for VORTEX_DEPLOY_WEBHOOK_URL." && exit 1
@@ -50,4 +50,4 @@ else
   exit 1
 fi
 
-pass "Finished WEBHOOK deployment."
+pass "Finished webhook deployment."

--- a/.vortex/tooling/src/doctor
+++ b/.vortex/tooling/src/doctor
@@ -74,7 +74,7 @@ warn() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 # @formatter:on
 
 for cmd in docker pygmy ahoy; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
@@ -84,7 +84,7 @@ for cmd in docker pygmy ahoy; do command -v "${cmd}" >/dev/null || {
 main() {
   [ "${1:-}" = "info" ] && system_info && exit
 
-  info "Checking project requirements"
+  info "Checking project requirements."
 
   if [ "${VORTEX_DOCTOR_CHECK_TOOLS}" = "1" ]; then
     [ "$(command_exists docker)" = "1" ] && fail "Please install Docker (https://www.docker.com/get-started)." && exit 1
@@ -131,7 +131,7 @@ main() {
         exit 1
       fi
     done
-    pass "All containers are running"
+    pass "All containers are running."
   fi
 
   if [ "${VORTEX_DOCTOR_CHECK_SSH}" = "1" ]; then
@@ -165,7 +165,7 @@ main() {
     # Check that the key is injected into pygmy ssh-agent container.
     if ! pygmy status 2>&1 | grep -q "${VORTEX_SSH_FILE}"; then
       warn "SSH key is not added to pygmy."
-      note "The SSH key will not be available in CLI container. Run 'pygmy restart' and then 'ahoy up'"
+      note "The SSH key will not be available in the CLI container. Run 'pygmy restart' and then 'ahoy up'."
     else
       ssh_key_added_to_pygmy=1
     fi
@@ -184,9 +184,9 @@ main() {
     # Check that ssh key is available in the container, but only if the above checks passed.
     if [ "${ssh_key_added_to_pygmy}" = "1" ] && [ "${ssh_key_volume_mounted}" = "1" ]; then
       if ! docker compose exec -T cli bash -c "ssh-add -L | grep -q 'ssh-rsa'"; then
-        fail "SSH key was not added into container. Run 'pygmy restart'."
+        fail "SSH key was not added to the container. Run 'pygmy restart'."
       else
-        pass "SSH key is available within CLI container."
+        pass "SSH key is available within the CLI container."
       fi
     fi
   fi

--- a/.vortex/tooling/src/download-db
+++ b/.vortex/tooling/src/download-db
@@ -54,7 +54,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 info "Started database${_db_index:+ ${_db_index}} download."
 
-[ "${VORTEX_DOWNLOAD_DB_PROCEED}" != "1" ] && pass "Skipping database download as DB_DOWNLOAD_PROCEED is not set to 1." && exit 0
+[ "${VORTEX_DOWNLOAD_DB_PROCEED}" != "1" ] && pass "Skipped database download as DB_DOWNLOAD_PROCEED is not set to 1." && exit 0
 
 # Skip file existence check for container_registry source as the database is
 # stored as a Docker image, not a file.

--- a/.vortex/tooling/src/download-db-acquia
+++ b/.vortex/tooling/src/download-db-acquia
@@ -84,7 +84,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 # @formatter:on
 
 for cmd in php curl gunzip; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
@@ -214,7 +214,7 @@ if [ "$VORTEX_DOWNLOAD_DB_FRESH" = "1" ]; then
   note "Fresh backup will be downloaded."
 fi
 
-task "Discovering latest backup ID for DB ${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}."
+task "Discovering latest backup ID for database ${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}."
 backups_json=$(curl --progress-bar -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/environments/${env_id}/databases/${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}/backups?sort=created")
 [ "${VORTEX_DEBUG-}" = "1" ] && note "Backups API response: ${backups_json}"
 
@@ -233,7 +233,7 @@ fi
 # Acquia response has all backups sorted chronologically by created date.
 backup_id=$(echo "${backups_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "id")
 [ "${VORTEX_DEBUG-}" = "1" ] && note "Extracted backup ID: ${backup_id}"
-[ -z "${backup_id}" ] && fail "Unable to discover backup ID for DB '${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}'. API response: ${backups_json}" && exit 1
+[ -z "${backup_id}" ] && fail "Unable to discover backup ID for database '${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}'. API response: ${backups_json}" && exit 1
 
 # Insert backup id as a suffix.
 file_extension="${VORTEX_DOWNLOAD_DB_ACQUIA_DB_FILE##*.}"
@@ -246,13 +246,13 @@ file_name_compressed="${file_name}.gz"
 [ "${VORTEX_DEBUG-}" = "1" ] && note "Compressed file name: ${file_name_compressed}"
 
 if [ -f "${file_name_discovered}" ]; then
-  note "Found existing cached DB file \"${file_name_discovered}\" for DB \"${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}\"."
+  note "Found existing cached database file \"${file_name_discovered}\" for database \"${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}\"."
 else
   # If the gzipped version exists, then we don't need to re-download it.
   if [ ! -f "${file_name_compressed}" ]; then
-    note "Using the latest backup ID ${backup_id} for DB ${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}."
+    note "Using the latest backup ID ${backup_id} for database ${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}."
 
-    [ ! -d "${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR:-}" ] && note "Creating dump directory ${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR}" && mkdir -p "${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR}"
+    [ ! -d "${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR:-}" ] && note "Creating dump directory ${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR}." && mkdir -p "${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR}"
 
     task "Discovering backup URL."
     # The Acquia API responds with a 200 and a JSON body containing the
@@ -266,7 +266,7 @@ else
     [ "${VORTEX_DEBUG-}" = "1" ] && note "Extracted backup URL: ${backup_url}"
     [ -z "${backup_url}" ] && fail "Unable to discover backup URL for backup ID '${backup_id}'. API response: ${backup_url_json}" && exit 1
 
-    task "Downloading DB dump into file ${file_name_compressed}."
+    task "Downloading database dump into file ${file_name_compressed}."
     curl --progress-bar -L "${backup_url}" -o "${file_name_compressed}"
     download_result=$?
 
@@ -280,13 +280,13 @@ else
       exit 1
     fi
 
-    [ "${VORTEX_DEBUG-}" = "1" ] && note "Download completed successfully"
+    [ "${VORTEX_DEBUG-}" = "1" ] && note "Download completed successfully."
   else
-    pass "Found existing cached gzipped DB file ${file_name_compressed} for DB ${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}."
+    pass "Found existing cached gzipped database file ${file_name_compressed} for database ${VORTEX_DOWNLOAD_DB_ACQUIA_DB_NAME}."
   fi
 
-  task "Expanding DB file ${file_name_compressed} into ${file_name}."
-  [ "${VORTEX_DEBUG-}" = "1" ] && note "Starting decompression of ${file_name_compressed}"
+  task "Expanding database file ${file_name_compressed} into ${file_name}."
+  [ "${VORTEX_DEBUG-}" = "1" ] && note "Starting decompression of ${file_name_compressed}."
 
   # Test the gzip file first to ensure it's valid. Leave the file in place
   # on failure so it can be inspected.
@@ -302,13 +302,13 @@ else
   # Check decompression result and file validity. Leave both files in place
   # on failure so they can be inspected.
   if [ "${decompress_result}" != 0 ] || [ ! -f "${file_name}" ] || [ ! -s "${file_name}" ]; then
-    fail "Unable to process DB dump file \"${file_name}\". Decompression exit code: ${decompress_result}"
+    fail "Unable to process database dump file \"${file_name}\". Decompression exit code: ${decompress_result}"
     exit 1
   fi
 
   rm "${file_name_compressed}"
 
-  [ "${VORTEX_DEBUG-}" = "1" ] && note "Decompression completed successfully"
+  [ "${VORTEX_DEBUG-}" = "1" ] && note "Decompression completed successfully."
 fi
 
 task "Renaming file \"${file_name}\" to \"${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR}/${VORTEX_DOWNLOAD_DB_ACQUIA_DB_FILE}\"."
@@ -317,6 +317,6 @@ task "Renaming file \"${file_name}\" to \"${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR}/${
 mv "${file_name}" "${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR}/${VORTEX_DOWNLOAD_DB_ACQUIA_DB_FILE}"
 mv_result=$?
 [ "${mv_result}" -ne 0 ] && fail "Unable to rename file from '${file_name}' to '${VORTEX_DOWNLOAD_DB_ACQUIA_DB_DIR}/${VORTEX_DOWNLOAD_DB_ACQUIA_DB_FILE}'. mv exit code: ${mv_result}" && exit 1
-[ "${VORTEX_DEBUG-}" = "1" ] && note "File rename completed successfully"
+[ "${VORTEX_DEBUG-}" = "1" ] && note "File rename completed successfully."
 
 pass "Finished database dump download from Acquia."

--- a/.vortex/tooling/src/download-db-container-registry
+++ b/.vortex/tooling/src/download-db-container-registry
@@ -57,7 +57,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 #shellcheck disable=SC2043
 for cmd in docker; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 

--- a/.vortex/tooling/src/download-db-ftp
+++ b/.vortex/tooling/src/download-db-ftp
@@ -59,7 +59,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 #shellcheck disable=SC2043
 for cmd in curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 

--- a/.vortex/tooling/src/download-db-lagoon
+++ b/.vortex/tooling/src/download-db-lagoon
@@ -98,7 +98,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 # @formatter:on
 
 for cmd in ssh rsync; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 

--- a/.vortex/tooling/src/download-db-s3
+++ b/.vortex/tooling/src/download-db-s3
@@ -60,7 +60,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 # @formatter:on
 
 for cmd in curl openssl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 

--- a/.vortex/tooling/src/download-db-url
+++ b/.vortex/tooling/src/download-db-url
@@ -47,7 +47,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 # @formatter:on
 
 for cmd in curl unzip; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 

--- a/.vortex/tooling/src/export-db
+++ b/.vortex/tooling/src/export-db
@@ -30,7 +30,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 #shellcheck disable=SC2043
 for cmd in docker; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 

--- a/.vortex/tooling/src/export-db-image
+++ b/.vortex/tooling/src/export-db-image
@@ -38,7 +38,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 #shellcheck disable=SC2043
 for cmd in docker; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 

--- a/.vortex/tooling/src/info
+++ b/.vortex/tooling/src/info
@@ -27,7 +27,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 [ -n "${VORTEX_HOST_HAS_SEQUELACE:-}" ] && sequelace="('ahoy db' to start SequelAce)" || sequelace=""
 
-info "Project information"
+info "Project information:"
 
 echo
 note "Project name                : ${VORTEX_PROJECT}"

--- a/.vortex/tooling/src/login-container-registry
+++ b/.vortex/tooling/src/login-container-registry
@@ -46,7 +46,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 #shellcheck disable=SC2043
 for cmd in docker; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
@@ -58,5 +58,5 @@ elif [ -n "${VORTEX_LOGIN_CONTAINER_REGISTRY_USER}" ] && [ -n "${VORTEX_LOGIN_CO
   task "Logging in to registry \"${VORTEX_LOGIN_CONTAINER_REGISTRY}\"."
   echo "${VORTEX_LOGIN_CONTAINER_REGISTRY_PASS}" | docker login --username "${VORTEX_LOGIN_CONTAINER_REGISTRY_USER}" --password-stdin "${VORTEX_LOGIN_CONTAINER_REGISTRY}"
 else
-  note "Skipping login to the container registry as either VORTEX_LOGIN_CONTAINER_REGISTRY_USER or VORTEX_CONTAINER_REGISTRY_USER or VORTEX_LOGIN_CONTAINER_REGISTRY_PASS or VORTEX_CONTAINER_REGISTRY_PASS was not provided."
+  note "Skipped login to the container registry as either VORTEX_LOGIN_CONTAINER_REGISTRY_USER or VORTEX_CONTAINER_REGISTRY_USER or VORTEX_LOGIN_CONTAINER_REGISTRY_PASS or VORTEX_CONTAINER_REGISTRY_PASS was not provided."
 fi

--- a/.vortex/tooling/src/notify
+++ b/.vortex/tooling/src/notify
@@ -57,13 +57,13 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 info "Started dispatching notifications."
 
-[ -n "${VORTEX_NOTIFY_SKIP:-}" ] && pass "Skipping dispatching notifications." && exit 0
+[ -n "${VORTEX_NOTIFY_SKIP:-}" ] && pass "Skipped dispatching notifications." && exit 0
 
 # Validate required variables.
-[ -z "${VORTEX_NOTIFY_BRANCH}" ] && fail "Missing required value for VORTEX_NOTIFY_BRANCH" && exit 1
-[ -z "${VORTEX_NOTIFY_SHA}" ] && fail "Missing required value for VORTEX_NOTIFY_SHA" && exit 1
-[ -z "${VORTEX_NOTIFY_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_LABEL" && exit 1
-[ -z "${VORTEX_NOTIFY_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_ENVIRONMENT_URL" && exit 1
+[ -z "${VORTEX_NOTIFY_BRANCH}" ] && fail "Missing required value for VORTEX_NOTIFY_BRANCH." && exit 1
+[ -z "${VORTEX_NOTIFY_SHA}" ] && fail "Missing required value for VORTEX_NOTIFY_SHA." && exit 1
+[ -z "${VORTEX_NOTIFY_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_LABEL." && exit 1
+[ -z "${VORTEX_NOTIFY_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_ENVIRONMENT_URL." && exit 1
 
 # Auto-generate LOGIN_URL if not provided.
 if [ -z "${VORTEX_NOTIFY_LOGIN_URL}" ]; then

--- a/.vortex/tooling/src/notify-diffy
+++ b/.vortex/tooling/src/notify-diffy
@@ -69,7 +69,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 # @formatter:on
 
 for cmd in curl php; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
@@ -77,7 +77,7 @@ info "Started Diffy notification."
 
 # Skip on pre_deployment - the target environment is not yet ready.
 if [ "${VORTEX_NOTIFY_DIFFY_EVENT}" = "pre_deployment" ]; then
-  pass "Skipping Diffy notification for pre_deployment event."
+  pass "Skipped Diffy notification for pre_deployment event."
   exit 0
 fi
 
@@ -85,17 +85,17 @@ fi
 # deployment is dispatched and the workflow gates on PR + label.
 if [ -n "${VORTEX_NOTIFY_DIFFY_BRANCHES}" ]; then
   if ! echo ",${VORTEX_NOTIFY_DIFFY_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_DIFFY_BRANCH},"; then
-    pass "Skipping Diffy notification for branch '${VORTEX_NOTIFY_DIFFY_BRANCH}' (not in branch allowlist)."
+    pass "Skipped Diffy notification for branch '${VORTEX_NOTIFY_DIFFY_BRANCH}' (not in branch allowlist)."
     exit 0
   fi
 fi
 
 # Validate required values.
-[ -z "${VORTEX_NOTIFY_DIFFY_TOKEN}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_TOKEN" && exit 1
-[ -z "${VORTEX_NOTIFY_DIFFY_REPOSITORY}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_REPOSITORY" && exit 1
-[ -z "${VORTEX_NOTIFY_DIFFY_BRANCH}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_BRANCH" && exit 1
-[ -z "${VORTEX_NOTIFY_DIFFY_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_ENVIRONMENT_URL" && exit 1
-[ -z "${VORTEX_NOTIFY_DIFFY_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_LABEL" && exit 1
+[ -z "${VORTEX_NOTIFY_DIFFY_TOKEN}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_TOKEN." && exit 1
+[ -z "${VORTEX_NOTIFY_DIFFY_REPOSITORY}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_REPOSITORY." && exit 1
+[ -z "${VORTEX_NOTIFY_DIFFY_BRANCH}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_BRANCH." && exit 1
+[ -z "${VORTEX_NOTIFY_DIFFY_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_ENVIRONMENT_URL." && exit 1
+[ -z "${VORTEX_NOTIFY_DIFFY_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_LABEL." && exit 1
 
 # Sanitize repository (extract owner/repo, hide host if any).
 repository_sanitized=$(echo "${VORTEX_NOTIFY_DIFFY_REPOSITORY}" | sed -E 's|^https?://[^/]+/||; s|\.git$||')

--- a/.vortex/tooling/src/notify-email
+++ b/.vortex/tooling/src/notify-email
@@ -67,7 +67,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 if [ -n "${VORTEX_NOTIFY_EMAIL_BRANCHES}" ]; then
   if ! echo ",${VORTEX_NOTIFY_EMAIL_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
-    pass "Skipping email notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
+    pass "Skipped email notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
     exit 0
   fi
 fi
@@ -92,7 +92,7 @@ fi
 
 # Skip if this is a pre-deployment event (email only for post-deployment).
 if [ "${VORTEX_NOTIFY_EMAIL_EVENT}" = "pre_deployment" ]; then
-  pass "Skipping email notification for pre_deployment event."
+  pass "Skipped email notification for pre_deployment event."
   exit 0
 fi
 

--- a/.vortex/tooling/src/notify-github
+++ b/.vortex/tooling/src/notify-github
@@ -57,22 +57,22 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 # @formatter:on
 
 for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
 if [ -n "${VORTEX_NOTIFY_GITHUB_BRANCHES}" ]; then
   if ! echo ",${VORTEX_NOTIFY_GITHUB_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
-    pass "Skipping GitHub notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
+    pass "Skipped GitHub notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
     exit 0
   fi
 fi
 
-[ -z "${VORTEX_NOTIFY_GITHUB_TOKEN}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_TOKEN" && exit 1
-[ -z "${VORTEX_NOTIFY_GITHUB_REPOSITORY}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_REPOSITORY" && exit 1
-[ -z "${VORTEX_NOTIFY_GITHUB_BRANCH}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_BRANCH" && exit 1
-[ -z "${VORTEX_NOTIFY_GITHUB_EVENT}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_EVENT" && exit 1
-[ -z "${VORTEX_NOTIFY_GITHUB_ENVIRONMENT_TYPE}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_ENVIRONMENT_TYPE" && exit 1
+[ -z "${VORTEX_NOTIFY_GITHUB_TOKEN}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_TOKEN." && exit 1
+[ -z "${VORTEX_NOTIFY_GITHUB_REPOSITORY}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_REPOSITORY." && exit 1
+[ -z "${VORTEX_NOTIFY_GITHUB_BRANCH}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_BRANCH." && exit 1
+[ -z "${VORTEX_NOTIFY_GITHUB_EVENT}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_EVENT." && exit 1
+[ -z "${VORTEX_NOTIFY_GITHUB_ENVIRONMENT_TYPE}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_ENVIRONMENT_TYPE." && exit 1
 
 info "Started GitHub notification for ${VORTEX_NOTIFY_GITHUB_EVENT} event."
 
@@ -118,7 +118,7 @@ if [ "${VORTEX_NOTIFY_GITHUB_EVENT}" = "pre_deployment" ]; then
 
   note "Marked deployment as started."
 else
-  [ -z "${VORTEX_NOTIFY_GITHUB_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_ENVIRONMENT_URL" && exit 1
+  [ -z "${VORTEX_NOTIFY_GITHUB_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_ENVIRONMENT_URL." && exit 1
 
   # Returns all deployment for this ref sorted from the latest to the oldest.
   payload="$(curl \

--- a/.vortex/tooling/src/notify-jira
+++ b/.vortex/tooling/src/notify-jira
@@ -77,27 +77,27 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 # @formatter:on
 
 for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
 if [ -n "${VORTEX_NOTIFY_JIRA_BRANCHES}" ]; then
   if ! echo ",${VORTEX_NOTIFY_JIRA_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
-    pass "Skipping JIRA notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
+    pass "Skipped JIRA notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
     exit 0
   fi
 fi
 
-[ -z "${VORTEX_NOTIFY_JIRA_USER_EMAIL}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_USER_EMAIL" && exit 1
-[ -z "${VORTEX_NOTIFY_JIRA_TOKEN}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_TOKEN" && exit 1
-[ -z "${VORTEX_NOTIFY_JIRA_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_LABEL" && exit 1
-[ -z "${VORTEX_NOTIFY_JIRA_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_PROJECT" && exit 1
+[ -z "${VORTEX_NOTIFY_JIRA_USER_EMAIL}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_USER_EMAIL." && exit 1
+[ -z "${VORTEX_NOTIFY_JIRA_TOKEN}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_TOKEN." && exit 1
+[ -z "${VORTEX_NOTIFY_JIRA_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_LABEL." && exit 1
+[ -z "${VORTEX_NOTIFY_JIRA_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_PROJECT." && exit 1
 
 info "Started JIRA notification."
 
 # Skip if this is a pre-deployment event (JIRA only processes post-deployment).
 if [ "${VORTEX_NOTIFY_JIRA_EVENT}" = "pre_deployment" ]; then
-  pass "Skipping JIRA notification for pre_deployment event."
+  pass "Skipped JIRA notification for pre_deployment event."
   exit 0
 fi
 
@@ -144,12 +144,12 @@ extract_issue() {
   echo "${1}" | sed -nE "s/([^\/]+\/)?([A-Za-z0-9]+\-[0-9]+).*/\2/p"
 }
 
-task "Extracting issue"
+task "Extracting issue."
 issue="$(extract_issue "${VORTEX_NOTIFY_JIRA_BRANCH}")"
 [ "${issue}" = "" ] && pass "Branch ${VORTEX_NOTIFY_JIRA_BRANCH} does not contain issue number." && exit 0
 note "Found issue ${issue}."
 
-task "Creating API token"
+task "Creating API token."
 base64_opts=() && [ "$(uname)" != "Darwin" ] && base64_opts=(-w 0)
 token="$(echo -n "${VORTEX_NOTIFY_JIRA_USER_EMAIL}:${VORTEX_NOTIFY_JIRA_TOKEN}" | base64 "${base64_opts[@]}")"
 
@@ -163,7 +163,7 @@ payload="$(curl \
 
 account_id="$(echo "${payload}" | extract_json_value "accountId" || echo "error")"
 
-[ "${#account_id}" -lt 24 ] && fail "Unable to authenticate" && echo "${payload}" && exit 1
+[ "${#account_id}" -lt 24 ] && fail "Unable to authenticate." && echo "${payload}" && exit 1
 echo "success"
 
 task "Posting a comment."
@@ -239,7 +239,7 @@ payload="$(curl \
 
 comment_id="$(echo "${payload}" | extract_json_value "id" || echo "error")"
 if [ "$(expr "x${comment_id}" : "x[0-9]*$")" -eq 0 ]; then
-  fail "Unable to create a comment"
+  fail "Unable to create a comment."
   echo "API Response: ${payload}"
   exit 1
 fi
@@ -247,7 +247,7 @@ fi
 pass "Posted comment with ID ${comment_id}."
 
 if [ -n "${VORTEX_NOTIFY_JIRA_TRANSITION}" ]; then
-  task "Transitioning issue to ${VORTEX_NOTIFY_JIRA_TRANSITION}"
+  task "Transitioning issue to ${VORTEX_NOTIFY_JIRA_TRANSITION}."
 
   echo -n "       Discovering transition ID for ${VORTEX_NOTIFY_JIRA_TRANSITION}..."
   payload="$(curl \
@@ -258,7 +258,7 @@ if [ -n "${VORTEX_NOTIFY_JIRA_TRANSITION}" ]; then
     --url "${VORTEX_NOTIFY_JIRA_ENDPOINT}/rest/api/3/issue/${issue}/transitions")"
 
   transition_id="$(echo "${payload}" | extract_json_value "transitions" | extract_json_value_by_value "name" "${VORTEX_NOTIFY_JIRA_TRANSITION}" "id" || echo "error")"
-  { [ "${transition_id}" = "" ] || [ "$(expr "x${transition_id}" : "x[0-9]*$")" -eq 0 ]; } && fail "Unable to retrieve transition ID" && exit 1
+  { [ "${transition_id}" = "" ] || [ "$(expr "x${transition_id}" : "x[0-9]*$")" -eq 0 ]; } && fail "Unable to retrieve transition ID." && exit 1
   echo "success"
 
   payload="$(curl \
@@ -269,11 +269,11 @@ if [ -n "${VORTEX_NOTIFY_JIRA_TRANSITION}" ]; then
     --url "${VORTEX_NOTIFY_JIRA_ENDPOINT}/rest/api/3/issue/${issue}/transitions" \
     --data "{ \"transition\": {\"id\": \"${transition_id}\"}}")"
 
-  pass "Transitioned issue to ${VORTEX_NOTIFY_JIRA_TRANSITION} "
+  pass "Transitioned issue to ${VORTEX_NOTIFY_JIRA_TRANSITION}."
 fi
 
 if [ -n "${VORTEX_NOTIFY_JIRA_ASSIGNEE_EMAIL:-}" ]; then
-  task "Assigning issue to ${VORTEX_NOTIFY_JIRA_ASSIGNEE_EMAIL}"
+  task "Assigning issue to ${VORTEX_NOTIFY_JIRA_ASSIGNEE_EMAIL}."
 
   echo -n "       Discovering user ID for ${VORTEX_NOTIFY_JIRA_ASSIGNEE_EMAIL}..."
   payload="$(curl \
@@ -284,7 +284,7 @@ if [ -n "${VORTEX_NOTIFY_JIRA_ASSIGNEE_EMAIL:-}" ]; then
     --url "${VORTEX_NOTIFY_JIRA_ENDPOINT}/rest/api/3/user/assignable/search?query=${VORTEX_NOTIFY_JIRA_ASSIGNEE_EMAIL}&issueKey=${issue}")"
 
   account_id="$(echo "${payload}" | extract_json_first_value "accountId" || echo "error")"
-  [ "${#account_id}" -lt 24 ] && fail "Unable to retrieve assignee account ID" && echo "${payload}" && exit 1
+  [ "${#account_id}" -lt 24 ] && fail "Unable to retrieve assignee account ID." && echo "${payload}" && exit 1
   echo "success"
 
   payload="$(curl \
@@ -295,7 +295,7 @@ if [ -n "${VORTEX_NOTIFY_JIRA_ASSIGNEE_EMAIL:-}" ]; then
     --url "${VORTEX_NOTIFY_JIRA_ENDPOINT}/rest/api/3/issue/${issue}/assignee" \
     --data "{ \"accountId\": \"${account_id}\"}")"
 
-  pass "Assigned issue to ${VORTEX_NOTIFY_JIRA_ASSIGNEE_EMAIL}"
+  pass "Assigned issue to ${VORTEX_NOTIFY_JIRA_ASSIGNEE_EMAIL}."
 fi
 
 pass "Finished JIRA notification."

--- a/.vortex/tooling/src/notify-newrelic
+++ b/.vortex/tooling/src/notify-newrelic
@@ -94,21 +94,21 @@ fi
 
 if [ -n "${VORTEX_NOTIFY_NEWRELIC_BRANCHES}" ]; then
   if ! echo ",${VORTEX_NOTIFY_NEWRELIC_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
-    pass "Skipping New Relic notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
+    pass "Skipped New Relic notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
     exit 0
   fi
 fi
 
 for cmd in curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
-[ -z "${VORTEX_NOTIFY_NEWRELIC_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_PROJECT" && exit 1
-[ -z "${VORTEX_NOTIFY_NEWRELIC_USER_KEY}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_USER_KEY" && exit 1
-[ -z "${VORTEX_NOTIFY_NEWRELIC_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_LABEL" && exit 1
-[ -z "${VORTEX_NOTIFY_NEWRELIC_APP_NAME}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_APP_NAME" && exit 1
-[ -z "${VORTEX_NOTIFY_NEWRELIC_USER}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_USER" && exit 1
+[ -z "${VORTEX_NOTIFY_NEWRELIC_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_PROJECT." && exit 1
+[ -z "${VORTEX_NOTIFY_NEWRELIC_USER_KEY}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_USER_KEY." && exit 1
+[ -z "${VORTEX_NOTIFY_NEWRELIC_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_LABEL." && exit 1
+[ -z "${VORTEX_NOTIFY_NEWRELIC_APP_NAME}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_APP_NAME." && exit 1
+[ -z "${VORTEX_NOTIFY_NEWRELIC_USER}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_USER." && exit 1
 
 info "Started New Relic notification."
 
@@ -127,7 +127,7 @@ fi
 
 # Skip if this is a pre-deployment event (New Relic only for post-deployment).
 if [ "${VORTEX_NOTIFY_NEWRELIC_EVENT}" = "pre_deployment" ]; then
-  pass "Skipping New Relic notification for pre_deployment event."
+  pass "Skipped New Relic notification for pre_deployment event."
   exit 0
 fi
 
@@ -151,7 +151,7 @@ if [ -z "${VORTEX_NOTIFY_NEWRELIC_CHANGELOG}" ]; then
   VORTEX_NOTIFY_NEWRELIC_CHANGELOG="${VORTEX_NOTIFY_NEWRELIC_DESCRIPTION}"
 fi
 
-task "Discovering APP id by name if it was not provided."
+task "Discovering application ID by name if it was not provided."
 if [ -z "${VORTEX_NOTIFY_NEWRELIC_APPID}" ] && [ -n "${VORTEX_NOTIFY_NEWRELIC_APP_NAME}" ]; then
   VORTEX_NOTIFY_NEWRELIC_APPID="$(curl -s -X GET "${VORTEX_NOTIFY_NEWRELIC_ENDPOINT}/applications.json" \
     -H "Api-Key: ${VORTEX_NOTIFY_NEWRELIC_USER_KEY}" \
@@ -191,7 +191,7 @@ if ! curl -X POST "${VORTEX_NOTIFY_NEWRELIC_ENDPOINT}/applications/${VORTEX_NOTI
     \"user\": \"${VORTEX_NOTIFY_NEWRELIC_USER}\"
   }
 }" | grep -q '201'; then
-  fail "Failed to create a deployment notification for application ${VORTEX_NOTIFY_NEWRELIC_APP_NAME} with ID ${VORTEX_NOTIFY_NEWRELIC_APPID}"
+  fail "Failed to create a deployment notification for application ${VORTEX_NOTIFY_NEWRELIC_APP_NAME} with ID ${VORTEX_NOTIFY_NEWRELIC_APPID}."
   exit 1
 fi
 

--- a/.vortex/tooling/src/notify-slack
+++ b/.vortex/tooling/src/notify-slack
@@ -63,22 +63,22 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 # @formatter:on
 
 for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
 if [ -n "${VORTEX_NOTIFY_SLACK_BRANCHES}" ]; then
   if ! echo ",${VORTEX_NOTIFY_SLACK_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
-    pass "Skipping Slack notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
+    pass "Skipped Slack notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
     exit 0
   fi
 fi
 
-[ -z "${VORTEX_NOTIFY_SLACK_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_PROJECT" && exit 1
-[ -z "${VORTEX_NOTIFY_SLACK_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_LABEL" && exit 1
-[ -z "${VORTEX_NOTIFY_SLACK_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_ENVIRONMENT_URL" && exit 1
-[ -z "${VORTEX_NOTIFY_SLACK_LOGIN_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_LOGIN_URL" && exit 1
-[ -z "${VORTEX_NOTIFY_SLACK_WEBHOOK}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_WEBHOOK" && exit 1
+[ -z "${VORTEX_NOTIFY_SLACK_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_PROJECT." && exit 1
+[ -z "${VORTEX_NOTIFY_SLACK_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_LABEL." && exit 1
+[ -z "${VORTEX_NOTIFY_SLACK_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_ENVIRONMENT_URL." && exit 1
+[ -z "${VORTEX_NOTIFY_SLACK_LOGIN_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_LOGIN_URL." && exit 1
+[ -z "${VORTEX_NOTIFY_SLACK_WEBHOOK}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_WEBHOOK." && exit 1
 
 info "Started Slack notification."
 
@@ -182,7 +182,7 @@ response=$(curl -s -o /dev/null -w "%{http_code}" \
   "${VORTEX_NOTIFY_SLACK_WEBHOOK}")
 
 if [ "${response}" != "200" ]; then
-  fail "Unable to send notification to Slack. HTTP status: ${response}"
+  fail "Unable to send notification to Slack. HTTP status: ${response}."
   exit 1
 fi
 

--- a/.vortex/tooling/src/notify-webhook
+++ b/.vortex/tooling/src/notify-webhook
@@ -60,30 +60,30 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 # @formatter:on
 
 for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
 if [ -n "${VORTEX_NOTIFY_WEBHOOK_BRANCHES}" ]; then
   if ! echo ",${VORTEX_NOTIFY_WEBHOOK_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
-    pass "Skipping Webhook notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
+    pass "Skipped webhook notification for branch '${VORTEX_NOTIFY_BRANCH-}'."
     exit 0
   fi
 fi
 
-[ -z "${VORTEX_NOTIFY_WEBHOOK_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_PROJECT" && exit 1
-[ -z "${VORTEX_NOTIFY_WEBHOOK_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_LABEL" && exit 1
-[ -z "${VORTEX_NOTIFY_WEBHOOK_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_ENVIRONMENT_URL" && exit 1
-[ -z "${VORTEX_NOTIFY_WEBHOOK_LOGIN_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_LOGIN_URL" && exit 1
-[ -z "${VORTEX_NOTIFY_WEBHOOK_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_URL" && exit 1
-[ -z "${VORTEX_NOTIFY_WEBHOOK_METHOD}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_METHOD" && exit 1
-[ -z "${VORTEX_NOTIFY_WEBHOOK_HEADERS}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_HEADERS" && exit 1
+[ -z "${VORTEX_NOTIFY_WEBHOOK_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_PROJECT." && exit 1
+[ -z "${VORTEX_NOTIFY_WEBHOOK_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_LABEL." && exit 1
+[ -z "${VORTEX_NOTIFY_WEBHOOK_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_ENVIRONMENT_URL." && exit 1
+[ -z "${VORTEX_NOTIFY_WEBHOOK_LOGIN_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_LOGIN_URL." && exit 1
+[ -z "${VORTEX_NOTIFY_WEBHOOK_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_URL." && exit 1
+[ -z "${VORTEX_NOTIFY_WEBHOOK_METHOD}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_METHOD." && exit 1
+[ -z "${VORTEX_NOTIFY_WEBHOOK_HEADERS}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_HEADERS." && exit 1
 
-info "Started Webhook notification."
+info "Started webhook notification."
 
 # Skip if this is a pre-deployment event (webhook only for post-deployment).
 if [ "${VORTEX_NOTIFY_WEBHOOK_EVENT}" = "pre_deployment" ]; then
-  pass "Skipping Webhook notification for pre_deployment event."
+  pass "Skipped webhook notification for pre_deployment event."
   exit 0
 fi
 
@@ -136,4 +136,4 @@ if ! curl -L -s -o /dev/null -w '%{http_code}' \
   exit 1
 fi
 
-pass "Finished Webhook notification."
+pass "Finished webhook notification."

--- a/.vortex/tooling/src/provision
+++ b/.vortex/tooling/src/provision
@@ -159,7 +159,7 @@ echo
 
 if [ "${VORTEX_PROVISION_VERIFY_CONFIG_UNCHANGED_AFTER_UPDATE}" = "1" ]; then
   for cmd in diff mktemp; do command -v "${cmd}" >/dev/null || {
-    fail "Command ${cmd} is not available"
+    fail "Command ${cmd} is not available."
     exit 1
   }; done
 fi

--- a/.vortex/tooling/src/reset
+++ b/.vortex/tooling/src/reset
@@ -21,7 +21,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 #shellcheck disable=SC2043
 for cmd in git; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
@@ -42,7 +42,7 @@ rm -rf \
 find . -type d -name node_modules | xargs rm -Rf
 
 if [ "${is_hard_reset}" = "1" ]; then
-  task "Changing permissions and remove all other untracked files."
+  task "Changing permissions and removing all other untracked files."
 
   git ls-files --others -i --exclude-from=.gitignore -z | while IFS= read -r -d '' file; do
     chmod 777 "${file}" >/dev/null || true

--- a/.vortex/tooling/src/setup-ssh
+++ b/.vortex/tooling/src/setup-ssh
@@ -68,7 +68,7 @@ else
 fi
 
 if [ "${file}" = false ]; then
-  pass "SSH key is set to false meaning that it is not required. Skipping setup."
+  pass "SSH key is set to false meaning that it is not required. Skipped setup."
   export "${file_var}=${file}"
   [ "${BASH_SOURCE[0]}" != "$0" ] && return 0 || exit 0
 fi

--- a/.vortex/tooling/src/task-copy-db-acquia
+++ b/.vortex/tooling/src/task-copy-db-acquia
@@ -74,7 +74,7 @@ extract_json_value() {
 # Pre-flight checks.
 #shellcheck disable=SC2043
 for cmd in curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
@@ -96,7 +96,7 @@ token=$(echo "${token_json}" | extract_json_value "access_token")
 task "Retrieving ${VORTEX_TASK_COPY_DB_ACQUIA_APP_NAME} application UUID."
 app_uuid_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications?filter=name%3D${VORTEX_TASK_COPY_DB_ACQUIA_APP_NAME/ /%20}")
 app_uuid=$(echo "${app_uuid_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "uuid")
-[ -z "${app_uuid}" ] && fail "Unable to retrieve an environment UUID." && exit 1
+[ -z "${app_uuid}" ] && fail "Unable to retrieve an application UUID." && exit 1
 
 task "Retrieving source environment ID."
 envs_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications/${app_uuid}/environments?filter=name%3D${VORTEX_TASK_COPY_DB_ACQUIA_SRC}")
@@ -108,7 +108,7 @@ envs_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorizatio
 dst_env_id=$(echo "${envs_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "id")
 [ -z "${dst_env_id}" ] && fail "Unable to retrieve destination environment ID." && exit 1
 
-task "Copying DB from ${VORTEX_TASK_COPY_DB_ACQUIA_SRC} to ${VORTEX_TASK_COPY_DB_ACQUIA_DST} environment."
+task "Copying database from ${VORTEX_TASK_COPY_DB_ACQUIA_SRC} to ${VORTEX_TASK_COPY_DB_ACQUIA_DST} environment."
 task_status_json=$(curl -X POST -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" -d "{\"source\":\"${src_env_id}\", \"name\":\"${VORTEX_TASK_COPY_DB_ACQUIA_NAME}\"}" "https://cloud.acquia.com/api/environments/${dst_env_id}/databases")
 notification_url=$(echo "${task_status_json}" | extract_json_value "_links" | extract_json_value "notification" | extract_json_value "href")
 
@@ -131,11 +131,11 @@ done
 echo
 
 if [ "${task_completed}" = "0" ]; then
-  fail "Unable to copy DB from ${VORTEX_TASK_COPY_DB_ACQUIA_SRC} to ${VORTEX_TASK_COPY_DB_ACQUIA_DST} environment."
+  fail "Unable to copy database from ${VORTEX_TASK_COPY_DB_ACQUIA_SRC} to ${VORTEX_TASK_COPY_DB_ACQUIA_DST} environment."
   exit 1
 fi
 
-note "Copied DB from ${VORTEX_TASK_COPY_DB_ACQUIA_SRC} to ${VORTEX_TASK_COPY_DB_ACQUIA_DST} environment."
+note "Copied database from ${VORTEX_TASK_COPY_DB_ACQUIA_SRC} to ${VORTEX_TASK_COPY_DB_ACQUIA_DST} environment."
 
 self_elapsed_time=$((SECONDS))
 note "Run duration: $((self_elapsed_time / 60)) min $((self_elapsed_time % 60)) sec."

--- a/.vortex/tooling/src/task-copy-files-acquia
+++ b/.vortex/tooling/src/task-copy-files-acquia
@@ -52,11 +52,11 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 # Pre-flight checks.
 for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
-info "Started database copying between environments in Acquia."
+info "Started files copying between environments in Acquia."
 
 #
 # Extract last value from JSON object passed via STDIN.
@@ -91,7 +91,7 @@ token=$(echo "${token_json}" | extract_json_value "access_token")
 task "Retrieving ${VORTEX_TASK_COPY_FILES_ACQUIA_APP_NAME} application UUID."
 app_uuid_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications?filter=name%3D${VORTEX_TASK_COPY_FILES_ACQUIA_APP_NAME/ /%20}")
 app_uuid=$(echo "${app_uuid_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "uuid")
-[ -z "${app_uuid}" ] && fail "Unable to retrieve an environment UUID." && exit 1
+[ -z "${app_uuid}" ] && fail "Unable to retrieve an application UUID." && exit 1
 
 task "Retrieving source environment ID."
 envs_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications/${app_uuid}/environments?filter=name%3D${VORTEX_TASK_COPY_FILES_ACQUIA_SRC}")

--- a/.vortex/tooling/src/task-custom-lagoon
+++ b/.vortex/tooling/src/task-custom-lagoon
@@ -87,7 +87,7 @@ if ! command -v lagoon >/dev/null || [ -n "${VORTEX_TASK_CUSTOM_LAGOON_CLI_FORCE
 fi
 
 for cmd in curl lagoon; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
@@ -97,7 +97,7 @@ lagoon config add --force -l "${VORTEX_TASK_CUSTOM_LAGOON_INSTANCE}" -g "${VORTE
 
 lagoon() { command lagoon --force --skip-update-check -i "${VORTEX_TASK_CUSTOM_LAGOON_SSH_FILE}" -l "${VORTEX_TASK_CUSTOM_LAGOON_INSTANCE}" -p "${VORTEX_TASK_CUSTOM_LAGOON_PROJECT}" "$@"; }
 
-task "Creating ${VORTEX_TASK_CUSTOM_LAGOON_NAME} task: project ${VORTEX_TASK_CUSTOM_LAGOON_PROJECT}, branch: ${VORTEX_TASK_CUSTOM_LAGOON_BRANCH}."
+task "Creating ${VORTEX_TASK_CUSTOM_LAGOON_NAME} task: project: ${VORTEX_TASK_CUSTOM_LAGOON_PROJECT}, branch: ${VORTEX_TASK_CUSTOM_LAGOON_BRANCH}."
 lagoon run custom -e "${VORTEX_TASK_CUSTOM_LAGOON_BRANCH}" -N "${VORTEX_TASK_CUSTOM_LAGOON_NAME}" -c "${VORTEX_TASK_CUSTOM_LAGOON_COMMAND}"
 
 pass "Finished Lagoon task ${VORTEX_TASK_CUSTOM_LAGOON_NAME}."

--- a/.vortex/tooling/src/task-purge-cache-acquia
+++ b/.vortex/tooling/src/task-purge-cache-acquia
@@ -52,7 +52,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 # Pre-flight checks.
 for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
@@ -91,7 +91,7 @@ token=$(echo "${token_json}" | extract_json_value "access_token")
 task "Retrieving ${VORTEX_TASK_PURGE_CACHE_ACQUIA_APP_NAME} application UUID."
 app_uuid_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications?filter=name%3D${VORTEX_TASK_PURGE_CACHE_ACQUIA_APP_NAME/ /%20}")
 app_uuid=$(echo "${app_uuid_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "uuid")
-[ -z "${app_uuid}" ] && fail "Unable to retrieve an environment UUID." && exit 1
+[ -z "${app_uuid}" ] && fail "Unable to retrieve an application UUID." && exit 1
 
 task "Retrieving environment ID."
 envs_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications/${app_uuid}/environments?filter=name%3D${VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV}")

--- a/.vortex/tooling/src/update-vortex
+++ b/.vortex/tooling/src/update-vortex
@@ -57,7 +57,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 
 # Pre-flight checks.
 for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 
@@ -72,7 +72,7 @@ done
 if [ -n "${VORTEX_INSTALLER_PATH}" ]; then
   note "Using installer script from local path: ${VORTEX_INSTALLER_PATH}"
   if [ ! -f "${VORTEX_INSTALLER_PATH}" ]; then
-    fail "Installer script not found at ${VORTEX_INSTALLER_PATH}"
+    fail "Installer script not found at ${VORTEX_INSTALLER_PATH}."
     exit 1
   fi
 else
@@ -80,7 +80,7 @@ else
   VORTEX_INSTALLER_PATH="installer.php"
   note "Downloading installer to ${VORTEX_INSTALLER_PATH}"
   if ! curl -fsSL "${VORTEX_INSTALLER_URL}?${VORTEX_INSTALLER_URL_CACHE_BUST}" -o "${VORTEX_INSTALLER_PATH}"; then
-    fail "Failed to download installer from ${VORTEX_INSTALLER_URL}"
+    fail "Failed to download installer from ${VORTEX_INSTALLER_URL}."
     exit 1
   fi
 fi

--- a/.vortex/tooling/src/upload-db-s3
+++ b/.vortex/tooling/src/upload-db-s3
@@ -51,7 +51,7 @@ fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 # @formatter:on
 
 for cmd in curl openssl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available"
+  fail "Command ${cmd} is not available."
   exit 1
 }; done
 

--- a/.vortex/tooling/tests/unit/deploy-artifact.bats
+++ b/.vortex/tooling/tests/unit/deploy-artifact.bats
@@ -17,7 +17,7 @@ load ../_helper.bash
   assert_success
 
   assert_output_contains "Found flag to skip all deployments."
-  assert_output_contains "Skipping deployment"
+  assert_output_contains "Skipped deployment"
 
   popd >/dev/null
 }
@@ -93,7 +93,7 @@ load ../_helper.bash
     "@curl -sS -L https://github.com/drevops/git-artifact/releases/download/1.4.0/git-artifact -o ${TMPDIR:-/tmp}/git-artifact"
     "@sha256sum -c # 1"
     "SHA256 checksum verification failed for git-artifact binary."
-    "- Finished ARTIFACT deployment."
+    "- Finished artifact deployment."
   )
   mocks="$(run_steps "setup")"
 
@@ -142,7 +142,7 @@ load ../_helper.bash
     "Copying git repo files meta file to the deploy code repo."
     "Copying deployment .gitignore as it may not exist in deploy code source files."
     "Running artifact builder."
-    "Finished ARTIFACT deployment."
+    "Finished artifact deployment."
   )
   mocks="$(run_steps "setup")"
 

--- a/.vortex/tooling/tests/unit/deploy-container-registry.bats
+++ b/.vortex/tooling/tests/unit/deploy-container-registry.bats
@@ -133,21 +133,21 @@ setup_robo_fixture() {
 
   run ./.vortex/tooling/src/deploy-container-registry
   assert_failure
-  assert_output_contains 'invalid key/value pair "service1" provided.'
+  assert_output_contains 'Invalid key/value pair "service1" provided.'
 
   # Using a space delimiter.
   export VORTEX_DEPLOY_CONTAINER_REGISTRY_MAP="service1=image1 service2=image2"
 
   run .vortex/tooling/src/deploy-container-registry
   assert_failure
-  assert_output_contains 'invalid key/value pair "service1=image1 service2=image2" provided.'
+  assert_output_contains 'Invalid key/value pair "service1=image1 service2=image2" provided.'
 
   # No comma delimiter
   export VORTEX_DEPLOY_CONTAINER_REGISTRY_MAP="service1=image1=service2=image2"
 
   run .vortex/tooling/src/deploy-container-registry
   assert_failure
-  assert_output_contains 'invalid key/value pair "service1=image1=service2=image2" provided.'
+  assert_output_contains 'Invalid key/value pair "service1=image1=service2=image2" provided.'
 
   popd >/dev/null
 }

--- a/.vortex/tooling/tests/unit/deploy-lagoon.bats
+++ b/.vortex/tooling/tests/unit/deploy-lagoon.bats
@@ -14,9 +14,9 @@ load ../_helper.bash
 
   run .vortex/tooling/src/deploy-lagoon
   assert_success
-  assert_output_contains "Started LAGOON deployment."
-  assert_output_contains "Lagoon does not support tag deployments. Skipping."
-  assert_output_contains "Finished LAGOON deployment."
+  assert_output_contains "Started Lagoon deployment."
+  assert_output_contains "Lagoon does not support tag deployments. Skipped."
+  assert_output_contains "Finished Lagoon deployment."
 
   popd >/dev/null
 }
@@ -69,15 +69,15 @@ load ../_helper.bash
   export VORTEX_DEPLOY_LAGOON_INSTANCE_PORT="32222"
 
   declare -a STEPS=(
-    "Started LAGOON deployment."
+    "Started Lagoon deployment."
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
-    "Deploying environment: project test_project, branch: test-branch."
+    "Deploying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch"
-    "Finished LAGOON deployment."
+    "Finished Lagoon deployment."
   )
 
   mocks="$(run_steps "setup")"
@@ -103,18 +103,18 @@ load ../_helper.bash
   local existing_env_json='{"data":[{"name":"test-branch","deploytype":"branch"}]}'
 
   declare -a STEPS=(
-    "Started LAGOON deployment."
+    "Started Lagoon deployment."
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # ${existing_env_json}"
     'Found already deployed environment for branch "test-branch".'
-    "Setting a DB overwrite flag to 0."
+    "Setting a database overwrite flag to 0."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
-    "Redeploying environment: project test_project, branch: test-branch."
+    "Redeploying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy latest --environment test-branch"
-    "Finished LAGOON deployment."
+    "Finished Lagoon deployment."
   )
 
   mocks="$(run_steps "setup")"
@@ -141,24 +141,24 @@ load ../_helper.bash
   local existing_env_json='{"data":[{"name":"test-branch","deploytype":"branch"}]}'
 
   declare -a STEPS=(
-    "Started LAGOON deployment."
+    "Started Lagoon deployment."
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # ${existing_env_json}"
     'Found already deployed environment for branch "test-branch".'
-    "Setting a DB overwrite flag to 0."
+    "Setting a database overwrite flag to 0."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
-    "Adding a DB import override flag for the current deployment."
+    "Adding a database import override flag for the current deployment."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global"
-    "Redeploying environment: project test_project, branch: test-branch."
+    "Redeploying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy latest --environment test-branch"
     "Waiting for deployment to be queued."
     "@sleep 10"
-    "Removing a DB import override flag for the current deployment."
+    "Removing a database import override flag for the current deployment."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
-    "Finished LAGOON deployment."
+    "Finished Lagoon deployment."
   )
 
   mocks="$(run_steps "setup")"
@@ -186,15 +186,15 @@ load ../_helper.bash
   export VORTEX_DEPLOY_LAGOON_INSTANCE="amazeeio"
 
   declare -a STEPS=(
-    "Started LAGOON deployment."
+    "Started Lagoon deployment."
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for PR deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
-    "Deploying environment: project test_project, PR: 123."
+    "Deploying environment: project: test_project, PR: 123."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 123 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-123"
-    "Finished LAGOON deployment."
+    "Finished Lagoon deployment."
   )
 
   mocks="$(run_steps "setup")"
@@ -225,18 +225,18 @@ load ../_helper.bash
   local existing_pr_env_json='{"data":[{"name":"pr-123","deploytype":"pullrequest"}]}'
 
   declare -a STEPS=(
-    "Started LAGOON deployment."
+    "Started Lagoon deployment."
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for PR deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # ${existing_pr_env_json}"
     'Found already deployed environment for PR "123".'
-    "Setting a DB overwrite flag to 0."
+    "Setting a database overwrite flag to 0."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment pr-123 --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
-    "Redeploying environment: project test_project, PR: 123."
+    "Redeploying environment: project: test_project, PR: 123."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 123 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-123"
-    "Finished LAGOON deployment."
+    "Finished Lagoon deployment."
   )
 
   mocks="$(run_steps "setup")"
@@ -268,24 +268,24 @@ load ../_helper.bash
   local existing_pr_env_json='{"data":[{"name":"pr-456","deploytype":"pullrequest"}]}'
 
   declare -a STEPS=(
-    "Started LAGOON deployment."
+    "Started Lagoon deployment."
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for PR deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # ${existing_pr_env_json}"
     'Found already deployed environment for PR "456".'
-    "Setting a DB overwrite flag to 0."
+    "Setting a database overwrite flag to 0."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment pr-456 --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
-    "Adding a DB import override flag for the current deployment."
+    "Adding a database import override flag for the current deployment."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment pr-456 --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global"
-    "Redeploying environment: project test_project, PR: 456."
+    "Redeploying environment: project: test_project, PR: 456."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 456 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-456"
     "Waiting for deployment to be queued."
     "@sleep 10"
-    "Removing a DB import override flag for the current deployment."
+    "Removing a database import override flag for the current deployment."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment pr-456 --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
-    "Finished LAGOON deployment."
+    "Finished Lagoon deployment."
   )
 
   mocks="$(run_steps "setup")"
@@ -310,13 +310,13 @@ load ../_helper.bash
   export VORTEX_DEPLOY_LAGOON_INSTANCE="amazeeio"
 
   declare -a STEPS=(
-    "Started LAGOON deployment."
+    "Started Lagoon deployment."
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
-    "Destroying environment: project test_project, branch: test-branch."
+    "Destroying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project delete environment --environment test-branch"
-    "Finished LAGOON deployment."
+    "Finished Lagoon deployment."
   )
 
   mocks="$(run_steps "setup")"
@@ -345,16 +345,16 @@ load ../_helper.bash
   local limit_error="Error: graphql: 'test-branch' would exceed the configured limit of 5 development environments for project test_project"
 
   declare -a STEPS=(
-    "Started LAGOON deployment."
+    "Started Lagoon deployment."
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
-    "Deploying environment: project test_project, branch: test-branch."
+    "Deploying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 1 # ${limit_error}"
     "Lagoon environment limit exceeded."
-    "Finished LAGOON deployment."
+    "Finished Lagoon deployment."
   )
 
   mocks="$(run_steps "setup")"
@@ -381,16 +381,16 @@ load ../_helper.bash
   local limit_error="Error: graphql: 'test-branch' would exceed the configured limit of 5 development environments for project test_project"
 
   declare -a STEPS=(
-    "Started LAGOON deployment."
+    "Started Lagoon deployment."
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
-    "Deploying environment: project test_project, branch: test-branch."
+    "Deploying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 1 # ${limit_error}"
     "Lagoon environment limit exceeded."
-    "[FAIL] LAGOON deployment completed with errors."
+    "[FAIL] Lagoon deployment completed with errors."
   )
 
   mocks="$(run_steps "setup")"
@@ -421,16 +421,16 @@ load ../_helper.bash
 
   # shellcheck disable=SC2034
   declare -a STEPS=(
-    "Started LAGOON deployment."
+    "Started Lagoon deployment."
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
     "Discovering existing environments for PR deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
-    "Deploying environment: project test_project, PR: 133."
+    "Deploying environment: project: test_project, PR: 133."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 133 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-133 # 1 # ${limit_error}"
     "Lagoon environment limit exceeded."
-    "Finished LAGOON deployment."
+    "Finished Lagoon deployment."
   )
 
   mocks="$(run_steps "setup")"

--- a/.vortex/tooling/tests/unit/deploy-webhook.bats
+++ b/.vortex/tooling/tests/unit/deploy-webhook.bats
@@ -43,7 +43,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy-webhook
   assert_success
   assert_output_contains "Webhook call completed."
-  assert_output_contains "Finished WEBHOOK deployment."
+  assert_output_contains "Finished webhook deployment."
 
   popd >/dev/null
 }

--- a/.vortex/tooling/tests/unit/deploy.bats
+++ b/.vortex/tooling/tests/unit/deploy.bats
@@ -27,7 +27,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy
   assert_success
   assert_output_contains "Found flag to skip all deployments."
-  assert_output_contains "Skipping deployment webhook."
+  assert_output_contains "Skipped deployment webhook."
 
   popd >/dev/null
 }
@@ -62,7 +62,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy
   assert_success
   assert_output_contains "Found flag to skip a deployment."
-  assert_output_not_contains "Skipping deployment"
+  assert_output_not_contains "Skipped deployment"
 
   popd >/dev/null
 }
@@ -79,7 +79,7 @@ load ../_helper.bash
   assert_success
   assert_output_contains "Found flag to skip a deployment."
   assert_output_contains "Found PR 123 in skip list."
-  assert_output_contains "Skipping deployment webhook."
+  assert_output_contains "Skipped deployment webhook."
 
   popd >/dev/null
 }
@@ -96,7 +96,7 @@ load ../_helper.bash
   assert_success
   assert_output_contains "Found flag to skip a deployment."
   assert_output_contains "Found PR 456 in skip list."
-  assert_output_contains "Skipping deployment webhook."
+  assert_output_contains "Skipped deployment webhook."
 
   popd >/dev/null
 }
@@ -117,7 +117,7 @@ load ../_helper.bash
   assert_success
   assert_output_contains "Found flag to skip a deployment."
   assert_output_not_contains "Found PR 999 in skip list."
-  assert_output_not_contains "Skipping deployment"
+  assert_output_not_contains "Skipped deployment"
 
   popd >/dev/null
 }
@@ -134,7 +134,7 @@ load ../_helper.bash
   assert_success
   assert_output_contains "Found flag to skip a deployment."
   assert_output_contains "Found branch feature/test in skip list."
-  assert_output_contains "Skipping deployment webhook."
+  assert_output_contains "Skipped deployment webhook."
 
   popd >/dev/null
 }
@@ -151,7 +151,7 @@ load ../_helper.bash
   assert_success
   assert_output_contains "Found flag to skip a deployment."
   assert_output_contains "Found branch hotfix/urgent in skip list."
-  assert_output_contains "Skipping deployment webhook."
+  assert_output_contains "Skipped deployment webhook."
 
   popd >/dev/null
 }
@@ -172,7 +172,7 @@ load ../_helper.bash
   assert_success
   assert_output_contains "Found flag to skip a deployment."
   assert_output_not_contains "Found branch develop in skip list."
-  assert_output_not_contains "Skipping deployment"
+  assert_output_not_contains "Skipped deployment"
 
   popd >/dev/null
 }
@@ -193,7 +193,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy
   assert_success
   assert_output_not_contains "Found flag to skip a deployment."
-  assert_output_not_contains "Skipping deployment"
+  assert_output_not_contains "Skipped deployment"
 
   popd >/dev/null
 }
@@ -209,7 +209,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy
   assert_success
   assert_output_contains "Found branch feature/my-feature in skip list."
-  assert_output_contains "Skipping deployment webhook."
+  assert_output_contains "Skipped deployment webhook."
 
   popd >/dev/null
 }
@@ -227,7 +227,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy
   assert_success
   assert_output_contains "Found PR 123 in skip list."
-  assert_output_contains "Skipping deployment webhook."
+  assert_output_contains "Skipped deployment webhook."
   assert_output_not_contains "Found branch"
 
   popd >/dev/null
@@ -244,7 +244,7 @@ load ../_helper.bash
 
   run .vortex/tooling/src/deploy
   assert_output_contains "Started deployment."
-  assert_output_contains "Started ARTIFACT deployment."
+  assert_output_contains "Started artifact deployment."
 
   popd >/dev/null
 }
@@ -260,7 +260,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy
   assert_success
   assert_output_contains "Found PR 123 in skip list."
-  assert_output_contains "Skipping deployment webhook,artifact,container_registry."
+  assert_output_contains "Skipped deployment webhook,artifact,container_registry."
 
   popd >/dev/null
 }
@@ -281,7 +281,7 @@ load ../_helper.bash
   assert_success
   assert_output_contains "Found flag to skip a deployment."
   assert_output_not_contains "Found PR"
-  assert_output_not_contains "Skipping deployment"
+  assert_output_not_contains "Skipped deployment"
 
   popd >/dev/null
 }
@@ -302,7 +302,7 @@ load ../_helper.bash
   assert_success
   assert_output_contains "Found flag to skip a deployment."
   assert_output_not_contains "Found branch"
-  assert_output_not_contains "Skipping deployment"
+  assert_output_not_contains "Skipped deployment"
 
   popd >/dev/null
 }
@@ -321,7 +321,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy
   assert_success
   assert_output_not_contains "Found flag to gate deployment"
-  assert_output_not_contains "Skipping deployment"
+  assert_output_not_contains "Skipped deployment"
 
   popd >/dev/null
 }
@@ -342,7 +342,7 @@ load ../_helper.bash
   assert_success
   assert_output_contains "Found flag to gate deployment on the 'deploy' label."
   assert_output_contains "PR 123 carries the 'deploy' label."
-  assert_output_not_contains "Skipping deployment"
+  assert_output_not_contains "Skipped deployment"
 
   popd >/dev/null
 }
@@ -359,7 +359,7 @@ load ../_helper.bash
   assert_success
   assert_output_contains "Found flag to gate deployment on the 'deploy' label."
   assert_output_contains "PR 123 does not carry the 'deploy' label."
-  assert_output_contains "Skipping deployment webhook."
+  assert_output_contains "Skipped deployment webhook."
 
   popd >/dev/null
 }
@@ -379,7 +379,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy
   assert_success
   assert_output_not_contains "Found flag to gate deployment"
-  assert_output_not_contains "Skipping deployment"
+  assert_output_not_contains "Skipped deployment"
 
   popd >/dev/null
 }
@@ -399,7 +399,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy
   assert_success
   assert_output_contains "PR 456 carries the 'deploy' label."
-  assert_output_not_contains "Skipping deployment"
+  assert_output_not_contains "Skipped deployment"
 
   popd >/dev/null
 }
@@ -417,7 +417,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy
   assert_success
   assert_output_contains "Found PR 123 in skip list."
-  assert_output_contains "Skipping deployment webhook."
+  assert_output_contains "Skipped deployment webhook."
   assert_output_not_contains "Found flag to gate deployment"
 
   popd >/dev/null
@@ -434,7 +434,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy
   assert_success
   assert_output_contains "PR 123 does not carry the 'deploy' label."
-  assert_output_contains "Skipping deployment webhook."
+  assert_output_contains "Skipped deployment webhook."
 
   popd >/dev/null
 }
@@ -450,7 +450,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy
   assert_success
   assert_output_contains "PR 123 does not carry the 'deploy' label."
-  assert_output_contains "Skipping deployment webhook."
+  assert_output_contains "Skipped deployment webhook."
 
   popd >/dev/null
 }
@@ -470,7 +470,7 @@ load ../_helper.bash
   run .vortex/tooling/src/deploy
   assert_success
   assert_output_contains "PR 123 carries the 'deploy to env' label."
-  assert_output_not_contains "Skipping deployment"
+  assert_output_not_contains "Skipped deployment"
 
   popd >/dev/null
 }

--- a/.vortex/tooling/tests/unit/download-db-acquia.bats
+++ b/.vortex/tooling/tests/unit/download-db-acquia.bats
@@ -33,7 +33,7 @@ bats_require_minimum_version 1.5.0
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod # {"_embedded":{"items":[{"id":"env-id-456","name":"prod"}]}}'
 
     # Mock backups curl call with its message
-    "Discovering latest backup ID for DB testdb."
+    "Discovering latest backup ID for database testdb."
     '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups?sort=created # {"_embedded":{"items":[{"id":"backup-id-789","completed":"2024-01-01T00:00:00+00:00"}]}}'
 
     # Mock backup URL curl call with its message
@@ -41,11 +41,11 @@ bats_require_minimum_version 1.5.0
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # {"url":"https://backup.example.com/db.sql.gz"}'
 
     # Mock file download curl call with its message and side effect to create zipped archive
-    "Downloading DB dump into file .data/testdb_backup_backup-id-789.sql.gz."
+    "Downloading database dump into file .data/testdb_backup_backup-id-789.sql.gz."
     '@curl --progress-bar -L https://backup.example.com/db.sql.gz -o .data/testdb_backup_backup-id-789.sql.gz # 0 #  # echo "CREATE TABLE test (id INT);" | gzip > .data/testdb_backup_backup-id-789.sql.gz'
 
     # Mock gunzip operations with their message
-    "Expanding DB file .data/testdb_backup_backup-id-789.sql.gz into .data/testdb_backup_backup-id-789.sql."
+    "Expanding database file .data/testdb_backup_backup-id-789.sql.gz into .data/testdb_backup_backup-id-789.sql."
     "@gunzip -t .data/testdb_backup_backup-id-789.sql.gz # 0"
     "@gunzip -c .data/testdb_backup_backup-id-789.sql.gz # 0 # CREATE TABLE test (id INT);"
 
@@ -105,11 +105,11 @@ bats_require_minimum_version 1.5.0
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod # {"_embedded":{"items":[{"id":"env-id-456","name":"prod"}]}}'
 
     # Mock backups curl call with its message
-    "Discovering latest backup ID for DB testdb."
+    "Discovering latest backup ID for database testdb."
     '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups?sort=created # {"_embedded":{"items":[{"id":"backup-id-123","completed":"2024-01-01T00:00:00+00:00"}]}}'
 
     # Assert cached file found message
-    'Found existing cached DB file ".data/testdb_backup_backup-id-123.sql" for DB "testdb".'
+    'Found existing cached database file ".data/testdb_backup_backup-id-123.sql" for database "testdb".'
 
     # Mock mv operation with its message and side effect to create final file
     'Renaming file ".data/testdb_backup_backup-id-123.sql" to ".data/db.sql".'
@@ -163,14 +163,14 @@ bats_require_minimum_version 1.5.0
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod # {"_embedded":{"items":[{"id":"env-id-456"}]}}'
 
     # Mock backups curl call with its message
-    "Discovering latest backup ID for DB testdb."
+    "Discovering latest backup ID for database testdb."
     '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups?sort=created # {"_embedded":{"items":[{"id":"backup-id-456"}]}}'
 
     # Assert cached compressed file found message
-    "[ OK ] Found existing cached gzipped DB file .data/testdb_backup_backup-id-456.sql.gz for DB testdb."
+    "[ OK ] Found existing cached gzipped database file .data/testdb_backup_backup-id-456.sql.gz for database testdb."
 
     # Mock gunzip operations with their message
-    "Expanding DB file .data/testdb_backup_backup-id-456.sql.gz into .data/testdb_backup_backup-id-456.sql."
+    "Expanding database file .data/testdb_backup_backup-id-456.sql.gz into .data/testdb_backup_backup-id-456.sql."
     "@gunzip -t .data/testdb_backup_backup-id-456.sql.gz # 0"
     "@gunzip -c .data/testdb_backup_backup-id-456.sql.gz # 0 # decompressed database content"
 
@@ -222,7 +222,7 @@ bats_require_minimum_version 1.5.0
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod # {"_embedded":{"items":[{"id":"env-id-456"}]}}'
 
     # Mock backups curl call with its message
-    "Discovering latest backup ID for DB testdb."
+    "Discovering latest backup ID for database testdb."
     '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups?sort=created # {"_embedded":{"items":[{"id":"backup-id-789"}]}}'
 
     # Mock backup URL curl call with its message
@@ -230,11 +230,11 @@ bats_require_minimum_version 1.5.0
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # {"url":"https://backup.example.com/db.sql.gz"}'
 
     # Mock file download curl call with its message and side effect to create zipped archive
-    "Downloading DB dump into file ./.data/testdb_backup_backup-id-789.sql.gz."
+    "Downloading database dump into file ./.data/testdb_backup_backup-id-789.sql.gz."
     '@curl --progress-bar -L https://backup.example.com/db.sql.gz -o ./.data/testdb_backup_backup-id-789.sql.gz # 0 #  # mkdir -p ./.data && echo "database content" | gzip > ./.data/testdb_backup_backup-id-789.sql.gz'
 
     # Mock gunzip operations with their message
-    "Expanding DB file ./.data/testdb_backup_backup-id-789.sql.gz into ./.data/testdb_backup_backup-id-789.sql."
+    "Expanding database file ./.data/testdb_backup_backup-id-789.sql.gz into ./.data/testdb_backup_backup-id-789.sql."
     "@gunzip -t ./.data/testdb_backup_backup-id-789.sql.gz # 0"
     "@gunzip -c ./.data/testdb_backup_backup-id-789.sql.gz # 0 # database content"
 
@@ -385,7 +385,7 @@ bats_require_minimum_version 1.5.0
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod # {"_embedded":{"items":[{"id":"env-id-456","name":"prod"}]}}'
 
     # Mock backups curl call with its message and error response
-    "Discovering latest backup ID for DB nonexistent-db."
+    "Discovering latest backup ID for database nonexistent-db."
     '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/nonexistent-db/backups?sort=created # {"error":"Database not found","message":"The specified database does not exist"}'
 
     # Assert database not found failure message
@@ -427,7 +427,7 @@ bats_require_minimum_version 1.5.0
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod # {"_embedded":{"items":[{"id":"env-id-456","name":"prod"}]}}'
 
     # Mock backups curl call with its message and empty response
-    "Discovering latest backup ID for DB testdb."
+    "Discovering latest backup ID for database testdb."
     '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups?sort=created # {"_embedded":{"items":[]}}'
 
     # Assert no backups found failure message
@@ -489,17 +489,17 @@ bats_require_minimum_version 1.5.0
     "       Fresh backup will be downloaded."
 
     # Continue with normal download flow
-    "[TASK] Discovering latest backup ID for DB testdb."
+    "[TASK] Discovering latest backup ID for database testdb."
     '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups?sort=created # {"_embedded":{"items":[{"id":"backup-id-new-123","completed":"2024-01-02T00:00:00+00:00"}]}}'
 
     # Rest of download steps...
     "[TASK] Discovering backup URL."
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-new-123/actions/download # {"url":"https://backup.example.com/db-fresh.sql.gz"}'
 
-    "[TASK] Downloading DB dump into file .data/testdb_backup_backup-id-new-123.sql.gz."
+    "[TASK] Downloading database dump into file .data/testdb_backup_backup-id-new-123.sql.gz."
     '@curl --progress-bar -L https://backup.example.com/db-fresh.sql.gz -o .data/testdb_backup_backup-id-new-123.sql.gz # 0 #  # echo "CREATE TABLE fresh (id INT);" | gzip > .data/testdb_backup_backup-id-new-123.sql.gz'
 
-    "[TASK] Expanding DB file .data/testdb_backup_backup-id-new-123.sql.gz into .data/testdb_backup_backup-id-new-123.sql."
+    "[TASK] Expanding database file .data/testdb_backup_backup-id-new-123.sql.gz into .data/testdb_backup_backup-id-new-123.sql."
     "@gunzip -t .data/testdb_backup_backup-id-new-123.sql.gz # 0"
     "@gunzip -c .data/testdb_backup_backup-id-new-123.sql.gz # 0 # CREATE TABLE fresh (id INT);"
 
@@ -749,7 +749,7 @@ bats_require_minimum_version 1.5.0
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod # {"_embedded":{"items":[{"id":"env-id-456","name":"prod"}]}}'
 
     # Mock backups curl call with its message
-    "Discovering latest backup ID for DB testdb."
+    "Discovering latest backup ID for database testdb."
     '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups?sort=created # {"_embedded":{"items":[{"id":"backup-id-789","completed":"2024-01-01T00:00:00+00:00"}]}}'
 
     # Mock backup URL curl call returning a JSON body without a usable URL
@@ -804,7 +804,7 @@ bats_require_minimum_version 1.5.0
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod # {"_embedded":{"items":[{"id":"env-id-456","name":"prod"}]}}'
 
     # Mock backups curl call with its message
-    "Discovering latest backup ID for DB testdb."
+    "Discovering latest backup ID for database testdb."
     '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups?sort=created # {"_embedded":{"items":[{"id":"backup-id-789","completed":"2024-01-01T00:00:00+00:00"}]}}'
 
     # Mock backup URL curl call returning a JSON error body without a url key
@@ -856,7 +856,7 @@ bats_require_minimum_version 1.5.0
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod # {"_embedded":{"items":[{"id":"env-id-456","name":"prod"}]}}'
 
     # Mock backups curl call with its message
-    "Discovering latest backup ID for DB testdb."
+    "Discovering latest backup ID for database testdb."
     '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups?sort=created # {"_embedded":{"items":[{"id":"backup-id-789","completed":"2024-01-01T00:00:00+00:00"}]}}'
 
     # Mock backup URL curl call returning a non-JSON body
@@ -902,16 +902,16 @@ bats_require_minimum_version 1.5.0
     "Retrieving prod environment ID."
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod # {"_embedded":{"items":[{"id":"env-id-456","name":"prod"}]}}'
 
-    "Discovering latest backup ID for DB testdb."
+    "Discovering latest backup ID for database testdb."
     '@curl --progress-bar -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups?sort=created # {"_embedded":{"items":[{"id":"backup-id-789","completed":"2024-01-01T00:00:00+00:00"}]}}'
 
     "Discovering backup URL."
     '@curl -s -L -H Accept: application/json, version=2 -H Authorization: Bearer test-token https://cloud.acquia.com/api/environments/env-id-456/databases/testdb/backups/backup-id-789/actions/download # {"url":"https://backup.example.com/db.sql.gz"}'
 
-    "Downloading DB dump into file .data/testdb_backup_backup-id-789.sql.gz."
+    "Downloading database dump into file .data/testdb_backup_backup-id-789.sql.gz."
     '@curl --progress-bar -L https://backup.example.com/db.sql.gz -o .data/testdb_backup_backup-id-789.sql.gz # 0 #  # echo "CREATE TABLE test (id INT);" | gzip > .data/testdb_backup_backup-id-789.sql.gz'
 
-    "Expanding DB file .data/testdb_backup_backup-id-789.sql.gz into .data/testdb_backup_backup-id-789.sql."
+    "Expanding database file .data/testdb_backup_backup-id-789.sql.gz into .data/testdb_backup_backup-id-789.sql."
     "@gunzip -t .data/testdb_backup_backup-id-789.sql.gz # 0"
     "@gunzip -c .data/testdb_backup_backup-id-789.sql.gz # 0 # CREATE TABLE test (id INT);"
 

--- a/.vortex/tooling/tests/unit/download-db.bats
+++ b/.vortex/tooling/tests/unit/download-db.bats
@@ -55,7 +55,7 @@ EOF
   run .vortex/tooling/src/download-db
   assert_success
   assert_output_contains "Started database download."
-  assert_output_contains "Skipping database download as DB_DOWNLOAD_PROCEED is not set to 1."
+  assert_output_contains "Skipped database download as DB_DOWNLOAD_PROCEED is not set to 1."
 
   # Test default source (should default to url/curl)
   mkdir -p .vortex/tooling/src

--- a/.vortex/tooling/tests/unit/login-container-registry.bats
+++ b/.vortex/tooling/tests/unit/login-container-registry.bats
@@ -55,7 +55,7 @@ load ../_helper.bash
 
   run .vortex/tooling/src/login-container-registry
   assert_success
-  assert_output_contains "Skipping login to the container registry as either VORTEX_LOGIN_CONTAINER_REGISTRY_USER or VORTEX_CONTAINER_REGISTRY_USER or VORTEX_LOGIN_CONTAINER_REGISTRY_PASS or VORTEX_CONTAINER_REGISTRY_PASS was not provided."
+  assert_output_contains "Skipped login to the container registry as either VORTEX_LOGIN_CONTAINER_REGISTRY_USER or VORTEX_CONTAINER_REGISTRY_USER or VORTEX_LOGIN_CONTAINER_REGISTRY_PASS or VORTEX_CONTAINER_REGISTRY_PASS was not provided."
 
   popd >/dev/null
 }

--- a/.vortex/tooling/tests/unit/notify-diffy.bats
+++ b/.vortex/tooling/tests/unit/notify-diffy.bats
@@ -22,7 +22,7 @@ load ../_helper.bash
   assert_success
 
   assert_output_contains "Started Diffy notification."
-  assert_output_contains "Skipping Diffy notification for pre_deployment event."
+  assert_output_contains "Skipped Diffy notification for pre_deployment event."
 
   popd >/dev/null || exit 1
 }
@@ -69,7 +69,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/notify
   assert_success
 
-  assert_output_contains "Skipping Diffy notification for branch 'feature/random'"
+  assert_output_contains "Skipped Diffy notification for branch 'feature/random'"
 
   popd >/dev/null || exit 1
 }

--- a/.vortex/tooling/tests/unit/notify-email.bats
+++ b/.vortex/tooling/tests/unit/notify-email.bats
@@ -82,7 +82,7 @@ load ../_helper.bash
 
   assert_output_contains "Started dispatching notifications."
   assert_output_contains "Started email notification."
-  assert_output_contains "Skipping email notification for pre_deployment event."
+  assert_output_contains "Skipped email notification for pre_deployment event."
   assert_output_not_contains "Notification email(s) sent"
   assert_output_contains "Finished dispatching notifications."
 
@@ -106,7 +106,7 @@ load ../_helper.bash
   assert_success
 
   assert_output_contains "Started dispatching notifications."
-  assert_output_contains "Skipping email notification for branch 'feature/test'."
+  assert_output_contains "Skipped email notification for branch 'feature/test'."
   assert_output_not_contains "Started email notification."
   assert_output_contains "Finished dispatching notifications."
 
@@ -125,7 +125,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/notify-email
   assert_success
 
-  assert_output_contains "Skipping email notification for branch ''."
+  assert_output_contains "Skipped email notification for branch ''."
   assert_output_not_contains "unbound variable"
 
   popd >/dev/null || exit 1

--- a/.vortex/tooling/tests/unit/notify-github.bats
+++ b/.vortex/tooling/tests/unit/notify-github.bats
@@ -247,7 +247,7 @@ load ../_helper.bash
   assert_success
 
   assert_output_contains "Started dispatching notifications."
-  assert_output_contains "Skipping GitHub notification for branch 'feature/test'."
+  assert_output_contains "Skipped GitHub notification for branch 'feature/test'."
   assert_output_not_contains "Started GitHub notification"
   assert_output_contains "Finished dispatching notifications."
 
@@ -266,7 +266,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/notify-github
   assert_success
 
-  assert_output_contains "Skipping GitHub notification for branch ''."
+  assert_output_contains "Skipped GitHub notification for branch ''."
   assert_output_not_contains "unbound variable"
 
   popd >/dev/null || exit 1

--- a/.vortex/tooling/tests/unit/notify-jira.bats
+++ b/.vortex/tooling/tests/unit/notify-jira.bats
@@ -75,7 +75,7 @@ load ../_helper.bash
 
   assert_output_contains "Started dispatching notifications."
   assert_output_contains "Started JIRA notification."
-  assert_output_contains "Skipping JIRA notification for pre_deployment event."
+  assert_output_contains "Skipped JIRA notification for pre_deployment event."
   assert_output_not_contains "Extracting issue"
   assert_output_contains "Finished dispatching notifications."
 
@@ -99,7 +99,7 @@ load ../_helper.bash
   assert_success
 
   assert_output_contains "Started dispatching notifications."
-  assert_output_contains "Skipping JIRA notification for branch 'feature/proj-1234-test'."
+  assert_output_contains "Skipped JIRA notification for branch 'feature/proj-1234-test'."
   assert_output_not_contains "Started JIRA notification."
   assert_output_contains "Finished dispatching notifications."
 
@@ -118,7 +118,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/notify-jira
   assert_success
 
-  assert_output_contains "Skipping JIRA notification for branch ''."
+  assert_output_contains "Skipped JIRA notification for branch ''."
   assert_output_not_contains "unbound variable"
 
   popd >/dev/null || exit 1

--- a/.vortex/tooling/tests/unit/notify-newrelic.bats
+++ b/.vortex/tooling/tests/unit/notify-newrelic.bats
@@ -24,7 +24,7 @@ load ../_helper.bash
   assert_output_contains "Started dispatching notifications."
   assert_output_contains "New Relic is not enabled."
   assert_output_not_contains "Started New Relic notification."
-  assert_output_not_contains "Discovering APP id"
+  assert_output_not_contains "Discovering application ID"
   assert_output_contains "Finished dispatching notifications."
 
   popd >/dev/null || exit 1
@@ -55,7 +55,7 @@ load ../_helper.bash
   assert_output_contains "Started dispatching notifications."
 
   assert_output_contains "Started New Relic notification."
-  assert_output_contains "Discovering APP id by name if it was not provided."
+  assert_output_contains "Discovering application ID by name if it was not provided."
   assert_output_contains "Checking if the application ID is valid."
   assert_output_contains "Creating a deployment notification for application testproject-main with ID 9876543210."
 
@@ -95,8 +95,8 @@ load ../_helper.bash
 
   assert_output_contains "Started dispatching notifications."
   assert_output_contains "Started New Relic notification."
-  assert_output_contains "Skipping New Relic notification for pre_deployment event."
-  assert_output_not_contains "Discovering APP id"
+  assert_output_contains "Skipped New Relic notification for pre_deployment event."
+  assert_output_not_contains "Discovering application ID"
   assert_output_contains "Finished dispatching notifications."
 
   popd >/dev/null || exit 1
@@ -119,7 +119,7 @@ load ../_helper.bash
   assert_success
 
   assert_output_contains "Started dispatching notifications."
-  assert_output_contains "Skipping New Relic notification for branch 'feature/test'."
+  assert_output_contains "Skipped New Relic notification for branch 'feature/test'."
   assert_output_not_contains "Started New Relic notification."
   assert_output_contains "Finished dispatching notifications."
 
@@ -139,7 +139,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/notify-newrelic
   assert_success
 
-  assert_output_contains "Skipping New Relic notification for branch ''."
+  assert_output_contains "Skipped New Relic notification for branch ''."
   assert_output_not_contains "unbound variable"
 
   popd >/dev/null || exit 1
@@ -169,7 +169,7 @@ load ../_helper.bash
 
   assert_output_contains "Started dispatching notifications."
   assert_output_contains "Started New Relic notification."
-  assert_output_not_contains "Skipping New Relic notification for branch"
+  assert_output_not_contains "Skipped New Relic notification for branch"
   assert_output_contains "Finished dispatching notifications."
 
   popd >/dev/null || exit 1

--- a/.vortex/tooling/tests/unit/notify-slack.bats
+++ b/.vortex/tooling/tests/unit/notify-slack.bats
@@ -288,7 +288,7 @@ load ../_helper.bash
   assert_success
 
   assert_output_contains "Started dispatching notifications."
-  assert_output_contains "Skipping Slack notification for branch 'feature/test'."
+  assert_output_contains "Skipped Slack notification for branch 'feature/test'."
   assert_output_not_contains "Started Slack notification."
   assert_output_contains "Finished dispatching notifications."
 
@@ -307,7 +307,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/notify-slack
   assert_success
 
-  assert_output_contains "Skipping Slack notification for branch ''."
+  assert_output_contains "Skipped Slack notification for branch ''."
   assert_output_not_contains "unbound variable"
 
   popd >/dev/null || exit 1

--- a/.vortex/tooling/tests/unit/notify-webhook.bats
+++ b/.vortex/tooling/tests/unit/notify-webhook.bats
@@ -29,9 +29,9 @@ load ../_helper.bash
 
   assert_output_contains "Started dispatching notifications."
 
-  assert_output_contains "Started Webhook notification."
+  assert_output_contains "Started webhook notification."
 
-  assert_output_contains "Finished Webhook notification."
+  assert_output_contains "Finished webhook notification."
 
   assert_output_contains "Finished dispatching notifications."
 
@@ -80,8 +80,8 @@ load ../_helper.bash
   assert_success
 
   assert_output_contains "Started dispatching notifications."
-  assert_output_contains "Started Webhook notification."
-  assert_output_contains "Skipping Webhook notification for pre_deployment event."
+  assert_output_contains "Started webhook notification."
+  assert_output_contains "Skipped webhook notification for pre_deployment event."
   assert_output_contains "Finished dispatching notifications."
 
   popd >/dev/null || exit 1
@@ -105,8 +105,8 @@ load ../_helper.bash
   assert_success
 
   assert_output_contains "Started dispatching notifications."
-  assert_output_contains "Skipping Webhook notification for branch 'feature/test'."
-  assert_output_not_contains "Started Webhook notification."
+  assert_output_contains "Skipped webhook notification for branch 'feature/test'."
+  assert_output_not_contains "Started webhook notification."
   assert_output_contains "Finished dispatching notifications."
 
   popd >/dev/null || exit 1
@@ -124,7 +124,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/notify-webhook
   assert_success
 
-  assert_output_contains "Skipping Webhook notification for branch ''."
+  assert_output_contains "Skipped webhook notification for branch ''."
   assert_output_not_contains "unbound variable"
 
   popd >/dev/null || exit 1

--- a/.vortex/tooling/tests/unit/notify.bats
+++ b/.vortex/tooling/tests/unit/notify.bats
@@ -22,7 +22,7 @@ load ../_helper.bash
   assert_success
 
   assert_output_contains "Started dispatching notifications."
-  assert_output_contains "Skipping dispatching notifications."
+  assert_output_contains "Skipped dispatching notifications."
   assert_output_not_contains "Finished dispatching notifications."
 
   popd >/dev/null || exit 1
@@ -92,7 +92,7 @@ load ../_helper.bash
 
   # Email: should skip pre_deployment
   assert_output_contains "Started email notification."
-  assert_output_contains "Skipping email notification for pre_deployment event."
+  assert_output_contains "Skipped email notification for pre_deployment event."
 
   # Slack: should execute for pre_deployment
   assert_output_contains "Started Slack notification."
@@ -101,7 +101,7 @@ load ../_helper.bash
 
   # NewRelic: should skip pre_deployment
   assert_output_contains "Started New Relic notification."
-  assert_output_contains "Skipping New Relic notification for pre_deployment event."
+  assert_output_contains "Skipped New Relic notification for pre_deployment event."
 
   # GitHub: should execute for pre_deployment
   assert_output_contains "Started GitHub notification for pre_deployment event."
@@ -109,12 +109,12 @@ load ../_helper.bash
   assert_output_contains "Finished GitHub notification for pre_deployment event."
 
   # Webhook: should skip pre_deployment
-  assert_output_contains "Started Webhook notification."
-  assert_output_contains "Skipping Webhook notification for pre_deployment event."
+  assert_output_contains "Started webhook notification."
+  assert_output_contains "Skipped webhook notification for pre_deployment event."
 
   # JIRA: should skip pre_deployment
   assert_output_contains "Started JIRA notification."
-  assert_output_contains "Skipping JIRA notification for pre_deployment event."
+  assert_output_contains "Skipped JIRA notification for pre_deployment event."
 
   assert_output_contains "Finished dispatching notifications."
 

--- a/.vortex/tooling/tests/unit/provision-migration.bats
+++ b/.vortex/tooling/tests/unit/provision-migration.bats
@@ -48,13 +48,13 @@ load ../_helper.bash
     "Verifying migration source database."
     "Enabling migration modules."
     "Starting migrations."
-    "Skipping rollback of all migrations."
+    "Skipped rollback of all migrations."
     "Running migration: ys_migrate_categories"
     "Finished migrations."
     "Finished migration operations."
 
     # Not expected.
-    "- Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1."
+    "- Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1."
     "- Using existing migration source database."
     "- Migration source database is corrupted."
     "- Rolling back all migrations."
@@ -85,7 +85,7 @@ load ../_helper.bash
 
     "Started migration operations."
     "Migration skip:          1"
-    "Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1."
+    "Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1."
 
     "- Importing migration source database."
     "- Starting migrations."
@@ -117,7 +117,7 @@ load ../_helper.bash
     "Started migration operations."
     "Environment: prod"
     "Migration skip:          1"
-    "Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1."
+    "Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1."
 
     "- Importing migration source database."
     "- Starting migrations."
@@ -341,7 +341,7 @@ load ../_helper.bash
     "Running migration: ys_migrate_categories"
     "Finished migration operations."
 
-    "- Skipping rollback of all migrations."
+    "- Skipped rollback of all migrations."
   )
 
   mocks="$(run_steps "setup")"

--- a/.vortex/tooling/tests/unit/provision.bats
+++ b/.vortex/tooling/tests/unit/provision.bats
@@ -1224,7 +1224,7 @@ assert_provision_info() {
     "@drush -y php:eval print \Drupal\core\Site\Settings::get('environment'); # prod"
     "  ==> Started example operations."
     "      Environment: prod"
-    "      Skipping example operations in production environment."
+    "      Skipped example operations in production environment."
     "  ==> Finished example operations."
     "Completed running of custom post-install script './scripts/provision-10-example.sh'."
 

--- a/scripts/provision-10-example.sh
+++ b/scripts/provision-10-example.sh
@@ -94,7 +94,7 @@ if echo "${environment}" | grep -q -e dev -e stage -e ci -e local; then
     note "Existing database detected. Performing additional example operations."
   fi
 else
-  note "Skipping example operations in production environment."
+  note "Skipped example operations in production environment."
 fi
 
 info "Finished example operations."

--- a/scripts/provision-20-migration.sh
+++ b/scripts/provision-20-migration.sh
@@ -70,7 +70,7 @@ note "Source DB import:        ${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}"
 echo
 
 if [ "${DRUPAL_MIGRATION_SKIP}" = "1" ]; then
-  info "Skipping migrations. DRUPAL_MIGRATION_SKIP is set to 1."
+  info "Skipped migrations. DRUPAL_MIGRATION_SKIP is set to 1."
   exit 0
 fi
 
@@ -84,7 +84,7 @@ run_migration() {
     exit 1
   }
 
-  task "Running migration: ${migration_name}"
+  task "Running migration: ${migration_name}."
   local opts=()
 
   opts+=("--feedback=${DRUPAL_MIGRATION_FEEDBACK}")
@@ -151,7 +151,7 @@ pass "Enabled migration modules."
 info "Starting migrations."
 
 if [ "${DRUPAL_MIGRATION_ROLLBACK_SKIP}" = "1" ]; then
-  note "Skipping rollback of all migrations."
+  note "Skipped rollback of all migrations."
 else
   task "Rolling back all migrations."
   drush migrate:rollback --all || true


### PR DESCRIPTION
Closes #2659

## Summary

The tooling scripts in `.vortex/tooling/src/` print progress via `info`/`note`/`task`/`pass`/`fail` helper functions, but messages were grammatically inconsistent and stylistically divergent across the ~34 scripts in scope. This sweeps every message to one style: full stop on prose messages (aligned `Label : value` summary rows, `:` headers, and `...` progress lines are exempt), `database` in prose while `DB` is retained in aligned summary labels, past-tense `pass`/skip messages, natural-case deployment type names, and corrected outright factual errors. BATS unit tests, `DeploymentTest`/`SubtestAhoyTrait` PHPUnit assertions, installer snapshot fixtures, and the docs example scripts are all kept in sync.

## Changes

- **Verb form:** `pass`/`[ OK ]` skip messages converted to past tense (`Skipped ...`); fixed a mixed participle/imperative verb form in `reset` (the example from the issue).
- **Punctuation:** full stop added to all prose messages; aligned `Label : value` summary rows, `:` section headers, and `...` progress lines left unterminated per convention.
- **Capitalization:** deployment type names un-shouted (`LAGOON` -> `Lagoon` proper noun; `ARTIFACT` -> `artifact`, `WEBHOOK` -> `webhook` common nouns; `container registry` already lowercase); a lowercase sentence start capitalized in `deploy-container-registry`.
- **Terminology:** `database` used in prose throughout; `DB` retained only in aligned summary labels where column alignment matters.
- **Correctness:** `task-copy-files-acquia` start message said "database copying" though the script copies files; three Acquia scripts said "environment UUID" where they had retrieved an "application UUID"; `notify-newrelic` "APP id" changed to "application ID"; a stray trailing space removed in `notify-jira`; `project: X, branch: Y` colon style made consistent in the Lagoon scripts.
- **Tests & fixtures:** synced BATS `assert_output_contains`/`assert_output_not_contains` assertions across the affected unit tests, updated `DeploymentTest` and `SubtestAhoyTrait` PHPUnit assertions, and regenerated the installer snapshot fixtures for the two `scripts/provision-*.sh` subscripts.
- **Docs:** aligned the maintenance boilerplate and provision example scripts that demonstrate these conventions.

## Before / After

```diff
# reset: mixed present-participle + bare imperative (the issue's example)
- task "Changing permissions and remove all other untracked files."
+ task "Changing permissions and removing all other untracked files."

# deploy: [ OK ]/pass skip message to past tense
- pass "Skipping deployment ${VORTEX_DEPLOY_TYPES}."
+ pass "Skipped deployment ${VORTEX_DEPLOY_TYPES}."

# deploy-lagoon: un-shout the proper noun
- info "Started LAGOON deployment."
+ info "Started Lagoon deployment."

# notify: full stop on a prose error message
- fail "Missing required value for VORTEX_NOTIFY_BRANCH"
+ fail "Missing required value for VORTEX_NOTIFY_BRANCH."

# download-db-acquia: database in prose (DB kept only in aligned labels)
- task "Downloading DB dump into file ${file_name_compressed}."
+ task "Downloading database dump into file ${file_name_compressed}."

# task-copy-files-acquia: start/finish must agree - this script copies files
- info "Started database copying between environments in Acquia."
+ info "Started files copying between environments in Acquia."
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized user-facing messages across all tooling scripts with consistent punctuation and formatting.
  * Updated operation status messages from present to past tense (e.g., "Skipped" instead of "Skipping").
  * Improved error message consistency with uniform capitalization and trailing periods.
  * Corrected technical terminology in status messages (e.g., "database" instead of "DB", "webhook" instead of "WEBHOOK").
  * Updated all corresponding tests to match revised output messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
</content>
