### PR TITLE
[#2652] Required 'drevops/vortex-tooling' as '^2.0@alpha' on 2.x.

### DIFF
--- a/.vortex/CLAUDE.md
+++ b/.vortex/CLAUDE.md
@@ -90,10 +90,15 @@ note() { printf "      %s\n" "${1}"; }
 ```
 
 **Publishing**: the version is injected at publish time - never hardcode
-`version` in the package `composer.json`. The path repository in the template's
-root `composer.json` declares `"versions": {"drevops/vortex-tooling": "1.2.0"}`
-so the in-repo copy resolves during development; the installer strips that entry
-from consumer sites so they resolve from Packagist.
+`version` in the package `composer.json`. While `2.0` is unreleased, the
+template's root `composer.json` requires
+`"drevops/vortex-tooling": "^2.0@alpha"` and the path repository pins
+`"versions": {"drevops/vortex-tooling": "2.0.0-alpha1"}` so the in-repo copy
+resolves during development. The installer strips that path repository from
+consumer sites; until a `2.0` pre-release is published to Packagist, scaffolded
+sites cannot resolve the tooling - acceptable during 2.x pre-release
+development. Once a `2.0` release is published, switch the constraint to a plain
+`^2.0`.
 
 ## Quick Commands
 

--- a/.vortex/tests/phpunit/Traits/SutTrait.php
+++ b/.vortex/tests/phpunit/Traits/SutTrait.php
@@ -120,7 +120,7 @@ trait SutTrait {
           'options' => [
             'symlink' => FALSE,
             'versions' => [
-              'drevops/vortex-tooling' => '1.2.0',
+              'drevops/vortex-tooling' => '2.0.0-alpha1',
             ],
           ],
         ];

--- a/.vortex/tooling/composer.json
+++ b/.vortex/tooling/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "drevops/vortex-tooling",
-    "description": "Shell scripts for Vortex-based Drupal projects (deploy, notify, provision, download/export DB, etc.).",
+    "description": "Vortex 2.x tooling: shell scripts for Drupal projects (deploy, notify, provision, database operations, etc.).",
     "license": "GPL-3.0-or-later",
     "type": "library",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.4",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^2.0",
-        "drevops/vortex-tooling": "^1.2.0",
+        "drevops/vortex-tooling": "^2.0@alpha",
         "drupal/admin_toolbar": "^3.6.3",
         "drupal/clamav": "^2.1",
         "drupal/coffee": "^2.0.1",
@@ -75,7 +75,7 @@
             "url": ".vortex/tooling",
             "options": {
                 "versions": {
-                    "drevops/vortex-tooling": "1.2.0"
+                    "drevops/vortex-tooling": "2.0.0-alpha1"
                 }
             }
         }

--- a/scripts/vortex-tooling.sh
+++ b/scripts/vortex-tooling.sh
@@ -81,4 +81,13 @@ fi
 
 composer --working-dir=vendor-temp install --no-dev --no-interaction
 
+#;< VORTEX_DEV
+# The 2.x tooling marks itself as "Vortex 2.x tooling" in its composer.json
+# description. Fail the bootstrap if a non-2.x tooling was resolved.
+if ! grep -q 'Vortex 2.x tooling' vendor-temp/vendor/drevops/vortex-tooling/composer.json; then
+  echo "ERROR: resolved drevops/vortex-tooling is not the 2.x tooling (composer.json description marker not found)." >&2
+  exit 1
+fi
+#;> VORTEX_DEV
+
 mv vendor-temp/vendor/drevops/vortex-tooling vendor/drevops/

--- a/scripts/vortex-tooling.sh
+++ b/scripts/vortex-tooling.sh
@@ -50,7 +50,7 @@ echo "{\"require\":{\"drevops/vortex-tooling\":\"${version}\"}}" >vendor-temp/co
 # In dev mode the package is not yet on Packagist, so add a path repository
 # pointing at the in-tree copy. The installer strips this VORTEX_DEV-fenced
 # block from consumer sites.
-composer --working-dir=vendor-temp config repositories.vortex-tooling --json '{"type":"path","url":"../.vortex/tooling","options":{"symlink":false,"versions":{"drevops/vortex-tooling":"1.2.0"}}}'
+composer --working-dir=vendor-temp config repositories.vortex-tooling --json '{"type":"path","url":"../.vortex/tooling","options":{"symlink":false,"versions":{"drevops/vortex-tooling":"2.0.0-alpha1"}}}'
 #;> VORTEX_DEV
 
 # Carry over inline patches declared for our package, if any.


### PR DESCRIPTION
Closes #2652

## Summary

On the `2.x` branch, `drevops/vortex-tooling` is now required as `^2.0@alpha` instead of the `^1.2.0` line inherited from `main`. The 2.x tooling ships breaking changes (e.g. `download-db` renamed to `fetch-db`) that are incompatible with the 1.x tooling, so a site built from `2.x` must consume the 2.x tooling line.

A plain `^2.0` cannot be used yet: no `2.0` release of `drevops/vortex-tooling` is published to Packagist (only the `2.x-dev` branch and the old `1.x` tags), and the installer strips the in-repo `path` repository from scaffolded sites. The `@alpha` stability flag lets the constraint resolve a `2.0` pre-release while keeping global `minimum-stability: stable` intact, and - unlike an inline `as 2.0.0` alias - it passes `composer validate --strict` with no CI changes. During `2.x` pre-release development the in-repo copy resolves locally and in CI via a `path` repository pinned to `2.0.0-alpha1`.

Real scaffolded sites cannot resolve the tooling from Packagist until a `2.0` pre-release is published there. This is acceptable during pre-release development and is tracked as a release activity in #2670 (publish the `2.0` tooling and switch the constraint to a plain `^2.0` before go-live).

## Changes

- **`composer.json`**: require `drevops/vortex-tooling` changed from `^1.2.0` to `^2.0@alpha`; `path`-repository version pin changed from `1.2.0` to `2.0.0-alpha1`.
- **`.vortex/tooling/composer.json`**: the package description now identifies the major line - `Vortex 2.x tooling: ...` - as a deliberate content marker. It lives in the tooling package's own source, so it genuinely distinguishes the 1.x and 2.x lines (unlike a version number, which is pinned externally), and it does not depend on any individual renamed command.
- **`scripts/vortex-tooling.sh`**: the host-side tooling bootstrap's dev-only `path`-repository pin changed from `1.2.0` to `2.0.0-alpha1`. Also added a `VORTEX_DEV`-fenced guard right after the throwaway `composer install` that greps the resolved package's `composer.json` for the `Vortex 2.x tooling` marker and hard-fails the bootstrap if it is absent - so a stale `1.x` constraint (e.g. from a bad rebase onto `main`) fails loudly instead of silently shipping the wrong tooling. Template-only (stripped from consumer sites).
- **`.vortex/tests/phpunit/Traits/SutTrait.php`**: the integration-test harness re-injects a `path` repository after the installer strips the real one; its pin changed from `1.2.0` to `2.0.0-alpha1` so the SUT resolves the in-repo tooling under the new constraint.
- **`.vortex/CLAUDE.md`**: Publishing note updated to document the `^2.0@alpha` pre-release mechanism.

Installer fixtures are unchanged: the version normaliser collapses the require string to `__VERSION__`, the tooling description lives under `.vortex/` (stripped on install), and the guard sits inside the `VORTEX_DEV` fence that the installer strips.

## Before / After

```
require drevops/vortex-tooling:
  before:  ^1.2.0          (1.x tooling - download-db family)
  after:   ^2.0@alpha      (2.x tooling - fetch-db family)

path-repo version pin (composer.json, scripts/vortex-tooling.sh, SutTrait.php):
  before:  1.2.0
  after:   2.0.0-alpha1

.vortex/tooling/composer.json description (2.x content marker):
  before:  "Shell scripts for Vortex-based Drupal projects (... download/export DB ...)."
  after:   "Vortex 2.x tooling: shell scripts for Drupal projects (... database operations ...)."

scripts/vortex-tooling.sh, after composer install (VORTEX_DEV-fenced):
  + hard-fail if the resolved tooling's composer.json lacks the "Vortex 2.x tooling" marker
```

This change lives on `2.x` only; `main` is unchanged and stays on the 1.x tooling line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated vortex-tooling dependency to version 2.0 alpha across configuration files and development scripts.

* **Documentation**
  * Updated publishing guidance to document vortex-tooling version management, including version injection at publish time and alpha pre-release constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
