### PR TITLE
[#2655] Migrated 'config.audit' to 'config.policy' for report-only installs.

### DIFF
--- a/.vortex/docs/content/development/composer.mdx
+++ b/.vortex/docs/content/development/composer.mdx
@@ -371,11 +371,11 @@ Configure the policy in your `composer.json` under the `config` section:
 }
 ```
 
-**Vortex** defaults:
+**Vortex** sets the following values:
 
-- **`advisories.block`** (`false`): security advisories do not block `composer install`, `composer update`, or `composer require`, so builds and deployments stay reproducible even when a new advisory is published upstream against an existing dependency.
-- **`advisories.audit`** (`fail`): the `composer audit` command still fails when an advisory is found, keeping vulnerabilities visible locally and in CI.
-- **`abandoned.audit`** (`report`): abandoned packages are reported as warnings but do not fail the audit.
+- **`advisories.block`** to `false`: security advisories do not block `composer install`, `composer update`, or `composer require`, so builds and deployments stay reproducible even when a new advisory is published upstream against an existing dependency. (Composer's own default is `true`.)
+- **`advisories.audit`** to `fail`: the `composer audit` command still fails when an advisory is found, keeping vulnerabilities visible locally and in CI.
+- **`abandoned.audit`** to `report`: abandoned packages are reported as warnings but do not fail the audit. (Composer's own default is `fail`.)
 
 Each section accepts `block` (refuse affected versions during `composer update`/`require`/`remove`), `audit` (`ignore`, `report`, or `fail` for the `composer audit` command), and `ignore`/`ignore-id`/`ignore-severity` for assessed exceptions.
 
@@ -393,14 +393,14 @@ If your project requires installation to hard-stop on advisories - for example, 
 
 ### Ignoring specific advisories
 
-When you've assessed an advisory and determined it doesn't affect your project, add it to the `ignore` list with a reason:
+When you've assessed an advisory and determined it doesn't affect your project, add it to the `ignore-id` list with a reason:
 
 ```json
 {
     "config": {
         "policy": {
             "advisories": {
-                "ignore": {
+                "ignore-id": {
                     "CVE-2024-1234": "Component is not used in our implementation.",
                     "GHSA-xxxx-yyyy-zzzz": "Patched via custom security fix."
                 }

--- a/.vortex/docs/content/development/composer.mdx
+++ b/.vortex/docs/content/development/composer.mdx
@@ -349,84 +349,70 @@ Composer Patches v2.x automatically generates a `patches.lock.json` file that co
 
 ## Security auditing
 
-Composer 2.9.0 introduced automatic security auditing that checks your dependencies for known security vulnerabilities and abandoned packages. This feature helps you maintain a secure codebase by alerting you to potential issues during package installation and updates.
+Composer 2.10.0 introduced a unified `config.policy` setting that controls both security auditing (reporting known security vulnerabilities and abandoned packages) and version blocking (refusing to install or update affected packages). **Vortex** uses it to keep vulnerabilities visible without blocking day-to-day dependency work.
 
 ### Configuration options
 
-Configure audit behavior in your `composer.json` under the `config` section:
+Configure the policy in your `composer.json` under the `config` section:
 
 ```json
 {
     "config": {
-        "audit": {
-            "abandoned": "report",
-            "block-insecure": true,
-            "ignore": {
-                "CVE-2024-1234": "The affected component is not in use in our application.",
-                "GHSA-xxxx-yyyy-zzzz": "Mitigated by additional security measures."
+        "policy": {
+            "advisories": {
+                "block": false,
+                "audit": "fail"
+            },
+            "abandoned": {
+                "audit": "report"
             }
         }
     }
 }
 ```
 
-**Available Options:**
+**Vortex** defaults:
 
-- **`block-insecure`**: Controls whether packages with security vulnerabilities block installation
-  - `true` (**Vortex** default): Blocks installation/update of vulnerable packages unless ignored
-  - `false`: Shows warnings but allows installation to proceed
-- **`abandoned`**: Controls how abandoned packages are handled
-  - `report` (**Vortex** default): Shows abandoned packages as warnings but doesn't fail
-  - `fail`: Audit command fails with non-zero exit code
-  - `ignore`: Skips abandoned packages in audit reports
-- **`ignore`**: Ignores specific security advisories by CVE or GHSA identifier (empty by default)
+- **`advisories.block`** (`false`): security advisories do not block `composer install`, `composer update`, or `composer require`, so builds and deployments stay reproducible even when a new advisory is published upstream against an existing dependency.
+- **`advisories.audit`** (`fail`): the `composer audit` command still fails when an advisory is found, keeping vulnerabilities visible locally and in CI.
+- **`abandoned.audit`** (`report`): abandoned packages are reported as warnings but do not fail the audit.
 
-### When to Use `block-insecure: false`
+Each section accepts `block` (refuse affected versions during `composer update`/`require`/`remove`), `audit` (`ignore`, `report`, or `fail` for the `composer audit` command), and `ignore`/`ignore-id`/`ignore-severity` for assessed exceptions.
 
-**Vortex** sets `block-insecure` to `true` by default to enforce security best practices. However, you may want to set it to `false` when:
+:::note Composer 2.10+
 
-- You need flexibility to evaluate vulnerabilities on your timeline
-- No secure version is immediately available
-- The vulnerability doesn't affect your specific use case
-- You're in active development and need uninterrupted workflow
-
-Keep it `true` (Vortex default) when:
-
-- Working on production sites with strict security requirements
-- Your deployment process can handle blocked installations
-- You want to enforce immediate action on security vulnerabilities
-- Your team has resources to quickly address security issues
-
-:::warning Vortex Security-First Philosophy
-
-**Vortex** adopts a security-first approach by setting `block-insecure: true` as the default. This prioritizes safety in automated deployments by preventing vulnerable packages from being installed without explicit review.
-
-If you need to override this setting for backwards compatibility, you can modify the `audit.block-insecure` configuration in your project's `composer.json` file. However, we strongly recommend addressing vulnerabilities by updating packages or using the `ignore` configuration for assessed exceptions, rather than routinely disabling security blocking.
-
-This approach ensures security issues are explicitly acknowledged and reviewed before being accepted into your codebase.
+`config.policy` requires Composer 2.10 or newer, which ships in the **Vortex** container images. On older Composer versions, use the legacy `config.audit` keys (`block-insecure`, `abandoned`) instead - they continue to work as a fallback.
 
 :::
 
+### Why advisories do not block installation
+
+Coupling installation to advisory publication makes builds non-deterministic: a newly published advisory against an already-installed dependency can fail every build - including work unrelated to security - until the advisory is assessed and ignored. **Vortex** decouples the two by setting `advisories.block` to `false` while keeping `advisories.audit` at `fail`, so installs and updates remain reproducible while vulnerabilities are still surfaced by `composer audit` and the CI lint job.
+
+If your project requires installation to hard-stop on advisories - for example, a production site with strict supply-chain controls - set `advisories.block` to `true`.
+
 ### Ignoring specific advisories
 
-When you've assessed a vulnerability and determined it doesn't affect your project, you can ignore it:
+When you've assessed an advisory and determined it doesn't affect your project, add it to the `ignore` list with a reason:
 
 ```json
 {
     "config": {
-        "audit": {
-            "ignore": {
-                "CVE-2024-1234": "Component is not used in our implementation.",
-                "GHSA-xxxx-yyyy-zzzz": "Patched via custom security fix."
+        "policy": {
+            "advisories": {
+                "ignore": {
+                    "CVE-2024-1234": "Component is not used in our implementation.",
+                    "GHSA-xxxx-yyyy-zzzz": "Patched via custom security fix."
+                }
             }
         }
     }
 }
 ```
 
-:::tip Document Your Decisions
+:::tip Document your decisions
 
-Always include reasons when ignoring advisories into your Git commit messages. This helps your team understand why a vulnerability was deemed acceptable and makes it easier to review these decisions in the future.
+Record the reason for each ignored advisory in your Git commit message. This helps your team understand why a vulnerability was deemed acceptable and makes the decision easy to review later.
 
 :::
 
@@ -465,10 +451,6 @@ Check your dependencies for security issues manually:
 
 ### CI/CD integration
 
-**Vortex** automatically runs `composer audit` as part of the CI/CD pipeline to
-check for security vulnerabilities during builds.
+**Vortex** runs `composer audit` as part of the CI lint job. Because `advisories.audit` is `fail`, the audit reports vulnerabilities and the lint job fails when any are found - even though installs and updates are not blocked.
 
-By default, audit failures will cause the CI build to fail. You can control this
-behavior using a repository variable `VORTEX_CI_COMPOSER_AUDIT_IGNORE_FAILURE`
-set to `1`. When this variable is set to `1`, the audit step will run but won't
-fail the build if vulnerabilities are found.
+By default that failure gates the build. Set the repository variable `VORTEX_CI_COMPOSER_AUDIT_IGNORE_FAILURE` to `1` to make the audit step run and report without failing the build - useful as a one-off bypass while a known advisory is being addressed.

--- a/.vortex/docs/content/development/faqs.mdx
+++ b/.vortex/docs/content/development/faqs.mdx
@@ -262,7 +262,7 @@ Provided that your stack is already running:
 
 1. **Update the affected package**: try a newer version that resolves the advisory: `composer update vendor/package-name`.
 2. **Review the advisory**: run `composer audit` for details and assess whether it affects your project.
-3. **Record an assessed exception**: if no fixed version is available yet, or the vulnerability doesn't affect your use case, add the advisory to the `config.policy.advisories.ignore` list in your `composer.json` with a documented reason.
+3. **Record an assessed exception**: if no fixed version is available yet, or the vulnerability doesn't affect your use case, add the advisory to the `config.policy.advisories.ignore-id` list in your `composer.json` with a documented reason.
 4. **Bypass CI for a known issue**: set `VORTEX_CI_COMPOSER_AUDIT_IGNORE_FAILURE` to `1` to let CI pass while the advisory is being addressed.
 
 ➡️ See [Composer > Security auditing](composer.mdx#security-auditing) for the full `config.policy` reference and guidance on choosing the right settings for your project.

--- a/.vortex/docs/content/development/faqs.mdx
+++ b/.vortex/docs/content/development/faqs.mdx
@@ -256,24 +256,16 @@ Provided that your stack is already running:
 
 ➡️ See [Composer > Patching](composer.mdx#patching)
 
-## What should I do when Composer blocks package installation due to security vulnerabilities?
+## What should I do when `composer audit` reports a security vulnerability?
 
-Starting with Composer 2.9.0, Composer can automatically block the installation
-or update of packages with known security vulnerabilities. If you encounter this
-issue, you have several options:
+**Vortex** does not block installation on security advisories by default, so `composer install` and `composer update` keep working. Advisories are surfaced by `composer audit`, which runs locally and in the CI lint job. When one appears:
 
-1. **Update the affected packages**: Try updating to newer versions that don't
-   have known vulnerabilities: `composer update vendor/package-name`
-2. **Review the vulnerability**: Run `composer audit` to see details about the
-   security issues and determine if they affect your project.
-3. **Adjust security settings**: If you need to proceed with installation despite
-   warnings (for example, if no secure version is available or the vulnerability
-   doesn't affect your use case), you can configure the `audit.block-insecure`
-   setting in your `composer.json`.
+1. **Update the affected package**: try a newer version that resolves the advisory: `composer update vendor/package-name`.
+2. **Review the advisory**: run `composer audit` for details and assess whether it affects your project.
+3. **Record an assessed exception**: if no fixed version is available yet, or the vulnerability doesn't affect your use case, add the advisory to the `config.policy.advisories.ignore` list in your `composer.json` with a documented reason.
+4. **Bypass CI for a known issue**: set `VORTEX_CI_COMPOSER_AUDIT_IGNORE_FAILURE` to `1` to let CI pass while the advisory is being addressed.
 
-➡️ See [Composer > Security auditing](composer.mdx#security-auditing) for detailed
-information about the `audit` configuration option and guidance on choosing the
-right security settings for your project.
+➡️ See [Composer > Security auditing](composer.mdx#security-auditing) for the full `config.policy` reference and guidance on choosing the right settings for your project.
 
 ## How to set a custom maintenance theme?
 

--- a/.vortex/docs/content/drupal/composer-json.mdx
+++ b/.vortex/docs/content/drupal/composer-json.mdx
@@ -227,23 +227,20 @@ specifies key configurations for Composer's behavior in the project.
   This setting specifies which Composer plugins are allowed to run. It's a
   security measure to prevent the execution of untrusted code from third-party
   plugins. Each plugin needs to be explicitly allowed to ensure it can execute.
-- [`audit`](https://getcomposer.org/doc/06-config.md#audit): Introduced in
-  Composer 2.9.0, this setting controls automatic security auditing of
-  dependencies during `composer install` and `composer update`. **Vortex**
-  enforces security best practices with the following configuration:
-  - `block-insecure` (default: `true`): Blocks installation of packages with
-    known security vulnerabilities unless explicitly ignored. This ensures
-    security issues are addressed before deployment.
-  - `abandoned` (default: `report`): Shows warnings for abandoned packages
-    without failing the build. Allows visibility into package maintenance status
-    while not blocking installations.
-  - `ignore` (default: `{}`): Empty object ready for adding assessed and
-    documented vulnerability exceptions. Use this to explicitly allow specific
-    CVE/GHSA advisories that have been reviewed and accepted.
+- [`policy`](https://getcomposer.org/doc/06-config.md#policy): Introduced in
+  Composer 2.10.0, this unified setting controls security auditing and version
+  blocking of dependencies. **Vortex** configures it to keep vulnerabilities
+  visible without blocking installs:
+  - `advisories.block` (set to `false`): security advisories do not block
+    `composer install`, `composer update`, or `composer require`, keeping builds
+    reproducible when new advisories are published upstream.
+  - `advisories.audit` (set to `fail`): `composer audit` still fails on
+    advisories, so they remain visible locally and in CI.
+  - `abandoned.audit` (set to `report`): abandoned packages are reported as
+    warnings without failing the audit.
   - See
     [Composer Security Auditing](../development/composer#security-auditing)
-    for comprehensive guidance on configuration options, ignoring specific
-    advisories, running audits, and best practices.
+    for the full reference, ignoring advisories, and best practices.
 - [`bump-after-update`](https://getcomposer.org/doc/06-config.md#bump-after-update):
   Automatically updates version constraints in `composer.json` to match currently
   installed package versions after running `composer update`. **Vortex** sets this

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
@@ -88,14 +88,19 @@
             "pyrech/composer-changelogs": true,
             "tbachert/spi": true
         },
-        "audit": {
-            "abandoned": "report",
-            "block-insecure": true
-        },
         "bump-after-update": true,
         "discard-changes": true,
         "platform": {
             "php": "__VERSION__"
+        },
+        "policy": {
+            "advisories": {
+                "block": false,
+                "audit": "fail"
+            },
+            "abandoned": {
+                "audit": "report"
+            }
         },
         "sort-packages": true
     },

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -118,38 +118,38 @@
+@@ -123,38 +123,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -118,38 +118,38 @@
+@@ -123,38 +123,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
@@ -37,9 +37,9 @@
 +            "drupal/core-vendor-hardening": true,
 +            "wikimedia/composer-merge-plugin": true
          },
-         "audit": {
-             "abandoned": "report",
-@@ -159,6 +166,19 @@
+         "bump-after-update": true,
+         "discard-changes": true,
+@@ -164,6 +171,19 @@
          "patchLevel": {
              "drupal/core": "-p2"
          },

--- a/composer.json
+++ b/composer.json
@@ -99,14 +99,19 @@
             "pyrech/composer-changelogs": true,
             "tbachert/spi": true
         },
-        "audit": {
-            "abandoned": "report",
-            "block-insecure": true
-        },
         "bump-after-update": true,
         "discard-changes": true,
         "platform": {
             "php": "8.4.21"
+        },
+        "policy": {
+            "advisories": {
+                "block": false,
+                "audit": "fail"
+            },
+            "abandoned": {
+                "audit": "report"
+            }
         },
         "sort-packages": true
     },


### PR DESCRIPTION
Closes #2655

## Summary

Migrates `config.audit` to Composer 2.10's `config.policy` format so that security advisory publication no longer blocks `composer install`, `composer update`, or `composer require`, while `composer audit` still fails in CI when an advisory is found.

**Before:**
```
config.audit.block-insecure: true
→ a new upstream advisory blocks every install/build immediately
```

**After:**
```
config.policy.advisories.block: false
→ installs and builds stay reproducible; composer audit still fails in CI
```

### Changes

**`composer.json`** - Replaced the legacy `config.audit` block with `config.policy` (Composer 2.10+):
- `advisories.block: false` - security advisories no longer block `composer install`, `composer update`, or `composer require`. Builds and deployments stay reproducible even when a new advisory is published upstream against an existing dependency.
- `advisories.audit: "fail"` - `composer audit` still exits non-zero when an advisory is found, so vulnerabilities remain visible locally and the CI lint job keeps surfacing them.
- `abandoned.audit: "report"` - abandoned packages are reported as warnings without failing the audit (preserves the prior `config.audit.abandoned: "report"` behaviour).

`VORTEX_CI_COMPOSER_AUDIT_IGNORE_FAILURE` and the CI workflow files are intentionally unchanged - the audit step continues to gate CI by default.

**Docs** - Rewrote the security-auditing sections across three pages to reflect the `config.policy` format and the new report-only-install behaviour:
- `.vortex/docs/content/development/composer.mdx`
- `.vortex/docs/content/development/faqs.mdx`
- `.vortex/docs/content/drupal/composer-json.mdx`

**Installer fixtures** - Regenerated the four affected `composer.json` snapshots under `.vortex/installer/tests/Fixtures/handler_process/` to match the migrated config.

### Notes

`config.policy` requires Composer >= 2.10, which ships in the `uselagoon/*:26.6.0` base images already on `main`. No image bumps are needed in this PR.

Screenshots: N/A (Composer config, docs, and test fixtures only).
