### PR TITLE
[#2673] Documented allowlisting Diffy's static IP in a WAF or CDN.

### DIFF
--- a/.vortex/docs/content/development/visual-regression.mdx
+++ b/.vortex/docs/content/development/visual-regression.mdx
@@ -49,6 +49,22 @@ project settings - the CLI flags act as an override for cases where
 hosting is provisioned with rotating credentials and storing them in
 Diffy is impractical.
 
+:::warning WAF / CDN access
+
+Diffy captures screenshots from a single static IP (`138.201.56.149`,
+IPv6 `2a01:4f8:172:1189::2`). When the source or target environment sits
+behind a WAF or CDN - Cloudflare, AWS CloudFront, Akamai, Incapsula, or
+similar - that layer can block or challenge Diffy's requests. Diffy then
+captures the block or challenge page instead of the real site, producing
+false visual differences.
+
+Allowlist Diffy's static IP in the protection layer so its requests reach
+the site. In Cloudflare, add an IP Access Rule for that address with the
+*Allow* action. For per-provider steps and the current IP, see Diffy's
+[bypass protection guidance](https://docs.diffy.website/features/bypass-protection-cloudfront-akamai-incapsula).
+
+:::
+
 ### Variables
 
 | Name | Default | Purpose |

--- a/.vortex/docs/cspell.json
+++ b/.vortex/docs/cspell.json
@@ -13,6 +13,7 @@
         "Diffy",
         "Dockerfiles",
         "GHSA",
+        "Incapsula",
         "NRAK",
         "REDIS",
         "Runsheet",


### PR DESCRIPTION
Closes #2673

## Summary

Documents that Diffy's screenshot worker uses a single static IP address (`138.201.56.149` / IPv6 `2a01:4f8:172:1189::2`) and that WAF or CDN layers (Cloudflare, AWS CloudFront, Akamai, Incapsula) can intercept its requests, causing the tool to capture a block or challenge page instead of the real site and producing false visual differences. A `:::warning` admonition is added to the Visual Regression docs page explaining this behaviour and how to allowlist the IP, with a link to Diffy's own bypass-protection guidance. `Incapsula` is also added to the docs spellcheck word list.

## Changes

- `.vortex/docs/content/development/visual-regression.mdx`: Added a `:::warning WAF / CDN access` Docusaurus admonition documenting Diffy's static IP, the risk of WAF/CDN interception, and allowlist instructions including a Cloudflare IP Access Rule example and a link to Diffy's upstream bypass-protection docs.
- `.vortex/docs/cspell.json`: Added `Incapsula` to the spellcheck word list.

## Screenshots

![Rendered WAF / CDN access admonition on the Visual regression docs page](https://raw.githubusercontent.com/drevops/vortex/3ea4619df72ca6283f911a37c489a16c93809f72/feature-2673-diffy-waf-allowlist/4b7aa0a66d215c2e9e01d97e4263464b0daf9c1d.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated visual regression testing documentation with guidance on allowlisting Diffy's static IP address when using WAF/CDN protection layers (such as Cloudflare, CloudFront, or Akamai) to prevent false visual regression detections caused by protection page captures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->