### PR TITLE
Excluded installer test fixtures from the Zizmor GitHub Actions audit.

### DIFF
--- a/.github/workflows/vortex-test-common.yml
+++ b/.github/workflows/vortex-test-common.yml
@@ -269,5 +269,9 @@ jobs:
       - name: Check GitHub Actions security with Zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         with:
+          # Audit only the real workflows. The default '.' also descends into the
+          # installer test fixtures, whose normalized '__HASH__' action refs are
+          # placeholders rather than real pins and raise false 'unpinned-uses'.
+          inputs: .github/workflows/
           config: .vortex/tests/zizmor.yml
         continue-on-error: ${{ vars.VORTEX_CI_ZIZMOR_IGNORE_FAILURE == '1' }}

--- a/.vortex/tests/zizmor.yml
+++ b/.vortex/tests/zizmor.yml
@@ -1,7 +1,10 @@
 # Zizmor configuration for auditing the Vortex template's own GitHub Actions
 # workflows. Consumed by the 'vortex-test-actions' job in
 # '.github/workflows/vortex-test-common.yml' (a maintenance-only workflow that
-# is not shipped to scaffolded projects).
+# is not shipped to scaffolded projects). That job scopes the audit to
+# '.github/workflows/', so the installer test fixtures are out of scope and
+# their placeholder action refs must not be silenced by basename entries here -
+# a basename like 'build-test-deploy.yml' would also match the real workflow.
 #
 # Every entry below documents an intentional, accepted finding. Genuine issues
 # are fixed in the workflows themselves rather than ignored here.


### PR DESCRIPTION
## Summary

The `vortex-test-actions` job ran `zizmorcore/zizmor-action` with its default `inputs: .`, so zizmor walked the entire repo and descended into the installer snapshot fixtures under `.vortex/installer/tests/Fixtures/`. Those fixtures deliberately normalize real action SHA pins to `__HASH__` placeholders (e.g. `uses: actions/cache/restore@__HASH__ # __VERSION__`) to keep snapshots stable across version bumps. Zizmor's offline `unpinned-uses` audit correctly flagged every `@__HASH__` as "not pinned to a hash", producing 30+ open GitHub code-scanning alerts - every one inside a fixture, none in a real workflow (the shipped workflows carry genuine SHA pins).

Scoping the audit to `.github/workflows/` makes zizmor audit only the 12 real workflows and excludes the fixtures, resolving all false findings. A denylist via the zizmor config was not viable: zizmor's `ignore` matches by basename only, so ignoring a fixture filename (e.g. `build-test-deploy.yml`) would also silence the identically-named real workflow. Once this lands on `main`, the existing code-scanning alerts will auto-resolve as fixed on the next SARIF upload.

## Changes

- `.github/workflows/vortex-test-common.yml` - added `inputs: .github/workflows/` to the "Check GitHub Actions security with Zizmor" step, scoping the scan to the real workflow directory only.
- `.vortex/tests/zizmor.yml` - extended the header comment to document the audit scope and to warn that basename-based ignores must not be added for fixture filenames (they would also match real workflows).

## Before / After

```
Before: zizmor input scope
.
├── .github/workflows/        ← 12 real workflows (genuine SHA pins) ✓
└── .vortex/
    └── installer/
        └── tests/
            └── Fixtures/     ← snapshot fixtures (__HASH__ placeholders) ✗ 30+ false alerts

After: zizmor input scope
.github/workflows/            ← 12 real workflows only ✓
```

## Notes

- Non-visual change (CI config YAML only).
- The `vortex-test-actions` CI job will re-run yamllint + actionlint + zizmor against `.github/workflows/` on this PR, which is the authoritative validation gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved false positive security alerts by refining audit scope to exclude test fixtures from analysis.

* **Chores**
  * Updated security audit configuration and documentation for improved clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->