### PR TITLE
Removed abandoned 'oomphinc/composer-installers-extender' package.

### DIFF
--- a/.vortex/docs/content/drupal/composer-json.mdx
+++ b/.vortex/docs/content/drupal/composer-json.mdx
@@ -107,11 +107,6 @@ specifies the essential packages and libraries your project needs.
 - [`drush/drush`](https://github.com/drush-ops/drush): A command-line shell and
   scripting interface for Drupal, providing a wide range of utilities to manage
   and interact with your Drupal sites.
-- [`oomphinc/composer-installers-extender`](https://github.com/oomphinc/composer-installers-extender):
-  Allows any package to be installed to a directory other than the
-  default `vendor` directory within a project on a package-by-package basis.
-  This plugin extends the `composer/installers` plugin to allow any arbitrary
-  package type to be handled by their custom installer.
 - [`webflo/drupal-finder`](https://github.com/webflo/drupal-finder): Locates
   Drupal installations in a directory structure.
 
@@ -295,9 +290,6 @@ needs and structure of your Drupal project.
 - [`installer-paths`](https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md):
   Defines custom installation paths for various types of packages like Drupal
   modules, themes, and libraries.
-- `installer-types`: Specifies additional installer types, such as `bower-asset`
-  and `npm-asset`, that are handled by
-  the `oomphinc/composer-installers-extender` plugin.
 - `patchLevel`: Defines the patch level for specific packages, in this
   case, `drupal/core`. The `-p` option followed by a number (e.g., `-p1`, `-p2`)
   in patch commands specifies the number of leading directories to strip from

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
@@ -32,7 +32,6 @@
         "drupal/testmode": "__VERSION__",
         "drupal/xmlsitemap": "__VERSION__",
         "drush/drush": "__VERSION__",
-        "oomphinc/composer-installers-extender": "__VERSION__",
         "webflo/drupal-finder": "__VERSION__"
     },
     "require-dev": {
@@ -84,7 +83,6 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
-            "oomphinc/composer-installers-extender": true,
             "php-http/discovery": true,
             "phpstan/extension-installer": true,
             "pyrech/composer-changelogs": true,
@@ -160,9 +158,6 @@
                 "type:drupal-custom-theme"
             ]
         },
-        "installer-types": [
-            "drupal-library"
-        ],
         "patchLevel": {
             "drupal/core": "-p2"
         },

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -125,38 +125,38 @@
+@@ -123,38 +123,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -125,38 +125,38 @@
+@@ -123,38 +123,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/composer.json
@@ -1,4 +1,4 @@
-@@ -45,7 +45,6 @@
+@@ -44,7 +44,6 @@
          "drevops/phpcs-standard": "__VERSION__",
          "drupal/coder": "__VERSION__",
          "drupal/drupal-extension": "__VERSION__",

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_testmode/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_testmode/composer.json
@@ -5,4 +5,4 @@
 -        "drupal/testmode": "__VERSION__",
          "drupal/xmlsitemap": "__VERSION__",
          "drush/drush": "__VERSION__",
-         "oomphinc/composer-installers-extender": "__VERSION__",
+         "webflo/drupal-finder": "__VERSION__"

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_xmlsitemap/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_xmlsitemap/composer.json
@@ -4,5 +4,5 @@
          "drupal/testmode": "__VERSION__",
 -        "drupal/xmlsitemap": "__VERSION__",
          "drush/drush": "__VERSION__",
-         "oomphinc/composer-installers-extender": "__VERSION__",
          "webflo/drupal-finder": "__VERSION__"
+     },

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_none/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_none/composer.json
@@ -26,9 +26,9 @@
 -        "drupal/testmode": "__VERSION__",
 -        "drupal/xmlsitemap": "__VERSION__",
          "drush/drush": "__VERSION__",
-         "oomphinc/composer-installers-extender": "__VERSION__",
          "webflo/drupal-finder": "__VERSION__"
-@@ -45,7 +28,6 @@
+     },
+@@ -44,7 +27,6 @@
          "drevops/phpcs-standard": "__VERSION__",
          "drupal/coder": "__VERSION__",
          "drupal/drupal-extension": "__VERSION__",

--- a/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
@@ -6,10 +6,10 @@
          "drupal/coffee": "__VERSION__",
          "drupal/config_split": "__VERSION__",
          "drupal/config_update": "__VERSION__",
-@@ -33,7 +34,9 @@
+@@ -32,7 +33,9 @@
+         "drupal/testmode": "__VERSION__",
          "drupal/xmlsitemap": "__VERSION__",
          "drush/drush": "__VERSION__",
-         "oomphinc/composer-installers-extender": "__VERSION__",
 -        "webflo/drupal-finder": "__VERSION__"
 +        "symfony/http-client": "^6.4 || ^7.0",
 +        "webflo/drupal-finder": "__VERSION__",
@@ -17,7 +17,7 @@
      },
      "require-dev": {
          "behat/behat": "__VERSION__",
-@@ -70,7 +73,7 @@
+@@ -69,7 +72,7 @@
              "url": "https://packages.drupal.org/8"
          }
      ],
@@ -26,7 +26,7 @@
      "prefer-stable": true,
      "autoload-dev": {
          "classmap": [
-@@ -88,7 +91,11 @@
+@@ -86,7 +89,11 @@
              "php-http/discovery": true,
              "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,
@@ -39,7 +39,7 @@
          },
          "bump-after-update": true,
          "discard-changes": true,
-@@ -166,6 +173,19 @@
+@@ -161,6 +168,19 @@
          "patchLevel": {
              "drupal/core": "-p2"
          },

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/composer.json
@@ -1,4 +1,4 @@
-@@ -38,27 +38,18 @@
+@@ -37,27 +37,18 @@
      "require-dev": {
          "behat/behat": "__VERSION__",
          "dantleech/gherkin-lint": "__VERSION__",
@@ -26,14 +26,13 @@
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
      },
      "conflict": {
-@@ -81,12 +72,10 @@
+@@ -80,11 +71,9 @@
          "allow-plugins": {
              "composer/installers": true,
              "cweagans/composer-patches": true,
 -            "dealerdirect/phpcodesniffer-composer-installer": true,
              "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
              "php-http/discovery": true,
 -            "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -38,27 +38,18 @@
+@@ -37,27 +37,18 @@
      "require-dev": {
          "behat/behat": "__VERSION__",
          "dantleech/gherkin-lint": "__VERSION__",
@@ -26,14 +26,13 @@
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
      },
      "conflict": {
-@@ -81,12 +72,10 @@
+@@ -80,11 +71,9 @@
          "allow-plugins": {
              "composer/installers": true,
              "cweagans/composer-patches": true,
 -            "dealerdirect/phpcodesniffer-composer-installer": true,
              "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
              "php-http/discovery": true,
 -            "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/composer.json
@@ -1,4 +1,4 @@
-@@ -36,15 +36,9 @@
+@@ -35,15 +35,9 @@
          "webflo/drupal-finder": "__VERSION__"
      },
      "require-dev": {
@@ -14,7 +14,7 @@
          "drupal/sdc_devel": "__VERSION__",
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
-@@ -53,10 +47,8 @@
+@@ -52,10 +46,8 @@
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
          "phpcompatibility/php-compatibility": "__VERSION__",
@@ -25,7 +25,7 @@
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
-@@ -72,11 +64,6 @@
+@@ -71,11 +63,6 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -36,15 +36,9 @@
+@@ -35,15 +35,9 @@
          "webflo/drupal-finder": "__VERSION__"
      },
      "require-dev": {
@@ -14,7 +14,7 @@
          "drupal/sdc_devel": "__VERSION__",
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
-@@ -53,10 +47,8 @@
+@@ -52,10 +46,8 @@
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
          "phpcompatibility/php-compatibility": "__VERSION__",
@@ -25,7 +25,7 @@
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
-@@ -72,11 +64,6 @@
+@@ -71,11 +63,6 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/composer.json
@@ -1,4 +1,4 @@
-@@ -36,15 +36,9 @@
+@@ -35,15 +35,9 @@
          "webflo/drupal-finder": "__VERSION__"
      },
      "require-dev": {

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -36,15 +36,9 @@
+@@ -35,15 +35,9 @@
          "webflo/drupal-finder": "__VERSION__"
      },
      "require-dev": {

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/composer.json
@@ -1,4 +1,4 @@
-@@ -38,12 +38,9 @@
+@@ -37,12 +37,9 @@
      "require-dev": {
          "behat/behat": "__VERSION__",
          "dantleech/gherkin-lint": "__VERSION__",
@@ -11,7 +11,7 @@
          "drupal/drupal-extension": "__VERSION__",
          "drupal/sdc_devel": "__VERSION__",
          "ergebnis/composer-normalize": "__VERSION__",
-@@ -52,7 +49,6 @@
+@@ -51,7 +48,6 @@
          "mglaman/phpstan-drupal": "__VERSION__",
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
@@ -19,11 +19,11 @@
          "phpspec/prophecy-phpunit": "__VERSION__",
          "phpstan/extension-installer": "__VERSION__",
          "phpstan/phpstan": "__VERSION__",
-@@ -81,7 +77,6 @@
+@@ -80,7 +76,6 @@
          "allow-plugins": {
              "composer/installers": true,
              "cweagans/composer-patches": true,
 -            "dealerdirect/phpcodesniffer-composer-installer": true,
              "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
+             "php-http/discovery": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -38,12 +38,9 @@
+@@ -37,12 +37,9 @@
      "require-dev": {
          "behat/behat": "__VERSION__",
          "dantleech/gherkin-lint": "__VERSION__",
@@ -11,7 +11,7 @@
          "drupal/drupal-extension": "__VERSION__",
          "drupal/sdc_devel": "__VERSION__",
          "ergebnis/composer-normalize": "__VERSION__",
-@@ -52,7 +49,6 @@
+@@ -51,7 +48,6 @@
          "mglaman/phpstan-drupal": "__VERSION__",
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
@@ -19,11 +19,11 @@
          "phpspec/prophecy-phpunit": "__VERSION__",
          "phpstan/extension-installer": "__VERSION__",
          "phpstan/phpstan": "__VERSION__",
-@@ -81,7 +77,6 @@
+@@ -80,7 +76,6 @@
          "allow-plugins": {
              "composer/installers": true,
              "cweagans/composer-patches": true,
 -            "dealerdirect/phpcodesniffer-composer-installer": true,
              "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
+             "php-http/discovery": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/composer.json
@@ -1,4 +1,4 @@
-@@ -49,13 +49,10 @@
+@@ -48,13 +48,10 @@
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
          "lullabot/php-webdriver": "__VERSION__",
@@ -12,9 +12,9 @@
          "phpunit/phpunit": "__VERSION__",
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
-@@ -86,7 +83,6 @@
+@@ -84,7 +81,6 @@
+             "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
              "php-http/discovery": true,
 -            "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -49,13 +49,10 @@
+@@ -48,13 +48,10 @@
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
          "lullabot/php-webdriver": "__VERSION__",
@@ -12,9 +12,9 @@
          "phpunit/phpunit": "__VERSION__",
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
-@@ -86,7 +83,6 @@
+@@ -84,7 +81,6 @@
+             "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
              "php-http/discovery": true,
 -            "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/composer.json
@@ -1,4 +1,4 @@
-@@ -53,10 +53,8 @@
+@@ -52,10 +52,8 @@
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
          "phpcompatibility/php-compatibility": "__VERSION__",
@@ -9,7 +9,7 @@
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
-@@ -72,11 +70,6 @@
+@@ -71,11 +69,6 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -53,10 +53,8 @@
+@@ -52,10 +52,8 @@
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
          "phpcompatibility/php-compatibility": "__VERSION__",
@@ -9,7 +9,7 @@
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
-@@ -72,11 +70,6 @@
+@@ -71,11 +69,6 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/composer.json
@@ -1,4 +1,4 @@
-@@ -51,7 +51,6 @@
+@@ -50,7 +50,6 @@
          "lullabot/php-webdriver": "__VERSION__",
          "mglaman/phpstan-drupal": "__VERSION__",
          "mikey179/vfsstream": "__VERSION__",
@@ -6,7 +6,7 @@
          "phpcompatibility/php-compatibility": "__VERSION__",
          "phpspec/prophecy-phpunit": "__VERSION__",
          "phpstan/extension-installer": "__VERSION__",
-@@ -58,7 +57,6 @@
+@@ -57,7 +56,6 @@
          "phpstan/phpstan": "__VERSION__",
          "phpunit/phpunit": "__VERSION__",
          "pyrech/composer-changelogs": "__VERSION__",

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -51,7 +51,6 @@
+@@ -50,7 +50,6 @@
          "lullabot/php-webdriver": "__VERSION__",
          "mglaman/phpstan-drupal": "__VERSION__",
          "mikey179/vfsstream": "__VERSION__",
@@ -6,7 +6,7 @@
          "phpcompatibility/php-compatibility": "__VERSION__",
          "phpspec/prophecy-phpunit": "__VERSION__",
          "phpstan/extension-installer": "__VERSION__",
-@@ -58,7 +57,6 @@
+@@ -57,7 +56,6 @@
          "phpstan/phpstan": "__VERSION__",
          "phpunit/phpunit": "__VERSION__",
          "pyrech/composer-changelogs": "__VERSION__",

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/composer.json
@@ -1,4 +1,4 @@
-@@ -36,29 +36,12 @@
+@@ -35,29 +35,12 @@
          "webflo/drupal-finder": "__VERSION__"
      },
      "require-dev": {
@@ -28,7 +28,7 @@
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
      },
      "conflict": {
-@@ -72,21 +55,14 @@
+@@ -71,20 +54,13 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,
@@ -44,7 +44,6 @@
 -            "dealerdirect/phpcodesniffer-composer-installer": true,
              "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
              "php-http/discovery": true,
 -            "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,

--- a/.vortex/tests/phpunit/Functional/ComposerInstallerTest.php
+++ b/.vortex/tests/phpunit/Functional/ComposerInstallerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\Vortex\Tests\Functional;
+
+use AlexSkrypnyk\File\File;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests that 'composer/installers' handles the 'drupal-library' package type.
+ *
+ * Vortex relies on 'composer/installers' alone (without an installer-extender
+ * plugin) to place 'drupal-library' packages into 'web/libraries/{$name}'.
+ * This guards that the install path keeps working using the template's own
+ * installer configuration.
+ */
+class ComposerInstallerTest extends FunctionalTestCase {
+
+  protected function setUp(): void {
+    // Only locations are required: the test reads the template 'composer.json'
+    // and runs Composer in a temporary directory. No SUT or Docker stack is
+    // involved, so the heavy parent setUp is intentionally not called.
+    self::locationsInit(File::cwd() . '/../..');
+  }
+
+  protected function tearDown(): void {
+    if ($this->tearDownShouldCleanup()) {
+      static::locationsTearDown();
+    }
+  }
+
+  #[Group('p1')]
+  public function testDrupalLibraryInstallsToWebLibraries(): void {
+    $this->logStepStart();
+
+    // Reuse the template's real installer configuration so this guards the
+    // shipped 'composer.json', not a hand-written copy.
+    $raw = file_get_contents(static::locationsRoot() . '/composer.json');
+    $template = is_string($raw) ? json_decode($raw, TRUE) : NULL;
+    if (!is_array($template)) {
+      throw new \RuntimeException('Unable to read the template composer.json.');
+    }
+
+    $require = $template['require'] ?? NULL;
+    $extra = $template['extra'] ?? NULL;
+    if (!is_array($require) || !is_array($extra)) {
+      throw new \RuntimeException('The template composer.json has no "require" or "extra" section.');
+    }
+
+    $installers_constraint = $require['composer/installers'] ?? NULL;
+    $installer_paths = $extra['installer-paths'] ?? NULL;
+    if (!is_string($installers_constraint) || !is_array($installer_paths)) {
+      throw new \RuntimeException('The template composer.json is missing "composer/installers" or "installer-paths".');
+    }
+
+    $library_name = 'vortex_test_library';
+
+    $this->logSubstep('Create a local fixture package of type "drupal-library"');
+    $library_dir = static::$tmp . '/fixture_library';
+    File::dump($library_dir . '/composer.json', (string) json_encode([
+      'name' => 'vortex-test/' . $library_name,
+      'type' => 'drupal-library',
+      'version' => '1.0.0',
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+    File::dump($library_dir . '/library.js', "// Fixture drupal-library payload.\n");
+
+    $this->logSubstep('Create a project using the template installer configuration');
+    $project_dir = static::$tmp . '/project';
+    File::dump($project_dir . '/composer.json', (string) json_encode([
+      'name' => 'vortex-test/project',
+      'require' => [
+        'composer/installers' => $installers_constraint,
+        'vortex-test/' . $library_name => '*',
+      ],
+      'repositories' => [
+        ['type' => 'path', 'url' => '../fixture_library', 'options' => ['symlink' => FALSE]],
+      ],
+      'extra' => ['installer-paths' => $installer_paths],
+      'config' => ['allow-plugins' => ['composer/installers' => TRUE]],
+      'minimum-stability' => 'stable',
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+
+    $this->cmd(
+      'composer --working-dir=' . escapeshellarg($project_dir) . ' update --no-interaction --no-progress',
+      txt: 'Install a "drupal-library" package using composer/installers',
+    );
+
+    $this->logSubstep('Assert composer/installers placed the package into web/libraries');
+    $installed_dir = $project_dir . '/web/libraries/' . $library_name;
+    $this->assertDirectoryExists($installed_dir, 'The "drupal-library" package is installed into web/libraries/{$name}.');
+    $this->assertFileExists($installed_dir . '/library.js', 'The "drupal-library" payload exists at the expected path.');
+    $this->assertDirectoryDoesNotExist($project_dir . '/vendor/vortex-test/' . $library_name, 'The "drupal-library" package is not installed into vendor/.');
+
+    $this->logStepFinish();
+  }
+
+}

--- a/.vortex/tests/phpunit/Functional/ComposerInstallerTest.php
+++ b/.vortex/tests/phpunit/Functional/ComposerInstallerTest.php
@@ -58,7 +58,7 @@ class ComposerInstallerTest extends FunctionalTestCase {
 
     $this->logSubstep('Create a local fixture package of type "drupal-library"');
     $library_dir = static::$tmp . '/fixture_library';
-    File::dump($library_dir . '/composer.json', (string) json_encode([
+    File::dump($library_dir . '/composer.json', json_encode([
       'name' => 'vortex-test/' . $library_name,
       'type' => 'drupal-library',
       'version' => '1.0.0',
@@ -67,7 +67,7 @@ class ComposerInstallerTest extends FunctionalTestCase {
 
     $this->logSubstep('Create a project using the template installer configuration');
     $project_dir = static::$tmp . '/project';
-    File::dump($project_dir . '/composer.json', (string) json_encode([
+    File::dump($project_dir . '/composer.json', json_encode([
       'name' => 'vortex-test/project',
       'require' => [
         'composer/installers' => $installers_constraint,

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "drupal/testmode": "^2.7.1",
         "drupal/xmlsitemap": "^2.0",
         "drush/drush": "^13.7.3",
-        "oomphinc/composer-installers-extender": "^2.0.1",
         "webflo/drupal-finder": "^1.3.1"
     },
     "require-dev": {
@@ -95,7 +94,6 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
-            "oomphinc/composer-installers-extender": true,
             "php-http/discovery": true,
             "phpstan/extension-installer": true,
             "pyrech/composer-changelogs": true,
@@ -171,9 +169,6 @@
                 "type:drupal-custom-theme"
             ]
         },
-        "installer-types": [
-            "drupal-library"
-        ],
         "patchLevel": {
             "drupal/core": "-p2"
         },


### PR DESCRIPTION
## Summary

Removed the abandoned `oomphinc/composer-installers-extender` package from `composer.json`. Its only role here was registering the `drupal-library` type via `extra.installer-types`, but `composer/installers` (already required at `^2.3`) supports `drupal-library` natively and reads the `extra.installer-paths` override itself - so the extender was redundant. No replacement is needed. A new functional test verifies that `composer/installers` alone places a `drupal-library` package into `web/libraries/{$name}`, and the installer fixture snapshots were regenerated to drop the removed package.

## Changes

- **`composer.json`**: removed `oomphinc/composer-installers-extender` from `require` and `config.allow-plugins`, and removed the now-unused `extra.installer-types` block (`["drupal-library"]`). `extra.installer-paths` is unchanged - it still maps `drupal-library` to `web/libraries/{$name}`.
- **`.vortex/docs/content/drupal/composer-json.mdx`**: removed the documentation bullets for `oomphinc/composer-installers-extender` and `installer-types`, which no longer apply.
- **`.vortex/tests/phpunit/Functional/ComposerInstallerTest.php`**: new functional test that reads the template's real `installer-paths`, installs a local fixture package of type `drupal-library` using `composer/installers` only, and asserts it lands in `web/libraries/{$name}` rather than `vendor/`.
- **`.vortex/installer/tests/Fixtures/handler_process/*/composer.json`**: regenerated via `ahoy update-snapshots` so every installer fixture output drops the removed package.

Note: `composer.lock` is gitignored in this template, so it is intentionally not part of the diff.

## Before / After

```
BEFORE
──────
composer.json
  require:               composer/installers: ^2.3
                         oomphinc/composer-installers-extender: ^2.0.1   ← redundant
  config.allow-plugins:  composer/installers, oomphinc/...-extender      ← redundant
  extra.installer-types: ["drupal-library"]                             ← redundant
  extra.installer-paths: web/libraries/{$name}  ⇐  type:drupal-library

  a "drupal-library" package
        ├─► composer/installers  (natively handles "drupal-library")
        └─► oomphinc extender    (re-registers "drupal-library" → duplicate handler)
                    │
                    ▼
            web/libraries/{$name}

AFTER
─────
composer.json
  require:               composer/installers: ^2.3
  config.allow-plugins:  composer/installers
  extra.installer-paths: web/libraries/{$name}  ⇐  type:drupal-library   (unchanged)

  a "drupal-library" package
        └─► composer/installers  (natively handles "drupal-library")
                    │
                    ▼
            web/libraries/{$name}   (same outcome, one less plugin)
```
