### PR TITLE
Forward-ported PHP dependency bumps and 'oomphinc/composer-installers-extender' removal from 'main'.

### DIFF
--- a/.vortex/docs/content/drupal/composer-json.mdx
+++ b/.vortex/docs/content/drupal/composer-json.mdx
@@ -107,11 +107,6 @@ specifies the essential packages and libraries your project needs.
 - [`drush/drush`](https://github.com/drush-ops/drush): A command-line shell and
   scripting interface for Drupal, providing a wide range of utilities to manage
   and interact with your Drupal sites.
-- [`oomphinc/composer-installers-extender`](https://github.com/oomphinc/composer-installers-extender):
-  Allows any package to be installed to a directory other than the
-  default `vendor` directory within a project on a package-by-package basis.
-  This plugin extends the `composer/installers` plugin to allow any arbitrary
-  package type to be handled by their custom installer.
 - [`webflo/drupal-finder`](https://github.com/webflo/drupal-finder): Locates
   Drupal installations in a directory structure.
 
@@ -295,9 +290,6 @@ needs and structure of your Drupal project.
 - [`installer-paths`](https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md):
   Defines custom installation paths for various types of packages like Drupal
   modules, themes, and libraries.
-- `installer-types`: Specifies additional installer types, such as `bower-asset`
-  and `npm-asset`, that are handled by
-  the `oomphinc/composer-installers-extender` plugin.
 - `patchLevel`: Defines the patch level for specific packages, in this
   case, `drupal/core`. The `-p` option followed by a number (e.g., `-p1`, `-p2`)
   in patch commands specifies the number of leading directories to strip from

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/composer.json
@@ -33,7 +33,6 @@
         "drupal/testmode": "__VERSION__",
         "drupal/xmlsitemap": "__VERSION__",
         "drush/drush": "__VERSION__",
-        "oomphinc/composer-installers-extender": "__VERSION__",
         "webflo/drupal-finder": "__VERSION__"
     },
     "require-dev": {
@@ -85,7 +84,6 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
-            "oomphinc/composer-installers-extender": true,
             "php-http/discovery": true,
             "phpstan/extension-installer": true,
             "pyrech/composer-changelogs": true,
@@ -161,9 +159,6 @@
                 "type:drupal-custom-theme"
             ]
         },
-        "installer-types": [
-            "drupal-library"
-        ],
         "patchLevel": {
             "drupal/core": "-p2"
         },

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -126,38 +126,38 @@
+@@ -124,38 +124,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/composer.json
@@ -1,4 +1,4 @@
-@@ -126,38 +126,38 @@
+@@ -124,38 +124,38 @@
                  "[web-root]/update.php": false
              },
              "locations": {

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/composer.json
@@ -1,4 +1,4 @@
-@@ -46,7 +46,6 @@
+@@ -45,7 +45,6 @@
          "drevops/phpcs-standard": "__VERSION__",
          "drupal/coder": "__VERSION__",
          "drupal/drupal-extension": "__VERSION__",

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_testmode/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_testmode/composer.json
@@ -5,4 +5,4 @@
 -        "drupal/testmode": "__VERSION__",
          "drupal/xmlsitemap": "__VERSION__",
          "drush/drush": "__VERSION__",
-         "oomphinc/composer-installers-extender": "__VERSION__",
+         "webflo/drupal-finder": "__VERSION__"

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_xmlsitemap/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_xmlsitemap/composer.json
@@ -4,5 +4,5 @@
          "drupal/testmode": "__VERSION__",
 -        "drupal/xmlsitemap": "__VERSION__",
          "drush/drush": "__VERSION__",
-         "oomphinc/composer-installers-extender": "__VERSION__",
          "webflo/drupal-finder": "__VERSION__"
+     },

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_none/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_none/composer.json
@@ -27,9 +27,9 @@
 -        "drupal/testmode": "__VERSION__",
 -        "drupal/xmlsitemap": "__VERSION__",
          "drush/drush": "__VERSION__",
-         "oomphinc/composer-installers-extender": "__VERSION__",
          "webflo/drupal-finder": "__VERSION__"
-@@ -46,7 +29,6 @@
+     },
+@@ -45,7 +28,6 @@
          "drevops/phpcs-standard": "__VERSION__",
          "drupal/coder": "__VERSION__",
          "drupal/drupal-extension": "__VERSION__",

--- a/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/starter_drupal_cms_profile/composer.json
@@ -6,10 +6,10 @@
          "drupal/coffee": "__VERSION__",
          "drupal/config_split": "__VERSION__",
          "drupal/config_update": "__VERSION__",
-@@ -34,7 +35,9 @@
+@@ -33,7 +34,9 @@
+         "drupal/testmode": "__VERSION__",
          "drupal/xmlsitemap": "__VERSION__",
          "drush/drush": "__VERSION__",
-         "oomphinc/composer-installers-extender": "__VERSION__",
 -        "webflo/drupal-finder": "__VERSION__"
 +        "symfony/http-client": "^6.4 || ^7.0",
 +        "webflo/drupal-finder": "__VERSION__",
@@ -17,7 +17,7 @@
      },
      "require-dev": {
          "behat/behat": "__VERSION__",
-@@ -71,7 +74,7 @@
+@@ -70,7 +73,7 @@
              "url": "https://packages.drupal.org/8"
          }
      ],
@@ -26,7 +26,7 @@
      "prefer-stable": true,
      "autoload-dev": {
          "classmap": [
-@@ -89,7 +92,11 @@
+@@ -87,7 +90,11 @@
              "php-http/discovery": true,
              "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,
@@ -39,7 +39,7 @@
          },
          "bump-after-update": true,
          "discard-changes": true,
-@@ -167,6 +174,19 @@
+@@ -162,6 +169,19 @@
          "patchLevel": {
              "drupal/core": "-p2"
          },

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/composer.json
@@ -1,4 +1,4 @@
-@@ -39,27 +39,18 @@
+@@ -38,27 +38,18 @@
      "require-dev": {
          "behat/behat": "__VERSION__",
          "dantleech/gherkin-lint": "__VERSION__",
@@ -26,14 +26,13 @@
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
      },
      "conflict": {
-@@ -82,12 +73,10 @@
+@@ -81,11 +72,9 @@
          "allow-plugins": {
              "composer/installers": true,
              "cweagans/composer-patches": true,
 -            "dealerdirect/phpcodesniffer-composer-installer": true,
              "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
              "php-http/discovery": true,
 -            "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -39,27 +39,18 @@
+@@ -38,27 +38,18 @@
      "require-dev": {
          "behat/behat": "__VERSION__",
          "dantleech/gherkin-lint": "__VERSION__",
@@ -26,14 +26,13 @@
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
      },
      "conflict": {
-@@ -82,12 +73,10 @@
+@@ -81,11 +72,9 @@
          "allow-plugins": {
              "composer/installers": true,
              "cweagans/composer-patches": true,
 -            "dealerdirect/phpcodesniffer-composer-installer": true,
              "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
              "php-http/discovery": true,
 -            "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/composer.json
@@ -1,4 +1,4 @@
-@@ -37,15 +37,9 @@
+@@ -36,15 +36,9 @@
          "webflo/drupal-finder": "__VERSION__"
      },
      "require-dev": {
@@ -14,7 +14,7 @@
          "drupal/sdc_devel": "__VERSION__",
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
-@@ -54,10 +48,8 @@
+@@ -53,10 +47,8 @@
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
          "phpcompatibility/php-compatibility": "__VERSION__",
@@ -25,7 +25,7 @@
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
-@@ -73,11 +65,6 @@
+@@ -72,11 +64,6 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -37,15 +37,9 @@
+@@ -36,15 +36,9 @@
          "webflo/drupal-finder": "__VERSION__"
      },
      "require-dev": {
@@ -14,7 +14,7 @@
          "drupal/sdc_devel": "__VERSION__",
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
-@@ -54,10 +48,8 @@
+@@ -53,10 +47,8 @@
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
          "phpcompatibility/php-compatibility": "__VERSION__",
@@ -25,7 +25,7 @@
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
-@@ -73,11 +65,6 @@
+@@ -72,11 +64,6 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/composer.json
@@ -1,4 +1,4 @@
-@@ -37,15 +37,9 @@
+@@ -36,15 +36,9 @@
          "webflo/drupal-finder": "__VERSION__"
      },
      "require-dev": {

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -37,15 +37,9 @@
+@@ -36,15 +36,9 @@
          "webflo/drupal-finder": "__VERSION__"
      },
      "require-dev": {

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/composer.json
@@ -1,4 +1,4 @@
-@@ -39,12 +39,9 @@
+@@ -38,12 +38,9 @@
      "require-dev": {
          "behat/behat": "__VERSION__",
          "dantleech/gherkin-lint": "__VERSION__",
@@ -11,7 +11,7 @@
          "drupal/drupal-extension": "__VERSION__",
          "drupal/sdc_devel": "__VERSION__",
          "ergebnis/composer-normalize": "__VERSION__",
-@@ -53,7 +50,6 @@
+@@ -52,7 +49,6 @@
          "mglaman/phpstan-drupal": "__VERSION__",
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
@@ -19,11 +19,11 @@
          "phpspec/prophecy-phpunit": "__VERSION__",
          "phpstan/extension-installer": "__VERSION__",
          "phpstan/phpstan": "__VERSION__",
-@@ -82,7 +78,6 @@
+@@ -81,7 +77,6 @@
          "allow-plugins": {
              "composer/installers": true,
              "cweagans/composer-patches": true,
 -            "dealerdirect/phpcodesniffer-composer-installer": true,
              "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
+             "php-http/discovery": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -39,12 +39,9 @@
+@@ -38,12 +38,9 @@
      "require-dev": {
          "behat/behat": "__VERSION__",
          "dantleech/gherkin-lint": "__VERSION__",
@@ -11,7 +11,7 @@
          "drupal/drupal-extension": "__VERSION__",
          "drupal/sdc_devel": "__VERSION__",
          "ergebnis/composer-normalize": "__VERSION__",
-@@ -53,7 +50,6 @@
+@@ -52,7 +49,6 @@
          "mglaman/phpstan-drupal": "__VERSION__",
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
@@ -19,11 +19,11 @@
          "phpspec/prophecy-phpunit": "__VERSION__",
          "phpstan/extension-installer": "__VERSION__",
          "phpstan/phpstan": "__VERSION__",
-@@ -82,7 +78,6 @@
+@@ -81,7 +77,6 @@
          "allow-plugins": {
              "composer/installers": true,
              "cweagans/composer-patches": true,
 -            "dealerdirect/phpcodesniffer-composer-installer": true,
              "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
+             "php-http/discovery": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/composer.json
@@ -1,4 +1,4 @@
-@@ -50,13 +50,10 @@
+@@ -49,13 +49,10 @@
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
          "lullabot/php-webdriver": "__VERSION__",
@@ -12,9 +12,9 @@
          "phpunit/phpunit": "__VERSION__",
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
-@@ -87,7 +84,6 @@
+@@ -85,7 +82,6 @@
+             "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
              "php-http/discovery": true,
 -            "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -50,13 +50,10 @@
+@@ -49,13 +49,10 @@
          "ergebnis/composer-normalize": "__VERSION__",
          "lullabot/mink-selenium2-driver": "__VERSION__",
          "lullabot/php-webdriver": "__VERSION__",
@@ -12,9 +12,9 @@
          "phpunit/phpunit": "__VERSION__",
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
-@@ -87,7 +84,6 @@
+@@ -85,7 +82,6 @@
+             "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
              "php-http/discovery": true,
 -            "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/composer.json
@@ -1,4 +1,4 @@
-@@ -54,10 +54,8 @@
+@@ -53,10 +53,8 @@
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
          "phpcompatibility/php-compatibility": "__VERSION__",
@@ -9,7 +9,7 @@
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
-@@ -73,11 +71,6 @@
+@@ -72,11 +70,6 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -54,10 +54,8 @@
+@@ -53,10 +53,8 @@
          "mikey179/vfsstream": "__VERSION__",
          "palantirnet/drupal-rector": "__VERSION__",
          "phpcompatibility/php-compatibility": "__VERSION__",
@@ -9,7 +9,7 @@
          "pyrech/composer-changelogs": "__VERSION__",
          "rector/rector": "__VERSION__",
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
-@@ -73,11 +71,6 @@
+@@ -72,11 +70,6 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/composer.json
@@ -1,4 +1,4 @@
-@@ -52,7 +52,6 @@
+@@ -51,7 +51,6 @@
          "lullabot/php-webdriver": "__VERSION__",
          "mglaman/phpstan-drupal": "__VERSION__",
          "mikey179/vfsstream": "__VERSION__",
@@ -6,7 +6,7 @@
          "phpcompatibility/php-compatibility": "__VERSION__",
          "phpspec/prophecy-phpunit": "__VERSION__",
          "phpstan/extension-installer": "__VERSION__",
-@@ -59,7 +58,6 @@
+@@ -58,7 +57,6 @@
          "phpstan/phpstan": "__VERSION__",
          "phpunit/phpunit": "__VERSION__",
          "pyrech/composer-changelogs": "__VERSION__",

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/composer.json
@@ -1,4 +1,4 @@
-@@ -52,7 +52,6 @@
+@@ -51,7 +51,6 @@
          "lullabot/php-webdriver": "__VERSION__",
          "mglaman/phpstan-drupal": "__VERSION__",
          "mikey179/vfsstream": "__VERSION__",
@@ -6,7 +6,7 @@
          "phpcompatibility/php-compatibility": "__VERSION__",
          "phpspec/prophecy-phpunit": "__VERSION__",
          "phpstan/extension-installer": "__VERSION__",
-@@ -59,7 +58,6 @@
+@@ -58,7 +57,6 @@
          "phpstan/phpstan": "__VERSION__",
          "phpunit/phpunit": "__VERSION__",
          "pyrech/composer-changelogs": "__VERSION__",

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/composer.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/composer.json
@@ -1,4 +1,4 @@
-@@ -37,29 +37,12 @@
+@@ -36,29 +36,12 @@
          "webflo/drupal-finder": "__VERSION__"
      },
      "require-dev": {
@@ -28,7 +28,7 @@
          "vincentlanglet/twig-cs-fixer": "__VERSION__"
      },
      "conflict": {
-@@ -73,21 +56,14 @@
+@@ -72,20 +55,13 @@
      ],
      "minimum-stability": "stable",
      "prefer-stable": true,
@@ -44,7 +44,6 @@
 -            "dealerdirect/phpcodesniffer-composer-installer": true,
              "drupal/core-composer-scaffold": true,
              "ergebnis/composer-normalize": true,
-             "oomphinc/composer-installers-extender": true,
              "php-http/discovery": true,
 -            "phpstan/extension-installer": true,
              "pyrech/composer-changelogs": true,

--- a/.vortex/tests/phpunit/Functional/ComposerInstallerTest.php
+++ b/.vortex/tests/phpunit/Functional/ComposerInstallerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\Vortex\Tests\Functional;
+
+use AlexSkrypnyk\File\File;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests that 'composer/installers' handles the 'drupal-library' package type.
+ *
+ * Vortex relies on 'composer/installers' alone (without an installer-extender
+ * plugin) to place 'drupal-library' packages into 'web/libraries/{$name}'.
+ * This guards that the install path keeps working using the template's own
+ * installer configuration.
+ */
+class ComposerInstallerTest extends FunctionalTestCase {
+
+  protected function setUp(): void {
+    // Only locations are required: the test reads the template 'composer.json'
+    // and runs Composer in a temporary directory. No SUT or Docker stack is
+    // involved, so the heavy parent setUp is intentionally not called.
+    self::locationsInit(File::cwd() . '/../..');
+  }
+
+  protected function tearDown(): void {
+    if ($this->tearDownShouldCleanup()) {
+      static::locationsTearDown();
+    }
+  }
+
+  #[Group('p1')]
+  public function testDrupalLibraryInstallsToWebLibraries(): void {
+    $this->logStepStart();
+
+    // Reuse the template's real installer configuration so this guards the
+    // shipped 'composer.json', not a hand-written copy.
+    $raw = file_get_contents(static::locationsRoot() . '/composer.json');
+    $template = is_string($raw) ? json_decode($raw, TRUE) : NULL;
+    if (!is_array($template)) {
+      throw new \RuntimeException('Unable to read the template composer.json.');
+    }
+
+    $require = $template['require'] ?? NULL;
+    $extra = $template['extra'] ?? NULL;
+    if (!is_array($require) || !is_array($extra)) {
+      throw new \RuntimeException('The template composer.json has no "require" or "extra" section.');
+    }
+
+    $installers_constraint = $require['composer/installers'] ?? NULL;
+    $installer_paths = $extra['installer-paths'] ?? NULL;
+    if (!is_string($installers_constraint) || !is_array($installer_paths)) {
+      throw new \RuntimeException('The template composer.json is missing "composer/installers" or "installer-paths".');
+    }
+
+    $library_name = 'vortex_test_library';
+
+    $this->logSubstep('Create a local fixture package of type "drupal-library"');
+    $library_dir = static::$tmp . '/fixture_library';
+    File::dump($library_dir . '/composer.json', json_encode([
+      'name' => 'vortex-test/' . $library_name,
+      'type' => 'drupal-library',
+      'version' => '1.0.0',
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+    File::dump($library_dir . '/library.js', "// Fixture drupal-library payload.\n");
+
+    $this->logSubstep('Create a project using the template installer configuration');
+    $project_dir = static::$tmp . '/project';
+    File::dump($project_dir . '/composer.json', json_encode([
+      'name' => 'vortex-test/project',
+      'require' => [
+        'composer/installers' => $installers_constraint,
+        'vortex-test/' . $library_name => '*',
+      ],
+      'repositories' => [
+        ['type' => 'path', 'url' => '../fixture_library', 'options' => ['symlink' => FALSE]],
+      ],
+      'extra' => ['installer-paths' => $installer_paths],
+      'config' => ['allow-plugins' => ['composer/installers' => TRUE]],
+      'minimum-stability' => 'stable',
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+
+    $this->cmd(
+      'composer --working-dir=' . escapeshellarg($project_dir) . ' update --no-interaction --no-progress',
+      txt: 'Install a "drupal-library" package using composer/installers',
+    );
+
+    $this->logSubstep('Assert composer/installers placed the package into web/libraries');
+    $installed_dir = $project_dir . '/web/libraries/' . $library_name;
+    $this->assertDirectoryExists($installed_dir, 'The "drupal-library" package is installed into web/libraries/{$name}.');
+    $this->assertFileExists($installed_dir . '/library.js', 'The "drupal-library" payload exists at the expected path.');
+    $this->assertDirectoryDoesNotExist($project_dir . '/vendor/vortex-test/' . $library_name, 'The "drupal-library" package is not installed into vendor/.');
+
+    $this->logStepFinish();
+  }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "webflo/drupal-finder": "^1.3.1"
     },
     "require-dev": {
-        "behat/behat": "^3.31.0",
+        "behat/behat": "^3.32.0",
         "dantleech/gherkin-lint": "^0.2.4",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.2.1",
         "drevops/behat-format-progress-fail": "^1.4",
@@ -48,7 +48,7 @@
         "drevops/phpcs-standard": "^0.7.0",
         "drupal/coder": "^9@alpha",
         "drupal/drupal-extension": "^6.0",
-        "drupal/sdc_devel": "^1.0",
+        "drupal/sdc_devel": "^1.0.2",
         "ergebnis/composer-normalize": "^2.52.0",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "lullabot/php-webdriver": "^2.0.7",
@@ -61,7 +61,7 @@
         "phpstan/phpstan": "^2.2.2",
         "phpunit/phpunit": "^11.5.55",
         "pyrech/composer-changelogs": "^2.2",
-        "rector/rector": "^2.4.6",
+        "rector/rector": "^2.5.0",
         "vincentlanglet/twig-cs-fixer": "^3.14"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "drupal/testmode": "^2.7.1",
         "drupal/xmlsitemap": "^2.0",
         "drush/drush": "^13.7.3",
-        "oomphinc/composer-installers-extender": "^2.0.1",
         "webflo/drupal-finder": "^1.3.1"
     },
     "require-dev": {
@@ -96,7 +95,6 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
             "ergebnis/composer-normalize": true,
-            "oomphinc/composer-installers-extender": true,
             "php-http/discovery": true,
             "phpstan/extension-installer": true,
             "pyrech/composer-changelogs": true,
@@ -172,9 +170,6 @@
                 "type:drupal-custom-theme"
             ]
         },
-        "installer-types": [
-            "drupal-library"
-        ],
         "patchLevel": {
             "drupal/core": "-p2"
         },


### PR DESCRIPTION
## Scope

Forward-ports 2 commits from `main` onto `2.x`.

## Applied

- `0e5e163e7` Update PHP - All packages except core (clean cherry-pick) - bumps `behat/behat` to `^3.32.0`, `drupal/sdc_devel` to `^1.0.2`, and `rector/rector` to `^2.5.0` in the template `composer.json`. The three constraints had identical context on `2.x`, so the cherry-pick applied without conflict.
- `ac72aed14` Removed abandoned `oomphinc/composer-installers-extender` package (source-only) - removes the package from the template `composer.json` (`require`, `allow-plugins`, and `extra.installer-types`), drops the corresponding entries from `composer-json.mdx`, and adds the new `ComposerInstallerTest` functional test asserting `composer/installers` alone places `drupal-library` packages into `web/libraries`. The upstream commit's 23 installer fixture hunks were not carried over; fixtures were regenerated instead (see Snapshots).

## Skipped

- `43b8f98f0` Excluded installer test fixtures from the Zizmor GitHub Actions audit - the functional change (scoping the Zizmor audit to `.github/workflows/`) is already present on `2.x`, introduced independently by the build-sidecar CI work. Only the explanatory comment wording differs, so there is nothing to port.

## Snapshots

`ahoy update-snapshots` was run. It regenerated exactly the 23 installer fixtures affected by the `oomphinc/composer-installers-extender` removal, matching the upstream commit's footprint (`_circleci` siblings consistent). A confirmation pass produced no further changes. No deleted-template-file `SutTrait.php` follow-up is required, as no template files were removed.

## Gates

Local `.vortex` `lint-tests` (phpcs, phpstan, rector) and `lint-docs` (eslint, prettier, markdownlint, cspell) pass for the two changed subsystems. The full template-test workflow runs in CI.

## Before / After

```
BEFORE (composer.json excerpt)
───────────────────────────────────────────────────────────────
"require": {
    ...
    "oomphinc/composer-installers-extender": "^2.0.1",
    "webflo/drupal-finder": "^1.3.1"
},
"require-dev": {
    "behat/behat": "^3.31.0",
    ...
    "drupal/sdc_devel": "^1.0",
    ...
    "rector/rector": "^2.4.6",
    ...
},
"allow-plugins": {
    ...
    "oomphinc/composer-installers-extender": true,
    ...
},
"extra": {
    "installer-paths": { ... },
    "installer-types": ["drupal-library"],
    ...
}

No 'ComposerInstallerTest' existed to guard install-path behaviour.

AFTER (composer.json excerpt)
───────────────────────────────────────────────────────────────
"require": {
    ...
    "webflo/drupal-finder": "^1.3.1"
},
"require-dev": {
    "behat/behat": "^3.32.0",
    ...
    "drupal/sdc_devel": "^1.0.2",
    ...
    "rector/rector": "^2.5.0",
    ...
},
"allow-plugins": {
    ...
    (oomphinc entry removed)
    ...
},
"extra": {
    "installer-paths": { ... },
    (installer-types section removed)
    ...
}

'.vortex/tests/phpunit/Functional/ComposerInstallerTest.php' added,
asserting 'composer/installers' alone routes 'drupal-library' packages
into 'web/libraries/{$name}' without the extender plugin.
```
