### PR TITLE
[#2636] Deferred CI dev-dependency install until after the database cache is saved.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,16 +276,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            #;< TOOL_JEST
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-            #;> TOOL_JEST
-
       #;< !PROVISION_TYPE_PROFILE
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
@@ -305,7 +295,50 @@ jobs:
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
+
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
+      - run:
+          name: Stash DB on non-primary runners so only the primary saves the cache
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: v26.6.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
       #;> !PROVISION_TYPE_PROFILE
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            #;< TOOL_JEST
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+            #;> TOOL_JEST
 
       - run:
           name: Provision site
@@ -322,29 +355,6 @@ jobs:
             #;> MIGRATION
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
-
-      #;< !PROVISION_TYPE_PROFILE
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
-            fi
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: v26.6.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-      #;> !PROVISION_TYPE_PROFILE
 
       #;< TOOL_JEST
       - run:

--- a/.circleci/vortex-test-common.yml
+++ b/.circleci/vortex-test-common.yml
@@ -163,16 +163,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            #;< TOOL_JEST
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-            #;> TOOL_JEST
-
       #;< !PROVISION_TYPE_PROFILE
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
@@ -192,7 +182,50 @@ jobs:
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
+
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
+      - run:
+          name: Stash DB on non-primary runners so only the primary saves the cache
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: v26.6.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
       #;> !PROVISION_TYPE_PROFILE
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            #;< TOOL_JEST
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+            #;> TOOL_JEST
 
       - run:
           name: Provision site
@@ -209,29 +242,6 @@ jobs:
             #;> MIGRATION
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
-
-      #;< !PROVISION_TYPE_PROFILE
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
-            fi
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: v26.6.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
-      #;> !PROVISION_TYPE_PROFILE
 
       #;< TOOL_JEST
       - run:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -324,15 +324,6 @@ jobs:
       - name: Build stack
         run: docker compose up --detach && docker builder prune --all --force
 
-      - name: Install development dependencies
-        run: |
-          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-            if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-            COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-          #;< TOOL_JEST
-          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-          #;> TOOL_JEST
-
       #;< !PROVISION_TYPE_PROFILE
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
@@ -363,6 +354,15 @@ jobs:
           path: .data
           key: v26.6.0-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
       #;> !PROVISION_TYPE_PROFILE
+
+      - name: Install development dependencies
+        run: |
+          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+            if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+            COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+          #;< TOOL_JEST
+          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+          #;> TOOL_JEST
 
       - name: Provision site
         run: |

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -281,13 +281,6 @@ jobs:
       - name: Build stack
         run: docker compose up --detach && docker builder prune --all --force
 
-      - name: Install development dependencies
-        run: |
-          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-            if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-            COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -316,6 +309,13 @@ jobs:
         with:
           path: .data
           key: __VERSION__-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
+
+      - name: Install development dependencies
+        run: |
+          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+            if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+            COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
       - name: Provision site
         run: |

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -240,14 +240,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -267,26 +259,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -297,6 +282,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
@@ -240,14 +240,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -267,26 +259,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -297,6 +282,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -240,14 +240,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -267,26 +259,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -297,6 +282,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
@@ -240,14 +240,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -267,26 +259,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -297,6 +282,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -240,14 +240,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -267,26 +259,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -297,6 +282,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -240,14 +240,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -267,26 +259,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -297,6 +282,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -245,14 +245,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -272,6 +264,47 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
+      - run:
+          name: Stash DB on non-primary runners so only the primary saves the cache
+          command: |
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
+            fi
+
+      - save_cache:
+          # Save cache per default branch and the timestamp.
+          # The cache will not be saved if it already exists.
+          # Note that the cache fallback flag is enabled for this case in order
+          # to save cache even if the fallback is not used when restoring it.
+          key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          paths:
+            - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
       - run:
           name: Provision site
           command: |
@@ -285,27 +318,6 @@ jobs:
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
           no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
-            fi
-
-      - save_cache:
-          # Save cache per default branch and the timestamp.
-          # The cache will not be saved if it already exists.
-          # Note that the cache fallback flag is enabled for this case in order
-          # to save cache even if the fallback is not used when restoring it.
-          key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-          paths:
-            - /root/project/.data
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -29,7 +29,7 @@
  
      steps:
        - name: Preserve $HOME set in the container
-@@ -235,49 +225,9 @@
+@@ -235,81 +225,12 @@
        - name: Install Vortex tooling
          run: ./scripts/vortex-tooling.sh
  
@@ -79,10 +79,6 @@
        - name: Build stack
          run: docker compose up --detach && docker builder prune --all --force
  
-@@ -288,35 +238,6 @@
-             COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-           docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
- 
 -      # Execute commands after the database download finished: if a fresh DB
 -      # dump was downloaded (cache miss), import it and export it back to
 -      # produce a clean dump cached for the rest of the day's builds. This also
@@ -112,9 +108,9 @@
 -          path: .data
 -          key: __VERSION__-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
 -
-       - name: Provision site
+       - name: Install development dependencies
          run: |
-           if [ -f .data/db.sql ]; then
+           docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
 @@ -498,7 +419,6 @@
    deploy:
      runs-on: ubuntu-latest

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -240,14 +240,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -267,26 +259,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -297,6 +282,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -228,14 +228,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -255,26 +247,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -285,6 +270,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -236,14 +236,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -263,26 +255,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -293,6 +278,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
@@ -17,14 +17,14 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -286,7 +281,6 @@
+@@ -315,7 +310,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       # Execute commands after the database download finished: if a fresh DB
-       # dump was downloaded (cache miss), import it and export it back to
+       - name: Provision site
+         run: |
 @@ -325,11 +319,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
@@ -235,13 +235,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -261,26 +254,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -291,6 +277,32 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with PHPUnit

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
@@ -22,14 +22,14 @@
    test:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -286,7 +276,6 @@
+@@ -315,7 +305,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       # Execute commands after the database download finished: if a fresh DB
-       # dump was downloaded (cache miss), import it and export it back to
+       - name: Provision site
+         run: |
 @@ -326,11 +315,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
@@ -229,13 +229,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -255,26 +248,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -285,6 +271,32 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with PHPUnit

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -236,14 +236,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -263,26 +255,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -293,6 +278,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
@@ -235,14 +235,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -262,26 +254,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -292,6 +277,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
@@ -1,11 +1,11 @@
-@@ -286,7 +286,6 @@
+@@ -315,7 +315,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       # Execute commands after the database download finished: if a fresh DB
-       # dump was downloaded (cache miss), import it and export it back to
+       - name: Provision site
+         run: |
 @@ -325,11 +324,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
@@ -240,13 +240,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -266,26 +259,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -296,6 +282,32 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with PHPUnit

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -236,14 +236,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -263,26 +255,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -293,6 +278,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -236,14 +236,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -263,26 +255,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -293,6 +278,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -240,14 +240,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -267,26 +259,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -297,6 +282,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -236,14 +236,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -263,26 +255,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -293,6 +278,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
@@ -240,14 +240,6 @@ jobs:
           name: Build stack
           command: docker compose up --detach && docker builder prune --all --force
 
-      - run:
-          name: Install development dependencies
-          command: |
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
-              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
-              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
-
       # Execute commands after the database download finished: if a fresh DB
       # dump was downloaded (cache miss), import it and export it back to
       # produce a clean dump cached for the rest of the day's builds. This also
@@ -267,26 +259,19 @@ jobs:
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
+      # Save the clean DB dump to the cache before the slow dev-dependency
+      # install and provisioning, so it lands sooner and survives a later
+      # failure. save_cache has no per-node runtime condition, and two parallel
+      # runners creating the same key concurrently fail the build, so only the
+      # primary runner may store it: stash .data aside on the non-primary
+      # runners to make their save a no-op, then restore it for provisioning.
       - run:
-          name: Provision site
+          name: Stash DB on non-primary runners so only the primary saves the cache
           command: |
-            if [ -f .data/db.sql ]; then
-              docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
-            fi
-            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
-          no_output_timeout: 30m
-
-      # Save the clean DB dump to cache from the primary parallel runner only.
-      # save_cache has no runtime condition, so drop the cached path on the
-      # non-primary runners to make their save a no-op and let only node 0 store
-      # the cache. The provision step above already consumed the dump.
-      - run:
-          name: Keep DB cache only on the primary parallel runner
-          command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ]; then
-              echo "Removing .data on non-primary node ${CIRCLE_NODE_INDEX} so only node 0 saves the DB cache."
-              rm -rf .data
+            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && [ -e .data ]; then
+              echo "Stashing .data on non-primary node ${CIRCLE_NODE_INDEX} so only the primary saves the DB cache."
+              rm -rf .data.nosave
+              mv .data .data.nosave
             fi
 
       - save_cache:
@@ -297,6 +282,33 @@ jobs:
           key: __VERSION__-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
+
+      - run:
+          name: Restore stashed DB on non-primary runners for provisioning
+          command: |
+            if [ -e .data.nosave ]; then
+              echo "Restoring stashed .data on node ${CIRCLE_NODE_INDEX} for provisioning."
+              rm -rf .data
+              mv .data.nosave .data
+            fi
+
+      - run:
+          name: Install development dependencies
+          command: |
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
+              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
+              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
+
+      - run:
+          name: Provision site
+          command: |
+            if [ -f .data/db.sql ]; then
+              docker compose exec cli mkdir -p .data
+              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            fi
+            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
+          no_output_timeout: 30m
 
       - run:
           name: Test with Jest

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -37,14 +37,14 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -286,7 +265,6 @@
+@@ -315,7 +294,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"${PACKAGE_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${PACKAGE_TOKEN-}\"}}'; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       # Execute commands after the database download finished: if a fresh DB
-       # dump was downloaded (cache miss), import it and export it back to
+       - name: Provision site
+         run: |
 @@ -326,71 +304,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/drevops/vortex-tooling/src/provision
          timeout-minutes: 30


### PR DESCRIPTION
Closes #2636

## Summary

Moved the `save_cache` step (and its guard logic) in the CI `test` job to run immediately after the database dump is exported, before `composer install`, `yarn install`, and `provision`. This ensures the cached DB dump lands sooner and is not lost if a later step fails. On GitHub Actions the change is a straight reorder since the `Save DB dump to cache` step is already gated to matrix instance 0 by a `if:` condition. On CircleCI, where `save_cache` has no per-node runtime condition, two parallel runners storing the same key concurrently would fail the build; the fix stashes `.data` aside on non-primary nodes immediately before `save_cache` (using a guarded `mv`) and restores it after, so only the primary runner writes to the cache while all runners retain the dump for `provision`.

## Changes

**`.github/workflows/build-test-deploy.yml`** - Moved the `Install development dependencies` step to after the existing `Save DB dump to cache` block; no guard logic needed as the `if: matrix.parallel-runner == 0` condition already restricts the save to a single runner.

**`.circleci/config.yml` and `.circleci/vortex-test-common.yml`** - Removed `Install development dependencies` from before `export-db`; inserted `Stash DB on non-primary runners so only the primary saves the cache` (conditional `mv .data .data.nosave`) and `save_cache` before `provision`; added `Restore stashed DB on non-primary runners for provisioning` (conditional `mv .data.nosave .data`) after `save_cache`; moved `Install development dependencies` to after the restore and before `provision`. Removed the now-superseded `Keep DB cache only on the primary parallel runner` step that destructively deleted `.data` post-provision.

**`.circleci/vortex-test-common.yml`** - Regenerated from the canonical `config.yml` to keep it in sync (mirrors the same reordering).

**`.vortex/installer/tests/Fixtures/`** - All installer snapshot fixtures were regenerated to reflect the new step order in both GitHub Actions and CircleCI variants.

## Before / After

```
GitHub Actions — test job step order
─────────────────────────────────────────────────────────────────────────
BEFORE                                  AFTER
──────────────────────────────────      ──────────────────────────────────
Build stack                             Build stack
│                                       │
▼                                       ▼
Install development dependencies  ──►  [moved to after cache save ─────►]
│                                       │
▼                                       ▼
Export / capture DB dump                Export / capture DB dump
│                                       │
▼                                       ▼
Save DB dump to cache                   Save DB dump to cache
(if: matrix.parallel-runner == 0)       (if: matrix.parallel-runner == 0)
│                                       │
▼                                       ▼
Provision site                          Install development dependencies
                                        │
                                        ▼
                                        Provision site

CircleCI — test job step order (parallel runners)
─────────────────────────────────────────────────────────────────────────
BEFORE                                  AFTER
──────────────────────────────────      ──────────────────────────────────
Build stack                             Build stack
│                                       │
▼                                       ▼
Install development dependencies  ──►  [moved to after cache save ─────►]
│                                       │
▼                                       ▼
Export / capture DB dump                Export / capture DB dump
│                                       │
▼                                       ▼
Keep DB cache only on primary           Stash .data on non-primary nodes
  (rm -rf .data on non-primary)           (mv .data .data.nosave, guarded)
│                                       │
▼                                       ▼
save_cache                              save_cache
│                                       │
▼                                       ▼
Provision site                          Restore stashed .data on
                                          non-primary nodes
                                          (mv .data.nosave .data, guarded)
                                        │
                                        ▼
                                        Install development dependencies
                                        │
                                        ▼
                                        Provision site

Key change on CircleCI: the old approach deleted .data so non-primary
runners had nothing to provision with; the new approach stashes and
restores it, so every runner provisions correctly.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline configuration for improved build reliability and efficiency during parallel testing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->