### PR TITLE
[#2697] Updated 'vincentlanglet/twig-cs-fixer' to v4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "phpunit/phpunit": "^11.5.55",
         "pyrech/composer-changelogs": "^2.2",
         "rector/rector": "^2.5.0",
-        "vincentlanglet/twig-cs-fixer": "^3.14"
+        "vincentlanglet/twig-cs-fixer": "^4.0"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
Closes #2697

## Summary

Updates `vincentlanglet/twig-cs-fixer` from `^3.14` to `^4.0` (resolves to `4.0.1`). This is a drop-in major bump for Vortex: our `.twig-cs-fixer.php` consumes the `TwigCsFixer` standard with a single `IndentRule(2)` override and an added `TwigTransTokenParser`, and every API we use is intact in v4.

## Changes

- `composer.json`: `vincentlanglet/twig-cs-fixer` constraint `^3.14` -> `^4.0`.
- `composer.lock` is gitignored in this repo, so it is regenerated by CI rather than committed.
- Installer and tests snapshots were regenerated and produced no fixture changes, because the dependency version is normalised to `__VERSION__` in the installer fixtures.
- `.twig-cs-fixer.php` is unchanged. No structural change is required (see below).

## What v4 brings, and how we treat it

The upstream [`UPGRADE.md`](https://github.com/VincentLanglet/Twig-CS-Fixer/blob/4.0.1/UPGRADE.md) breaking changes only affect code that references individual rule classes or implements custom rules:

- `OperatorSpacingRule` was split into `OperatorSpacingRule`, `TernaryOperatorSpacingRule` and `UnaryOperatorSpacingRule`. The bundled `TwigCsFixer` standard ships all three, so the only genuinely new rules our standard gains are the ternary and unary ones, enforcing the same spacing as before.
- Token types were reorganised (`OPERATOR_TYPE` split, `SPREAD_TYPE`/`ARROW_TYPE` removed, and `.` and `|` moved from punctuation to operator type). `OperatorSpacingRule` explicitly keeps `.`, `|`, `:`, `..` and `?.` at zero spaces, so `user.name` and `value|filter` stay valid Drupal style.
- `DelimiterSpacingRule`'s constructor gained optional override arguments; it stays backward compatible with no arguments.
- The custom-rule contracts changed. Vortex defines no custom rules, so this does not reach us.
- `twig/twig` minimum rose from `^3.4` to `^3.15`; Drupal core 11.3 already ships `twig/twig 3.27`, which satisfies it. PHP requirement is unchanged at `>=8.1`.

`IndentRule`'s first constructor argument is still `spaceRatio`, so `IndentRule(2)` keeps meaning 2-space indentation, and the `{# twig-cs-fixer-disable A.B:C:D #}` disable-comment syntax documented on the site is unchanged.

## Testing

CI runs the full template integration suite, which includes the `twig-cs-fixer lint` step against the shipped templates under v4. The three custom templates use modern Twig conventions and are expected to pass unchanged.

## Before / After

```
composer.json (vincentlanglet/twig-cs-fixer)

  before:  "^3.14"   ──►  Twig-CS-Fixer 3.x (twig/twig ^3.4)
  after:   "^4.0"    ──►  Twig-CS-Fixer 4.x (twig/twig ^3.15)

  .twig-cs-fixer.php:  unchanged  (standard ruleset + IndentRule(2) + TwigTransTokenParser)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to the latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->