### PR TITLE
[#2704] Fixed SDC lint check passing when 'sdc-devel:validate' reports problems.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -268,7 +268,11 @@ commands:
   #;< MODULE_SDC_DEVEL
   lint-sdc:
     usage: Validate Single Directory Components (requires a provisioned site).
-    cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
+    cmd: |
+      ahoy cli " \
+        output=\$(vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME} 2>&1); \
+        echo \"\${output}\"; \
+        if echo \"\${output}\" | grep -qE 'Critical|Errors?|Warnings?'; then echo 'SDC validation reported problems.'; exit 1; fi"
   #;> MODULE_SDC_DEVEL
   #;> DRUPAL_THEME
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,7 +460,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
       #;> MODULE_SDC_DEVEL
       #;> DRUPAL_THEME
 

--- a/.circleci/vortex-test-common.yml
+++ b/.circleci/vortex-test-common.yml
@@ -324,7 +324,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
       #;> MODULE_SDC_DEVEL
       #;> DRUPAL_THEME
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -540,7 +540,12 @@ jobs:
         if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
         run: |
           [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-          docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}"
+          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+          echo "${output}"
+          if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+            echo "SDC validation reported problems."
+            exit 1
+          fi
         continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
       #;> MODULE_SDC_DEVEL
       #;> DRUPAL_THEME

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
@@ -217,7 +217,11 @@ commands:
 
   lint-sdc:
     usage: Validate Single Directory Components (requires a provisioned site).
-    cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
+    cmd: |
+      ahoy cli " \
+        output=\$(vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME} 2>&1); \
+        echo \"\${output}\"; \
+        if echo \"\${output}\" | grep -qE 'Critical|Errors?|Warnings?'; then echo 'SDC validation reported problems.'; exit 1; fi"
 
   lint-fix:
     usage: Fix lint issues of back-end and front-end code.

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -468,7 +468,12 @@ jobs:
         if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
         run: |
           [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-          docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}"
+          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+          echo "${output}"
+          if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+            echo "SDC validation reported problems."
+            exit 1
+          fi
         continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
 
       - name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -400,7 +400,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
@@ -408,7 +408,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -400,7 +400,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
@@ -400,7 +400,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -528,100 +528,3 @@
+@@ -533,100 +533,3 @@
          timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
          with:
            detached: true

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -400,7 +400,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -400,7 +400,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -409,7 +409,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.ahoy.yml
@@ -1,10 +1,14 @@
-@@ -215,10 +215,6 @@
+@@ -215,14 +215,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
 -  lint-sdc:
 -    usage: Validate Single Directory Components (requires a provisioned site).
--    cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
+-    cmd: |
+-      ahoy cli " \
+-        output=\$(vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME} 2>&1); \
+-        echo \"\${output}\"; \
+-        if echo \"\${output}\" | grep -qE 'Critical|Errors?|Warnings?'; then echo 'SDC validation reported problems.'; exit 1; fi"
 -
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -464,13 +464,6 @@
+@@ -464,18 +464,6 @@
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
  
@@ -6,7 +6,12 @@
 -        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
--          docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}"
+-          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+-          echo "${output}"
+-          if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+-            echo "SDC validation reported problems."
+-            exit 1
+-          fi
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
 -
        - name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_none/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_none/.ahoy.yml
@@ -1,10 +1,14 @@
-@@ -215,10 +215,6 @@
+@@ -215,14 +215,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
 -  lint-sdc:
 -    usage: Validate Single Directory Components (requires a provisioned site).
--    cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
+-    cmd: |
+-      ahoy cli " \
+-        output=\$(vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME} 2>&1); \
+-        echo \"\${output}\"; \
+-        if echo \"\${output}\" | grep -qE 'Critical|Errors?|Warnings?'; then echo 'SDC validation reported problems.'; exit 1; fi"
 -
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_none/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -464,13 +464,6 @@
+@@ -464,18 +464,6 @@
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
  
@@ -6,7 +6,12 @@
 -        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
--          docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}"
+-          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+-          echo "${output}"
+-          if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+-            echo "SDC validation reported problems."
+-            exit 1
+-          fi
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
 -
        - name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -179,7 +179,7 @@
        - name: Login to container registry
          run: ./vendor/drevops/vortex-tooling/src/login-container-registry
  
-@@ -532,7 +388,6 @@
+@@ -537,7 +393,6 @@
    deploy:
      runs-on: ubuntu-latest
      needs: [build, lint]

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.ahoy.yml
@@ -40,18 +40,22 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -215,10 +195,6 @@
+@@ -215,14 +195,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
 -  lint-sdc:
 -    usage: Validate Single Directory Components (requires a provisioned site).
--    cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
+-    cmd: |
+-      ahoy cli " \
+-        output=\$(vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME} 2>&1); \
+-        echo \"\${output}\"; \
+-        if echo \"\${output}\" | grep -qE 'Critical|Errors?|Warnings?'; then echo 'SDC validation reported problems.'; exit 1; fi"
 -
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -236,7 +212,6 @@
+@@ -240,7 +212,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -463,13 +458,6 @@
+@@ -463,18 +458,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
@@ -19,7 +19,12 @@
 -        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
--          docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}"
+-          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+-          echo "${output}"
+-          if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+-            echo "SDC validation reported problems."
+-            exit 1
+-          fi
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
        - name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.ahoy.yml
@@ -40,18 +40,22 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -215,10 +195,6 @@
+@@ -215,14 +195,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
 -  lint-sdc:
 -    usage: Validate Single Directory Components (requires a provisioned site).
--    cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
+-    cmd: |
+-      ahoy cli " \
+-        output=\$(vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME} 2>&1); \
+-        echo \"\${output}\"; \
+-        if echo \"\${output}\" | grep -qE 'Critical|Errors?|Warnings?'; then echo 'SDC validation reported problems.'; exit 1; fi"
 -
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -236,7 +212,6 @@
+@@ -240,7 +212,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -463,13 +458,6 @@
+@@ -463,18 +458,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
@@ -19,7 +19,12 @@
 -        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
--          docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}"
+-          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+-          echo "${output}"
+-          if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+-            echo "SDC validation reported problems."
+-            exit 1
+-          fi
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
        - name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.ahoy.yml
@@ -40,18 +40,22 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -215,10 +195,6 @@
+@@ -215,14 +195,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
 -  lint-sdc:
 -    usage: Validate Single Directory Components (requires a provisioned site).
--    cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
+-    cmd: |
+-      ahoy cli " \
+-        output=\$(vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME} 2>&1); \
+-        echo \"\${output}\"; \
+-        if echo \"\${output}\" | grep -qE 'Critical|Errors?|Warnings?'; then echo 'SDC validation reported problems.'; exit 1; fi"
 -
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -236,7 +212,6 @@
+@@ -240,7 +212,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -463,13 +458,6 @@
+@@ -463,18 +458,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
@@ -19,7 +19,12 @@
 -        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
--          docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}"
+-          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+-          echo "${output}"
+-          if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+-            echo "SDC validation reported problems."
+-            exit 1
+-          fi
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
        - name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -400,7 +400,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/.ahoy.yml
@@ -16,7 +16,7 @@
    lint-fe:
      usage: Lint front-end code.
      cmd: |
-@@ -222,14 +214,7 @@
+@@ -226,14 +218,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.ahoy.yml
@@ -16,7 +16,7 @@
    lint-fe:
      usage: Lint front-end code.
      cmd: |
-@@ -222,14 +214,7 @@
+@@ -226,14 +218,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -388,7 +388,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.ahoy.yml
@@ -17,8 +17,8 @@
 -
    lint-sdc:
      usage: Validate Single Directory Components (requires a provisioned site).
-     cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
-@@ -238,35 +232,9 @@
+     cmd: |
+@@ -242,35 +236,9 @@
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -76,8 +76,8 @@
        - name: Validate Single Directory Components
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: |
-@@ -471,20 +407,6 @@
-           docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}"
+@@ -476,20 +412,6 @@
+           fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
 -      - name: Test with Behat
@@ -97,7 +97,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -501,16 +423,6 @@
+@@ -506,16 +428,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.ahoy.yml
@@ -17,8 +17,8 @@
 -
    lint-sdc:
      usage: Validate Single Directory Components (requires a provisioned site).
-     cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
-@@ -238,35 +232,9 @@
+     cmd: |
+@@ -242,35 +236,9 @@
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -356,7 +356,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Process test logs and artifacts

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.ahoy.yml
@@ -6,7 +6,7 @@
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint"
  
    lint-tests:
-@@ -235,7 +234,6 @@
+@@ -239,7 +238,6 @@
      usage: Fix lint issues of front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
@@ -14,7 +14,7 @@
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  
    test:
-@@ -258,10 +256,6 @@
+@@ -262,10 +260,6 @@
    test-functional-javascript:
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.ahoy.yml
@@ -6,7 +6,7 @@
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint"
  
    lint-tests:
-@@ -235,7 +234,6 @@
+@@ -239,7 +238,6 @@
      usage: Fix lint issues of front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
@@ -14,7 +14,7 @@
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  
    test:
-@@ -258,10 +256,6 @@
+@@ -262,10 +260,6 @@
    test-functional-javascript:
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
@@ -390,7 +390,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.ahoy.yml
@@ -47,18 +47,22 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -215,10 +187,6 @@
+@@ -215,14 +187,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
 -  lint-sdc:
 -    usage: Validate Single Directory Components (requires a provisioned site).
--    cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
+-    cmd: |
+-      ahoy cli " \
+-        output=\$(vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME} 2>&1); \
+-        echo \"\${output}\"; \
+-        if echo \"\${output}\" | grep -qE 'Critical|Errors?|Warnings?'; then echo 'SDC validation reported problems.'; exit 1; fi"
 -
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -235,8 +203,6 @@
+@@ -239,8 +203,6 @@
      usage: Fix lint issues of front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
@@ -67,7 +71,7 @@
  
    test:
      usage: Run all PHPUnit tests.
-@@ -258,10 +224,6 @@
+@@ -262,10 +224,6 @@
    test-functional-javascript:
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
@@ -42,7 +42,7 @@
        - name: Test with PHPUnit
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: docker compose exec -T cli vendor/bin/phpunit
-@@ -463,13 +447,6 @@
+@@ -463,18 +447,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
@@ -51,7 +51,12 @@
 -        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
--          docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}"
+-          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+-          echo "${output}"
+-          if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+-            echo "SDC validation reported problems."
+-            exit 1
+-          fi
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
        - name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.ahoy.yml
@@ -47,18 +47,22 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -215,10 +187,6 @@
+@@ -215,14 +187,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
 -  lint-sdc:
 -    usage: Validate Single Directory Components (requires a provisioned site).
--    cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
+-    cmd: |
+-      ahoy cli " \
+-        output=\$(vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME} 2>&1); \
+-        echo \"\${output}\"; \
+-        if echo \"\${output}\" | grep -qE 'Critical|Errors?|Warnings?'; then echo 'SDC validation reported problems.'; exit 1; fi"
 -
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -235,8 +203,6 @@
+@@ -239,8 +203,6 @@
      usage: Fix lint issues of front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
@@ -67,7 +71,7 @@
  
    test:
      usage: Run all PHPUnit tests.
-@@ -258,10 +224,6 @@
+@@ -262,10 +224,6 @@
    test-functional-javascript:
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.ahoy.yml
@@ -14,8 +14,8 @@
 -
    lint-sdc:
      usage: Validate Single Directory Components (requires a provisioned site).
-     cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
-@@ -262,11 +259,6 @@
+     cmd: |
+@@ -266,11 +263,6 @@
    test-js:
      usage: Run Jest JavaScript unit tests.
      cmd: ahoy cli "yarn test"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -9,9 +9,9 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -470,20 +466,6 @@
-           [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-           docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}"
+@@ -475,20 +471,6 @@
+             exit 1
+           fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
 -
 -      - name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.ahoy.yml
@@ -14,8 +14,8 @@
 -
    lint-sdc:
      usage: Validate Single Directory Components (requires a provisioned site).
-     cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
-@@ -262,11 +259,6 @@
+     cmd: |
+@@ -266,11 +263,6 @@
    test-js:
      usage: Run Jest JavaScript unit tests.
      cmd: ahoy cli "yarn test"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -396,7 +396,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Process test logs and artifacts

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
@@ -395,7 +395,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.ahoy.yml
@@ -40,18 +40,22 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -215,10 +195,6 @@
+@@ -215,14 +195,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
 -  lint-sdc:
 -    usage: Validate Single Directory Components (requires a provisioned site).
--    cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
+-    cmd: |
+-      ahoy cli " \
+-        output=\$(vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME} 2>&1); \
+-        echo \"\${output}\"; \
+-        if echo \"\${output}\" | grep -qE 'Critical|Errors?|Warnings?'; then echo 'SDC validation reported problems.'; exit 1; fi"
 -
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -236,7 +212,6 @@
+@@ -240,7 +212,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
@@ -22,7 +22,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -463,13 +453,6 @@
+@@ -463,18 +453,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
@@ -31,7 +31,12 @@
 -        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
--          docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}"
+-          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+-          echo "${output}"
+-          if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+-            echo "SDC validation reported problems."
+-            exit 1
+-          fi
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
        - name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -259,10 +259,6 @@
+@@ -263,10 +263,6 @@
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -259,10 +259,6 @@
+@@ -263,10 +263,6 @@
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
@@ -395,7 +395,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/.ahoy.yml
@@ -6,7 +6,7 @@
        ahoy cli vendor/bin/phpstan
        ahoy cli vendor/bin/rector --dry-run
  
-@@ -229,7 +228,6 @@
+@@ -233,7 +232,6 @@
      usage: Fix lint issues of back-end code.
      cmd: |
        ahoy cli vendor/bin/rector

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.ahoy.yml
@@ -6,7 +6,7 @@
        ahoy cli vendor/bin/phpstan
        ahoy cli vendor/bin/rector --dry-run
  
-@@ -229,7 +228,6 @@
+@@ -233,7 +232,6 @@
      usage: Fix lint issues of back-end code.
      cmd: |
        ahoy cli vendor/bin/rector

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -396,7 +396,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -396,7 +396,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -238,27 +238,6 @@
+@@ -242,27 +242,6 @@
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -65,7 +65,7 @@
        - name: Validate Single Directory Components
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: |
-@@ -501,16 +441,6 @@
+@@ -506,16 +446,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -238,27 +238,6 @@
+@@ -242,27 +242,6 @@
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -360,7 +360,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/.ahoy.yml
@@ -6,7 +6,7 @@
  
    lint-fe:
      usage: Lint front-end code.
-@@ -228,7 +227,6 @@
+@@ -232,7 +231,6 @@
    lint-be-fix:
      usage: Fix lint issues of back-end code.
      cmd: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.ahoy.yml
@@ -6,7 +6,7 @@
  
    lint-fe:
      usage: Lint front-end code.
-@@ -228,7 +227,6 @@
+@@ -232,7 +231,6 @@
    lint-be-fix:
      usage: Fix lint issues of back-end code.
      cmd: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -396,7 +396,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
@@ -400,7 +400,12 @@ jobs:
           command: |
             [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
-            docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" || [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ]
+            output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+            echo "${output}"
+            if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+              echo "SDC validation reported problems."
+              [ "${VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE:-0}" -eq 1 ] || exit 1
+            fi
 
       - run:
           name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.ahoy.yml
@@ -40,18 +40,22 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -215,10 +195,6 @@
+@@ -215,14 +195,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
 -  lint-sdc:
 -    usage: Validate Single Directory Components (requires a provisioned site).
--    cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
+-    cmd: |
+-      ahoy cli " \
+-        output=\$(vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME} 2>&1); \
+-        echo \"\${output}\"; \
+-        if echo \"\${output}\" | grep -qE 'Critical|Errors?|Warnings?'; then echo 'SDC validation reported problems.'; exit 1; fi"
 -
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -236,7 +212,6 @@
+@@ -240,7 +212,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -463,13 +458,6 @@
+@@ -463,18 +458,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
@@ -19,7 +19,12 @@
 -        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
--          docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}"
+-          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
+-          echo "${output}"
+-          if echo "${output}" | grep -qE 'Critical|Errors?|Warnings?'; then
+-            echo "SDC validation reported problems."
+-            exit 1
+-          fi
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
        - name: Test with Behat

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.ahoy.yml
@@ -27,8 +27,8 @@
 -
    lint-sdc:
      usage: Validate Single Directory Components (requires a provisioned site).
-     cmd: ahoy cli "vendor/bin/drush sdc-devel:validate \${DRUPAL_THEME}"
-@@ -222,51 +207,13 @@
+     cmd: |
+@@ -226,51 +211,13 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -117,8 +117,8 @@
        - name: Validate Single Directory Components
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: |
-@@ -471,20 +384,6 @@
-           docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}"
+@@ -476,20 +389,6 @@
+           fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
 -      - name: Test with Behat
@@ -138,7 +138,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -501,16 +400,6 @@
+@@ -506,16 +405,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/tests/phpunit/Functional/AhoyWorkflowTest.php
+++ b/.vortex/tests/phpunit/Functional/AhoyWorkflowTest.php
@@ -64,6 +64,8 @@ class AhoyWorkflowTest extends FunctionalTestCase {
 
     $this->subtestAhoyLintFe();
 
+    $this->subtestAhoyLintSdc();
+
     $this->subtestAhoyLintTests();
 
     $this->subtestAhoyReset();

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -401,6 +401,25 @@ trait SubtestAhoyTrait {
     $this->logStepFinish();
   }
 
+  protected function subtestAhoyLintSdc(string $webroot = 'web'): void {
+    $this->logStepStart();
+
+    $this->logSubstep('Assert that SDC validation succeeds on valid components');
+    $this->cmd('ahoy lint-sdc', tio: 120, ito: 90, txt: '`ahoy lint-sdc` runs successfully on valid components');
+
+    $this->logSubstep('Assert that SDC validation failure works');
+    $component = $webroot . '/themes/custom/star_wars/components/button/button.twig';
+    $this->fileAppend($component, "\n{{ broken");
+    $this->syncToContainer($component);
+
+    $this->cmdFail('ahoy lint-sdc', tio: 120, ito: 90, txt: '`ahoy lint-sdc` fails as expected on a component with a Twig error');
+
+    $this->fileRestore($component);
+    $this->syncToContainer($component);
+
+    $this->logStepFinish();
+  }
+
   protected function subtestAhoyLintTests(): void {
     $this->logStepStart();
 


### PR DESCRIPTION
Closes #2704

## Summary

The SDC lint gate introduced in #2671 was never actually enforced: `drush sdc-devel:validate` always exits 0 regardless of whether it found problems, so the check silently passed even when components had Twig errors or missing templates. This PR makes the gate functional by capturing the command output and pattern-matching against the severity labels that `sdc_devel` actually emits.

## Changes

- **`.ahoy.yml`** - `lint-sdc` command now captures `drush sdc-devel:validate` output and exits 1 when the output contains `Critical`, `Error(s)`, or `Warning(s)`. The exit-code check is replaced with an output grep because (a) the command always exits 0, and (b) the success message itself contains the word "errors" (lowercase), making a case-insensitive match impossible.
- **`.github/workflows/build-test-deploy.yml`** - "Validate Single Directory Components" step applies the same capture-and-grep approach. The `continue-on-error` opt-out via `VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE` is preserved.
- **`.circleci/config.yml`** - Equivalent fix; the `VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE` guard is preserved.
- **`.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php`** - Added `subtestAhoyLintSdc` with two assertions: `ahoy lint-sdc` passes on the valid shipped theme components (false-positive guard), and fails when a component template contains an unterminated Twig tag (proving the gate catches real breakage).
- **`.vortex/tests/phpunit/Functional/AhoyWorkflowTest.php`** - Wired in `subtestAhoyLintSdc`.
- **Snapshot fixtures** - Regenerated across all installer fixture variants to reflect the updated `lint-sdc` command body and CI step contents.

## Before / After

```
BEFORE
------
ahoy lint-sdc
  └─ drush sdc-devel:validate
       exits 0 (always, even with problems)
         └─ step trusts exit code
              └─ always green (gate is toothless)

VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE opt-out: inert (step never fails)


AFTER
-----
ahoy lint-sdc
  └─ drush sdc-devel:validate
       output captured (exit code ignored)
         └─ grep -qE 'Critical|Errors?|Warnings?'
              ├─ match found  -> exit 1  (build fails)
              └─ no match     -> exit 0  (build passes)

VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE opt-out: functional (skips the exit 1)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Single Directory Components (SDC) validation by capturing the linter’s combined output and failing when it contains critical/error/warning indicators, instead of relying on exit codes.
  * Applied the same output-scanning behavior consistently across linting in CI, while preserving the existing bypass option via an ignore-failure flag.

* **Tests**
  * Expanded stateless workflow coverage to run an additional SDC lint subtest.
  * Added a test that intentionally breaks an SDC/Twig component, verifies the lint fails, then restores it and confirms lint passes again.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->