### PR TITLE
Updated the database base image, theme dependencies, and a pinned GitHub Action.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ jobs:
       # Enforce fresh DB build (do not rely on fallback caches).
       VORTEX_CI_DB_CACHE_FALLBACK: 'no'
       # Always use fresh base image for the database (if database-in-image storage is used).
-      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:26.1.0
+      VORTEX_DB_IMAGE_BASE: drevops/mariadb-drupal-data:26.6.0
       # Deploy container image (if database-in-image storage is used).
       VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED: 1
       # Do not build the Drupal front-end.

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -493,7 +493,7 @@ jobs:
 
       - name: Post coverage summary as PR comment
         if: ${{ github.event_name == 'pull_request' && (matrix.instance == 0 || strategy.job-total == 1) && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
-        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: coverage-gha
           message: |

--- a/.github/workflows/test-vr.yml
+++ b/.github/workflows/test-vr.yml
@@ -278,7 +278,7 @@ jobs:
 
     steps:
       - name: Post sticky PR comment
-        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           number: ${{ needs.vr-compare.outputs.pr_number }}
           header: vr-diffy

--- a/.github/workflows/vortex-test-docs.yml
+++ b/.github/workflows/vortex-test-docs.yml
@@ -170,7 +170,7 @@ jobs:
       # on forks, where 'pull_requests' is empty.
       - name: Post documentation preview link
         if: github.event.workflow_run.head_branch != 'main' && github.event.workflow_run.pull_requests[0].number && steps.netlify.outputs.deploy-url
-        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           number: ${{ github.event.workflow_run.pull_requests[0].number }}
           header: docs-preview

--- a/web/themes/custom/your_site_theme/yarn.lock
+++ b/web/themes/custom/your_site_theme/yarn.lock
@@ -497,9 +497,9 @@ at-least-node@^1.0.0:
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 autoprefixer@^10.4.22:
-  version "10.5.1"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.5.1.tgz#e54daa8e80b8c54572cd9d5100bb58c866059014"
-  integrity sha512-jwM2pcTuCWUoN70FEvf5XrXyDbUgRURK4FnU8v0jWZZYU/KkVvN9T33mu1sVLFY9JW3kTWzKheEpn6xYLRc/VA==
+  version "10.5.2"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.5.2.tgz#5d7dcaab1c294038fe51e0fa3738d28e559caac0"
+  integrity sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==
   dependencies:
     browserslist "^4.28.4"
     caniuse-lite "^1.0.30001799"
@@ -2181,9 +2181,9 @@ node-exports-info@^1.6.0:
     semver "^6.3.1"
 
 node-releases@^2.0.48:
-  version "2.0.48"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.48.tgz#4da73d040ada751fc9959d993f27de48792e3b7d"
-  integrity sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==
+  version "2.0.49"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.49.tgz#1a1f4176b683d22614f61adc1c842c187431841a"
+  integrity sha512-f06bl1D+8ZDkn2oOQQKAh5/otFWqVnM1Q5oerA8Pex7UfT66Tx4IPHIqVVFKqFT3FUtaDstdgkM7yT7JWhqxfw==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Summary

Refreshed the `drevops/mariadb-drupal-data` base image pin in the CircleCI database-in-image job, which Renovate does not track because it is set via a `VORTEX_DB_IMAGE_BASE` environment variable rather than a standard `image:` field. Also bumped the `marocchino/sticky-pull-request-comment` GitHub Action to its latest patch release and pulled in two transitive patch updates to the theme's Yarn lockfile.

## Changes

- `.circleci/config.yml`: `drevops/mariadb-drupal-data` base image `26.1.0` -> `26.6.0` (`VORTEX_DB_IMAGE_BASE` env in the `vortex-dev-database-ii` job).
- `web/themes/custom/your_site_theme/yarn.lock`: `autoprefixer` `10.5.1` -> `10.5.2` and `node-releases` `2.0.48` -> `2.0.49` patch bumps.
- `.github/workflows/build-test-deploy.yml`, `test-vr.yml`, `vortex-test-docs.yml`: `marocchino/sticky-pull-request-comment` pinned SHA updated from `70d2764d` (`v3`) to `0ea0beb6` (`v3.0.4`).

## Before / After

```
Before                                    After
─────────────────────────────────────    ─────────────────────────────────────
VORTEX_DB_IMAGE_BASE:                    VORTEX_DB_IMAGE_BASE:
  drevops/mariadb-drupal-data:26.1.0       drevops/mariadb-drupal-data:26.6.0
  (Jan 2025 — stale vs 26.6.x cycle)      (current Lagoon 26.6.x cycle)

sticky-pull-request-comment:             sticky-pull-request-comment:
  @70d2764d  # v3                          @0ea0beb6  # v3.0.4
  (unpinned minor; no patch fixes)         (latest patch release)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the database image used for nightly database builds to a newer version.
  * Refreshed the action used for posting pull request comments in coverage, visual regression, and documentation preview workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->