### PR TITLE
[#2713] Converted 'ahoy reset hard' to the 'ahoy reset --hard' option flag.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -199,7 +199,7 @@ commands:
     cmd: \[ -n "${VORTEX_DB_IMAGE}" \] && docker pull ${VORTEX_DB_IMAGE} || true
 
   reset:
-    usage: Remove containers, all build files. Use with `hard` to reset repository to the last commit.
+    usage: Remove containers, all build files. Use with `--hard` to reset repository to the last commit.
     aliases: [prune, delete]
     cmd: |
       ahoy confirm "All containers and build files will be removed. Proceed?" || exit 0

--- a/.vortex/docs/content/development/README.mdx
+++ b/.vortex/docs/content/development/README.mdx
@@ -203,7 +203,7 @@ all containers and downloaded dependency packages (`vendor`, `node_modules` etc.
     # Reset local environment
     ahoy reset
     # Fully reset repository to a state as if it was just cloned
-    ahoy reset hard
+    ahoy reset --hard
     ```
   </TabItem>
   <TabItem value="docker-compose" label="Docker Compose">
@@ -213,7 +213,7 @@ all containers and downloaded dependency packages (`vendor`, `node_modules` etc.
     ./vendor/drevops/vortex-tooling/src/reset
     # Fully reset repository to a state as if it was just cloned
     docker compose down
-    ./vendor/drevops/vortex-tooling/src/reset hard
+    ./vendor/drevops/vortex-tooling/src/reset --hard
     ```
   </TabItem>
 </Tabs>

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
@@ -156,7 +156,7 @@ commands:
     cmd: \[ -n "${VORTEX_DB_IMAGE}" \] && docker pull ${VORTEX_DB_IMAGE} || true
 
   reset:
-    usage: Remove containers, all build files. Use with `hard` to reset repository to the last commit.
+    usage: Remove containers, all build files. Use with `--hard` to reset repository to the last commit.
     aliases: [prune, delete]
     cmd: |
       ahoy confirm "All containers and build files will be removed. Proceed?" || exit 0

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -804,7 +804,7 @@ trait SubtestAhoyTrait {
     $this->assertDirectoryExists('.logs/screenshots');
 
     $this->logSubstep('Run hard reset');
-    $this->cmd('ahoy reset hard');
+    $this->cmd('ahoy reset --hard');
     sleep(10);
 
     $this->logSubstep('Assert expected files and directories present or absent after reset');

--- a/.vortex/tooling/src/reset
+++ b/.vortex/tooling/src/reset
@@ -25,7 +25,10 @@ for cmd in git; do command -v "${cmd}" >/dev/null || {
   exit 1
 }; done
 
-is_hard_reset="$([ "${1:-}" == "hard" ] && echo "1" || echo "0")"
+is_hard_reset=0
+case " $* " in
+  *" --hard "*) is_hard_reset=1 ;;
+esac
 
 info "Started reset."
 

--- a/.vortex/tooling/src/reset
+++ b/.vortex/tooling/src/reset
@@ -26,9 +26,9 @@ for cmd in git; do command -v "${cmd}" >/dev/null || {
 }; done
 
 is_hard_reset=0
-case " $* " in
-  *" --hard "*) is_hard_reset=1 ;;
-esac
+for arg in "$@"; do
+  [ "${arg}" = "--hard" ] && is_hard_reset=1
+done
 
 info "Started reset."
 

--- a/.vortex/tooling/tests/unit/reset.bats
+++ b/.vortex/tooling/tests/unit/reset.bats
@@ -46,7 +46,10 @@ load ../_helper.bash
   assert_success
   assert_output_contains "Started reset."
   assert_output_contains "Finished reset."
+  assert_output_not_contains "Changing permissions and removing all other untracked files."
   assert_output_not_contains "Resetting repository files."
+  assert_output_not_contains "Removing all untracked files."
+  assert_output_not_contains "Removing empty directories."
 
   popd >/dev/null
 }

--- a/.vortex/tooling/tests/unit/reset.bats
+++ b/.vortex/tooling/tests/unit/reset.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+##
+# Unit tests for the reset script.
+#
+# shellcheck disable=SC2030,SC2031
+
+load ../_helper.bash
+
+@test "reset: soft reset skips the hard-reset steps" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  run .vortex/tooling/src/reset
+  assert_success
+  assert_output_contains "Started reset."
+  assert_output_contains "Finished reset."
+  assert_output_not_contains "Changing permissions and removing all other untracked files."
+  assert_output_not_contains "Resetting repository files."
+  assert_output_not_contains "Removing all untracked files."
+  assert_output_not_contains "Removing empty directories."
+
+  popd >/dev/null
+}
+
+@test "reset: --hard runs the hard-reset steps" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Stub git so the hard-reset branch runs without mutating the fixture repo.
+  mock_command "git" >/dev/null
+
+  run .vortex/tooling/src/reset --hard
+  assert_success
+  assert_output_contains "Started reset."
+  assert_output_contains "Changing permissions and removing all other untracked files."
+  assert_output_contains "Resetting repository files."
+  assert_output_contains "Removing all untracked files."
+  assert_output_contains "Removing empty directories."
+  assert_output_contains "Finished reset."
+
+  popd >/dev/null
+}
+
+@test "reset: legacy 'hard' positional no longer triggers a hard reset" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  run .vortex/tooling/src/reset hard
+  assert_success
+  assert_output_contains "Started reset."
+  assert_output_contains "Finished reset."
+  assert_output_not_contains "Resetting repository files."
+
+  popd >/dev/null
+}


### PR DESCRIPTION
Closes #2713

## Summary

Converts the `ahoy reset hard` positional modifier to the option flag `ahoy reset --hard`, making the interface consistent with the option-based convention used throughout the ahoy interface. The `reset` script now parses arguments via an exact-token loop, matching only the literal `--hard` flag - the legacy positional `hard` is intentionally no longer honoured. Docs, tests, and the installer baseline fixture are updated to match.

## Changes

**Core script (`.vortex/tooling/src/reset`)**
- Replaced the single `$1 == "hard"` positional check with a loop over all arguments that tests each against `--hard` by exact string equality.

**Ahoy interface (`.ahoy.yml`)**
- Updated the `reset` command usage text from `` Use with `hard` `` to `` Use with `--hard` ``.

**Documentation (`.vortex/docs/content/development/README.mdx`)**
- Updated both `ahoy reset hard` and `./vendor/…/reset hard` examples to the `--hard` option form.

**Tests**
- Updated the BDD integration test in `.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php` to call `ahoy reset --hard`.
- Added `.vortex/tooling/tests/unit/reset.bats` with three BATS unit tests: soft reset (no flag), `--hard` triggers the full reset path, and the legacy positional `hard` is explicitly verified to no longer trigger a hard reset.

**Installer fixture (`.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml`)**
- Regenerated baseline snapshot to reflect the updated usage string.

## Before / After

```
BEFORE
──────────────────────────────────────────────────────────────────
 Interface       ahoy reset hard
                 ./vendor/.../reset hard

 Script parse    is_hard_reset="$([ "${1:-}" == "hard" ] && echo "1" || echo "0")"
                 ↑ positional — matches any first argument of "hard"

 Legacy support  ahoy reset hard   → hard reset (positional)
                 ahoy reset --hard → soft reset (flag ignored)


AFTER
──────────────────────────────────────────────────────────────────
 Interface       ahoy reset --hard
                 ./vendor/.../reset --hard

 Script parse    is_hard_reset=0
                 for arg in "$@"; do
                   [ "${arg}" = "--hard" ] && is_hard_reset=1
                 done
                 ↑ exact-token loop — only "--hard" triggers hard reset

 Legacy support  ahoy reset hard   → soft reset (no longer honoured)
                 ahoy reset --hard → hard reset (only supported form)
```
