### PR TITLE
[#2719] Added a platform-agnostic 'task' runner for hosting operations.

### DIFF
--- a/.vortex/docs/content/hosting/acquia.mdx
+++ b/.vortex/docs/content/hosting/acquia.mdx
@@ -84,3 +84,31 @@ or CI builds:
 ```shell
 ahoy download-db
 ```
+
+### Run a hosting task
+
+Copying databases or files between environments and purging the edge cache run
+through a single, platform-agnostic task runner that dispatches each operation
+to the implementation for the configured hosting platform:
+
+```shell
+./vendor/drevops/vortex-tooling/src/task <operation>
+```
+
+| Operation     | Description                            |
+|---------------|----------------------------------------|
+| `copy-db`     | Copy the database between environments |
+| `copy-files`  | Copy files between environments        |
+| `purge-cache` | Purge the edge (Varnish) cache         |
+
+The platform is read from `VORTEX_PLATFORM`, or from `VORTEX_TASK_PLATFORM` to
+override a single task. The Acquia deployment hooks export `VORTEX_PLATFORM`
+themselves; set it yourself when running an operation manually - for example,
+from your local machine:
+
+```shell
+VORTEX_PLATFORM=acquia ./vendor/drevops/vortex-tooling/src/task copy-db
+```
+
+Each operation reads its configuration - application name, API credentials, and
+source and destination environments - from your `.env` and `.env.local` files.

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/copy-db.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/copy-db.sh
@@ -14,6 +14,7 @@ pushd "/var/www/html/${site}.${target_env}" >/dev/null || exit 1
 
 [ "${VORTEX_TASK_COPY_DB_ACQUIA_SKIP}" = "1" ] && echo "Skipping copying of database between Acquia environments." && exit 0
 
+export VORTEX_PLATFORM=acquia
 export VORTEX_ACQUIA_KEY="${VORTEX_ACQUIA_KEY?not set}"
 export VORTEX_ACQUIA_SECRET="${VORTEX_ACQUIA_SECRET?not set}"
 export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
@@ -21,6 +22,6 @@ export VORTEX_TASK_COPY_DB_ACQUIA_SRC="${VORTEX_TASK_COPY_DB_ACQUIA_SRC:-prod}"
 export VORTEX_TASK_COPY_DB_ACQUIA_DST="${VORTEX_TASK_COPY_DB_ACQUIA_DST:-${target_env}}"
 export VORTEX_TASK_COPY_DB_ACQUIA_NAME="${VORTEX_TASK_COPY_DB_ACQUIA_NAME?not set}"
 
-./vendor/drevops/vortex-tooling/src/task copy-db-acquia
+./vendor/drevops/vortex-tooling/src/task copy-db
 
 popd >/dev/null || exit 1

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/copy-db.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/copy-db.sh
@@ -21,6 +21,6 @@ export VORTEX_TASK_COPY_DB_ACQUIA_SRC="${VORTEX_TASK_COPY_DB_ACQUIA_SRC:-prod}"
 export VORTEX_TASK_COPY_DB_ACQUIA_DST="${VORTEX_TASK_COPY_DB_ACQUIA_DST:-${target_env}}"
 export VORTEX_TASK_COPY_DB_ACQUIA_NAME="${VORTEX_TASK_COPY_DB_ACQUIA_NAME?not set}"
 
-./vendor/drevops/vortex-tooling/src/task-copy-db-acquia
+./vendor/drevops/vortex-tooling/src/task copy-db-acquia
 
 popd >/dev/null || exit 1

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/copy-files.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/copy-files.sh
@@ -20,6 +20,6 @@ export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
 export VORTEX_TASK_COPY_FILES_ACQUIA_SRC="${VORTEX_TASK_COPY_FILES_ACQUIA_SRC:-prod}"
 export VORTEX_TASK_COPY_FILES_ACQUIA_DST="${VORTEX_TASK_COPY_FILES_ACQUIA_DST:-${target_env}}"
 
-./vendor/drevops/vortex-tooling/src/task-copy-files-acquia
+./vendor/drevops/vortex-tooling/src/task copy-files-acquia
 
 popd >/dev/null || exit 1

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/copy-files.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/copy-files.sh
@@ -14,12 +14,13 @@ pushd "/var/www/html/${site}.${target_env}" >/dev/null || exit 1
 
 [ "${VORTEX_TASK_COPY_FILES_ACQUIA_SKIP}" = "1" ] && echo "Skipping copying of files between Acquia environments." && exit 0
 
+export VORTEX_PLATFORM=acquia
 export VORTEX_ACQUIA_KEY="${VORTEX_ACQUIA_KEY?not set}"
 export VORTEX_ACQUIA_SECRET="${VORTEX_ACQUIA_SECRET?not set}"
 export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
 export VORTEX_TASK_COPY_FILES_ACQUIA_SRC="${VORTEX_TASK_COPY_FILES_ACQUIA_SRC:-prod}"
 export VORTEX_TASK_COPY_FILES_ACQUIA_DST="${VORTEX_TASK_COPY_FILES_ACQUIA_DST:-${target_env}}"
 
-./vendor/drevops/vortex-tooling/src/task copy-files-acquia
+./vendor/drevops/vortex-tooling/src/task copy-files
 
 popd >/dev/null || exit 1

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/purge-cache.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/purge-cache.sh
@@ -14,12 +14,13 @@ pushd "/var/www/html/${site}.${target_env}" >/dev/null || exit 1
 
 [ "${VORTEX_PURGE_CACHE_ACQUIA_SKIP}" = "1" ] && echo "Skipping purging of cache in Acquia environment." && exit 0
 
+export VORTEX_PLATFORM=acquia
 export VORTEX_ACQUIA_KEY="${VORTEX_ACQUIA_KEY?not set}"
 export VORTEX_ACQUIA_SECRET="${VORTEX_ACQUIA_SECRET?not set}"
 export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
 export VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV="${VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV:-${target_env}}"
 export VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE="${VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE:-"/var/www/html/${site}.${target_env}/hooks/library/domains.txt"}"
 
-./vendor/drevops/vortex-tooling/src/task purge-cache-acquia
+./vendor/drevops/vortex-tooling/src/task purge-cache
 
 popd >/dev/null || exit 1

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/purge-cache.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/hooks/library/purge-cache.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#!/usr/bin/env bash
 ##
 # Acquia Cloud hook: Purge edge cache in an environment.
 #
@@ -21,6 +20,6 @@ export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
 export VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV="${VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV:-${target_env}}"
 export VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE="${VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE:-"/var/www/html/${site}.${target_env}/hooks/library/domains.txt"}"
 
-./vendor/drevops/vortex-tooling/src/task-purge-cache-acquia
+./vendor/drevops/vortex-tooling/src/task purge-cache-acquia
 
 popd >/dev/null || exit 1

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/copy-db.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/copy-db.sh
@@ -14,6 +14,7 @@ pushd "/var/www/html/${site}.${target_env}" >/dev/null || exit 1
 
 [ "${VORTEX_TASK_COPY_DB_ACQUIA_SKIP}" = "1" ] && echo "Skipping copying of database between Acquia environments." && exit 0
 
+export VORTEX_PLATFORM=acquia
 export VORTEX_ACQUIA_KEY="${VORTEX_ACQUIA_KEY?not set}"
 export VORTEX_ACQUIA_SECRET="${VORTEX_ACQUIA_SECRET?not set}"
 export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
@@ -21,6 +22,6 @@ export VORTEX_TASK_COPY_DB_ACQUIA_SRC="${VORTEX_TASK_COPY_DB_ACQUIA_SRC:-prod}"
 export VORTEX_TASK_COPY_DB_ACQUIA_DST="${VORTEX_TASK_COPY_DB_ACQUIA_DST:-${target_env}}"
 export VORTEX_TASK_COPY_DB_ACQUIA_NAME="${VORTEX_TASK_COPY_DB_ACQUIA_NAME?not set}"
 
-./vendor/drevops/vortex-tooling/src/task copy-db-acquia
+./vendor/drevops/vortex-tooling/src/task copy-db
 
 popd >/dev/null || exit 1

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/copy-db.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/copy-db.sh
@@ -21,6 +21,6 @@ export VORTEX_TASK_COPY_DB_ACQUIA_SRC="${VORTEX_TASK_COPY_DB_ACQUIA_SRC:-prod}"
 export VORTEX_TASK_COPY_DB_ACQUIA_DST="${VORTEX_TASK_COPY_DB_ACQUIA_DST:-${target_env}}"
 export VORTEX_TASK_COPY_DB_ACQUIA_NAME="${VORTEX_TASK_COPY_DB_ACQUIA_NAME?not set}"
 
-./vendor/drevops/vortex-tooling/src/task-copy-db-acquia
+./vendor/drevops/vortex-tooling/src/task copy-db-acquia
 
 popd >/dev/null || exit 1

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/copy-files.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/copy-files.sh
@@ -20,6 +20,6 @@ export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
 export VORTEX_TASK_COPY_FILES_ACQUIA_SRC="${VORTEX_TASK_COPY_FILES_ACQUIA_SRC:-prod}"
 export VORTEX_TASK_COPY_FILES_ACQUIA_DST="${VORTEX_TASK_COPY_FILES_ACQUIA_DST:-${target_env}}"
 
-./vendor/drevops/vortex-tooling/src/task-copy-files-acquia
+./vendor/drevops/vortex-tooling/src/task copy-files-acquia
 
 popd >/dev/null || exit 1

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/copy-files.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/copy-files.sh
@@ -14,12 +14,13 @@ pushd "/var/www/html/${site}.${target_env}" >/dev/null || exit 1
 
 [ "${VORTEX_TASK_COPY_FILES_ACQUIA_SKIP}" = "1" ] && echo "Skipping copying of files between Acquia environments." && exit 0
 
+export VORTEX_PLATFORM=acquia
 export VORTEX_ACQUIA_KEY="${VORTEX_ACQUIA_KEY?not set}"
 export VORTEX_ACQUIA_SECRET="${VORTEX_ACQUIA_SECRET?not set}"
 export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
 export VORTEX_TASK_COPY_FILES_ACQUIA_SRC="${VORTEX_TASK_COPY_FILES_ACQUIA_SRC:-prod}"
 export VORTEX_TASK_COPY_FILES_ACQUIA_DST="${VORTEX_TASK_COPY_FILES_ACQUIA_DST:-${target_env}}"
 
-./vendor/drevops/vortex-tooling/src/task copy-files-acquia
+./vendor/drevops/vortex-tooling/src/task copy-files
 
 popd >/dev/null || exit 1

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/purge-cache.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/purge-cache.sh
@@ -14,12 +14,13 @@ pushd "/var/www/html/${site}.${target_env}" >/dev/null || exit 1
 
 [ "${VORTEX_PURGE_CACHE_ACQUIA_SKIP}" = "1" ] && echo "Skipping purging of cache in Acquia environment." && exit 0
 
+export VORTEX_PLATFORM=acquia
 export VORTEX_ACQUIA_KEY="${VORTEX_ACQUIA_KEY?not set}"
 export VORTEX_ACQUIA_SECRET="${VORTEX_ACQUIA_SECRET?not set}"
 export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
 export VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV="${VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV:-${target_env}}"
 export VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE="${VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE:-"/var/www/html/${site}.${target_env}/hooks/library/domains.txt"}"
 
-./vendor/drevops/vortex-tooling/src/task purge-cache-acquia
+./vendor/drevops/vortex-tooling/src/task purge-cache
 
 popd >/dev/null || exit 1

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/purge-cache.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/hooks/library/purge-cache.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#!/usr/bin/env bash
 ##
 # Acquia Cloud hook: Purge edge cache in an environment.
 #
@@ -21,6 +20,6 @@ export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
 export VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV="${VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV:-${target_env}}"
 export VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE="${VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE:-"/var/www/html/${site}.${target_env}/hooks/library/domains.txt"}"
 
-./vendor/drevops/vortex-tooling/src/task-purge-cache-acquia
+./vendor/drevops/vortex-tooling/src/task purge-cache-acquia
 
 popd >/dev/null || exit 1

--- a/.vortex/tooling/src/task
+++ b/.vortex/tooling/src/task
@@ -31,6 +31,11 @@ esac
 
 [ -z "${VORTEX_TASK_PLATFORM}" ] && fail "Missing hosting platform. Set VORTEX_PLATFORM or VORTEX_TASK_PLATFORM." && exit 1
 
+case "${VORTEX_TASK_PLATFORM}" in
+  acquia | lagoon) ;;
+  *) fail "Unsupported hosting platform '${VORTEX_TASK_PLATFORM}'." && exit 1 ;;
+esac
+
 task_script="$(dirname "${BASH_SOURCE[0]}")/task-${operation}-${VORTEX_TASK_PLATFORM}"
 [ ! -x "${task_script}" ] && fail "Operation '${operation}' is not supported on the '${VORTEX_TASK_PLATFORM}' platform." && exit 1
 

--- a/.vortex/tooling/src/task
+++ b/.vortex/tooling/src/task
@@ -19,7 +19,9 @@ shift
 
 case "${command}" in
   copy-db-acquia | copy-files-acquia | purge-cache-acquia)
-    "$(dirname "${BASH_SOURCE[0]}")/task-${command}" "$@"
+    task_script="$(dirname "${BASH_SOURCE[0]}")/task-${command}"
+    [ ! -x "${task_script}" ] && fail "Task script '${task_script}' is missing or not executable." && exit 1
+    "${task_script}" "$@"
     ;;
   *)
     fail "Unsupported task command '${command}' provided."

--- a/.vortex/tooling/src/task
+++ b/.vortex/tooling/src/task
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+##
+# Run a task.
+#
+# This is a router script to call the relevant task script based on the command.
+#
+# shellcheck disable=SC1090,SC1091
+
+set -eu
+[ "${VORTEX_DEBUG-}" = "1" ] && set -x
+
+# @formatter:off
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+# @formatter:on
+
+command="${1:-}"
+[ -z "${command}" ] && fail "Missing task command." && exit 1
+shift
+
+case "${command}" in
+  copy-db-acquia | copy-files-acquia | purge-cache-acquia)
+    "$(dirname "${BASH_SOURCE[0]}")/task-${command}" "$@"
+    ;;
+  *)
+    fail "Unsupported task command '${command}' provided."
+    exit 1
+    ;;
+esac

--- a/.vortex/tooling/src/task
+++ b/.vortex/tooling/src/task
@@ -1,30 +1,37 @@
 #!/usr/bin/env bash
 ##
-# Run a task.
+# Run a hosting task.
 #
-# This is a router script to call the relevant task script based on the command.
+# This is a router script that dispatches a platform-agnostic operation to the
+# implementation for the configured hosting platform: 'task <operation> [args...]'
+# runs the 'task-<operation>-<platform>' sibling script.
+#
+# The platform is read from VORTEX_TASK_PLATFORM, falling back to VORTEX_PLATFORM.
 #
 # shellcheck disable=SC1090,SC1091
 
 set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
+# Hosting platform to run the operation for.
+VORTEX_TASK_PLATFORM="${VORTEX_TASK_PLATFORM:-${VORTEX_PLATFORM:-}}"
+
 # @formatter:off
 fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
 # @formatter:on
 
-command="${1:-}"
-[ -z "${command}" ] && fail "Missing task command." && exit 1
+operation="${1:-}"
+[ -z "${operation}" ] && fail "Missing task operation." && exit 1
 shift
 
-case "${command}" in
-  copy-db-acquia | copy-files-acquia | purge-cache-acquia)
-    task_script="$(dirname "${BASH_SOURCE[0]}")/task-${command}"
-    [ ! -x "${task_script}" ] && fail "Task script '${task_script}' is missing or not executable." && exit 1
-    "${task_script}" "$@"
-    ;;
-  *)
-    fail "Unsupported task command '${command}' provided."
-    exit 1
-    ;;
+case "${operation}" in
+  copy-db | copy-files | purge-cache) ;;
+  *) fail "Unsupported task operation '${operation}'." && exit 1 ;;
 esac
+
+[ -z "${VORTEX_TASK_PLATFORM}" ] && fail "Missing hosting platform. Set VORTEX_PLATFORM or VORTEX_TASK_PLATFORM." && exit 1
+
+task_script="$(dirname "${BASH_SOURCE[0]}")/task-${operation}-${VORTEX_TASK_PLATFORM}"
+[ ! -x "${task_script}" ] && fail "Operation '${operation}' is not supported on the '${VORTEX_TASK_PLATFORM}' platform." && exit 1
+
+"${task_script}" "$@"

--- a/.vortex/tooling/tests/unit/task.bats
+++ b/.vortex/tooling/tests/unit/task.bats
@@ -43,6 +43,18 @@ load ../_helper.bash
   popd >/dev/null || exit 1
 }
 
+@test "Task: unsupported platform" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  unset VORTEX_TASK_PLATFORM
+  export VORTEX_PLATFORM=invalid-platform
+  run ./.vortex/tooling/src/task copy-db
+  assert_failure
+  assert_output_contains "Unsupported hosting platform 'invalid-platform'."
+
+  popd >/dev/null || exit 1
+}
+
 @test "Task: operation not supported on platform" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 

--- a/.vortex/tooling/tests/unit/task.bats
+++ b/.vortex/tooling/tests/unit/task.bats
@@ -2,71 +2,103 @@
 ##
 # Unit tests for the task router.
 #
-# The task-specific logic lives in the dispatched sibling scripts
-# (task-copy-db-acquia, task-copy-files-acquia, task-purge-cache-acquia); these
-# tests cover only the router's command resolution and error handling.
+# The router resolves a platform-agnostic operation to the
+# 'task-<operation>-<platform>' sibling that implements it; these tests cover
+# operation validation, platform resolution, and dispatch. The
+# operation-specific logic is owned by the sibling scripts.
 #
 #shellcheck disable=SC2030,SC2031,SC2034
 
 load ../_helper.bash
 
-@test "Task: missing command" {
+@test "Task: missing operation" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
   run ./.vortex/tooling/src/task
   assert_failure
-  assert_output_contains "Missing task command."
+  assert_output_contains "Missing task operation."
 
   popd >/dev/null || exit 1
 }
 
-@test "Task: unsupported command" {
+@test "Task: unsupported operation" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
-  run ./.vortex/tooling/src/task invalid-command
+  run ./.vortex/tooling/src/task invalid-operation
   assert_failure
-  assert_output_contains "Unsupported task command 'invalid-command' provided."
+  assert_output_contains "Unsupported task operation 'invalid-operation'."
 
   popd >/dev/null || exit 1
 }
 
-@test "Task: missing sibling script" {
+@test "Task: missing platform" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
-  chmod -x ./.vortex/tooling/src/task-copy-db-acquia
-  run ./.vortex/tooling/src/task copy-db-acquia
+  unset VORTEX_TASK_PLATFORM
+  unset VORTEX_PLATFORM
+  run ./.vortex/tooling/src/task copy-db
   assert_failure
-  assert_output_contains "is missing or not executable."
+  assert_output_contains "Missing hosting platform. Set VORTEX_PLATFORM or VORTEX_TASK_PLATFORM."
 
   popd >/dev/null || exit 1
 }
 
-@test "Task: dispatches copy-db-acquia" {
+@test "Task: operation not supported on platform" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Lagoon has no copy-db implementation, so the sibling resolution fails.
+  unset VORTEX_TASK_PLATFORM
+  export VORTEX_PLATFORM=lagoon
+  run ./.vortex/tooling/src/task copy-db
+  assert_failure
+  assert_output_contains "Operation 'copy-db' is not supported on the 'lagoon' platform."
+
+  popd >/dev/null || exit 1
+}
+
+@test "Task: platform from VORTEX_PLATFORM dispatches copy-db" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
   # Without credentials the sibling prints its banner and then fails on the
   # missing-key guard before any network call, which proves the routing.
-  run ./.vortex/tooling/src/task copy-db-acquia
+  unset VORTEX_TASK_PLATFORM
+  export VORTEX_PLATFORM=acquia
+  run ./.vortex/tooling/src/task copy-db
   assert_failure
   assert_output_contains "Started database copying between environments in Acquia."
 
   popd >/dev/null || exit 1
 }
 
-@test "Task: dispatches copy-files-acquia" {
+@test "Task: VORTEX_TASK_PLATFORM overrides VORTEX_PLATFORM" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
-  run ./.vortex/tooling/src/task copy-files-acquia
+  export VORTEX_PLATFORM=lagoon
+  export VORTEX_TASK_PLATFORM=acquia
+  run ./.vortex/tooling/src/task copy-db
+  assert_failure
+  assert_output_contains "Started database copying between environments in Acquia."
+
+  popd >/dev/null || exit 1
+}
+
+@test "Task: platform override dispatches copy-files" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_TASK_PLATFORM=acquia
+  run ./.vortex/tooling/src/task copy-files
   assert_failure
   assert_output_contains "Started files copying between environments in Acquia."
 
   popd >/dev/null || exit 1
 }
 
-@test "Task: dispatches purge-cache-acquia" {
+@test "Task: platform from VORTEX_PLATFORM dispatches purge-cache" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
-  run ./.vortex/tooling/src/task purge-cache-acquia
+  unset VORTEX_TASK_PLATFORM
+  export VORTEX_PLATFORM=acquia
+  run ./.vortex/tooling/src/task purge-cache
   assert_failure
   assert_output_contains "Started cache purging in Acquia."
 

--- a/.vortex/tooling/tests/unit/task.bats
+++ b/.vortex/tooling/tests/unit/task.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+##
+# Unit tests for the task router.
+#
+# The task-specific logic lives in the dispatched sibling scripts
+# (task-copy-db-acquia, task-copy-files-acquia, task-purge-cache-acquia); these
+# tests cover only the router's command resolution and error handling.
+#
+#shellcheck disable=SC2030,SC2031,SC2034
+
+load ../_helper.bash
+
+@test "Task: missing command" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  run ./.vortex/tooling/src/task
+  assert_failure
+  assert_output_contains "Missing task command."
+
+  popd >/dev/null || exit 1
+}
+
+@test "Task: unsupported command" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  run ./.vortex/tooling/src/task invalid-command
+  assert_failure
+  assert_output_contains "Unsupported task command 'invalid-command' provided."
+
+  popd >/dev/null || exit 1
+}
+
+@test "Task: dispatches copy-db-acquia" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # Without credentials the sibling prints its banner and then fails on the
+  # missing-key guard before any network call, which proves the routing.
+  run ./.vortex/tooling/src/task copy-db-acquia
+  assert_failure
+  assert_output_contains "Started database copying between environments in Acquia."
+
+  popd >/dev/null || exit 1
+}
+
+@test "Task: dispatches copy-files-acquia" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  run ./.vortex/tooling/src/task copy-files-acquia
+  assert_failure
+  assert_output_contains "Started files copying between environments in Acquia."
+
+  popd >/dev/null || exit 1
+}
+
+@test "Task: dispatches purge-cache-acquia" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  run ./.vortex/tooling/src/task purge-cache-acquia
+  assert_failure
+  assert_output_contains "Started cache purging in Acquia."
+
+  popd >/dev/null || exit 1
+}

--- a/.vortex/tooling/tests/unit/task.bats
+++ b/.vortex/tooling/tests/unit/task.bats
@@ -30,6 +30,17 @@ load ../_helper.bash
   popd >/dev/null || exit 1
 }
 
+@test "Task: missing sibling script" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  chmod -x ./.vortex/tooling/src/task-copy-db-acquia
+  run ./.vortex/tooling/src/task copy-db-acquia
+  assert_failure
+  assert_output_contains "is missing or not executable."
+
+  popd >/dev/null || exit 1
+}
+
 @test "Task: dispatches copy-db-acquia" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 

--- a/hooks/library/copy-db.sh
+++ b/hooks/library/copy-db.sh
@@ -14,6 +14,7 @@ pushd "/var/www/html/${site}.${target_env}" >/dev/null || exit 1
 
 [ "${VORTEX_TASK_COPY_DB_ACQUIA_SKIP}" = "1" ] && echo "Skipping copying of database between Acquia environments." && exit 0
 
+export VORTEX_PLATFORM=acquia
 export VORTEX_ACQUIA_KEY="${VORTEX_ACQUIA_KEY?not set}"
 export VORTEX_ACQUIA_SECRET="${VORTEX_ACQUIA_SECRET?not set}"
 export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
@@ -21,6 +22,6 @@ export VORTEX_TASK_COPY_DB_ACQUIA_SRC="${VORTEX_TASK_COPY_DB_ACQUIA_SRC:-prod}"
 export VORTEX_TASK_COPY_DB_ACQUIA_DST="${VORTEX_TASK_COPY_DB_ACQUIA_DST:-${target_env}}"
 export VORTEX_TASK_COPY_DB_ACQUIA_NAME="${VORTEX_TASK_COPY_DB_ACQUIA_NAME?not set}"
 
-./vendor/drevops/vortex-tooling/src/task copy-db-acquia
+./vendor/drevops/vortex-tooling/src/task copy-db
 
 popd >/dev/null || exit 1

--- a/hooks/library/copy-db.sh
+++ b/hooks/library/copy-db.sh
@@ -21,6 +21,6 @@ export VORTEX_TASK_COPY_DB_ACQUIA_SRC="${VORTEX_TASK_COPY_DB_ACQUIA_SRC:-prod}"
 export VORTEX_TASK_COPY_DB_ACQUIA_DST="${VORTEX_TASK_COPY_DB_ACQUIA_DST:-${target_env}}"
 export VORTEX_TASK_COPY_DB_ACQUIA_NAME="${VORTEX_TASK_COPY_DB_ACQUIA_NAME?not set}"
 
-./vendor/drevops/vortex-tooling/src/task-copy-db-acquia
+./vendor/drevops/vortex-tooling/src/task copy-db-acquia
 
 popd >/dev/null || exit 1

--- a/hooks/library/copy-files.sh
+++ b/hooks/library/copy-files.sh
@@ -20,6 +20,6 @@ export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
 export VORTEX_TASK_COPY_FILES_ACQUIA_SRC="${VORTEX_TASK_COPY_FILES_ACQUIA_SRC:-prod}"
 export VORTEX_TASK_COPY_FILES_ACQUIA_DST="${VORTEX_TASK_COPY_FILES_ACQUIA_DST:-${target_env}}"
 
-./vendor/drevops/vortex-tooling/src/task-copy-files-acquia
+./vendor/drevops/vortex-tooling/src/task copy-files-acquia
 
 popd >/dev/null || exit 1

--- a/hooks/library/copy-files.sh
+++ b/hooks/library/copy-files.sh
@@ -14,12 +14,13 @@ pushd "/var/www/html/${site}.${target_env}" >/dev/null || exit 1
 
 [ "${VORTEX_TASK_COPY_FILES_ACQUIA_SKIP}" = "1" ] && echo "Skipping copying of files between Acquia environments." && exit 0
 
+export VORTEX_PLATFORM=acquia
 export VORTEX_ACQUIA_KEY="${VORTEX_ACQUIA_KEY?not set}"
 export VORTEX_ACQUIA_SECRET="${VORTEX_ACQUIA_SECRET?not set}"
 export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
 export VORTEX_TASK_COPY_FILES_ACQUIA_SRC="${VORTEX_TASK_COPY_FILES_ACQUIA_SRC:-prod}"
 export VORTEX_TASK_COPY_FILES_ACQUIA_DST="${VORTEX_TASK_COPY_FILES_ACQUIA_DST:-${target_env}}"
 
-./vendor/drevops/vortex-tooling/src/task copy-files-acquia
+./vendor/drevops/vortex-tooling/src/task copy-files
 
 popd >/dev/null || exit 1

--- a/hooks/library/purge-cache.sh
+++ b/hooks/library/purge-cache.sh
@@ -14,12 +14,13 @@ pushd "/var/www/html/${site}.${target_env}" >/dev/null || exit 1
 
 [ "${VORTEX_PURGE_CACHE_ACQUIA_SKIP}" = "1" ] && echo "Skipping purging of cache in Acquia environment." && exit 0
 
+export VORTEX_PLATFORM=acquia
 export VORTEX_ACQUIA_KEY="${VORTEX_ACQUIA_KEY?not set}"
 export VORTEX_ACQUIA_SECRET="${VORTEX_ACQUIA_SECRET?not set}"
 export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
 export VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV="${VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV:-${target_env}}"
 export VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE="${VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE:-"/var/www/html/${site}.${target_env}/hooks/library/domains.txt"}"
 
-./vendor/drevops/vortex-tooling/src/task purge-cache-acquia
+./vendor/drevops/vortex-tooling/src/task purge-cache
 
 popd >/dev/null || exit 1

--- a/hooks/library/purge-cache.sh
+++ b/hooks/library/purge-cache.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#!/usr/bin/env bash
 ##
 # Acquia Cloud hook: Purge edge cache in an environment.
 #
@@ -21,6 +20,6 @@ export VORTEX_ACQUIA_APP_NAME="${VORTEX_ACQUIA_APP_NAME:-${site}}"
 export VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV="${VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV:-${target_env}}"
 export VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE="${VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE:-"/var/www/html/${site}.${target_env}/hooks/library/domains.txt"}"
 
-./vendor/drevops/vortex-tooling/src/task-purge-cache-acquia
+./vendor/drevops/vortex-tooling/src/task purge-cache-acquia
 
 popd >/dev/null || exit 1


### PR DESCRIPTION
Closes #2719

## Summary

Introduces a single, platform-agnostic `task` runner at `vendor/drevops/vortex-tooling/src/task` so the Acquia Cloud hooks dispatch operations through one entrypoint - `task <operation>` - instead of calling the individual `task-*-acquia` scripts directly. This unblocks #2715 (exposing the tooling scripts as `vendor/bin/` binaries), where `task` becomes the public entrypoint and the platform-specific `task-*-acquia` scripts stay internal.

The runner resolves a platform-agnostic operation to the implementation for the configured hosting platform - `task-<operation>-<platform>` - reusing the existing `notify` router pattern. The platform is read from `VORTEX_TASK_PLATFORM`, falling back to `VORTEX_PLATFORM`; the Acquia hooks export `VORTEX_PLATFORM=acquia`. Both the operation and the platform are validated against whitelists before the sibling path is built, and the sibling is required to be executable, so only approved scripts can run.

## Changes

### Task runner

- New `.vortex/tooling/src/task` dispatches `task <operation> [args...]` to `task-<operation>-<platform>`. It validates the operation (`copy-db`, `copy-files`, `purge-cache`) and the platform (`acquia`, `lagoon`) against whitelists, requires the resolved sibling script to be executable, and forwards trailing arguments. It fails with a clear message on a missing or unknown operation, a missing or unsupported platform, or an operation that the platform does not implement.
- The three `task-*-acquia` scripts are unchanged - they become internal platform implementations reached only through the router, so behaviour (environment variables, output, exit codes) is identical.

### Acquia hooks

- `hooks/library/copy-db.sh`, `hooks/library/copy-files.sh`, and `hooks/library/purge-cache.sh` now `export VORTEX_PLATFORM=acquia` and call `task <operation>` instead of `task-<operation>-acquia`. A duplicate `#!/usr/bin/env bash` shebang was removed from `purge-cache.sh`.

### Tests

- New `.vortex/tooling/tests/unit/task.bats` with 9 cases covering operation validation, platform resolution (`VORTEX_PLATFORM`, the `VORTEX_TASK_PLATFORM` override and its precedence), the missing-platform, unsupported-platform and unsupported-operation-on-platform errors, and dispatch of each operation.

### Documentation

- `.vortex/docs/content/hosting/acquia.mdx` gains a "Run a hosting task" section documenting the `task <operation>` DX, the operation table, and platform selection via `VORTEX_PLATFORM` / `VORTEX_TASK_PLATFORM`.

### Fixtures

- Regenerated the mirrored Acquia hook snapshot fixtures under `.vortex/installer/tests/Fixtures/handler_process/`.

## Before / After

```
BEFORE                                AFTER

Acquia hook                           Acquia hook
  │                                     │ export VORTEX_PLATFORM=acquia
  ▼                                     ▼
task-copy-db-acquia   (direct)        task copy-db            (agnostic)
task-copy-files-acquia (direct)         │
task-purge-cache-acquia (direct)        ▼
                                      task  (validate operation + platform)
each script is its own entrypoint       │
                                        ▼
                                      task-copy-db-acquia     (internal impl)
```
