### PR TITLE
[#2718] Used 'export-db' for the Lagoon pre-deployment database backup.

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -43,7 +43,7 @@ tasks:
         command: |
           if [ "$LAGOON_ENVIRONMENT_TYPE" = "production" ] || [ "$LAGOON_GIT_BRANCH" = "${VORTEX_LAGOON_PRODUCTION_BRANCH:-main}" ]; then
             echo "==> Running in PRODUCTION environment."
-            VORTEX_DB_DIR=/app/web/sites/default/files/private/pre_deployment_backups ./vendor/drevops/vortex-tooling/src/export-db-file
+            VORTEX_DB_DIR=/app/web/sites/default/files/private/pre_deployment_backups ./vendor/drevops/vortex-tooling/src/export-db
           fi
         service: cli
     #;< !PROVISION_TYPE_PROFILE

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_lagoon/.lagoon.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_lagoon/.lagoon.yml
@@ -41,7 +41,7 @@ tasks:
         command: |
           if [ "$LAGOON_ENVIRONMENT_TYPE" = "production" ] || [ "$LAGOON_GIT_BRANCH" = "${VORTEX_LAGOON_PRODUCTION_BRANCH:-main}" ]; then
             echo "==> Running in PRODUCTION environment."
-            VORTEX_DB_DIR=/app/web/sites/default/files/private/pre_deployment_backups ./vendor/drevops/vortex-tooling/src/export-db-file
+            VORTEX_DB_DIR=/app/web/sites/default/files/private/pre_deployment_backups ./vendor/drevops/vortex-tooling/src/export-db
           fi
         service: cli
 

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___lagoon/.lagoon.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___lagoon/.lagoon.yml
@@ -41,7 +41,7 @@ tasks:
         command: |
           if [ "$LAGOON_ENVIRONMENT_TYPE" = "production" ] || [ "$LAGOON_GIT_BRANCH" = "${VORTEX_LAGOON_PRODUCTION_BRANCH:-main}" ]; then
             echo "==> Running in PRODUCTION environment."
-            VORTEX_DB_DIR=/app/web/sites/default/files/private/pre_deployment_backups ./vendor/drevops/vortex-tooling/src/export-db-file
+            VORTEX_DB_DIR=/app/web/sites/default/files/private/pre_deployment_backups ./vendor/drevops/vortex-tooling/src/export-db
           fi
         service: cli
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_lagoon/.lagoon.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_lagoon/.lagoon.yml
@@ -41,7 +41,7 @@ tasks:
         command: |
           if [ "$LAGOON_ENVIRONMENT_TYPE" = "production" ] || [ "$LAGOON_GIT_BRANCH" = "${VORTEX_LAGOON_PRODUCTION_BRANCH:-main}" ]; then
             echo "==> Running in PRODUCTION environment."
-            VORTEX_DB_DIR=/app/web/sites/default/files/private/pre_deployment_backups ./vendor/drevops/vortex-tooling/src/export-db-file
+            VORTEX_DB_DIR=/app/web/sites/default/files/private/pre_deployment_backups ./vendor/drevops/vortex-tooling/src/export-db
           fi
         service: cli
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.lagoon.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.lagoon.yml
@@ -41,7 +41,7 @@ tasks:
         command: |
           if [ "$LAGOON_ENVIRONMENT_TYPE" = "production" ] || [ "$LAGOON_GIT_BRANCH" = "${VORTEX_LAGOON_PRODUCTION_BRANCH:-main}" ]; then
             echo "==> Running in PRODUCTION environment."
-            VORTEX_DB_DIR=/app/web/sites/default/files/private/pre_deployment_backups ./vendor/drevops/vortex-tooling/src/export-db-file
+            VORTEX_DB_DIR=/app/web/sites/default/files/private/pre_deployment_backups ./vendor/drevops/vortex-tooling/src/export-db
           fi
         service: cli
 

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_database_lagoon/.lagoon.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_database_lagoon/.lagoon.yml
@@ -41,7 +41,7 @@ tasks:
         command: |
           if [ "$LAGOON_ENVIRONMENT_TYPE" = "production" ] || [ "$LAGOON_GIT_BRANCH" = "${VORTEX_LAGOON_PRODUCTION_BRANCH:-main}" ]; then
             echo "==> Running in PRODUCTION environment."
-            VORTEX_DB_DIR=/app/web/sites/default/files/private/pre_deployment_backups ./vendor/drevops/vortex-tooling/src/export-db-file
+            VORTEX_DB_DIR=/app/web/sites/default/files/private/pre_deployment_backups ./vendor/drevops/vortex-tooling/src/export-db
           fi
         service: cli
 

--- a/.vortex/tooling/src/export-db
+++ b/.vortex/tooling/src/export-db
@@ -26,29 +26,26 @@ note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
 fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+is_host() { [ "${RUN_ON_HOST:-$(command -v docker >/dev/null 2>&1 && echo 1 || echo 0)}" = 1 ]; }
 # @formatter:on
-
-#shellcheck disable=SC2043
-for cmd in docker; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
 
 info "Started database export."
 
-if [ -z "${VORTEX_EXPORT_DB_IMAGE}" ]; then
-  # Export database as a file.
-  docker compose exec -T cli ./vendor/drevops/vortex-tooling/src/export-db-file "$@"
-else
-  # Export database as a container image.
-  VORTEX_EXPORT_DB_IMAGE="${VORTEX_EXPORT_DB_IMAGE}" "$(dirname "${BASH_SOURCE[0]}")/export-db-image" "$@"
+if is_host; then
+  if [ -z "${VORTEX_EXPORT_DB_IMAGE}" ]; then
+    docker compose exec -T cli ./vendor/drevops/vortex-tooling/src/export-db-file "$@"
+  else
+    VORTEX_EXPORT_DB_IMAGE="${VORTEX_EXPORT_DB_IMAGE}" "$(dirname "${BASH_SOURCE[0]}")/export-db-image" "$@"
 
-  # Deploy container image.
-  # @todo Move deployment into a separate script.
-  if [ "${VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED:-}" = "1" ]; then
-    VORTEX_DEPLOY_CONTAINER_REGISTRY_MAP=database=${VORTEX_EXPORT_DB_IMAGE} \
-      "$(dirname "${BASH_SOURCE[0]}")/deploy-container-registry"
+    # Deploy container image.
+    # @todo Move deployment into a separate script.
+    if [ "${VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED:-}" = "1" ]; then
+      VORTEX_DEPLOY_CONTAINER_REGISTRY_MAP=database=${VORTEX_EXPORT_DB_IMAGE} \
+        "$(dirname "${BASH_SOURCE[0]}")/deploy-container-registry"
+    fi
   fi
+else
+  "$(dirname "${BASH_SOURCE[0]}")/export-db-file" "$@"
 fi
 
 pass "Finished database export."

--- a/.vortex/tooling/tests/unit/export-db.bats
+++ b/.vortex/tooling/tests/unit/export-db.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+##
+# Unit tests for export-db router script.
+#
+# shellcheck disable=SC2030,SC2031
+
+load ../_helper.bash
+
+@test "export-db: Exports as a file in place when not on the host" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export RUN_ON_HOST=0
+
+  mock_docker=$(mock_command "docker")
+  mock_export_db_file=$(mock_command ".vortex/tooling/src/export-db-file")
+  mock_set_output "${mock_export_db_file}" "Exported in place." 1
+
+  run .vortex/tooling/src/export-db
+  assert_success
+  assert_output_contains "Started database export."
+  assert_output_contains "Exported in place."
+  assert_output_contains "Finished database export."
+
+  assert_equal "1" "$(mock_get_call_num "${mock_export_db_file}")"
+  assert_equal "0" "$(mock_get_call_num "${mock_docker}")"
+
+  popd >/dev/null
+}
+
+@test "export-db: Exports as a file through Docker Compose on the host" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export RUN_ON_HOST=1
+
+  mock_docker=$(mock_command "docker")
+  mock_set_output "${mock_docker}" "Exported through Docker Compose." 1
+
+  run .vortex/tooling/src/export-db
+  assert_success
+  assert_output_contains "Exported through Docker Compose."
+  assert_output_contains "Finished database export."
+
+  assert_equal "1" "$(mock_get_call_num "${mock_docker}")"
+  assert_equal "compose exec -T cli ./vendor/drevops/vortex-tooling/src/export-db-file" "$(mock_get_call_args "${mock_docker}" 1)"
+
+  popd >/dev/null
+}
+
+@test "export-db: Detects the host from the Docker CLI when the override is unset" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  mock_docker=$(mock_command "docker")
+  mock_set_output "${mock_docker}" "Exported through detected Docker." 1
+
+  run .vortex/tooling/src/export-db
+  assert_success
+  assert_output_contains "Exported through detected Docker."
+
+  assert_equal "1" "$(mock_get_call_num "${mock_docker}")"
+
+  popd >/dev/null
+}
+
+@test "export-db: Exports as a container image on the host when an image name is set" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export RUN_ON_HOST=1
+  export VORTEX_EXPORT_DB_IMAGE="myorg/myapp"
+
+  mock_export_db_image=$(mock_command ".vortex/tooling/src/export-db-image")
+  mock_set_output "${mock_export_db_image}" "Exported as a container image." 1
+  mock_deploy=$(mock_command ".vortex/tooling/src/deploy-container-registry")
+
+  run .vortex/tooling/src/export-db
+  assert_success
+  assert_output_contains "Exported as a container image."
+  assert_output_contains "Finished database export."
+
+  assert_equal "1" "$(mock_get_call_num "${mock_export_db_image}")"
+  assert_equal "0" "$(mock_get_call_num "${mock_deploy}")"
+
+  popd >/dev/null
+}
+
+@test "export-db: Deploys the container image when deployment is requested" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export RUN_ON_HOST=1
+  export VORTEX_EXPORT_DB_IMAGE="myorg/myapp"
+  export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=1
+
+  mock_export_db_image=$(mock_command ".vortex/tooling/src/export-db-image")
+  mock_set_output "${mock_export_db_image}" "Exported as a container image." 1
+  mock_deploy=$(mock_command ".vortex/tooling/src/deploy-container-registry")
+  mock_set_output "${mock_deploy}" "Deployed the container image." 1
+
+  run .vortex/tooling/src/export-db
+  assert_success
+  assert_output_contains "Exported as a container image."
+  assert_output_contains "Deployed the container image."
+
+  assert_equal "1" "$(mock_get_call_num "${mock_export_db_image}")"
+  assert_equal "1" "$(mock_get_call_num "${mock_deploy}")"
+
+  popd >/dev/null
+}

--- a/.vortex/tooling/tests/unit/export-db.bats
+++ b/.vortex/tooling/tests/unit/export-db.bats
@@ -6,22 +6,28 @@
 
 load ../_helper.bash
 
+# Replaces a sibling tooling script with a stub that prints a marker. The router
+# dispatches to siblings by explicit path, so a PATH-based mock cannot intercept
+# them - the file itself must be replaced.
+stub_sibling() {
+  mkdir -p .vortex/tooling/src
+  printf '#!/usr/bin/env bash\necho "%s"\n' "${2}" >".vortex/tooling/src/${1}"
+  chmod +x ".vortex/tooling/src/${1}"
+}
+
 @test "export-db: Exports as a file in place when not on the host" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
   export RUN_ON_HOST=0
 
   mock_docker=$(mock_command "docker")
-  mock_export_db_file=$(mock_command ".vortex/tooling/src/export-db-file")
-  mock_set_output "${mock_export_db_file}" "Exported in place." 1
+  stub_sibling "export-db-file" "Exported in place."
 
   run .vortex/tooling/src/export-db
   assert_success
   assert_output_contains "Started database export."
   assert_output_contains "Exported in place."
   assert_output_contains "Finished database export."
-
-  assert_equal "1" "$(mock_get_call_num "${mock_export_db_file}")"
   assert_equal "0" "$(mock_get_call_num "${mock_docker}")"
 
   popd >/dev/null
@@ -39,7 +45,6 @@ load ../_helper.bash
   assert_success
   assert_output_contains "Exported through Docker Compose."
   assert_output_contains "Finished database export."
-
   assert_equal "1" "$(mock_get_call_num "${mock_docker}")"
   assert_equal "compose exec -T cli ./vendor/drevops/vortex-tooling/src/export-db-file" "$(mock_get_call_args "${mock_docker}" 1)"
 
@@ -55,7 +60,6 @@ load ../_helper.bash
   run .vortex/tooling/src/export-db
   assert_success
   assert_output_contains "Exported through detected Docker."
-
   assert_equal "1" "$(mock_get_call_num "${mock_docker}")"
 
   popd >/dev/null
@@ -67,17 +71,14 @@ load ../_helper.bash
   export RUN_ON_HOST=1
   export VORTEX_EXPORT_DB_IMAGE="myorg/myapp"
 
-  mock_export_db_image=$(mock_command ".vortex/tooling/src/export-db-image")
-  mock_set_output "${mock_export_db_image}" "Exported as a container image." 1
-  mock_deploy=$(mock_command ".vortex/tooling/src/deploy-container-registry")
+  stub_sibling "export-db-image" "Exported as a container image."
+  stub_sibling "deploy-container-registry" "Deployed the container image."
 
   run .vortex/tooling/src/export-db
   assert_success
   assert_output_contains "Exported as a container image."
   assert_output_contains "Finished database export."
-
-  assert_equal "1" "$(mock_get_call_num "${mock_export_db_image}")"
-  assert_equal "0" "$(mock_get_call_num "${mock_deploy}")"
+  assert_output_not_contains "Deployed the container image."
 
   popd >/dev/null
 }
@@ -89,18 +90,13 @@ load ../_helper.bash
   export VORTEX_EXPORT_DB_IMAGE="myorg/myapp"
   export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=1
 
-  mock_export_db_image=$(mock_command ".vortex/tooling/src/export-db-image")
-  mock_set_output "${mock_export_db_image}" "Exported as a container image." 1
-  mock_deploy=$(mock_command ".vortex/tooling/src/deploy-container-registry")
-  mock_set_output "${mock_deploy}" "Deployed the container image." 1
+  stub_sibling "export-db-image" "Exported as a container image."
+  stub_sibling "deploy-container-registry" "Deployed the container image."
 
   run .vortex/tooling/src/export-db
   assert_success
   assert_output_contains "Exported as a container image."
   assert_output_contains "Deployed the container image."
-
-  assert_equal "1" "$(mock_get_call_num "${mock_export_db_image}")"
-  assert_equal "1" "$(mock_get_call_num "${mock_deploy}")"
 
   popd >/dev/null
 }


### PR DESCRIPTION
Closes #2718

## Summary

Switches the Lagoon pre-deployment database backup from calling `export-db-file` directly to calling the public `export-db` router. The router now detects whether it is running on the host (via a `RUN_ON_HOST` override or presence of `docker` in `PATH`) and dispatches accordingly: inside a Lagoon container (off-host) it runs `export-db-file` in place without requiring Docker, while on the host it continues to use `docker compose exec` for file exports or `export-db-image` for image exports. Unit tests cover all dispatch paths.

## Changes

- `.lagoon.yml`: replaced `export-db-file` with `export-db` in the pre-deployment backup task; `VORTEX_DB_DIR` preserved, no new flags added.
- `.vortex/tooling/src/export-db`: added `is_host()` helper (honours `RUN_ON_HOST` override, else probes `command -v docker`); restructured dispatch so off-host runs `export-db-file` in place and on-host continues the existing Docker Compose / image paths; removed the hard `docker` dependency check that blocked container-side execution.
- `.vortex/tooling/tests/unit/export-db.bats`: new unit tests covering in-place file export (off-host), Docker Compose file export (on-host), auto-detection via Docker CLI, image export, and image export with registry deployment.
- 5 installer Lagoon fixture snapshots regenerated to reflect the `.lagoon.yml` change.

## Before / After

```
BEFORE
──────
.lagoon.yml pre-deploy task
  └─ calls export-db-file directly
       └─ runs inside Lagoon container
            └─ FAIL: export-db-file is an internal script;
                      export-db required Docker (unavailable in container)

export-db (host-only)
  ├─ requires docker in PATH (hard check, exits if missing)
  ├─ no image → docker compose exec ... export-db-file
  └─ image set → export-db-image [→ deploy-container-registry]

AFTER
─────
.lagoon.yml pre-deploy task
  └─ calls export-db (public router)
       └─ is_host()? NO (inside Lagoon container, no docker)
            └─ runs export-db-file in place (no Docker needed) ✓

export-db (host + container aware)
  ├─ is_host()? YES (docker found or RUN_ON_HOST=1)
  │    ├─ no image → docker compose exec -T cli export-db-file
  │    └─ image set → export-db-image [→ deploy-container-registry]
  └─ is_host()? NO
       └─ export-db-file in place (zero Docker dependency)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database export now automatically chooses the appropriate execution mode based on the environment, improving reliability across host and container setups.
  * Production backup handling now uses the updated database export flow during rollout.

* **Bug Fixes**
  * Improved consistency for database backup and export operations by simplifying how the export path is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->