### PR TITLE
[#2723] Extracted the container image deployment from 'export-db' into a dedicated script.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       #;< MIGRATION
@@ -278,7 +278,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -286,6 +286,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.circleci/vortex-test-common.yml
+++ b/.circleci/vortex-test-common.yml
@@ -142,7 +142,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       #;< MIGRATION
@@ -161,7 +161,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -169,6 +169,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -285,7 +285,7 @@ jobs:
 
       - name: Fetch DB
         run: |
-          VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
         timeout-minutes: 30
         #;< DB_FETCH_SOURCE_ACQUIA
@@ -301,7 +301,7 @@ jobs:
 
       - name: Export DB
         run: |
-          if [ ! -f /tmp/fetch-db-success ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
+          if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
           ./vendor/drevops/vortex-tooling/src/login-container-registry
           docker compose up --detach && sleep 15
           docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -257,13 +257,13 @@ jobs:
 
       - name: Fetch DB
         run: |
-          VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
         timeout-minutes: 30
 
       - name: Export DB
         run: |
-          if [ ! -f /tmp/fetch-db-success ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
+          if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
           ./vendor/drevops/vortex-tooling/src/login-container-registry
           docker compose up --detach && sleep 15
           docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -245,7 +245,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -253,6 +253,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -245,7 +245,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -253,6 +253,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/db_fetch_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/db_fetch_source_acquia/.github/workflows/build-test-deploy.yml
@@ -1,5 +1,5 @@
 @@ -260,6 +260,9 @@
-           VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+           VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
 +        env:

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -245,7 +245,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -253,6 +253,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -245,7 +245,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -253,6 +253,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -245,7 +245,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -253,6 +253,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/.github/workflows/build-test-deploy.yml
@@ -1,5 +1,5 @@
 @@ -260,6 +260,9 @@
-           VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+           VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
 +        env:

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/.github/workflows/build-test-deploy.yml
@@ -1,5 +1,5 @@
 @@ -260,6 +260,9 @@
-           VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+           VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
            echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
          timeout-minutes: 30
 +        env:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -245,7 +245,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -253,6 +253,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
@@ -7,7 +7,7 @@
 +
        - name: Export DB
          run: |
-           if [ ! -f /tmp/fetch-db-success ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
+           if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -395,6 +398,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       - run:
@@ -250,7 +250,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -258,6 +258,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
@@ -7,7 +7,7 @@
 +
        - name: Export DB
          run: |
-           if [ ! -f /tmp/fetch-db-success ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
+           if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -395,6 +398,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.github/workflows/build-test-deploy.yml
@@ -7,7 +7,7 @@
 +
        - name: Export DB
          run: |
-           if [ ! -f /tmp/fetch-db-success ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
+           if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -395,6 +398,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.github/workflows/build-test-deploy.yml
@@ -7,7 +7,7 @@
 +
        - name: Export DB
          run: |
-           if [ ! -f /tmp/fetch-db-success ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
+           if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -395,6 +398,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.github/workflows/build-test-deploy.yml
@@ -7,7 +7,7 @@
 +
        - name: Export DB
          run: |
-           if [ ! -f /tmp/fetch-db-success ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
+           if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -395,6 +398,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.github/workflows/build-test-deploy.yml
@@ -7,7 +7,7 @@
 +
        - name: Export DB
          run: |
-           if [ ! -f /tmp/fetch-db-success ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
+           if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -395,6 +398,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.github/workflows/build-test-deploy.yml
@@ -7,7 +7,7 @@
 +
        - name: Export DB
          run: |
-           if [ ! -f /tmp/fetch-db-success ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
+           if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -395,6 +398,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.github/workflows/build-test-deploy.yml
@@ -7,7 +7,7 @@
 +
        - name: Export DB
          run: |
-           if [ ! -f /tmp/fetch-db-success ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
+           if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -395,6 +398,10 @@
            if [ -f .data/db.sql ]; then
              docker compose exec cli mkdir -p .data

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -101,13 +101,13 @@
 -
 -      - name: Fetch DB
 -        run: |
--          VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+-          VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
 -          echo "db_hash=${{ hashFiles('.data') }}" >> "$GITHUB_ENV"
 -        timeout-minutes: 30
 -
 -      - name: Export DB
 -        run: |
--          if [ ! -f /tmp/fetch-db-success ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
+-          if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 -          ./vendor/drevops/vortex-tooling/src/login-container-registry
 -          docker compose up --detach && sleep 15
 -          docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -245,7 +245,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -253,6 +253,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -221,7 +221,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -233,7 +233,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -241,6 +241,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -241,7 +241,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -249,6 +249,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
@@ -228,7 +228,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -240,7 +240,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -248,6 +248,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -234,7 +234,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -242,6 +242,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -241,7 +241,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -249,6 +249,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
@@ -228,7 +228,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -240,7 +240,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -248,6 +248,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -245,7 +245,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -253,6 +253,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -241,7 +241,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -249,6 +249,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -241,7 +241,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -249,6 +249,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -245,7 +245,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -253,6 +253,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -241,7 +241,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -249,6 +249,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
 
       - run:
           name: Fetch DB
-          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-success ./vendor/drevops/vortex-tooling/src/fetch-db
+          command: VORTEX_FETCH_DB_SEMAPHORE=/tmp/fetch-db-fresh ./vendor/drevops/vortex-tooling/src/fetch-db
           no_output_timeout: 30m
 
       # Execute commands after database fetch script finished: if the
@@ -245,7 +245,7 @@ jobs:
       - run:
           name: Export DB after fetch
           command: |
-            [ ! -f /tmp/fetch-db-success ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/drevops/vortex-tooling/src/login-container-registry
             docker compose up --detach && sleep 15
             docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
@@ -253,6 +253,18 @@ jobs:
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/drevops/vortex-tooling/src/export-db db.sql
             docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+          no_output_timeout: 30m
+
+      # Deploy the freshly-exported database image to the container registry.
+      # No-op unless a fresh DB was fetched (the fetch semaphore), the project
+      # uses database-in-image storage (VORTEX_DB_IMAGE), and deployment was
+      # requested (VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED, in the script).
+      - run:
+          name: Deploy DB image
+          command: |
+            [ -z "${VORTEX_DB_IMAGE:-}" ] && echo "==> Database-in-image storage is not used. DB image deployment will not proceed." && exit 0
+            [ ! -f /tmp/fetch-db-fresh ] && echo "==> No freshly fetched database. DB image deployment will not proceed." && exit 0
+            ./vendor/drevops/vortex-tooling/src/deploy-db-image
           no_output_timeout: 30m
 
       - save_cache:

--- a/.vortex/tooling/src/deploy-db-image
+++ b/.vortex/tooling/src/deploy-db-image
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 ##
-# Export database.
+# Deploy exported database container image to the container registry.
 #
-# This is a router script to call relevant scripts based on type.
-#
-# IMPORTANT! This script runs on the host or inside the container, routing the
-# work to the appropriate location.
+# IMPORTANT! This script runs outside the container on the host system.
 #
 # shellcheck disable=SC1090,SC1091
 
@@ -14,9 +11,7 @@ t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && if [ -f ./.env.local ]
 set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
-# Name of the database container image to use. Uncomment to use an image with
-# a DB data loaded into it.
-# @see https://github.com/drevops/mariadb-drupal-data to seed your DB image.
+# Container image to deploy in a form of `<org>/<repository>`.
 VORTEX_EXPORT_DB_IMAGE="${VORTEX_EXPORT_DB_IMAGE:-${VORTEX_DB_IMAGE:-}}"
 
 # ------------------------------------------------------------------------------
@@ -27,19 +22,14 @@ note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
 fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
-is_host() { [ "${RUN_ON_HOST:-$(command -v docker >/dev/null 2>&1 && echo 1 || echo 0)}" = 1 ]; }
 # @formatter:on
 
-info "Started database export."
+info "Started database container image deployment."
 
-if is_host; then
-  if [ -z "${VORTEX_EXPORT_DB_IMAGE}" ]; then
-    docker compose exec -T cli ./vendor/drevops/vortex-tooling/src/export-db-file "$@"
-  else
-    VORTEX_EXPORT_DB_IMAGE="${VORTEX_EXPORT_DB_IMAGE}" "$(dirname "${BASH_SOURCE[0]}")/export-db-image" "$@"
-  fi
-else
-  "$(dirname "${BASH_SOURCE[0]}")/export-db-file" "$@"
-fi
+[ "${VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED:-}" != "1" ] && pass "Skipped database container image deployment as VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED is not set to 1." && exit 0
 
-pass "Finished database export."
+[ -z "${VORTEX_EXPORT_DB_IMAGE}" ] && fail "Container image name is not specified. Please provide container image as a variable VORTEX_EXPORT_DB_IMAGE in a format <org>/<repository>." && exit 1
+
+VORTEX_DEPLOY_CONTAINER_REGISTRY_MAP="database=${VORTEX_EXPORT_DB_IMAGE}" "$(dirname "${BASH_SOURCE[0]}")/deploy-container-registry"
+
+pass "Finished database container image deployment."

--- a/.vortex/tooling/tests/unit/deploy-db-image.bats
+++ b/.vortex/tooling/tests/unit/deploy-db-image.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+##
+# Unit tests for deploy-db-image script.
+#
+# The stub map markers use single quotes on purpose: the `${...}` must reach the
+# generated stub literally and expand when the stub runs, not when the test
+# calls stub_sibling - so SC2016 is suppressed here.
+#
+# shellcheck disable=SC2016,SC2030,SC2031
+
+load ../_helper.bash
+
+# Replaces a sibling tooling script with a stub that prints a marker. The script
+# dispatches to siblings by explicit path, so a PATH-based mock cannot intercept
+# them - the file itself must be replaced.
+stub_sibling() {
+  mkdir -p .vortex/tooling/src
+  printf '#!/usr/bin/env bash\necho "%s"\n' "${2}" >".vortex/tooling/src/${1}"
+  chmod +x ".vortex/tooling/src/${1}"
+}
+
+@test "deploy-db-image: Skips deployment when it is not requested" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  unset VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED
+  export VORTEX_EXPORT_DB_IMAGE="myorg/myapp"
+
+  stub_sibling "deploy-container-registry" "Deployed the container image."
+
+  run .vortex/tooling/src/deploy-db-image
+  assert_success
+  assert_output_contains "Skipped database container image deployment as VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED is not set to 1."
+  assert_output_not_contains "Deployed the container image."
+
+  popd >/dev/null
+}
+
+@test "deploy-db-image: Deploys the image when requested" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=1
+  export VORTEX_EXPORT_DB_IMAGE="myorg/myapp"
+
+  stub_sibling "deploy-container-registry" 'Deployed with map: ${VORTEX_DEPLOY_CONTAINER_REGISTRY_MAP}'
+
+  run .vortex/tooling/src/deploy-db-image
+  assert_success
+  assert_output_contains "Started database container image deployment."
+  assert_output_contains "Deployed with map: database=myorg/myapp"
+  assert_output_contains "Finished database container image deployment."
+
+  popd >/dev/null
+}
+
+@test "deploy-db-image: Resolves the image from VORTEX_DB_IMAGE when VORTEX_EXPORT_DB_IMAGE is not set" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=1
+  unset VORTEX_EXPORT_DB_IMAGE
+  export VORTEX_DB_IMAGE="myorg/fallback"
+
+  stub_sibling "deploy-container-registry" 'Deployed with map: ${VORTEX_DEPLOY_CONTAINER_REGISTRY_MAP}'
+
+  run .vortex/tooling/src/deploy-db-image
+  assert_success
+  assert_output_contains "Deployed with map: database=myorg/fallback"
+
+  popd >/dev/null
+}
+
+@test "deploy-db-image: Fails when the image name is not specified" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=1
+  unset VORTEX_EXPORT_DB_IMAGE
+  unset VORTEX_DB_IMAGE
+
+  run .vortex/tooling/src/deploy-db-image
+  assert_failure
+  assert_output_contains "Container image name is not specified."
+
+  popd >/dev/null
+}
+
+@test "deploy-db-image: Fails when the container registry deployment fails" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=1
+  export VORTEX_EXPORT_DB_IMAGE="myorg/myapp"
+
+  mkdir -p .vortex/tooling/src
+  printf '#!/usr/bin/env bash\nexit 1\n' >.vortex/tooling/src/deploy-container-registry
+  chmod +x .vortex/tooling/src/deploy-container-registry
+
+  run .vortex/tooling/src/deploy-db-image
+  assert_failure
+  assert_output_contains "Started database container image deployment."
+  assert_output_not_contains "Finished database container image deployment."
+
+  popd >/dev/null
+}

--- a/.vortex/tooling/tests/unit/export-db.bats
+++ b/.vortex/tooling/tests/unit/export-db.bats
@@ -72,31 +72,11 @@ stub_sibling() {
   export VORTEX_EXPORT_DB_IMAGE="myorg/myapp"
 
   stub_sibling "export-db-image" "Exported as a container image."
-  stub_sibling "deploy-container-registry" "Deployed the container image."
 
   run .vortex/tooling/src/export-db
   assert_success
   assert_output_contains "Exported as a container image."
   assert_output_contains "Finished database export."
-  assert_output_not_contains "Deployed the container image."
-
-  popd >/dev/null
-}
-
-@test "export-db: Deploys the container image when deployment is requested" {
-  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
-
-  export RUN_ON_HOST=1
-  export VORTEX_EXPORT_DB_IMAGE="myorg/myapp"
-  export VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=1
-
-  stub_sibling "export-db-image" "Exported as a container image."
-  stub_sibling "deploy-container-registry" "Deployed the container image."
-
-  run .vortex/tooling/src/export-db
-  assert_success
-  assert_output_contains "Exported as a container image."
-  assert_output_contains "Deployed the container image."
 
   popd >/dev/null
 }


### PR DESCRIPTION
Closes #2723

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#123] Verb in past tense.`
- [x] Ticket number `#2723` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Added `.vortex/tooling/src/deploy-db-image`: a dedicated, independently-callable script that deploys an exported database container image to the container registry. It is gated by `VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED`, resolves `VORTEX_EXPORT_DB_IMAGE` (falling back to `VORTEX_DB_IMAGE`), builds `VORTEX_DEPLOY_CONTAINER_REGISTRY_MAP=database=<image>`, and delegates to `deploy-container-registry`.
2. Reduced `.vortex/tooling/src/export-db` to a pure exporter: removed the inline container-registry deployment and the `# @todo Move deployment into a separate script.` comment. `export-db` now only exports a database (file or image) and no longer knows anything about deployment.
3. Wired the deployment as a separate `Deploy DB image` step in the CircleCI `database` job (`.circleci/config.yml`), after `Export DB after fetch`. It is a no-op unless the project uses database-in-image storage (`VORTEX_DB_IMAGE`) and a fresh database was fetched this run (the `/tmp/fetch-db-fresh` semaphore); `deploy-db-image` then additionally requires `VORTEX_EXPORT_DB_CONTAINER_REGISTRY_DEPLOY_PROCEED=1`. This preserves the prior behaviour (only the CircleCI nightly job deploys) while taking deployment out of `export-db`.
4. Renamed the fetch semaphore file from `/tmp/fetch-db-success` to `/tmp/fetch-db-fresh` (in both `.circleci/config.yml` and `.github/workflows/build-test-deploy.yml`), since `fetch-db` writes it only on a genuine fresh fetch, not on a cache hit - the name now states what the file means.
5. Regenerated `.circleci/vortex-test-common.yml` (via `php .vortex/tests/generate-vortex-dev-circleci`) and the installer fixtures (via `ahoy update-snapshots`).
6. Added `.vortex/tooling/tests/unit/deploy-db-image.bats` (5 tests: skips when deployment is not requested; deploys with the correct registry map; resolves the image from the `VORTEX_DB_IMAGE` fallback; fails when no image name is set; fails when the registry deployment fails). Updated `.vortex/tooling/tests/unit/export-db.bats` to assert `export-db` only exports, removing the deploy assertions since deployment has left `export-db`.

## Screenshots

N/A

## Before / After

```
BEFORE - deployment is fused into the exporter
────────────────────────────────────────────────────────────────
CI "Export DB after fetch" step  (gated: fresh fetch)
  └── export-db db.sql
        └── export-db-image                       image built
              └── if PROCEED=1                     ← deploy lives
                    deploy-container-registry         inside export

AFTER - export and deploy are separate steps, each gated
────────────────────────────────────────────────────────────────
CI "Export DB after fetch" step  (gated: fresh fetch)
  └── export-db db.sql
        └── export-db-image                       image built

CI "Deploy DB image" step
  ├── gate: VORTEX_DB_IMAGE set              (database-in-image)
  ├── gate: /tmp/fetch-db-fresh present      (fresh DB this run)
  └── deploy-db-image
        └── gate: PROCEED=1                   (operator opt-in)
              VORTEX_DEPLOY_CONTAINER_REGISTRY_MAP=database=<image>
                deploy-container-registry
```
