### PR TITLE
[#2729] Clarified that 'export-db' and 'import-db' run on the host or in the container.

### DIFF
--- a/.vortex/tooling/src/export-db
+++ b/.vortex/tooling/src/export-db
@@ -4,7 +4,8 @@
 #
 # This is a router script to call relevant scripts based on type.
 #
-# IMPORTANT! This script runs outside the container on the host system.
+# IMPORTANT! This script runs on the host or inside the container, routing the
+# work to the appropriate location.
 #
 # shellcheck disable=SC1090,SC1091
 

--- a/.vortex/tooling/src/import-db
+++ b/.vortex/tooling/src/import-db
@@ -4,7 +4,8 @@
 #
 # This is a router script to call relevant scripts based on type.
 #
-# IMPORTANT! This script runs outside the container on the host system.
+# IMPORTANT! This script runs on the host or inside the container, routing the
+# work to the appropriate location.
 #
 # shellcheck disable=SC1090,SC1091
 


### PR DESCRIPTION
Closes #2729

## Summary

Corrected the header comment in `export-db` and `import-db` to accurately describe their dual-mode routing behaviour. Both scripts define `is_host()` and either delegate into the container via `docker compose exec` (when running on the host) or execute the worker script directly (when already inside the container). The old comment falsely implied host-only execution. The other 18 tooling scripts that share the original wording are genuinely host-only and were intentionally left unchanged.

## Changes

- `.vortex/tooling/src/export-db` - updated header comment to reflect host-or-container routing.
- `.vortex/tooling/src/import-db` - same correction.

## Before / After

```
┌─────────────────────────────────────────────────────────────────────┐
│  BEFORE (misleading - implied host-only)                            │
├─────────────────────────────────────────────────────────────────────┤
│  # IMPORTANT! This script runs outside the container on the host    │
│  # system.                                                          │
└─────────────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────────┐
│  AFTER (accurate - describes dual-mode routing)                     │
├─────────────────────────────────────────────────────────────────────┤
│  # IMPORTANT! This script runs on the host or inside the            │
│  # container, routing the work to the appropriate location.         │
└─────────────────────────────────────────────────────────────────────┘

Routing logic (both scripts):

  HOST                              CONTAINER
  ┌──────────────────┐              ┌──────────────────────────┐
  │  export-db /     │─is_host()──▶ │  docker compose exec -T  │
  │  import-db       │    true      │  cli ./<worker>-db-file  │
  │  (router)        │              └──────────────────────────┘
  │                  │─is_host()──▶ runs <worker>-db-file
  │                  │    false       directly in place
  └──────────────────┘
```
