### PR TITLE
[#2731] Documented tagging 'drevops/vortex-tooling' before each Vortex release.

### DIFF
--- a/.vortex/docs/content/contributing/maintenance/_release_template.md
+++ b/.vortex/docs/content/contributing/maintenance/_release_template.md
@@ -70,10 +70,12 @@
 - [ ] Updated PHP version in `phpcs.xml` for `testVersion`.
 - [ ] Updated PHP version in `phpstan.neon` for `phpVersion`.
 - [ ] Updated minor version of all packages in `composer.json`.
+- [ ] Tagged `drevops/vortex-tooling` before the Vortex tag when the tooling changed, and pinned the freshly tagged version as the upper boundary in `composer.json`.
 - [ ] Updated minor version of dependencies in theme's `package.json`.
 - [ ] Update `drevops/ci-runner` to the latest version in `.circleci/config.yml` and `.github/workflows/build-test-deploy.yml`.
 - [ ] Incremented the cache version in `.circleci/config.yml` and `.github/workflows/build-test-deploy.yml`.
 - [ ] Updated documentation.
+- [ ] Tagged the Vortex release.
 
 ---
 

--- a/.vortex/docs/content/contributing/maintenance/release.mdx
+++ b/.vortex/docs/content/contributing/maintenance/release.mdx
@@ -73,7 +73,7 @@ The following rules apply to every release:
 1. **Vortex is always tagged.** A release always creates the **Vortex** tag, whether or not the tooling changed.
 2. **The tooling is always referenced by a tag.** The `drevops/vortex-tooling` requirement in **Vortex**'s root `composer.json` must point at a published tag - never a branch or a development alias.
 3. **The tooling is tagged before Vortex when it changed.** When `.vortex/tooling/` has changed since the previous **Vortex** release, create and publish the new `drevops/vortex-tooling` tag *before* tagging **Vortex**.
-4. **Vortex pins the new tooling tag as its upper boundary.** When the tooling is tagged for a release, require that freshly tagged `drevops/vortex-tooling` version in root `composer.json` with a tilde constraint (for example `~1.3.0`), so the upper boundary stays within the tagged minor and the release cannot float onto a tooling version that was never released with it.
+4. **Vortex caps its tooling requirement at the tagged version.** When the tooling is tagged for a release, require that freshly tagged `drevops/vortex-tooling` version in root `composer.json` with a tilde constraint (for example `~1.3.0`). This makes the freshly tagged version the upper boundary of the requirement at the minor level: later patch releases within the same minor are still accepted, but the requirement cannot float onto a newer minor that was never published with the release.
 
 ## Release Process
 
@@ -89,7 +89,7 @@ renovate --schedule= --force-cli=true drevops/vortex
 4. Update PHP version in `phpcs.xml` for `testVersion`.
 5. Update PHP version in `phpstan.neon` for `phpVersion`. Run `php -r "echo PHP_VERSION_ID . PHP_EOL;"` in the container to get the current PHP version.
 6. Tag `drevops/vortex-tooling` first when it changed. If `.vortex/tooling/` changed since the previous release, create and publish a new `drevops/vortex-tooling` tag now - before the **Vortex** tag (see [Tagging](#tagging)).
-7. Increment minor version of all packages in `composer.json`. Run `composer update -W && composer bump`. When the tooling was tagged in the previous step, pin the `drevops/vortex-tooling` constraint to that freshly tagged version as its upper boundary (for example `~1.3.0`); otherwise keep the existing tag constraint.
+7. Increment minor version of all packages in `composer.json`. Run `composer update -W && composer bump`. When the tooling was tagged in the previous step, require that freshly tagged `drevops/vortex-tooling` version with a tilde constraint (for example `~1.3.0`, see [Tagging](#tagging)); otherwise keep the existing tag constraint.
 8. Update minor version of dependencies in theme's `package.json`.
 9. Increment the cache version in `.circleci/config.yml` and `.github/workflows/build-test-deploy.yml`.
 10. Updated documentation with `cd .vortex && ahoy update-docs`.

--- a/.vortex/docs/content/contributing/maintenance/release.mdx
+++ b/.vortex/docs/content/contributing/maintenance/release.mdx
@@ -61,6 +61,20 @@ Consumer projects created from Vortex should continue to use Git Flow.
 
 :::
 
+## Tagging
+
+A release produces two tags, and their order is fixed: **tag the tooling first, then tag Vortex.**
+
+- **`drevops/vortex-tooling`** - the shipped tooling package, split from `.vortex/tooling/`. Its branches are mirrored to the package repository automatically, but tags are created manually as part of cutting a release.
+- **Vortex** - the template itself.
+
+The following rules apply to every release:
+
+1. **Vortex is always tagged.** A release always creates the **Vortex** tag, whether or not the tooling changed.
+2. **The tooling is always referenced by a tag.** The `drevops/vortex-tooling` requirement in **Vortex**'s root `composer.json` must point at a published tag - never a branch or a development alias.
+3. **The tooling is tagged before Vortex when it changed.** When `.vortex/tooling/` has changed since the previous **Vortex** release, create and publish the new `drevops/vortex-tooling` tag *before* tagging **Vortex**.
+4. **Vortex pins the tooling tag as its upper boundary.** Require the freshly tagged `drevops/vortex-tooling` version in root `composer.json` with a tilde constraint (for example `~1.3.0`), so the upper boundary stays within the tagged minor and the release cannot float onto a tooling version that was never released with it.
+
 ## Release Process
 
 Follow the steps below to release a new version of the Vortex:
@@ -74,12 +88,13 @@ renovate --schedule= --force-cli=true drevops/vortex
 3. Update PHP version in `composer.json` for `config.platform`.
 4. Update PHP version in `phpcs.xml` for `testVersion`.
 5. Update PHP version in `phpstan.neon` for `phpVersion`. Run `php -r "echo PHP_VERSION_ID . PHP_EOL;"` in the container to get the current PHP version.
-6. Increment minor version of all packages in `composer.json`. Run `composer update -W && composer bump`.
-7. Update minor version of dependencies in theme's `package.json`.
-8. Increment the cache version in `.circleci/config.yml` and `.github/workflows/build-test-deploy.yml`.
-9. Updated documentation with `cd .vortex && ahoy update-docs`.
-10. Update installer video with `cd .vortex && ahoy update-videos installer`.
-11. Create new release notes using release template:
+6. Tag `drevops/vortex-tooling` first when it changed. If `.vortex/tooling/` changed since the previous release, create and publish a new `drevops/vortex-tooling` tag now - before the **Vortex** tag (see [Tagging](#tagging)).
+7. Increment minor version of all packages in `composer.json`. Run `composer update -W && composer bump`. Then pin the `drevops/vortex-tooling` constraint to the freshly tagged version as its upper boundary (for example `~1.3.0`).
+8. Update minor version of dependencies in theme's `package.json`.
+9. Increment the cache version in `.circleci/config.yml` and `.github/workflows/build-test-deploy.yml`.
+10. Updated documentation with `cd .vortex && ahoy update-docs`.
+11. Update installer video with `cd .vortex && ahoy update-videos installer`.
+12. Tag the **Vortex** release and publish the GitHub release using the template below. **Vortex** is always tagged; when the tooling changed, its tag is created first (see [Tagging](#tagging)).
 
 import CodeBlock from '@theme/CodeBlock';
 import ReleaseTemplate from '!!raw-loader!./_release_template.md'

--- a/.vortex/docs/content/contributing/maintenance/release.mdx
+++ b/.vortex/docs/content/contributing/maintenance/release.mdx
@@ -63,7 +63,7 @@ Consumer projects created from Vortex should continue to use Git Flow.
 
 ## Tagging
 
-A release produces two tags, and their order is fixed: **tag the tooling first, then tag Vortex.**
+A release always produces a **Vortex** tag, and also a `drevops/vortex-tooling` tag when the tooling changed. When both are created, their order is fixed: **tag the tooling first, then tag Vortex.**
 
 - **`drevops/vortex-tooling`** - the shipped tooling package, split from `.vortex/tooling/`. Its branches are mirrored to the package repository automatically, but tags are created manually as part of cutting a release.
 - **Vortex** - the template itself.
@@ -73,7 +73,7 @@ The following rules apply to every release:
 1. **Vortex is always tagged.** A release always creates the **Vortex** tag, whether or not the tooling changed.
 2. **The tooling is always referenced by a tag.** The `drevops/vortex-tooling` requirement in **Vortex**'s root `composer.json` must point at a published tag - never a branch or a development alias.
 3. **The tooling is tagged before Vortex when it changed.** When `.vortex/tooling/` has changed since the previous **Vortex** release, create and publish the new `drevops/vortex-tooling` tag *before* tagging **Vortex**.
-4. **Vortex pins the tooling tag as its upper boundary.** Require the freshly tagged `drevops/vortex-tooling` version in root `composer.json` with a tilde constraint (for example `~1.3.0`), so the upper boundary stays within the tagged minor and the release cannot float onto a tooling version that was never released with it.
+4. **Vortex pins the new tooling tag as its upper boundary.** When the tooling is tagged for a release, require that freshly tagged `drevops/vortex-tooling` version in root `composer.json` with a tilde constraint (for example `~1.3.0`), so the upper boundary stays within the tagged minor and the release cannot float onto a tooling version that was never released with it.
 
 ## Release Process
 
@@ -89,7 +89,7 @@ renovate --schedule= --force-cli=true drevops/vortex
 4. Update PHP version in `phpcs.xml` for `testVersion`.
 5. Update PHP version in `phpstan.neon` for `phpVersion`. Run `php -r "echo PHP_VERSION_ID . PHP_EOL;"` in the container to get the current PHP version.
 6. Tag `drevops/vortex-tooling` first when it changed. If `.vortex/tooling/` changed since the previous release, create and publish a new `drevops/vortex-tooling` tag now - before the **Vortex** tag (see [Tagging](#tagging)).
-7. Increment minor version of all packages in `composer.json`. Run `composer update -W && composer bump`. Then pin the `drevops/vortex-tooling` constraint to the freshly tagged version as its upper boundary (for example `~1.3.0`).
+7. Increment minor version of all packages in `composer.json`. Run `composer update -W && composer bump`. When the tooling was tagged in the previous step, pin the `drevops/vortex-tooling` constraint to that freshly tagged version as its upper boundary (for example `~1.3.0`); otherwise keep the existing tag constraint.
 8. Update minor version of dependencies in theme's `package.json`.
 9. Increment the cache version in `.circleci/config.yml` and `.github/workflows/build-test-deploy.yml`.
 10. Updated documentation with `cd .vortex && ahoy update-docs`.


### PR DESCRIPTION
Closes #2731

## Summary

The release procedure for Vortex did not define any relationship between `drevops/vortex-tooling` tags and Vortex releases, leaving the tooling dependency free to float onto unpublished or future minor versions after a release was cut. This change documents the required tagging order (tooling first when changed, then Vortex), the tilde-constraint rule for pinning the tooling version in `composer.json`, and adds the corresponding checklist items to the release template so the steps are not missed during a release.

## Changes

**`.vortex/docs/content/contributing/maintenance/release.mdx`**

- Added a new `## Tagging` policy section above the Release Process that defines four rules: Vortex is always tagged; the tooling is always referenced by a published tag (never a branch); the tooling is tagged before Vortex when it changed; Vortex caps its tooling requirement at the freshly tagged version using a tilde constraint.
- Renumbered the Release Process steps (old 6-11 became 7-12) to insert step 6 ("Tag `drevops/vortex-tooling` first when it changed") and step 7 now also instructs the releaser to apply the tilde-constrained tooling version in `composer.json` when a new tooling tag was created.
- Step 12 (was 11) now explicitly states that Vortex is always tagged and, when the tooling changed, its tag must be created first.

**`.vortex/docs/content/contributing/maintenance/_release_template.md`**

- Added checklist item: "Tagged `drevops/vortex-tooling` before the Vortex tag when the tooling changed, and pinned the freshly tagged version as the upper boundary in `composer.json`."
- Added checklist item: "Tagged the Vortex release."

## Before / After

```
BEFORE
┌─────────────────────────────────────────────────────────────┐
│ Release Process                                             │
│                                                             │
│  Step 6: composer update -W && composer bump                │
│           (tooling constraint: floating, no upper bound)    │
│  Step 11: Create GitHub release                             │
│                                                             │
│  No tooling tag step                                        │
│  No ordering between tooling and Vortex tags                │
│  composer.json may reference a branch or float              │
└─────────────────────────────────────────────────────────────┘

AFTER
┌─────────────────────────────────────────────────────────────┐
│ Tagging policy (new section)                                │
│  1. Vortex is always tagged.                                │
│  2. Tooling is always referenced by a published tag.        │
│  3. Tooling is tagged before Vortex when it changed.        │
│  4. Vortex caps tooling at the tagged minor (~1.3.0).       │
│                                                             │
│ Release Process                                             │
│  Step 6: Tag drevops/vortex-tooling first (if changed)      │
│  Step 7: composer bump + pin tooling with tilde constraint  │
│  Step 12: Tag Vortex (tooling tag already published)        │
│                                                             │
│  Order enforced: tooling tag -> composer pin -> Vortex tag  │
└─────────────────────────────────────────────────────────────┘
```
