### PR TITLE
[#2725] Moved 'require-tooling' into the ahoy entrypoint.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -395,18 +395,19 @@ commands:
 # 2. Read variables from .env file (while respecting existing values) to load
 #    and pass updated environment variables' values into already running
 #    containers.
-# 3. Ensure the Vortex tooling package is present in vendor/ so host-side
-#    commands work on a fresh clone before a full 'composer install' has run.
-#    Only the top-level call runs the check; the exported sentinel makes the
-#    nested 'ahoy' calls that a command chains (e.g. 'ahoy build' runs 'ahoy
-#    reset', which removes vendor/) skip it and avoid a redundant reinstall.
+# 3. Ensure the Vortex tooling package is present in vendor/ (via
+#    'scripts/vortex-tooling.sh') so host-side commands work on a fresh clone
+#    before a full 'composer install' has run. Export AHOY_TOOLING_ENSURED so
+#    the nested 'ahoy' calls a command chains (e.g. 'ahoy build' runs 'ahoy
+#    reset', which removes vendor/) inherit it and skip the re-check.
 entrypoint:
   - bash
   - -c
   - -e
   - |
     t=$(mktemp) && export -p > "$t" && set -a && . ./.env && if [ -f ./.env.local ];then . ./.env.local;fi && set +a && . "$t" && rm "$t" && unset t
-    if [ -z "${AHOY_TOOLING_ENSURED:-}" ]; then export AHOY_TOOLING_ENSURED=1; ./scripts/vortex-tooling.sh; fi
+    ./scripts/vortex-tooling.sh
+    export AHOY_TOOLING_ENSURED=1
     bash -e -c "$0" "$@"
   - '{{cmd}}'
   - '{{name}}'

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -395,19 +395,15 @@ commands:
 # 2. Read variables from .env file (while respecting existing values) to load
 #    and pass updated environment variables' values into already running
 #    containers.
-# 3. Ensure the Vortex tooling package is present in vendor/ (via
-#    'scripts/vortex-tooling.sh') so host-side commands work on a fresh clone
-#    before a full 'composer install' has run. Export AHOY_TOOLING_ENSURED so
-#    the nested 'ahoy' calls a command chains (e.g. 'ahoy build' runs 'ahoy
-#    reset', which removes vendor/) inherit it and skip the re-check.
+# 3. Ensure the Vortex tooling package is present in vendor/ so host-side
+#    commands work on a fresh clone before a full 'composer install' has run.
 entrypoint:
   - bash
   - -c
   - -e
   - |
     t=$(mktemp) && export -p > "$t" && set -a && . ./.env && if [ -f ./.env.local ];then . ./.env.local;fi && set +a && . "$t" && rm "$t" && unset t
-    ./scripts/vortex-tooling.sh
-    export AHOY_TOOLING_ENSURED=1
+    if [ -z "${AHOY_VORTEX_TOOLING_READY:-}" ]; then export AHOY_VORTEX_TOOLING_READY=1; ./scripts/vortex-tooling.sh; fi
     bash -e -c "$0" "$@"
   - '{{cmd}}'
   - '{{name}}'

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -142,7 +142,6 @@ commands:
     usage: Fetch database. Run with "--fresh" option to force fresh database backup.
     aliases: [download-db, db-download, db-fetch]
     cmd: |
-      ahoy require-tooling
       case " $* " in *" --fresh "*) export VORTEX_FETCH_DB_FRESH=1 VORTEX_FETCH_DB_FORCE=1;; esac
       ./vendor/drevops/vortex-tooling/src/fetch-db
 
@@ -151,7 +150,6 @@ commands:
     usage: Fetch second database (migration). Run with "--fresh" to force.
     aliases: [download-db2, db2-download, db2-fetch]
     cmd: |
-      ahoy require-tooling
       case " $* " in *" --fresh "*) export VORTEX_FETCH_DB2_FRESH=1 VORTEX_FETCH_DB2_FORCE=1;; esac
       VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/fetch-db
   #;> MIGRATION
@@ -186,7 +184,6 @@ commands:
     usage: Export database dump or database image (if VORTEX_DB_IMAGE variable is set).
     aliases: [db-export, db-dump, dump-db]
     cmd: |
-      ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/export-db "$@"
 
   import-db:
@@ -194,7 +191,6 @@ commands:
     aliases: [db-import]
     cmd: |
       ahoy confirm "Running this command will replace your current database. Are you sure?" || exit 0
-      ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/import-db "$@"
 
   pull-db:
@@ -347,20 +343,17 @@ commands:
     usage: Run remote deployment procedures.
     cmd: |
       ahoy confirm "Deployment usually runs in CI. Are you sure you want to proceed with manual deployment? (Run as ahoy deploy [type1,[type2..]], where [type] is 'code', 'container_registry', 'webhook')" || exit 0
-      ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/deploy "$@"
 
   doctor:
     usage: Find problems with current project setup.
     aliases: [diagnose, health]
     cmd: |
-      ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/doctor "$@"
 
   update-vortex:
     usage: Update project from the Vortex template repository.
     cmd: |
-      ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/update-vortex "$@"
 
   local:
@@ -397,25 +390,23 @@ commands:
       fi
     hide: true
 
-  # Internal utility command that ensures the Vortex tooling package is
-  # available in vendor/. Installs just the tooling (not the full dep tree)
-  # so commands like 'ahoy fetch-db' work on a fresh clone before a full
-  # 'composer install' has run.
-  require-tooling:
-    cmd: ./scripts/vortex-tooling.sh
-    hide: true
-
 # Override entrypoint to alter default behavior of Ahoy.
 # 1. Exit the script if any statement returns a non-true return value.
 # 2. Read variables from .env file (while respecting existing values) to load
 #    and pass updated environment variables' values into already running
 #    containers.
+# 3. Ensure the Vortex tooling package is present in vendor/ so host-side
+#    commands work on a fresh clone before a full 'composer install' has run.
+#    Only the top-level call runs the check; the exported sentinel makes the
+#    nested 'ahoy' calls that a command chains (e.g. 'ahoy build' runs 'ahoy
+#    reset', which removes vendor/) skip it and avoid a redundant reinstall.
 entrypoint:
   - bash
   - -c
   - -e
   - |
     t=$(mktemp) && export -p > "$t" && set -a && . ./.env && if [ -f ./.env.local ];then . ./.env.local;fi && set +a && . "$t" && rm "$t" && unset t
+    if [ -z "${AHOY_TOOLING_ENSURED:-}" ]; then export AHOY_TOOLING_ENSURED=1; ./scripts/vortex-tooling.sh; fi
     bash -e -c "$0" "$@"
   - '{{cmd}}'
   - '{{name}}'

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
@@ -335,19 +335,15 @@ commands:
 # 2. Read variables from .env file (while respecting existing values) to load
 #    and pass updated environment variables' values into already running
 #    containers.
-# 3. Ensure the Vortex tooling package is present in vendor/ (via
-#    'scripts/vortex-tooling.sh') so host-side commands work on a fresh clone
-#    before a full 'composer install' has run. Export AHOY_TOOLING_ENSURED so
-#    the nested 'ahoy' calls a command chains (e.g. 'ahoy build' runs 'ahoy
-#    reset', which removes vendor/) inherit it and skip the re-check.
+# 3. Ensure the Vortex tooling package is present in vendor/ so host-side
+#    commands work on a fresh clone before a full 'composer install' has run.
 entrypoint:
   - bash
   - -c
   - -e
   - |
     t=$(mktemp) && export -p > "$t" && set -a && . ./.env && if [ -f ./.env.local ];then . ./.env.local;fi && set +a && . "$t" && rm "$t" && unset t
-    ./scripts/vortex-tooling.sh
-    export AHOY_TOOLING_ENSURED=1
+    if [ -z "${AHOY_VORTEX_TOOLING_READY:-}" ]; then export AHOY_VORTEX_TOOLING_READY=1; ./scripts/vortex-tooling.sh; fi
     bash -e -c "$0" "$@"
   - '{{cmd}}'
   - '{{name}}'

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
@@ -119,7 +119,6 @@ commands:
     usage: Fetch database. Run with "--fresh" option to force fresh database backup.
     aliases: [download-db, db-download, db-fetch]
     cmd: |
-      ahoy require-tooling
       case " $* " in *" --fresh "*) export VORTEX_FETCH_DB_FRESH=1 VORTEX_FETCH_DB_FORCE=1;; esac
       ./vendor/drevops/vortex-tooling/src/fetch-db
 
@@ -143,7 +142,6 @@ commands:
     usage: Export database dump or database image (if VORTEX_DB_IMAGE variable is set).
     aliases: [db-export, db-dump, dump-db]
     cmd: |
-      ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/export-db "$@"
 
   import-db:
@@ -151,7 +149,6 @@ commands:
     aliases: [db-import]
     cmd: |
       ahoy confirm "Running this command will replace your current database. Are you sure?" || exit 0
-      ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/import-db "$@"
 
   pull-db:
@@ -286,20 +283,17 @@ commands:
     usage: Run remote deployment procedures.
     cmd: |
       ahoy confirm "Deployment usually runs in CI. Are you sure you want to proceed with manual deployment? (Run as ahoy deploy [type1,[type2..]], where [type] is 'code', 'container_registry', 'webhook')" || exit 0
-      ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/deploy "$@"
 
   doctor:
     usage: Find problems with current project setup.
     aliases: [diagnose, health]
     cmd: |
-      ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/doctor "$@"
 
   update-vortex:
     usage: Update project from the Vortex template repository.
     cmd: |
-      ahoy require-tooling
       ./vendor/drevops/vortex-tooling/src/update-vortex "$@"
 
   local:
@@ -336,25 +330,23 @@ commands:
       fi
     hide: true
 
-  # Internal utility command that ensures the Vortex tooling package is
-  # available in vendor/. Installs just the tooling (not the full dep tree)
-  # so commands like 'ahoy fetch-db' work on a fresh clone before a full
-  # 'composer install' has run.
-  require-tooling:
-    cmd: ./scripts/vortex-tooling.sh
-    hide: true
-
 # Override entrypoint to alter default behavior of Ahoy.
 # 1. Exit the script if any statement returns a non-true return value.
 # 2. Read variables from .env file (while respecting existing values) to load
 #    and pass updated environment variables' values into already running
 #    containers.
+# 3. Ensure the Vortex tooling package is present in vendor/ so host-side
+#    commands work on a fresh clone before a full 'composer install' has run.
+#    Only the top-level call runs the check; the exported sentinel makes the
+#    nested 'ahoy' calls that a command chains (e.g. 'ahoy build' runs 'ahoy
+#    reset', which removes vendor/) skip it and avoid a redundant reinstall.
 entrypoint:
   - bash
   - -c
   - -e
   - |
     t=$(mktemp) && export -p > "$t" && set -a && . ./.env && if [ -f ./.env.local ];then . ./.env.local;fi && set +a && . "$t" && rm "$t" && unset t
+    if [ -z "${AHOY_TOOLING_ENSURED:-}" ]; then export AHOY_TOOLING_ENSURED=1; ./scripts/vortex-tooling.sh; fi
     bash -e -c "$0" "$@"
   - '{{cmd}}'
   - '{{name}}'

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
@@ -335,18 +335,19 @@ commands:
 # 2. Read variables from .env file (while respecting existing values) to load
 #    and pass updated environment variables' values into already running
 #    containers.
-# 3. Ensure the Vortex tooling package is present in vendor/ so host-side
-#    commands work on a fresh clone before a full 'composer install' has run.
-#    Only the top-level call runs the check; the exported sentinel makes the
-#    nested 'ahoy' calls that a command chains (e.g. 'ahoy build' runs 'ahoy
-#    reset', which removes vendor/) skip it and avoid a redundant reinstall.
+# 3. Ensure the Vortex tooling package is present in vendor/ (via
+#    'scripts/vortex-tooling.sh') so host-side commands work on a fresh clone
+#    before a full 'composer install' has run. Export AHOY_TOOLING_ENSURED so
+#    the nested 'ahoy' calls a command chains (e.g. 'ahoy build' runs 'ahoy
+#    reset', which removes vendor/) inherit it and skip the re-check.
 entrypoint:
   - bash
   - -c
   - -e
   - |
     t=$(mktemp) && export -p > "$t" && set -a && . ./.env && if [ -f ./.env.local ];then . ./.env.local;fi && set +a && . "$t" && rm "$t" && unset t
-    if [ -z "${AHOY_TOOLING_ENSURED:-}" ]; then export AHOY_TOOLING_ENSURED=1; ./scripts/vortex-tooling.sh; fi
+    ./scripts/vortex-tooling.sh
+    export AHOY_TOOLING_ENSURED=1
     bash -e -c "$0" "$@"
   - '{{cmd}}'
   - '{{name}}'

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
@@ -20,6 +20,12 @@
 set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
+# A set AHOY_TOOLING_ENSURED marks that an outer invocation has already
+# ensured the tooling for this process tree, so there is nothing to do here.
+# This avoids a redundant reinstall when an outer command removes vendor/
+# part-way through (e.g. a reset) before its later steps run.
+[ -n "${AHOY_TOOLING_ENSURED:-}" ] && exit 0
+
 # Already installed - nothing to do.
 if [ -d ./vendor/drevops/vortex-tooling ]; then
   exit 0

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
@@ -20,12 +20,6 @@
 set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
-# A set AHOY_TOOLING_ENSURED marks that an outer invocation has already
-# ensured the tooling for this process tree, so there is nothing to do here.
-# This avoids a redundant reinstall when an outer command removes vendor/
-# part-way through (e.g. a reset) before its later steps run.
-[ -n "${AHOY_TOOLING_ENSURED:-}" ] && exit 0
-
 # Already installed - nothing to do.
 if [ -d ./vendor/drevops/vortex-tooling ]; then
   exit 0

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.ahoy.yml
@@ -21,7 +21,7 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -123,6 +132,14 @@
+@@ -122,6 +131,13 @@
        case " $* " in *" --fresh "*) export VORTEX_FETCH_DB_FRESH=1 VORTEX_FETCH_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/fetch-db
  
@@ -29,14 +29,13 @@
 +    usage: Fetch second database (migration). Run with "--fresh" to force.
 +    aliases: [download-db2, db2-download, db2-fetch]
 +    cmd: |
-+      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_FETCH_DB2_FRESH=1 VORTEX_FETCH_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/fetch-db
 +
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -130,6 +147,13 @@
+@@ -129,6 +145,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.ahoy.yml
@@ -21,7 +21,7 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -123,6 +132,14 @@
+@@ -122,6 +131,13 @@
        case " $* " in *" --fresh "*) export VORTEX_FETCH_DB_FRESH=1 VORTEX_FETCH_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/fetch-db
  
@@ -29,14 +29,13 @@
 +    usage: Fetch second database (migration). Run with "--fresh" to force.
 +    aliases: [download-db2, db2-download, db2-fetch]
 +    cmd: |
-+      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_FETCH_DB2_FRESH=1 VORTEX_FETCH_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/fetch-db
 +
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -130,6 +147,13 @@
+@@ -129,6 +145,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.ahoy.yml
@@ -21,7 +21,7 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -123,6 +132,14 @@
+@@ -122,6 +131,13 @@
        case " $* " in *" --fresh "*) export VORTEX_FETCH_DB_FRESH=1 VORTEX_FETCH_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/fetch-db
  
@@ -29,14 +29,13 @@
 +    usage: Fetch second database (migration). Run with "--fresh" to force.
 +    aliases: [download-db2, db2-download, db2-fetch]
 +    cmd: |
-+      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_FETCH_DB2_FRESH=1 VORTEX_FETCH_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/fetch-db
 +
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -130,6 +147,13 @@
+@@ -129,6 +145,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.ahoy.yml
@@ -21,7 +21,7 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -123,6 +132,14 @@
+@@ -122,6 +131,13 @@
        case " $* " in *" --fresh "*) export VORTEX_FETCH_DB_FRESH=1 VORTEX_FETCH_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/fetch-db
  
@@ -29,14 +29,13 @@
 +    usage: Fetch second database (migration). Run with "--fresh" to force.
 +    aliases: [download-db2, db2-download, db2-fetch]
 +    cmd: |
-+      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_FETCH_DB2_FRESH=1 VORTEX_FETCH_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/fetch-db
 +
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -130,6 +147,13 @@
+@@ -129,6 +145,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.ahoy.yml
@@ -21,7 +21,7 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -123,6 +132,14 @@
+@@ -122,6 +131,13 @@
        case " $* " in *" --fresh "*) export VORTEX_FETCH_DB_FRESH=1 VORTEX_FETCH_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/fetch-db
  
@@ -29,14 +29,13 @@
 +    usage: Fetch second database (migration). Run with "--fresh" to force.
 +    aliases: [download-db2, db2-download, db2-fetch]
 +    cmd: |
-+      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_FETCH_DB2_FRESH=1 VORTEX_FETCH_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/fetch-db
 +
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -130,6 +147,13 @@
+@@ -129,6 +145,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.ahoy.yml
@@ -21,7 +21,7 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -123,6 +132,14 @@
+@@ -122,6 +131,13 @@
        case " $* " in *" --fresh "*) export VORTEX_FETCH_DB_FRESH=1 VORTEX_FETCH_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/fetch-db
  
@@ -29,14 +29,13 @@
 +    usage: Fetch second database (migration). Run with "--fresh" to force.
 +    aliases: [download-db2, db2-download, db2-fetch]
 +    cmd: |
-+      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_FETCH_DB2_FRESH=1 VORTEX_FETCH_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/fetch-db
 +
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -130,6 +147,13 @@
+@@ -129,6 +145,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.ahoy.yml
@@ -21,7 +21,7 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -123,6 +132,14 @@
+@@ -122,6 +131,13 @@
        case " $* " in *" --fresh "*) export VORTEX_FETCH_DB_FRESH=1 VORTEX_FETCH_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/fetch-db
  
@@ -29,14 +29,13 @@
 +    usage: Fetch second database (migration). Run with "--fresh" to force.
 +    aliases: [download-db2, db2-download, db2-fetch]
 +    cmd: |
-+      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_FETCH_DB2_FRESH=1 VORTEX_FETCH_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/fetch-db
 +
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -130,6 +147,13 @@
+@@ -129,6 +145,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.ahoy.yml
@@ -21,7 +21,7 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -123,6 +132,14 @@
+@@ -122,6 +131,13 @@
        case " $* " in *" --fresh "*) export VORTEX_FETCH_DB_FRESH=1 VORTEX_FETCH_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/fetch-db
  
@@ -29,14 +29,13 @@
 +    usage: Fetch second database (migration). Run with "--fresh" to force.
 +    aliases: [download-db2, db2-download, db2-fetch]
 +    cmd: |
-+      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_FETCH_DB2_FRESH=1 VORTEX_FETCH_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/fetch-db
 +
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -130,6 +147,13 @@
+@@ -129,6 +145,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.ahoy.yml
@@ -21,7 +21,7 @@
    # ----------------------------------------------------------------------------
    # Container commands.
    # ----------------------------------------------------------------------------
-@@ -123,6 +132,14 @@
+@@ -122,6 +131,13 @@
        case " $* " in *" --fresh "*) export VORTEX_FETCH_DB_FRESH=1 VORTEX_FETCH_DB_FORCE=1;; esac
        ./vendor/drevops/vortex-tooling/src/fetch-db
  
@@ -29,14 +29,13 @@
 +    usage: Fetch second database (migration). Run with "--fresh" to force.
 +    aliases: [download-db2, db2-download, db2-fetch]
 +    cmd: |
-+      ahoy require-tooling
 +      case " $* " in *" --fresh "*) export VORTEX_FETCH_DB2_FRESH=1 VORTEX_FETCH_DB2_FORCE=1;; esac
 +      VORTEX_DB_INDEX=2 ./vendor/drevops/vortex-tooling/src/fetch-db
 +
    reload-db:
      usage: Reload the database container using local database image.
      cmd: |
-@@ -130,6 +147,13 @@
+@@ -129,6 +145,13 @@
        docker compose rm --force --stop --volumes database
        docker compose build database
        ahoy up

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -218,14 +218,6 @@
+@@ -215,14 +215,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_none/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_none/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -218,14 +218,6 @@
+@@ -215,14 +215,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -115,14 +115,6 @@
+@@ -115,13 +115,6 @@
      usage: Unblock user 1 and generate a one time login link.
      cmd: ahoy cli ./vendor/drevops/vortex-tooling/src/login
  
@@ -6,7 +6,6 @@
 -    usage: Fetch database. Run with "--fresh" option to force fresh database backup.
 -    aliases: [download-db, db-download, db-fetch]
 -    cmd: |
--      ahoy require-tooling
 -      case " $* " in *" --fresh "*) export VORTEX_FETCH_DB_FRESH=1 VORTEX_FETCH_DB_FORCE=1;; esac
 -      ./vendor/drevops/vortex-tooling/src/fetch-db
 -

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.ahoy.yml
@@ -6,7 +6,7 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -173,25 +172,7 @@
+@@ -170,25 +169,7 @@
      aliases: [fe-install]
      cmd: |
        ahoy cli "yarn install --frozen-lockfile"
@@ -32,7 +32,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -211,7 +192,6 @@
+@@ -208,7 +189,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
        ahoy cli "yarn run lint"
@@ -40,7 +40,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -218,14 +198,6 @@
+@@ -215,14 +195,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
@@ -55,7 +55,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -243,7 +215,6 @@
+@@ -240,7 +212,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.ahoy.yml
@@ -6,7 +6,7 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -173,25 +172,7 @@
+@@ -170,25 +169,7 @@
      aliases: [fe-install]
      cmd: |
        ahoy cli "yarn install --frozen-lockfile"
@@ -32,7 +32,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -211,7 +192,6 @@
+@@ -208,7 +189,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
        ahoy cli "yarn run lint"
@@ -40,7 +40,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -218,14 +198,6 @@
+@@ -215,14 +195,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
@@ -55,7 +55,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -243,7 +215,6 @@
+@@ -240,7 +212,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.ahoy.yml
@@ -6,7 +6,7 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -173,25 +172,7 @@
+@@ -170,25 +169,7 @@
      aliases: [fe-install]
      cmd: |
        ahoy cli "yarn install --frozen-lockfile"
@@ -32,7 +32,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -211,7 +192,6 @@
+@@ -208,7 +189,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
        ahoy cli "yarn run lint"
@@ -40,7 +40,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -218,14 +198,6 @@
+@@ -215,14 +195,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
@@ -55,7 +55,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -243,7 +215,6 @@
+@@ -240,7 +212,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -195,17 +195,9 @@
+@@ -192,17 +192,9 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
@@ -16,7 +16,7 @@
    lint-fe:
      usage: Lint front-end code.
      cmd: |
-@@ -229,14 +221,7 @@
+@@ -226,14 +218,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -195,17 +195,9 @@
+@@ -192,17 +192,9 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
@@ -16,7 +16,7 @@
    lint-fe:
      usage: Lint front-end code.
      cmd: |
-@@ -229,14 +221,7 @@
+@@ -226,14 +218,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -197,7 +197,6 @@
+@@ -194,7 +194,6 @@
      cmd: |
        ahoy lint-be
        ahoy lint-fe
@@ -6,7 +6,7 @@
  
    lint-be:
      usage: Lint back-end code.
-@@ -213,11 +212,6 @@
+@@ -210,11 +209,6 @@
        ahoy cli "yarn run lint"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint"
  
@@ -18,7 +18,7 @@
    lint-sdc:
      usage: Validate Single Directory Components (requires a provisioned site).
      cmd: |
-@@ -245,35 +239,9 @@
+@@ -242,35 +236,9 @@
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -197,7 +197,6 @@
+@@ -194,7 +194,6 @@
      cmd: |
        ahoy lint-be
        ahoy lint-fe
@@ -6,7 +6,7 @@
  
    lint-be:
      usage: Lint back-end code.
-@@ -213,11 +212,6 @@
+@@ -210,11 +209,6 @@
        ahoy cli "yarn run lint"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint"
  
@@ -18,7 +18,7 @@
    lint-sdc:
      usage: Validate Single Directory Components (requires a provisioned site).
      cmd: |
-@@ -245,35 +239,9 @@
+@@ -242,35 +236,9 @@
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -210,7 +210,6 @@
+@@ -207,7 +207,6 @@
      usage: Lint front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
@@ -6,7 +6,7 @@
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint"
  
    lint-tests:
-@@ -242,7 +241,6 @@
+@@ -239,7 +238,6 @@
      usage: Fix lint issues of front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
@@ -14,7 +14,7 @@
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  
    test:
-@@ -265,10 +263,6 @@
+@@ -262,10 +260,6 @@
    test-functional-javascript:
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -210,7 +210,6 @@
+@@ -207,7 +207,6 @@
      usage: Lint front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
@@ -6,7 +6,7 @@
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint"
  
    lint-tests:
-@@ -242,7 +241,6 @@
+@@ -239,7 +238,6 @@
      usage: Fix lint issues of front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
@@ -14,7 +14,7 @@
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  
    test:
-@@ -265,10 +263,6 @@
+@@ -262,10 +260,6 @@
    test-functional-javascript:
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.ahoy.yml
@@ -7,7 +7,7 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -168,30 +166,6 @@
+@@ -165,30 +163,6 @@
          bash ./vendor/drevops/vortex-tooling/src/reset "$@"
        fi
  
@@ -38,7 +38,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -210,8 +184,6 @@
+@@ -207,8 +181,6 @@
      usage: Lint front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
@@ -47,7 +47,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -218,14 +190,6 @@
+@@ -215,14 +187,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
@@ -62,7 +62,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -242,8 +206,6 @@
+@@ -239,8 +203,6 @@
      usage: Fix lint issues of front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
@@ -71,7 +71,7 @@
  
    test:
      usage: Run all PHPUnit tests.
-@@ -265,10 +227,6 @@
+@@ -262,10 +224,6 @@
    test-functional-javascript:
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.ahoy.yml
@@ -7,7 +7,7 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -168,30 +166,6 @@
+@@ -165,30 +163,6 @@
          bash ./vendor/drevops/vortex-tooling/src/reset "$@"
        fi
  
@@ -38,7 +38,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -210,8 +184,6 @@
+@@ -207,8 +181,6 @@
      usage: Lint front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
@@ -47,7 +47,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -218,14 +190,6 @@
+@@ -215,14 +187,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
@@ -62,7 +62,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -242,8 +206,6 @@
+@@ -239,8 +203,6 @@
      usage: Fix lint issues of front-end code.
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
@@ -71,7 +71,7 @@
  
    test:
      usage: Run all PHPUnit tests.
-@@ -265,10 +227,6 @@
+@@ -262,10 +224,6 @@
    test-functional-javascript:
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -197,7 +197,6 @@
+@@ -194,7 +194,6 @@
      cmd: |
        ahoy lint-be
        ahoy lint-fe
@@ -6,7 +6,7 @@
  
    lint-be:
      usage: Lint back-end code.
-@@ -216,8 +215,6 @@
+@@ -213,8 +212,6 @@
    lint-tests:
      usage: Lint tests code.
      cmd: |
@@ -15,7 +15,7 @@
    lint-sdc:
      usage: Validate Single Directory Components (requires a provisioned site).
      cmd: |
-@@ -269,11 +266,6 @@
+@@ -266,11 +263,6 @@
    test-js:
      usage: Run Jest JavaScript unit tests.
      cmd: ahoy cli "yarn test"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -197,7 +197,6 @@
+@@ -194,7 +194,6 @@
      cmd: |
        ahoy lint-be
        ahoy lint-fe
@@ -6,7 +6,7 @@
  
    lint-be:
      usage: Lint back-end code.
-@@ -216,8 +215,6 @@
+@@ -213,8 +212,6 @@
    lint-tests:
      usage: Lint tests code.
      cmd: |
@@ -15,7 +15,7 @@
    lint-sdc:
      usage: Validate Single Directory Components (requires a provisioned site).
      cmd: |
-@@ -269,11 +266,6 @@
+@@ -266,11 +263,6 @@
    test-js:
      usage: Run Jest JavaScript unit tests.
      cmd: ahoy cli "yarn test"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.ahoy.yml
@@ -6,7 +6,7 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -173,25 +172,7 @@
+@@ -170,25 +169,7 @@
      aliases: [fe-install]
      cmd: |
        ahoy cli "yarn install --frozen-lockfile"
@@ -32,7 +32,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -211,7 +192,6 @@
+@@ -208,7 +189,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
        ahoy cli "yarn run lint"
@@ -40,7 +40,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -218,14 +198,6 @@
+@@ -215,14 +195,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
@@ -55,7 +55,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -243,7 +215,6 @@
+@@ -240,7 +212,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -266,10 +266,6 @@
+@@ -263,10 +263,6 @@
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -266,10 +266,6 @@
+@@ -263,10 +263,6 @@
      usage: Run PHPUnit functional JavaScript tests.
      cmd: ahoy cli vendor/bin/phpunit --testsuite=functional-javascript "$@"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -202,7 +202,6 @@
+@@ -199,7 +199,6 @@
    lint-be:
      usage: Lint back-end code.
      cmd: |
@@ -6,7 +6,7 @@
        ahoy cli vendor/bin/phpstan
        ahoy cli vendor/bin/rector --dry-run
  
-@@ -236,7 +235,6 @@
+@@ -233,7 +232,6 @@
      usage: Fix lint issues of back-end code.
      cmd: |
        ahoy cli vendor/bin/rector

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -202,7 +202,6 @@
+@@ -199,7 +199,6 @@
    lint-be:
      usage: Lint back-end code.
      cmd: |
@@ -6,7 +6,7 @@
        ahoy cli vendor/bin/phpstan
        ahoy cli vendor/bin/rector --dry-run
  
-@@ -236,7 +235,6 @@
+@@ -233,7 +232,6 @@
      usage: Fix lint issues of back-end code.
      cmd: |
        ahoy cli vendor/bin/rector

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -203,7 +203,6 @@
+@@ -200,7 +200,6 @@
      usage: Lint back-end code.
      cmd: |
        ahoy cli vendor/bin/phpcs

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -203,7 +203,6 @@
+@@ -200,7 +200,6 @@
      usage: Lint back-end code.
      cmd: |
        ahoy cli vendor/bin/phpcs

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -245,27 +245,6 @@
+@@ -242,27 +242,6 @@
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -245,27 +245,6 @@
+@@ -242,27 +242,6 @@
        ahoy cli "yarn run lint-fix"
        ahoy cli "yarn run --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} lint-fix"
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -204,7 +204,6 @@
+@@ -201,7 +201,6 @@
      cmd: |
        ahoy cli vendor/bin/phpcs
        ahoy cli vendor/bin/phpstan
@@ -6,7 +6,7 @@
  
    lint-fe:
      usage: Lint front-end code.
-@@ -235,7 +234,6 @@
+@@ -232,7 +231,6 @@
    lint-be-fix:
      usage: Fix lint issues of back-end code.
      cmd: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -204,7 +204,6 @@
+@@ -201,7 +201,6 @@
      cmd: |
        ahoy cli vendor/bin/phpcs
        ahoy cli vendor/bin/phpstan
@@ -6,7 +6,7 @@
  
    lint-fe:
      usage: Lint front-end code.
-@@ -235,7 +234,6 @@
+@@ -232,7 +231,6 @@
    lint-be-fix:
      usage: Fix lint issues of back-end code.
      cmd: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.ahoy.yml
@@ -6,7 +6,7 @@
        VORTEX_SHOW_LOGIN=0 ahoy provision  # Provision the site.
        VORTEX_SHOW_LOGIN=1 ahoy info       # Show information and a login link.
  
-@@ -173,25 +172,7 @@
+@@ -170,25 +169,7 @@
      aliases: [fe-install]
      cmd: |
        ahoy cli "yarn install --frozen-lockfile"
@@ -32,7 +32,7 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
-@@ -211,7 +192,6 @@
+@@ -208,7 +189,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint
        ahoy cli "yarn run lint"
@@ -40,7 +40,7 @@
  
    lint-tests:
      usage: Lint tests code.
-@@ -218,14 +198,6 @@
+@@ -215,14 +195,6 @@
      cmd: |
        ahoy cli vendor/bin/gherkinlint lint tests/behat/features
  
@@ -55,7 +55,7 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |
-@@ -243,7 +215,6 @@
+@@ -240,7 +212,6 @@
      cmd: |
        ahoy cli vendor/bin/twig-cs-fixer lint --fix
        ahoy cli "yarn run lint-fix"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.ahoy.yml
@@ -1,4 +1,4 @@
-@@ -195,29 +195,14 @@
+@@ -192,29 +192,14 @@
    lint:
      usage: Lint back-end and front-end code.
      cmd: |
@@ -28,7 +28,7 @@
    lint-sdc:
      usage: Validate Single Directory Components (requires a provisioned site).
      cmd: |
-@@ -229,51 +214,13 @@
+@@ -226,51 +211,13 @@
    lint-fix:
      usage: Fix lint issues of back-end and front-end code.
      cmd: |

--- a/scripts/vortex-tooling.sh
+++ b/scripts/vortex-tooling.sh
@@ -20,6 +20,12 @@
 set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
+# A set AHOY_TOOLING_ENSURED marks that an outer invocation has already
+# ensured the tooling for this process tree, so there is nothing to do here.
+# This avoids a redundant reinstall when an outer command removes vendor/
+# part-way through (e.g. a reset) before its later steps run.
+[ -n "${AHOY_TOOLING_ENSURED:-}" ] && exit 0
+
 # Already installed - nothing to do.
 if [ -d ./vendor/drevops/vortex-tooling ]; then
   exit 0

--- a/scripts/vortex-tooling.sh
+++ b/scripts/vortex-tooling.sh
@@ -20,12 +20,6 @@
 set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
-# A set AHOY_TOOLING_ENSURED marks that an outer invocation has already
-# ensured the tooling for this process tree, so there is nothing to do here.
-# This avoids a redundant reinstall when an outer command removes vendor/
-# part-way through (e.g. a reset) before its later steps run.
-[ -n "${AHOY_TOOLING_ENSURED:-}" ] && exit 0
-
 # Already installed - nothing to do.
 if [ -d ./vendor/drevops/vortex-tooling ]; then
   exit 0


### PR DESCRIPTION
Closes #2725

Seven host-side ahoy commands (`fetch-db`, `fetch-db2`, `export-db`, `import-db`, `deploy`, `doctor`, `update-vortex`) each began with an inline `ahoy require-tooling` call. That call, and the now-unused hidden `require-tooling` command, are removed. The ahoy `entrypoint` now ensures the `drevops/vortex-tooling` package is present in `vendor/` (by running `./scripts/vortex-tooling.sh`) for every top-level ahoy invocation. An exported flag (`AHOY_VORTEX_TOOLING_READY`) causes the nested `ahoy` calls that a command chains internally to skip the check - this matters because `ahoy build` runs `ahoy reset` (which does `rm -rf ./vendor`) and then `ahoy up`; without the flag that nested `ahoy up` would trigger a redundant tooling reinstall, which also fails in the functional-test SUT where the package is not yet on Packagist. The guard lives entirely in the entrypoint, so `scripts/vortex-tooling.sh` stays caller-agnostic (it only answers "is the tooling present?"). Net effect: the seven commands are cleaner, and every top-level command - including `info`/`login`/`provision` which previously did not ensure tooling - now does. The fixture changes are regenerated installer snapshots reflecting the updated `.ahoy.yml`.

## Before / After

```
BEFORE — tooling check duplicated in each command
──────────────────────────────────────────────────────────────────────
  entrypoint:
    - bash -e -c "..."          # loads .env; no tooling check

  fetch-db:
    ahoy require-tooling        # ← each command runs its own check
    ./vendor/.../fetch-db

  export-db / import-db / deploy / doctor / update-vortex / fetch-db2:
    ahoy require-tooling        # ← duplicated in every one
    ./vendor/.../...

  require-tooling (hidden):     # ← dedicated command for the check
    cmd: ./scripts/vortex-tooling.sh

AFTER — single entrypoint check; flag prevents nested re-runs
──────────────────────────────────────────────────────────────────────
  entrypoint:
    - bash -e -c "..."          # loads .env
    if [ -z "${AHOY_VORTEX_TOOLING_READY:-}" ]; then export AHOY_VORTEX_TOOLING_READY=1; ./scripts/vortex-tooling.sh; fi
    bash -e -c "$0" "$@"

  fetch-db:                     # ← clean; no require-tooling call
    ./vendor/.../fetch-db

  export-db / import-db / deploy / doctor / update-vortex / fetch-db2:
    ./vendor/.../...            # ← all clean

  # require-tooling command removed entirely
  # nested calls (e.g. ahoy build → ahoy reset → ahoy up) skip via the flag
  # scripts/vortex-tooling.sh stays caller-agnostic (just "is tooling present?")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified command execution: key workflow commands no longer require an explicit pre-step to ensure needed tooling is available.
  * Improved environment handling by automatically loading settings from `.env` and (when present) `.env.local` before running commands.
  * Reduced repeated setup work by ensuring the Vortex tooling setup script runs only once per command run, improving reliability and speed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
