### PR TITLE
[#2752] Fixed 'vortex-tooling.sh' binary-linking guard and a stray brace in '.env.local.example'.

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -56,7 +56,7 @@ VORTEX_ACQUIA_SECRET=
 #;< DB_FETCH_SOURCE_LAGOON
 # Database dump file sourced from Lagoon.
 
-# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 # VORTEX_FETCH_DB_SSH_FILE=
 #;> DB_FETCH_SOURCE_LAGOON
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
@@ -8,7 +8,8 @@
 # Composer project in 'vendor-temp/', so the project's main vendor/ and
 # composer.lock are not touched.
 #
-# Idempotent: exits early if 'vendor/drevops/vortex-tooling/' already exists.
+# Idempotent: exits early only once the package and its 'vendor/bin/vortex-*'
+# proxies are both present.
 #
 # Patches declared for 'drevops/vortex-tooling' in the project composer.json
 # under 'extra.patches' (and the optional 'extra.patches-file') are copied
@@ -20,8 +21,8 @@
 set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
-# Already installed - nothing to do.
-if [ -d ./vendor/drevops/vortex-tooling ]; then
+# Already installed and its binaries linked - nothing to do.
+if [ -d ./vendor/drevops/vortex-tooling ] && ls ./vendor/bin/vortex-* >/dev/null 2>&1; then
   exit 0
 fi
 

--- a/.vortex/installer/tests/Fixtures/handler_process/db_fetch_source_lagoon/.env.local.example
+++ b/.vortex/installer/tests/Fixtures/handler_process/db_fetch_source_lagoon/.env.local.example
@@ -5,5 +5,5 @@
 +
 +# Database dump file sourced from Lagoon.
 +
-+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
++# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 +# VORTEX_FETCH_DB_SSH_FILE=

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_lagoon/.env.local.example
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_lagoon/.env.local.example
@@ -5,5 +5,5 @@
 +
 +# Database dump file sourced from Lagoon.
 +
-+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
++# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 +# VORTEX_FETCH_DB_SSH_FILE=

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___lagoon/.env.local.example
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___lagoon/.env.local.example
@@ -5,5 +5,5 @@
 +
 +# Database dump file sourced from Lagoon.
 +
-+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
++# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 +# VORTEX_FETCH_DB_SSH_FILE=

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_lagoon/.env.local.example
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_lagoon/.env.local.example
@@ -5,5 +5,5 @@
 +
 +# Database dump file sourced from Lagoon.
 +
-+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
++# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 +# VORTEX_FETCH_DB_SSH_FILE=

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.env.local.example
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.env.local.example
@@ -5,5 +5,5 @@
 +
 +# Database dump file sourced from Lagoon.
 +
-+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
++# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 +# VORTEX_FETCH_DB_SSH_FILE=

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_database_lagoon/.env.local.example
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_database_lagoon/.env.local.example
@@ -5,5 +5,5 @@
 +
 +# Database dump file sourced from Lagoon.
 +
-+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
++# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 +# VORTEX_FETCH_DB_SSH_FILE=

--- a/scripts/vortex-tooling.sh
+++ b/scripts/vortex-tooling.sh
@@ -8,7 +8,8 @@
 # Composer project in 'vendor-temp/', so the project's main vendor/ and
 # composer.lock are not touched.
 #
-# Idempotent: exits early if 'vendor/drevops/vortex-tooling/' already exists.
+# Idempotent: exits early only once the package and its 'vendor/bin/vortex-*'
+# proxies are both present.
 #
 # Patches declared for 'drevops/vortex-tooling' in the project composer.json
 # under 'extra.patches' (and the optional 'extra.patches-file') are copied
@@ -20,8 +21,8 @@
 set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
-# Already installed - nothing to do.
-if [ -d ./vendor/drevops/vortex-tooling ]; then
+# Already installed and its binaries linked - nothing to do.
+if [ -d ./vendor/drevops/vortex-tooling ] && ls ./vendor/bin/vortex-* >/dev/null 2>&1; then
   exit 0
 fi
 


### PR DESCRIPTION
Closes #2752

## Summary

Broadened the idempotency guard in `scripts/vortex-tooling.sh` to require both the `vendor/drevops/vortex-tooling/` directory and the `vendor/bin/vortex-*` binary proxies to be present before short-circuiting. A clone that had the package directory from an older pre-binary version of `drevops/vortex-tooling` would hit the old guard and exit early, leaving the binaries unlinked and breaking every `ahoy` command that delegates to `vendor/bin/vortex-*`. Also fixed a stray trailing `}` in the Lagoon SSH file path default shown in the `.env.local.example` comment. Installer snapshot fixtures were regenerated to match both changes.

## Changes

- **`scripts/vortex-tooling.sh`** - Guard condition extended with `ls ./vendor/bin/vortex-* >/dev/null 2>&1` so the script proceeds to link binaries whenever they are absent, even if the package directory already exists. Updated the docblock and the guard comment to reflect the new two-part condition.
- **`.env.local.example`** - Removed the stray `}` at the end of `"${HOME}/.ssh/id_rsa}"` in the Lagoon SSH file comment (typo: the closing brace belonged to the variable expansion, not the path string).
- **`.vortex/installer/tests/Fixtures/`** - Regenerated `_baseline/scripts/vortex-tooling.sh` and six Lagoon-hosting-scenario `.env.local.example` fixtures to reflect the two changes above.

## Before / After

```
BEFORE - old guard (package dir only)
┌─────────────────────────────────────────────────────────────────────┐
│ Scenario: stale vendor/drevops/vortex-tooling/ present,            │
│           vendor/bin/vortex-* proxies absent                        │
├─────────────────────────────────────────────────────────────────────┤
│  vortex-tooling.sh                                                  │
│    if [ -d ./vendor/drevops/vortex-tooling ]; then                 │
│      exit 0   <── fires; binaries never linked                      │
│    fi                                                               │
│                                                                     │
│  Result: ahoy calls vendor/bin/vortex-* → "command not found"      │
└─────────────────────────────────────────────────────────────────────┘

AFTER - new guard (package dir AND binaries)
┌─────────────────────────────────────────────────────────────────────┐
│ Scenario: stale vendor/drevops/vortex-tooling/ present,            │
│           vendor/bin/vortex-* proxies absent                        │
├─────────────────────────────────────────────────────────────────────┤
│  vortex-tooling.sh                                                  │
│    if [ -d ./vendor/drevops/vortex-tooling ] &&                    │
│       ls ./vendor/bin/vortex-* >/dev/null 2>&1; then               │
│      exit 0   <── does NOT fire; continues to link binaries         │
│    fi                                                               │
│                                                                     │
│  Result: binaries linked → ahoy commands work as expected           │
└─────────────────────────────────────────────────────────────────────┘

.env.local.example comment fix
  Before: Defaults to "${HOME}/.ssh/id_rsa}"   ← stray }
  After:  Defaults to "${HOME}/.ssh/id_rsa"    ← correct
```

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected an example SSH key path in the environment setup guide.

* **Bug Fixes**
  * Improved tooling startup checks so it only skips setup when both the installed package and its command shortcuts are present, helping avoid incomplete tool installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->