### PR TITLE
Forward-ported new 'main' commits onto '2.x'.

### DIFF
--- a/.claude/skills/prepare-vortex-release/SKILL.md
+++ b/.claude/skills/prepare-vortex-release/SKILL.md
@@ -68,6 +68,19 @@ Work through each checklist item from the release process doc:
    (`phpVersion`), and `phpcs.xml` (`testVersion`) if needed.
 4. **Composer packages** - Run `composer update -W` then check composer.json was bumped
    (the project uses `bump-after-update` config).
+   - **`drevops/vortex-tooling` version pin (update EVERY spot in lockstep).** When
+     `.vortex/tooling/` changed and a new `drevops/vortex-tooling` tag is published for
+     this release, the pinned version MUST be updated in **all** the spots below at once,
+     or resolution breaks and CI fails - the dev/CI `require-tooling` bootstrap becomes
+     unresolvable, and the workflow-test SUT Docker build hits a higher-priority path repo
+     that no longer matches the `~<new>` constraint: (a) the `require` constraint in root
+     `composer.json`; (b) the path-repository `versions` override in root `composer.json`;
+     (c) the hardcoded `versions` override in `scripts/vortex-tooling.sh` (inside the
+     `#;< VORTEX_DEV` throwaway path-repo config); and (d) the `versions` override in
+     `.vortex/tests/phpunit/Traits/SutTrait.php` (the test-harness `.tooling-source` path
+     repo). **After bumping, grep the whole repo for the previous tooling version**
+     (e.g. `grep -rn "vortex-tooling.*<old-version>" --exclude-dir=vendor`) - this is the
+     authoritative check, since new pin spots have been added over time.
 5. **Theme dependencies** - Run `yarn upgrade` in `web/themes/custom/your_site_theme/`.
    Use yarn, NOT npm.
 6. **CI runner** - Check if `drevops/ci-runner` is at the latest version.

--- a/.env.local.example
+++ b/.env.local.example
@@ -56,7 +56,7 @@ VORTEX_ACQUIA_SECRET=
 #;< DB_FETCH_SOURCE_LAGOON
 # Database dump file sourced from Lagoon.
 
-# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 # VORTEX_FETCH_DB_SSH_FILE=
 #;> DB_FETCH_SOURCE_LAGOON
 

--- a/.vortex/installer/tests/Fixtures/handler_process/db_fetch_source_lagoon/.env.local.example
+++ b/.vortex/installer/tests/Fixtures/handler_process/db_fetch_source_lagoon/.env.local.example
@@ -5,5 +5,5 @@
 +
 +# Database dump file sourced from Lagoon.
 +
-+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
++# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 +# VORTEX_FETCH_DB_SSH_FILE=

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_lagoon/.env.local.example
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_lagoon/.env.local.example
@@ -5,5 +5,5 @@
 +
 +# Database dump file sourced from Lagoon.
 +
-+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
++# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 +# VORTEX_FETCH_DB_SSH_FILE=

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___lagoon/.env.local.example
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___lagoon/.env.local.example
@@ -5,5 +5,5 @@
 +
 +# Database dump file sourced from Lagoon.
 +
-+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
++# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 +# VORTEX_FETCH_DB_SSH_FILE=

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_lagoon/.env.local.example
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_lagoon/.env.local.example
@@ -5,5 +5,5 @@
 +
 +# Database dump file sourced from Lagoon.
 +
-+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
++# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 +# VORTEX_FETCH_DB_SSH_FILE=

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.env.local.example
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.env.local.example
@@ -5,5 +5,5 @@
 +
 +# Database dump file sourced from Lagoon.
 +
-+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
++# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 +# VORTEX_FETCH_DB_SSH_FILE=

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_database_lagoon/.env.local.example
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_database_lagoon/.env.local.example
@@ -5,5 +5,5 @@
 +
 +# Database dump file sourced from Lagoon.
 +
-+# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa}".
++# SSH file used to fetch the database dump from Lagoon. Defaults to "${HOME}/.ssh/id_rsa".
 +# VORTEX_FETCH_DB_SSH_FILE=

--- a/.vortex/tooling/phpstan.neon
+++ b/.vortex/tooling/phpstan.neon
@@ -15,6 +15,8 @@ parameters:
     - vendor/*
     - node_modules/*
 
+  treatPhpDocTypesAsCertain: false
+
   ignoreErrors:
     -
       # Since tests and data providers do not have to have parameter docblocks,


### PR DESCRIPTION
## Scope
Forward-ports 2 commits from `main` onto `2.x` (plus a mechanical snapshot regeneration). This run's other 5 candidates were already effectively present on `2.x` and are listed under Skipped. It also clears a pre-existing, unrelated `2.x` tooling PHPStan failure so CI on this branch is fully green (see Tooling CI fix).

## Applied
- `6963d3fb` Fixed 'vortex-tooling.sh' binary-linking guard and a stray brace in '.env.local.example' - **adapted**: only the `.env.local.example` stray-brace fix (`id_rsa}` -> `id_rsa`) was ported. The commit's `scripts/vortex-tooling.sh` guard hardening is already present on `2.x` in a more robust form (it checks `vendor/bin/vortex-*` and self-heals), so that hunk was intentionally dropped.
- `8718f343` Prepared the 1.40.0 'Spectrum' release - **partial**: only the version-agnostic `prepare-vortex-release/SKILL.md` maintenance note (update all four `drevops/vortex-tooling` version-pin spots in lockstep) was ported. All release churn - tooling version bumps (`1.2.0` -> `1.3.0`), dependency bumps, and demo-video regeneration - is main-line only, because `2.x` tooling is `2.0.0-alpha1`.

## Skipped
- `79ca82b1` Update actions/cache digest to 55cc834 - `2.x` already pins the exact digest `55cc834...` in all three workflow spots.
- `abd9ed50` Documented all 'require' packages on the composer.json doc page - already forward-ported to `2.x` via its own commit, adapted to `2.x`'s package set.
- `03d95343` Prefixed all tooling scripts with 'vortex-' and surfaced them as Composer binaries - `2.x`'s PHP tooling already uses the `vortex-` prefix and carries a byte-identical composer `bin` array.
- `2c9b459a` Renamed 'VORTEX_LOCALDEV_URL' to 'LOCALDEV_URL' - already renamed on `2.x`; zero stale references remain.
- `d3dfcdea` Renamed 'DRUPAL_ENVIRONMENT' to 'ENVIRONMENT_TYPE' - already renamed on `2.x`; zero stale references remain.

## Tooling CI fix
Not part of the forward-port: `vortex-test-tooling` was already failing on `2.x` before this branch (red on `2.x` HEAD `453cf1da6`). The `drevops/vortex-tooling` package ships no `composer.lock`, so CI resolves the newest PHPStan on each run; the bump from `2.2.2` to `2.2.3` began treating `ob_get_clean()`'s PHPDoc `string|false` return as a certain `string`, so the defensive `assertIsString()` guards in the Helpers unit tests were reported as always-true (`method.alreadyNarrowedType`). Setting `treatPhpDocTypesAsCertain: false` in `.vortex/tooling/phpstan.neon` - matching the settings already present in `.vortex/installer/phpstan.neon` and the root `phpstan.neon` - resolves all four errors and keeps the guards, which are legitimate because `ob_get_clean()` genuinely returns `string|false` at runtime.

## Snapshots
`ahoy update-snapshots` ran in the foreground and regenerated 6 Lagoon `.env.local.example` installer fixtures for the brace fix (132 unchanged, 6 updated, 0 failed), auto-committed as "Updated snapshots.". No template files were deleted, so no `SutTrait.php` follow-up is outstanding. A pre-existing, unrelated orphan fixture directory `db_download_source_lagoon/` on `2.x` carries the same brace and stale `download` wording; it is unreferenced and absent from the 138 active datasets, so it is out of scope for this port (separate `2.x` housekeeping).

## Gates
Local `ahoy lint` (from `.vortex/`) is clean across all subsystems, and the tooling package's own `composer lint` and full test suite (711 tests) pass against PHPStan `2.2.3`. On this PR the entire CI matrix is green, including all three `vortex-test-tooling` jobs and the full `vortex-test-workflow` template-test matrix.

## Screenshots
N/A

## Before / After

```
.env.local.example (line 59) - stray brace in the Lagoon SSH default path:
  before:  Defaults to "${HOME}/.ssh/id_rsa}".
  after:   Defaults to "${HOME}/.ssh/id_rsa".

.vortex/tooling/phpstan.neon - align with installer/root configs:
  before:  (no treatPhpDocTypesAsCertain key -> defaults to true)
           assertIsString($output) flagged as always-true on ob_get_clean()
  after:   treatPhpDocTypesAsCertain: false
           guards accepted; tooling PHPStan clean
```

The trailing `}` after `id_rsa` was a stray brace making the default look like `~/.ssh/id_rsa}` (an invalid path); the fix removes it, and six Lagoon installer fixtures were regenerated to match. The tooling PHPStan config change brings the tooling package in line with the installer and root configs.
