### PR TITLE
[#2767] Fixed 'VORTEX_DB_DIR' and 'VORTEX_DB_FILE' ignored for indexed DB fetches.

### DIFF
--- a/.vortex/tooling/src/vortex-fetch-db
+++ b/.vortex/tooling/src/vortex-fetch-db
@@ -35,12 +35,12 @@ VORTEX_FETCH_DB_PROCEED="${!_v:-1}"
 # Database dump file name.
 _v="VORTEX_FETCH_DB${_db_index}_FILE"
 _vs="VORTEX_DB${_db_index}_FILE"
-VORTEX_FETCH_DB_FILE="${!_v:-${!_vs:-db.sql}}"
+VORTEX_FETCH_DB_FILE="${!_v:-${!_vs:-${VORTEX_DB_FILE:-db.sql}}}"
 
 # Directory with database dump file.
 _v="VORTEX_FETCH_DB${_db_index}_DIR"
 _vs="VORTEX_DB${_db_index}_DIR"
-VORTEX_FETCH_DB_DIR="${!_v:-${!_vs:-./.data}}"
+VORTEX_FETCH_DB_DIR="${!_v:-${!_vs:-${VORTEX_DB_DIR:-./.data}}}"
 
 # ------------------------------------------------------------------------------
 

--- a/.vortex/tooling/src/vortex-fetch-db-acquia
+++ b/.vortex/tooling/src/vortex-fetch-db-acquia
@@ -53,13 +53,13 @@ VORTEX_FETCH_DB_ACQUIA_DB_NAME="${!_v:-}"
 _v="VORTEX_FETCH_DB${_db_index}_ACQUIA_DB_DIR"
 _vs="VORTEX_FETCH_DB${_db_index}_DIR"
 _vss="VORTEX_DB${_db_index}_DIR"
-VORTEX_FETCH_DB_ACQUIA_DB_DIR="${!_v:-${!_vs:-${!_vss:-./.data}}}"
+VORTEX_FETCH_DB_ACQUIA_DB_DIR="${!_v:-${!_vs:-${!_vss:-${VORTEX_DB_DIR:-./.data}}}}"
 
 # Database dump file name.
 _v="VORTEX_FETCH_DB${_db_index}_ACQUIA_DB_FILE"
 _vs="VORTEX_FETCH_DB${_db_index}_FILE"
 _vss="VORTEX_DB${_db_index}_FILE"
-VORTEX_FETCH_DB_ACQUIA_DB_FILE="${!_v:-${!_vs:-${!_vss:-db.sql}}}"
+VORTEX_FETCH_DB_ACQUIA_DB_FILE="${!_v:-${!_vs:-${!_vss:-${VORTEX_DB_FILE:-db.sql}}}}"
 
 # Flag to fetch a fresh copy of the database by triggering a new backup.
 _v="VORTEX_FETCH_DB${_db_index}_FRESH"

--- a/.vortex/tooling/src/vortex-fetch-db-container-registry
+++ b/.vortex/tooling/src/vortex-fetch-db-container-registry
@@ -38,7 +38,7 @@ VORTEX_FETCH_DB_CONTAINER_REGISTRY_PASS="${!_v:-${VORTEX_CONTAINER_REGISTRY_PASS
 _v="VORTEX_FETCH_DB${_db_index}_CONTAINER_REGISTRY_DB_DIR"
 _vs="VORTEX_FETCH_DB${_db_index}_DIR"
 _vss="VORTEX_DB${_db_index}_DIR"
-VORTEX_FETCH_DB_CONTAINER_REGISTRY_DB_DIR="${!_v:-${!_vs:-${!_vss:-./.data}}}"
+VORTEX_FETCH_DB_CONTAINER_REGISTRY_DB_DIR="${!_v:-${!_vs:-${!_vss:-${VORTEX_DB_DIR:-./.data}}}}"
 
 # The base container image used as a fallback when the archive does not exist.
 _v="VORTEX_FETCH_DB${_db_index}_CONTAINER_REGISTRY_IMAGE_BASE"

--- a/.vortex/tooling/src/vortex-fetch-db-ftp
+++ b/.vortex/tooling/src/vortex-fetch-db-ftp
@@ -39,13 +39,13 @@ VORTEX_FETCH_DB_FTP_FILE="${!_v:-}"
 _v="VORTEX_FETCH_DB${_db_index}_FTP_DB_DIR"
 _vs="VORTEX_FETCH_DB${_db_index}_DIR"
 _vss="VORTEX_DB${_db_index}_DIR"
-VORTEX_FETCH_DB_FTP_DB_DIR="${!_v:-${!_vs:-${!_vss:-./.data}}}"
+VORTEX_FETCH_DB_FTP_DB_DIR="${!_v:-${!_vs:-${!_vss:-${VORTEX_DB_DIR:-./.data}}}}"
 
 # Database dump file name.
 _v="VORTEX_FETCH_DB${_db_index}_FTP_DB_FILE"
 _vs="VORTEX_FETCH_DB${_db_index}_FILE"
 _vss="VORTEX_DB${_db_index}_FILE"
-VORTEX_FETCH_DB_FTP_DB_FILE="${!_v:-${!_vs:-${!_vss:-db.sql}}}"
+VORTEX_FETCH_DB_FTP_DB_FILE="${!_v:-${!_vs:-${!_vss:-${VORTEX_DB_FILE:-db.sql}}}}"
 
 #-------------------------------------------------------------------------------
 

--- a/.vortex/tooling/src/vortex-fetch-db-lagoon
+++ b/.vortex/tooling/src/vortex-fetch-db-lagoon
@@ -76,13 +76,13 @@ VORTEX_FETCH_DB_LAGOON_SSH_USER="${!_v:-${VORTEX_FETCH_DB_LAGOON_PROJECT}-${VORT
 _v="VORTEX_FETCH_DB${_db_index}_LAGOON_DB_DIR"
 _vs="VORTEX_FETCH_DB${_db_index}_DIR"
 _vss="VORTEX_DB${_db_index}_DIR"
-VORTEX_FETCH_DB_LAGOON_DB_DIR="${!_v:-${!_vs:-${!_vss:-./.data}}}"
+VORTEX_FETCH_DB_LAGOON_DB_DIR="${!_v:-${!_vs:-${!_vss:-${VORTEX_DB_DIR:-./.data}}}}"
 
 # Database dump file name on the host.
 _v="VORTEX_FETCH_DB${_db_index}_LAGOON_DB_FILE"
 _vs="VORTEX_FETCH_DB${_db_index}_FILE"
 _vss="VORTEX_DB${_db_index}_FILE"
-VORTEX_FETCH_DB_LAGOON_DB_FILE="${!_v:-${!_vs:-${!_vss:-db.sql}}}"
+VORTEX_FETCH_DB_LAGOON_DB_FILE="${!_v:-${!_vs:-${!_vss:-${VORTEX_DB_FILE:-db.sql}}}}"
 
 # Name of the webroot directory with Drupal codebase.
 WEBROOT="${WEBROOT:-web}"

--- a/.vortex/tooling/src/vortex-fetch-db-s3
+++ b/.vortex/tooling/src/vortex-fetch-db-s3
@@ -41,13 +41,13 @@ VORTEX_FETCH_DB_S3_PREFIX="${!_v:-${S3_PREFIX:-}}"
 _v="VORTEX_FETCH_DB${_db_index}_S3_DB_DIR"
 _vs="VORTEX_FETCH_DB${_db_index}_DIR"
 _vss="VORTEX_DB${_db_index}_DIR"
-VORTEX_FETCH_DB_S3_DB_DIR="${!_v:-${!_vs:-${!_vss:-./.data}}}"
+VORTEX_FETCH_DB_S3_DB_DIR="${!_v:-${!_vs:-${!_vss:-${VORTEX_DB_DIR:-./.data}}}}"
 
 # Database dump file name.
 _v="VORTEX_FETCH_DB${_db_index}_S3_DB_FILE"
 _vs="VORTEX_FETCH_DB${_db_index}_FILE"
 _vss="VORTEX_DB${_db_index}_FILE"
-VORTEX_FETCH_DB_S3_DB_FILE="${!_v:-${!_vs:-${!_vss:-db.sql}}}"
+VORTEX_FETCH_DB_S3_DB_FILE="${!_v:-${!_vs:-${!_vss:-${VORTEX_DB_FILE:-db.sql}}}}"
 
 # ------------------------------------------------------------------------------
 

--- a/.vortex/tooling/src/vortex-fetch-db-url
+++ b/.vortex/tooling/src/vortex-fetch-db-url
@@ -24,13 +24,13 @@ VORTEX_FETCH_DB_URL="${!_v:-}"
 _v="VORTEX_FETCH_DB${_db_index}_URL_DB_DIR"
 _vs="VORTEX_FETCH_DB${_db_index}_DIR"
 _vss="VORTEX_DB${_db_index}_DIR"
-VORTEX_FETCH_DB_URL_DB_DIR="${!_v:-${!_vs:-${!_vss:-./.data}}}"
+VORTEX_FETCH_DB_URL_DB_DIR="${!_v:-${!_vs:-${!_vss:-${VORTEX_DB_DIR:-./.data}}}}"
 
 # Database dump file name.
 _v="VORTEX_FETCH_DB${_db_index}_URL_DB_FILE"
 _vs="VORTEX_FETCH_DB${_db_index}_FILE"
 _vss="VORTEX_DB${_db_index}_FILE"
-VORTEX_FETCH_DB_URL_DB_FILE="${!_v:-${!_vs:-${!_vss:-db.sql}}}"
+VORTEX_FETCH_DB_URL_DB_FILE="${!_v:-${!_vs:-${!_vss:-${VORTEX_DB_FILE:-db.sql}}}}"
 
 # Password for unzipping password-protected zip files.
 _v="VORTEX_FETCH_DB${_db_index}_UNZIP_PASSWORD"

--- a/.vortex/tooling/tests/unit/fetch-db-url.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-url.bats
@@ -25,6 +25,46 @@ load ../_helper.bash
   popd >/dev/null
 }
 
+@test "fetch-db-url: Resolve indexed dir from plain VORTEX_DB_DIR fallback" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  mock_curl=$(mock_command "curl")
+  mock_set_side_effect "${mock_curl}" "mkdir -p custom_data && touch custom_data/db2.sql" 1
+
+  # The migration DB (index 2) has no per-index directory in the fixture, so the
+  # non-indexed VORTEX_DB_DIR base must be used for the fetch target directory.
+  export VORTEX_DB_INDEX="2"
+  export VORTEX_FETCH_DB2_URL="http://example.com/db.sql"
+  export VORTEX_DB_DIR="custom_data"
+
+  run .vortex/tooling/src/vortex-fetch-db-url
+  assert_success
+  # curl writes into custom_data, resolved via the plain VORTEX_DB_DIR fallback.
+  assert_contains "custom_data/" "$(mock_get_call_args "${mock_curl}" 1)"
+
+  popd >/dev/null
+}
+
+@test "fetch-db-url: Resolve indexed file name from plain VORTEX_DB_FILE fallback" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  mock_curl=$(mock_command "curl")
+  mock_set_side_effect "${mock_curl}" "mkdir -p .data && touch .data/custom.sql" 1
+
+  # An index with no per-index file override must fall back to the non-indexed
+  # VORTEX_DB_FILE for the fetch target file name.
+  export VORTEX_DB_INDEX="3"
+  export VORTEX_FETCH_DB3_URL="http://example.com/db.sql"
+  export VORTEX_DB_FILE="custom.sql"
+
+  run .vortex/tooling/src/vortex-fetch-db-url
+  assert_success
+  # curl writes custom.sql, resolved via the plain VORTEX_DB_FILE fallback.
+  assert_contains "/custom.sql" "$(mock_get_call_args "${mock_curl}" 1)"
+
+  popd >/dev/null
+}
+
 @test "fetch-db-url: Fetch zip file without password" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 

--- a/.vortex/tooling/tests/unit/fetch-db.bats
+++ b/.vortex/tooling/tests/unit/fetch-db.bats
@@ -184,6 +184,59 @@ EOF
   popd >/dev/null
 }
 
+@test "fetch-db: Resolve indexed dir from plain VORTEX_DB_DIR fallback" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # The migration DB (index 2) has a per-index file name (db2.sql) but no
+  # per-index directory, so the non-indexed VORTEX_DB_DIR must act as the base
+  # directory. An existing dump placed there should be discovered.
+  mkdir -p custom_data
+  touch custom_data/db2.sql
+
+  mock_ls=$(mock_command "ls")
+  mock_set_output "${mock_ls}" "total 0" 1
+
+  export VORTEX_DB_INDEX="2"
+  export VORTEX_FETCH_DB2_SOURCE="url"
+  export VORTEX_FETCH_DB2_PROCEED="1"
+  export VORTEX_DB_DIR="custom_data"
+
+  run .vortex/tooling/src/vortex-fetch-db
+  assert_success
+  # The router resolved the indexed dump directory to custom_data via the
+  # plain VORTEX_DB_DIR fallback and found the existing dump there.
+  assert_output_contains "Found existing database dump file(s)."
+  assert_output_contains "Using existing database dump file(s)."
+
+  popd >/dev/null
+}
+
+@test "fetch-db: Resolve indexed file name from plain VORTEX_DB_FILE fallback" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  # An index with no per-index file override (unlike index 2, which the fixture
+  # sets to db2.sql) must fall back to the non-indexed VORTEX_DB_FILE for the
+  # dump file name. An existing dump with that name should be discovered.
+  mkdir -p .data
+  touch .data/custom.sql
+
+  mock_ls=$(mock_command "ls")
+  mock_set_output "${mock_ls}" "total 0" 1
+
+  export VORTEX_DB_INDEX="3"
+  export VORTEX_FETCH_DB3_SOURCE="url"
+  export VORTEX_FETCH_DB3_PROCEED="1"
+  export VORTEX_DB_FILE="custom.sql"
+
+  run .vortex/tooling/src/vortex-fetch-db
+  assert_success
+  # The router resolved the indexed dump file name to custom.sql via the
+  # plain VORTEX_DB_FILE fallback and found the existing dump.
+  assert_output_contains "Found existing database dump file(s)."
+
+  popd >/dev/null
+}
+
 @test "fetch-db: Existing database file handling" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 

--- a/.vortex/tooling/tests/unit/fetch-db.bats
+++ b/.vortex/tooling/tests/unit/fetch-db.bats
@@ -199,6 +199,9 @@ EOF
   export VORTEX_DB_INDEX="2"
   export VORTEX_FETCH_DB2_SOURCE="url"
   export VORTEX_FETCH_DB2_PROCEED="1"
+  # Set the per-index file name explicitly so the fixture name matches the
+  # resolved dump file rather than relying on the fixture .env default.
+  export VORTEX_FETCH_DB2_FILE="db2.sql"
   export VORTEX_DB_DIR="custom_data"
 
   run .vortex/tooling/src/vortex-fetch-db


### PR DESCRIPTION
Closes #2767

## Summary

`vortex-fetch-db` and its source resolvers (`vortex-fetch-db-url`, `-ftp`, `-acquia`, `-lagoon`, `-s3`, `-container-registry`) resolved the DB dump output directory and file name for indexed fetches (`VORTEX_DB_INDEX=N`) without ever falling back to the non-indexed base variables `VORTEX_DB_DIR` / `VORTEX_DB_FILE`. As a result, a plain `VORTEX_DB_DIR` was honoured for the primary DB fetch but silently ignored for indexed DBs, which fell through to the hardcoded `./.data` default instead. This adds `${VORTEX_DB_DIR:-...}` and `${VORTEX_DB_FILE:-...}` as the innermost fallback in the directory/file resolution chain, so indexed fetches honour the same base variables as the primary DB and align with `scripts/provision-20-migration.sh`, which already reads the migration DB from `${VORTEX_DB_DIR}/db2.sql`.

## Changes

- Router (`vortex-fetch-db`) and all 6 source resolvers now fall back to `VORTEX_DB_DIR` for the output directory when no indexed or per-index override is set.
- Router and 5 of the 6 resolvers now fall back to `VORTEX_DB_FILE` for the output file name (`vortex-fetch-db-container-registry` is excluded - it always writes a hardcoded `db.tar`).
- Added 4 new BATS tests covering the `_DIR` and `_FILE` fallback for the router and the `vortex-fetch-db-url` resolver.

## Before / After

```
VORTEX_DB_INDEX=2, only VORTEX_DB_DIR=/tmp/data exported

Before                                          After
──────                                          ─────
VORTEX_FETCH_DB2_DIR  (unset)                    VORTEX_FETCH_DB2_DIR  (unset)
   └─ VORTEX_DB2_DIR  (unset)                       └─ VORTEX_DB2_DIR  (unset)
      └─ ./.data      ← writes here                    └─ VORTEX_DB_DIR (/tmp/data) ← writes here
                                                          └─ ./.data
VORTEX_DB_DIR (/tmp/data) IGNORED               VORTEX_DB_DIR honoured; fetch aligns with provision read
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database dump path and filename fallback handling across multiple fetch methods.
  * When specific per-environment values are missing, the tools now more reliably use broader database directory and filename settings before defaulting.
  * Added coverage for the new fallback behavior to help prevent path resolution regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->