### PR TITLE
[#1384] Rebuilt the Acquia database fetch on the native 'acli' CLI and reworked tooling task output.

### DIFF
--- a/.vortex/docs/content/hosting/acquia.mdx
+++ b/.vortex/docs/content/hosting/acquia.mdx
@@ -97,6 +97,11 @@ Authentication uses your Acquia Cloud API key and secret from `.env` and
 home directory rather than your global `~/.acquia` configuration, so any Acquia
 credentials you already have locally are left untouched.
 
+The source application is auto-discovered from those credentials. When they
+expose more than one application, set `VORTEX_FETCH_DB_ACQUIA_APP_NAME` to pick
+one - it matches an application by its name, hosting id (for example
+`prod:<name>`), machine name or uuid.
+
 By default the latest existing backup is downloaded. Force a new backup and wait
 for it to complete with:
 

--- a/.vortex/docs/content/hosting/acquia.mdx
+++ b/.vortex/docs/content/hosting/acquia.mdx
@@ -86,6 +86,24 @@ or CI builds:
 ahoy fetch-db
 ```
 
+This wraps the provider-native [Acquia CLI](https://github.com/acquia/cli). If an
+`acli` binary is already on your `PATH`, **Vortex** uses it as-is. Otherwise it
+downloads a pinned release into a cache directory (`.artifacts/tmp` by default,
+overridable with `VORTEX_ACLI_PATH`) and reuses that copy on later runs, so
+nothing needs to be pre-installed.
+
+Authentication uses your Acquia Cloud API key and secret from `.env` and
+`.env.local`. They are passed to the CLI for a single run against an isolated
+home directory rather than your global `~/.acquia` configuration, so any Acquia
+credentials you already have locally are left untouched.
+
+By default the latest existing backup is downloaded. Force a new backup and wait
+for it to complete with:
+
+```shell
+ahoy fetch-db --fresh
+```
+
 ### Run a hosting task
 
 Copying databases or files between environments and purging the edge cache run

--- a/.vortex/docs/cspell.json
+++ b/.vortex/docs/cspell.json
@@ -19,6 +19,7 @@
         "Runsheet",
         "Runsheets",
         "Upsun",
+        "acli",
         "acquia",
         "amazee",
         "amazeeio",

--- a/.vortex/tooling/playground/fetch-db-acquia.php
+++ b/.vortex/tooling/playground/fetch-db-acquia.php
@@ -1,0 +1,110 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * @file
+ * Manual runner for the Acquia database download script.
+ *
+ * Exercises 'vortex-fetch-db-acquia' end to end against a real Acquia Cloud
+ * environment - acli resolution, the isolated ACLI_HOME auth and the backup
+ * download - without a full project checkout. Every connection detail is read
+ * from the environment; nothing is hardcoded.
+ *
+ * Usage:
+ *   VORTEX_FETCH_DB_ACQUIA_KEY=... \
+ *   VORTEX_FETCH_DB_ACQUIA_SECRET=... \
+ *   VORTEX_FETCH_DB_ACQUIA_APP_NAME="My App" \
+ *   VORTEX_FETCH_DB_ENVIRONMENT=prod \
+ *   VORTEX_FETCH_DB_ACQUIA_DB_NAME=my_db \
+ *   ./playground/fetch-db-acquia.php [--fresh]
+ *
+ * Pass '--fresh' (or set VORTEX_FETCH_DB_FRESH=1) to trigger a new backup and
+ * wait for it instead of downloading the latest existing one.
+ *
+ * Optional overrides (defaults in brackets):
+ *   VORTEX_FETCH_DB_ACQUIA_DB_DIR   [.artifacts/tmp/playground-acquia]
+ *   VORTEX_FETCH_DB_ACQUIA_DB_FILE  [db.sql]
+ *   VORTEX_ACLI_PATH                [.artifacts/tmp/playground-acquia]
+ *                                   acli phar and isolated ACLI_HOME.
+ */
+
+declare(strict_types=1);
+
+namespace DrevOps\VortexTooling;
+
+require_once __DIR__ . '/../src/helpers.php';
+
+echo "=== Acquia database download runner ===\n\n";
+
+$required = [
+  'VORTEX_FETCH_DB_ACQUIA_KEY',
+  'VORTEX_FETCH_DB_ACQUIA_SECRET',
+  'VORTEX_FETCH_DB_ACQUIA_APP_NAME',
+  'VORTEX_FETCH_DB_ENVIRONMENT',
+  'VORTEX_FETCH_DB_ACQUIA_DB_NAME',
+];
+
+$missing = array_filter($required, fn(string $name): bool => getenv($name) === FALSE || getenv($name) === '');
+if ($missing !== []) {
+  // Nothing to download without credentials and a target, so an unconfigured
+  // run is a no-op rather than a failure.
+  echo "Skipping: set " . implode(', ', $missing) . " to run.\n";
+  echo "See the file header for the full usage example.\n";
+  exit(0);
+}
+
+// Keep all scratch under the gitignored '.artifacts/tmp' at the repo root.
+$scratch = dirname(__DIR__, 3) . '/.artifacts/tmp/playground-acquia';
+
+// Force a new backup with the '--fresh' flag or VORTEX_FETCH_DB_FRESH=1.
+$fresh = in_array('--fresh', (array) ($_SERVER['argv'] ?? []), TRUE) || getenv('VORTEX_FETCH_DB_FRESH') === '1';
+
+// Playground-scoped defaults; every value is overridable via the environment.
+$config = [
+  'VORTEX_FETCH_DB_ACQUIA_DB_DIR' => getenv('VORTEX_FETCH_DB_ACQUIA_DB_DIR') ?: $scratch,
+  'VORTEX_FETCH_DB_ACQUIA_DB_FILE' => getenv('VORTEX_FETCH_DB_ACQUIA_DB_FILE') ?: 'db.sql',
+  'VORTEX_ACLI_PATH' => getenv('VORTEX_ACLI_PATH') ?: $scratch,
+  'VORTEX_FETCH_DB_FRESH' => $fresh ? '1' : '',
+];
+
+foreach ($config as $name => $value) {
+  putenv($name . '=' . $value);
+}
+
+echo "Configuration:\n";
+echo "  Application:  " . getenv('VORTEX_FETCH_DB_ACQUIA_APP_NAME') . "\n";
+echo "  Environment:  " . getenv('VORTEX_FETCH_DB_ENVIRONMENT') . "\n";
+echo "  Database:     " . getenv('VORTEX_FETCH_DB_ACQUIA_DB_NAME') . "\n";
+echo "  Download dir: " . $config['VORTEX_FETCH_DB_ACQUIA_DB_DIR'] . "\n";
+echo "  acli cache:   " . $config['VORTEX_ACLI_PATH'] . "\n";
+echo "  Fresh backup: " . ($fresh ? 'yes' : 'no (use the latest existing backup)') . "\n\n";
+
+$dest = $config['VORTEX_FETCH_DB_ACQUIA_DB_DIR'] . '/' . $config['VORTEX_FETCH_DB_ACQUIA_DB_FILE'];
+if (is_file($dest)) {
+  unlink($dest);
+}
+
+echo "Running vortex-fetch-db-acquia...\n\n";
+// Inherit the real stdio streams so the script sees a TTY and keeps its colour
+// output; a piped subprocess (passthru) would disable colours.
+$descriptors = [0 => STDIN, 1 => STDOUT, 2 => STDERR];
+$process = proc_open('php ' . escapeshellarg(__DIR__ . '/../src/vortex-fetch-db-acquia'), $descriptors, $pipes);
+$exit_code = is_resource($process) ? proc_close($process) : 1;
+
+echo "\n";
+echo "Exit code: " . $exit_code . "\n";
+
+if (is_file($dest)) {
+  $size = (int) filesize($dest);
+  $handle = fopen($dest, 'r');
+  $first_line = $handle !== FALSE ? (fgets($handle) ?: '') : '';
+  if ($handle !== FALSE) {
+    fclose($handle);
+  }
+  echo "Downloaded:   " . $dest . " (" . number_format($size) . " bytes)\n";
+  echo "First line:   " . trim($first_line) . "\n";
+  echo "\nResult: " . ($exit_code === 0 ? "\xE2\x9C\x93 SUCCESS" : "\xE2\x9C\x97 FAILED (non-zero exit)") . "\n";
+}
+else {
+  echo "\nResult: \xE2\x9C\x97 FAILED (no dump written to " . $dest . ")\n";
+}

--- a/.vortex/tooling/src/helpers.php
+++ b/.vortex/tooling/src/helpers.php
@@ -706,6 +706,31 @@ function acli_home(): string {
 
   if (!is_dir($home)) {
     mkdir($home, 0755, TRUE);
+    // The isolated home caches acli's token and state; remove it when the run
+    // ends so no credentials linger on disk afterwards.
+    register_shutdown_function(static function () use ($home): void {
+      // @codeCoverageIgnoreStart
+      if (!is_dir($home)) {
+        return;
+      }
+
+      $items = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($home, \RecursiveDirectoryIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
+      foreach ($items as $item) {
+        if (!$item instanceof \SplFileInfo) {
+          continue;
+        }
+
+        if ($item->isDir()) {
+          rmdir($item->getPathname());
+        }
+        else {
+          unlink($item->getPathname());
+        }
+      }
+
+      rmdir($home);
+      // @codeCoverageIgnoreEnd
+    });
   }
 
   return $home;
@@ -735,8 +760,14 @@ function acli_home(): string {
  *   The captured command output.
  */
 function acli_exec(string $bin, string $subcommand, array $ctx, ?int &$exit_code = NULL): string {
-  $env = sprintf('ACLI_HOME=%s ACLI_KEY=%s ACLI_SECRET=%s ACLI_NO_TELEMETRY=1', escapeshellarg($ctx['home']), escapeshellarg($ctx['key']), escapeshellarg($ctx['secret']));
-  $cmd = sprintf('%s %s %s --no-interaction 2>&1', $env, escapeshellarg($bin), $subcommand);
+  // Pass credentials through the process environment rather than the command
+  // line, so they are never exposed in the process list (e.g. `ps`).
+  putenv('ACLI_HOME=' . $ctx['home']);
+  putenv('ACLI_KEY=' . $ctx['key']);
+  putenv('ACLI_SECRET=' . $ctx['secret']);
+  putenv('ACLI_NO_TELEMETRY=1');
+
+  $cmd = sprintf('%s %s --no-interaction 2>&1', escapeshellarg($bin), $subcommand);
 
   $exit_code_provided = $exit_code !== NULL;
   if (!$exit_code_provided) {

--- a/.vortex/tooling/src/helpers.php
+++ b/.vortex/tooling/src/helpers.php
@@ -248,13 +248,16 @@ function fail_no_exit(string $format, ...$args): void {
  *   Whatever $operation returns.
  */
 function task_progress(string $message, callable $operation): mixed {
-  echo term_supports_color() ? "\033[34m[TASK] " . $message . "\033[0m" : '[TASK] ' . $message;
+  $color = term_supports_color();
+  // Leave the colour open so the progress dots inherit the task colour; it is
+  // closed together with the trailing newline once the operation returns.
+  echo $color ? "\033[34m[TASK] " . $message : '[TASK] ' . $message;
 
   try {
     return $operation();
   }
   finally {
-    echo PHP_EOL;
+    echo ($color ? "\033[0m" : '') . PHP_EOL;
   }
 }
 
@@ -267,6 +270,22 @@ function task_progress(string $message, callable $operation): mixed {
 function progress_dot(): void {
   echo '.';
   flush();
+}
+
+/**
+ * Sleep for a number of seconds, emitting a progress dot every second.
+ *
+ * Use inside a task_progress() operation so a fixed wait or a status-poll
+ * interval keeps the task line ticking rather than appearing to hang.
+ *
+ * @param int $seconds
+ *   The number of seconds to wait.
+ */
+function sleep_progress(int $seconds): void {
+  for ($second = 0; $second < $seconds; $second++) {
+    sleep(1);
+    progress_dot();
+  }
 }
 
 /**

--- a/.vortex/tooling/src/helpers.php
+++ b/.vortex/tooling/src/helpers.php
@@ -232,6 +232,44 @@ function fail_no_exit(string $format, ...$args): void {
 }
 
 /**
+ * Run an operation under a task line that stays open for progress dots.
+ *
+ * Prints the task line without a trailing newline, runs the operation - which
+ * emits its own progress dots while it works (see progress_dot()) - then closes
+ * the line. This keeps long-running steps such as downloads and status polling
+ * visibly alive instead of appearing to hang.
+ *
+ * @param string $message
+ *   The already-formatted task message.
+ * @param callable $operation
+ *   The work to run; its return value is passed through unchanged.
+ *
+ * @return mixed
+ *   Whatever $operation returns.
+ */
+function task_progress(string $message, callable $operation): mixed {
+  echo term_supports_color() ? "\033[34m[TASK] " . $message . "\033[0m" : '[TASK] ' . $message;
+
+  try {
+    return $operation();
+  }
+  finally {
+    echo PHP_EOL;
+  }
+}
+
+/**
+ * Emit a single progress dot for a long-running task and flush it immediately.
+ *
+ * Flushing matters during a blocking transfer so the dots appear as the work
+ * happens rather than all at once when the call returns.
+ */
+function progress_dot(): void {
+  echo '.';
+  flush();
+}
+
+/**
  * Output a failure message.
  *
  * @param string $format
@@ -927,6 +965,24 @@ function request(string $url, array $options = []): array {
       }
       $opts[CURLOPT_FILE] = $save_fh;
       unset($opts[CURLOPT_RETURNTRANSFER]);
+    }
+
+    // Emit a progress dot roughly once per second while the transfer runs.
+    if (!empty($options['progress'])) {
+      $opts[CURLOPT_NOPROGRESS] = FALSE;
+      $opts[CURLOPT_XFERINFOFUNCTION] = static function (mixed $ch, int $dltotal, int $dlnow, int $ultotal, int $ulnow): int {
+        // @codeCoverageIgnoreStart
+        static $last = 0;
+        $now = time();
+
+        if ($dlnow > 0 && $now !== $last) {
+          progress_dot();
+          $last = $now;
+        }
+
+        return 0;
+        // @codeCoverageIgnoreEnd
+      };
     }
 
     curl_setopt_array($ch, $opts);

--- a/.vortex/tooling/src/helpers.php
+++ b/.vortex/tooling/src/helpers.php
@@ -183,8 +183,10 @@ function note(string $format, ...$args): void {
  * [TASK] line (the body may emit progress dots via progress_dot()/
  * sleep_progress() while it works), then reports [ OK ] with the done message.
  * The body signals failure by throwing: the thrown message is reported as
- * [FAIL] and the script exits with an error. This keeps each task's intent,
- * work and outcome in one place and guarantees every task ends with a status.
+ * [FAIL]. A fatal task then exits the script; a non-fatal one returns NULL so a
+ * best-effort loop can carry on to its next item. This keeps each task's
+ * intent, work and outcome in one place and guarantees every task ends with a
+ * status.
  *
  * @param string $doing
  *   The present-tense task message, e.g. 'Downloading the backup.'.
@@ -194,11 +196,15 @@ function note(string $format, ...$args): void {
  *   the work is done.
  * @param callable|null $body
  *   The work to perform; throw to fail the task with the thrown message.
+ * @param bool $fatal
+ *   Whether a thrown failure exits the script. TRUE (default) reports [FAIL]
+ *   and exits; FALSE reports [FAIL] and returns NULL so the caller continues.
  *
  * @return mixed
- *   Whatever the body returns, or NULL when announcing only.
+ *   Whatever the body returns, or NULL when announcing only or when a non-fatal
+ *   body fails.
  */
-function task(string $doing, string|\Closure|null $done = NULL, ?callable $body = NULL): mixed {
+function task(string $doing, string|\Closure|null $done = NULL, ?callable $body = NULL, bool $fatal = TRUE): mixed {
   $color = term_supports_color();
 
   if ($body === NULL) {
@@ -218,6 +224,13 @@ function task(string $doing, string|\Closure|null $done = NULL, ?callable $body 
   }
   catch (\Throwable $e) {
     echo ($color ? "\033[0m" : '') . PHP_EOL;
+
+    if (!$fatal) {
+      fail_no_exit('%s', $e->getMessage());
+
+      return NULL;
+    }
+
     fail('%s', $e->getMessage());
   }
 
@@ -270,36 +283,6 @@ function fail_no_exit(string $format, ...$args): void {
 }
 
 /**
- * Run an operation under a task line that stays open for progress dots.
- *
- * Prints the task line without a trailing newline, runs the operation - which
- * emits its own progress dots while it works (see progress_dot()) - then closes
- * the line. This keeps long-running steps such as downloads and status polling
- * visibly alive instead of appearing to hang.
- *
- * @param string $message
- *   The already-formatted task message.
- * @param callable $operation
- *   The work to run; its return value is passed through unchanged.
- *
- * @return mixed
- *   Whatever $operation returns.
- */
-function task_progress(string $message, callable $operation): mixed {
-  $color = term_supports_color();
-  // Leave the colour open so the progress dots inherit the task colour; it is
-  // closed together with the trailing newline once the operation returns.
-  echo $color ? "\033[34m[TASK] " . $message : '[TASK] ' . $message;
-
-  try {
-    return $operation();
-  }
-  finally {
-    echo ($color ? "\033[0m" : '') . PHP_EOL;
-  }
-}
-
-/**
  * Emit a single progress dot for a long-running task and flush it immediately.
  *
  * Flushing matters during a blocking transfer so the dots appear as the work
@@ -313,8 +296,8 @@ function progress_dot(): void {
 /**
  * Sleep for a number of seconds, emitting a progress dot every second.
  *
- * Use inside a task_progress() operation so a fixed wait or a status-poll
- * interval keeps the task line ticking rather than appearing to hang.
+ * Use inside a task() body so a fixed wait or a status-poll interval keeps the
+ * task line ticking rather than appearing to hang.
  *
  * @param int $seconds
  *   The number of seconds to wait.

--- a/.vortex/tooling/src/helpers.php
+++ b/.vortex/tooling/src/helpers.php
@@ -176,17 +176,55 @@ function note(string $format, ...$args): void {
 }
 
 /**
- * Output a task message.
+ * Announce a task, or run its body and report the outcome.
  *
- * @param string $format
- *   Format string for sprintf().
- * @param bool|float|int|string|null ...$args
- *   Arguments for sprintf().
+ * With only a message, announces the task - a caller then follows with its own
+ * pass()/fail(). With a done message and a body, it runs the body under a live
+ * [TASK] line (the body may emit progress dots via progress_dot()/
+ * sleep_progress() while it works), then reports [ OK ] with the done message.
+ * The body signals failure by throwing: the thrown message is reported as
+ * [FAIL] and the script exits with an error. This keeps each task's intent,
+ * work and outcome in one place and guarantees every task ends with a status.
+ *
+ * @param string $doing
+ *   The present-tense task message, e.g. 'Downloading the backup.'.
+ * @param string|\Closure|null $done
+ *   The success message reported when a body completes. A closure receives the
+ *   body's return value and produces the message, for outcomes known only once
+ *   the work is done.
+ * @param callable|null $body
+ *   The work to perform; throw to fail the task with the thrown message.
+ *
+ * @return mixed
+ *   Whatever the body returns, or NULL when announcing only.
  */
-function task(string $format, ...$args): void {
-  echo term_supports_color() ?
-    "\033[34m[TASK] " . sprintf($format, ...$args) . "\033[0m\n" :
-    sprintf('[TASK] %s%s', sprintf($format, ...$args), PHP_EOL);
+function task(string $doing, string|\Closure|null $done = NULL, ?callable $body = NULL): mixed {
+  $color = term_supports_color();
+
+  if ($body === NULL) {
+    echo $color ? "\033[34m[TASK] " . $doing . "\033[0m" . PHP_EOL : '[TASK] ' . $doing . PHP_EOL;
+
+    return NULL;
+  }
+
+  echo $color ? "\033[34m[TASK] " . $doing : '[TASK] ' . $doing;
+
+  try {
+    $result = $body();
+    echo ($color ? "\033[0m" : '') . PHP_EOL;
+    pass('%s', $done instanceof \Closure ? (string) $done($result) : (string) $done);
+
+    return $result;
+  }
+  catch (\Throwable $e) {
+    echo ($color ? "\033[0m" : '') . PHP_EOL;
+    fail('%s', $e->getMessage());
+  }
+
+  // @codeCoverageIgnoreStart
+  // Unreachable: fail() above terminates the script.
+  return NULL;
+  // @codeCoverageIgnoreEnd
 }
 
 /**
@@ -452,7 +490,7 @@ function lagoon_cli_resolve(): string {
   $base = sprintf('https://github.com/uselagoon/lagoon-cli/releases/download/%s', $version);
   $asset = sprintf('lagoon-cli-%s-%s-%s', $version, $platform, $arch);
 
-  task('Downloading the Lagoon CLI "%s" to "%s".', $version, $bin);
+  task(sprintf('Downloading the Lagoon CLI "%s" to "%s".', $version, $bin));
   $response = request($base . '/' . $asset, ['method' => 'GET', 'save_to' => $bin, 'timeout' => 120]);
   if (!$response['ok']) {
     @unlink($bin);
@@ -639,7 +677,7 @@ function acli_resolve(): string {
 
   $url = sprintf('https://github.com/acquia/cli/releases/download/%s/acli.phar', $version);
 
-  task('Downloading the Acquia CLI "%s" to "%s".', $version, $bin);
+  task(sprintf('Downloading the Acquia CLI "%s" to "%s".', $version, $bin));
   $response = request($url, ['method' => 'GET', 'save_to' => $bin, 'timeout' => 120]);
   if (!$response['ok']) {
     @unlink($bin);
@@ -986,16 +1024,18 @@ function request(string $url, array $options = []): array {
       unset($opts[CURLOPT_RETURNTRANSFER]);
     }
 
-    // Emit a progress dot roughly once per second while the transfer runs.
-    if (!empty($options['progress'])) {
+    // Report transfer progress to the caller's callback about once a second.
+    // The callback owns any output; request() stays output-agnostic.
+    if (isset($options['on_progress']) && is_callable($options['on_progress'])) {
+      $on_progress = $options['on_progress'];
       $opts[CURLOPT_NOPROGRESS] = FALSE;
-      $opts[CURLOPT_XFERINFOFUNCTION] = static function (mixed $ch, int $dltotal, int $dlnow, int $ultotal, int $ulnow): int {
+      $opts[CURLOPT_XFERINFOFUNCTION] = static function (mixed $ch, int $dltotal, int $dlnow, int $ultotal, int $ulnow) use ($on_progress): int {
         // @codeCoverageIgnoreStart
         static $last = 0;
         $now = time();
 
         if ($dlnow > 0 && $now !== $last) {
-          progress_dot();
+          $on_progress();
           $last = $now;
         }
 

--- a/.vortex/tooling/src/helpers.php
+++ b/.vortex/tooling/src/helpers.php
@@ -681,42 +681,56 @@ function acli_resolve(): string {
  * ID so concurrent runs sharing the cache directory do not clash.
  *
  * @return string
- *   Path to the home directory; it is created if missing.
+ *   Path to the home directory; any stale copy is cleared and it is recreated.
  */
 function acli_home(): string {
   $dir = (string) getenv_default('VORTEX_ACLI_PATH', '.artifacts/tmp');
   $home = $dir . '/acli-home-' . getmypid();
 
-  if (!is_dir($home)) {
-    mkdir($home, 0755, TRUE);
-    // The isolated home caches acli's token and state; remove it when the run
-    // ends so no credentials linger on disk afterwards.
-    register_shutdown_function(static function () use ($home): void {
-      // @codeCoverageIgnoreStart
-      if (!is_dir($home)) {
-        return;
-      }
+  // A home left behind by a crashed run that reused this PID would hand acli
+  // stale cached credentials; clear it so every run starts from a clean home.
+  acli_home_remove($home);
+  mkdir($home, 0755, TRUE);
 
-      $items = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($home, \RecursiveDirectoryIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
-      foreach ($items as $item) {
-        if (!$item instanceof \SplFileInfo) {
-          continue;
-        }
-
-        if ($item->isDir()) {
-          rmdir($item->getPathname());
-        }
-        else {
-          unlink($item->getPathname());
-        }
-      }
-
-      rmdir($home);
-      // @codeCoverageIgnoreEnd
-    });
-  }
+  // The isolated home caches acli's token and state; remove it when the run
+  // ends so no credentials linger on disk afterwards.
+  register_shutdown_function(static function () use ($home): void {
+    // @codeCoverageIgnoreStart
+    acli_home_remove($home);
+    // @codeCoverageIgnoreEnd
+  });
 
   return $home;
+}
+
+/**
+ * Recursively remove an isolated Acquia CLI home directory.
+ *
+ * @param string $home
+ *   Path to the directory to remove; a no-op when it does not exist.
+ */
+function acli_home_remove(string $home): void {
+  if (!is_dir($home)) {
+    return;
+  }
+
+  $items = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($home, \RecursiveDirectoryIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
+  foreach ($items as $item) {
+    // @codeCoverageIgnoreStart
+    if (!$item instanceof \SplFileInfo) {
+      continue;
+    }
+    // @codeCoverageIgnoreEnd
+
+    if ($item->isDir()) {
+      rmdir($item->getPathname());
+    }
+    else {
+      unlink($item->getPathname());
+    }
+  }
+
+  rmdir($home);
 }
 
 /**

--- a/.vortex/tooling/src/helpers.php
+++ b/.vortex/tooling/src/helpers.php
@@ -550,6 +550,116 @@ function lagoon_exec(string $bin, string $subcommand, array $ctx, ?int &$exit_co
 }
 
 /**
+ * Resolve the Acquia CLI binary, installing it on demand.
+ *
+ * Prefers an 'acli' already available on PATH. Otherwise reuses a phar
+ * previously downloaded to the cache directory, or downloads it there once.
+ * This lets the same scripts run where acli is not pre-installed, without
+ * re-downloading on every invocation. The Acquia CLI ships as a
+ * platform-independent PHP phar, so there is no per-architecture asset.
+ *
+ * @return string
+ *   Path to the Acquia CLI binary.
+ */
+function acli_resolve(): string {
+  if (command_path('acli')) {
+    note('Using the Acquia CLI found on PATH.');
+    return 'acli';
+  }
+
+  $dir = (string) getenv_default('VORTEX_ACLI_PATH', '.artifacts/tmp');
+  $version = getenv_default('VORTEX_ACLI_VERSION', '2.61.3');
+  $bin = $dir . '/acli';
+
+  if (is_executable($bin)) {
+    note('Reusing the Acquia CLI previously downloaded to "%s".', $bin);
+    return $bin;
+  }
+
+  if (!is_dir($dir)) {
+    mkdir($dir, 0755, TRUE);
+  }
+
+  $url = sprintf('https://github.com/acquia/cli/releases/download/%s/acli.phar', $version);
+
+  task('Downloading the Acquia CLI "%s" to "%s".', $version, $bin);
+  $response = request($url, ['method' => 'GET', 'save_to' => $bin, 'timeout' => 120]);
+  if (!$response['ok']) {
+    @unlink($bin);
+    fail('Failed to download the Acquia CLI from "%s": %s', $url, $response['error'] ?? 'Unknown error');
+  }
+
+  chmod($bin, 0755);
+
+  return $bin;
+}
+
+/**
+ * Path to an ephemeral Acquia CLI home directory scoped to a single run.
+ *
+ * Pointing 'ACLI_HOME' at a throwaway directory keeps acli's credentials,
+ * cached tokens and active-environment state out of a developer's global
+ * '~/.acquia' configuration. The directory name is suffixed with the process
+ * ID so concurrent runs sharing the cache directory do not clash.
+ *
+ * @return string
+ *   Path to the home directory; it is created if missing.
+ */
+function acli_home(): string {
+  $dir = (string) getenv_default('VORTEX_ACLI_PATH', '.artifacts/tmp');
+  $home = $dir . '/acli-home-' . getmypid();
+
+  if (!is_dir($home)) {
+    mkdir($home, 0755, TRUE);
+  }
+
+  return $home;
+}
+
+/**
+ * Run an Acquia CLI subcommand and capture its output.
+ *
+ * The isolated home directory and API credentials are threaded from the context
+ * so acli authenticates headlessly without touching the global '~/.acquia'
+ * configuration; command-specific arguments are provided by the caller in the
+ * subcommand.
+ *
+ * @param string $bin
+ *   The Acquia CLI binary.
+ * @param string $subcommand
+ *   The subcommand with its command-specific arguments.
+ * @param array{home: string, key: string, secret: string} $ctx
+ *   Execution context: the isolated ACLI_HOME and the API key and secret.
+ * @param int|null $exit_code
+ *   (optional) Variable to capture the exit code. Pass an initialised variable
+ *   (e.g. `$exit_code = 0`) to suppress the automatic fail() on non-zero exit.
+ *
+ * @param-out int $exit_code
+ *
+ * @return string
+ *   The captured command output.
+ */
+function acli_exec(string $bin, string $subcommand, array $ctx, ?int &$exit_code = NULL): string {
+  $env = sprintf('ACLI_HOME=%s ACLI_KEY=%s ACLI_SECRET=%s ACLI_NO_TELEMETRY=1', escapeshellarg($ctx['home']), escapeshellarg($ctx['key']), escapeshellarg($ctx['secret']));
+  $cmd = sprintf('%s %s %s --no-interaction 2>&1', $env, escapeshellarg($bin), $subcommand);
+
+  $exit_code_provided = $exit_code !== NULL;
+  if (!$exit_code_provided) {
+    $exit_code = 0;
+  }
+
+  ob_start();
+  passthru($cmd, $exit_code);
+  $output = ob_get_clean();
+
+  if (!$exit_code_provided && $exit_code !== 0) {
+    fail('Acquia CLI command "%s" failed with exit code %s. Output: %s', $subcommand, $exit_code, $output);
+  }
+
+  return $output === FALSE ? '' : $output;
+}
+
+/**
  * Recursively copy a directory.
  *
  * @param string $src

--- a/.vortex/tooling/src/vortex-deploy-artifact
+++ b/.vortex/tooling/src/vortex-deploy-artifact
@@ -135,17 +135,16 @@ if (file_exists($deploy_artifact_root . '/.gitignore.artifact')) {
   copy($deploy_artifact_root . '/.gitignore.artifact', $deploy_artifact_src . '/.gitignore.artifact');
 }
 
-task('Running artifact builder.');
-$git_artifact_args = [
-  escapeshellarg($git_artifact_bin),
-  escapeshellarg($deploy_git_remote),
-  '--root=' . escapeshellarg($deploy_artifact_root),
-  '--src=' . escapeshellarg($deploy_artifact_src),
-  '--branch=' . escapeshellarg($deploy_artifact_dst_branch),
-  '--gitignore=' . escapeshellarg($deploy_artifact_src . '/.gitignore.artifact'),
-  '--log=' . escapeshellarg($deploy_artifact_log),
-  '-vvv',
-];
-passthru_or_fail(implode(' ', $git_artifact_args));
-
-pass('Finished artifact deployment.');
+task('Running artifact builder.', 'Finished artifact deployment.', function () use ($git_artifact_bin, $deploy_git_remote, $deploy_artifact_root, $deploy_artifact_src, $deploy_artifact_dst_branch, $deploy_artifact_log): void {
+  $git_artifact_args = [
+    escapeshellarg($git_artifact_bin),
+    escapeshellarg($deploy_git_remote),
+    '--root=' . escapeshellarg($deploy_artifact_root),
+    '--src=' . escapeshellarg($deploy_artifact_src),
+    '--branch=' . escapeshellarg($deploy_artifact_dst_branch),
+    '--gitignore=' . escapeshellarg($deploy_artifact_src . '/.gitignore.artifact'),
+    '--log=' . escapeshellarg($deploy_artifact_log),
+    '-vvv',
+  ];
+  passthru_or_fail(implode(' ', $git_artifact_args));
+});

--- a/.vortex/tooling/src/vortex-deploy-lagoon
+++ b/.vortex/tooling/src/vortex-deploy-lagoon
@@ -98,16 +98,16 @@ passthru_or_fail(__DIR__ . '/vortex-setup-ssh');
 
 $lagoon_config_file = lagoon_config_file();
 
-task('Configuring Lagoon instance.');
-lagoon_config($lagoon_bin, $lagoon_config_file, $lagoon_instance, $lagoon_instance_graphql, $lagoon_instance_hostname, $lagoon_instance_port);
-pass('Configured Lagoon instance.');
+task('Configuring Lagoon instance.', 'Configured Lagoon instance.', function () use ($lagoon_bin, $lagoon_config_file, $lagoon_instance, $lagoon_instance_graphql, $lagoon_instance_hostname, $lagoon_instance_port): void {
+  lagoon_config($lagoon_bin, $lagoon_config_file, $lagoon_instance, $lagoon_instance_graphql, $lagoon_instance_hostname, $lagoon_instance_port);
+});
 
 // Surface the CLI version and authenticated identity so the run is observable.
 lagoon_print_version($lagoon_bin, $lagoon_config_file);
 
-task('Checking Lagoon authenticated identity.');
-echo lagoon_run_cli('whoami');
-pass('Checked Lagoon authenticated identity.');
+task('Checking Lagoon authenticated identity.', 'Checked Lagoon authenticated identity.', function (): void {
+  echo lagoon_run_cli('whoami');
+});
 
 /**
  * Run Lagoon CLI command.
@@ -141,25 +141,30 @@ function lagoon_run_cli(string $subcommand, ?int &$subcommand_exit_code = NULL):
 function lagoon_get_existing_environments(bool $is_branch): array {
   $deploy_type = $is_branch ? 'branch' : 'pullrequest';
 
-  task(sprintf('Discovering existing environments for %s deployments.', $deploy_type));
-  $json = lagoon_run_cli('list environments --output-json --pretty');
+  $names = task(
+    sprintf('Discovering existing environments for %s deployments.', $deploy_type),
+    fn(array $names): string => sprintf('Discovered %d existing %s environment(s).', count($names), $deploy_type),
+    function () use ($deploy_type): array {
+      $json = lagoon_run_cli('list environments --output-json --pretty');
 
-  $names = [];
+      $names = [];
 
-  $data = json_decode($json, TRUE);
-  if (is_array($data) && isset($data['data']) && is_array($data['data'])) {
-    foreach ($data['data'] as $env) {
-      if (isset($env['deploytype']) && str_contains($env['deploytype'], $deploy_type)) {
-        if (isset($env['name'])) {
-          $names[] = $env['name'];
+      $data = json_decode($json, TRUE);
+      if (is_array($data) && isset($data['data']) && is_array($data['data'])) {
+        foreach ($data['data'] as $env) {
+          if (isset($env['deploytype']) && str_contains($env['deploytype'], $deploy_type)) {
+            if (isset($env['name'])) {
+              $names[] = $env['name'];
+            }
+          }
         }
       }
-    }
-  }
 
-  pass(sprintf('Discovered %d existing %s environment(s).', count($names), $deploy_type));
+      return $names;
+    },
+  );
 
-  return $names;
+  return is_array($names) ? $names : [];
 }
 
 /**
@@ -190,9 +195,9 @@ function lagoon_handle_environment_limit_exceeded(string $output, int $exit_code
 }
 
 if ($deploy_action === 'destroy') {
-  task(sprintf('Destroying environment: project %s, branch: %s.', $lagoon_project, $deploy_branch));
-  lagoon_run_cli(sprintf('delete environment --environment %s', escapeshellarg($deploy_branch)));
-  pass('Destroyed the environment.');
+  task(sprintf('Destroying environment: project %s, branch: %s.', $lagoon_project, $deploy_branch), 'Destroyed the environment.', function () use ($deploy_branch): void {
+    lagoon_run_cli(sprintf('delete environment --environment %s', escapeshellarg($deploy_branch)));
+  });
 }
 else {
   if (!empty($deploy_pr)) {
@@ -207,14 +212,14 @@ else {
       // Explicitly set DB overwrite flag to 0 due to a bug in Lagoon.
       // @see https://github.com/uselagoon/lagoon/issues/1922
       // @todo Review and remove this workaround as the issue is fixed.
-      task('Setting a database overwrite flag to 0.');
-      lagoon_run_cli(sprintf('update variable --environment %s --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global', escapeshellarg($deploy_pr_full)));
-      pass('Set the database overwrite flag to 0.');
+      task('Setting a database overwrite flag to 0.', 'Set the database overwrite flag to 0.', function () use ($deploy_pr_full): void {
+        lagoon_run_cli(sprintf('update variable --environment %s --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global', escapeshellarg($deploy_pr_full)));
+      });
 
       if ($deploy_action === 'deploy_override_db') {
-        task('Adding a database import override flag for the current deployment.');
-        lagoon_run_cli(sprintf('update variable --environment %s --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global', escapeshellarg($deploy_pr_full)));
-        pass('Added the database import override flag.');
+        task('Adding a database import override flag for the current deployment.', 'Added the database import override flag.', function () use ($deploy_pr_full): void {
+          lagoon_run_cli(sprintf('update variable --environment %s --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global', escapeshellarg($deploy_pr_full)));
+        });
       }
 
       task(sprintf('Redeploying environment: project %s, PR: %s.', $lagoon_project, $deploy_pr));
@@ -223,14 +228,13 @@ else {
       $exit_code = lagoon_handle_environment_limit_exceeded($deploy_output, $exit_code);
 
       if ($deploy_action === 'deploy_override_db') {
-        task_progress('Waiting for deployment to be queued.', function (): void {
+        task('Waiting for deployment to be queued.', 'Waited for the deployment to be queued.', function (): void {
           sleep_progress(10);
         });
-        pass('Waited for the deployment to be queued.');
 
-        task('Removing a database import override flag for the current deployment.');
-        lagoon_run_cli(sprintf('update variable --environment %s --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global', escapeshellarg($deploy_pr_full)));
-        pass('Removed the database import override flag.');
+        task('Removing a database import override flag for the current deployment.', 'Removed the database import override flag.', function () use ($deploy_pr_full): void {
+          lagoon_run_cli(sprintf('update variable --environment %s --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global', escapeshellarg($deploy_pr_full)));
+        });
       }
     }
     // Fresh deployment.
@@ -252,14 +256,14 @@ else {
       // Explicitly set DB overwrite flag to 0 due to a bug in Lagoon.
       // @see https://github.com/uselagoon/lagoon/issues/1922
       // @todo Review and remove this workaround as the issue is fixed.
-      task('Setting a database overwrite flag to 0.');
-      lagoon_run_cli(sprintf('update variable --environment %s --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global', escapeshellarg($deploy_branch)));
-      pass('Set the database overwrite flag to 0.');
+      task('Setting a database overwrite flag to 0.', 'Set the database overwrite flag to 0.', function () use ($deploy_branch): void {
+        lagoon_run_cli(sprintf('update variable --environment %s --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global', escapeshellarg($deploy_branch)));
+      });
 
       if ($deploy_action === 'deploy_override_db') {
-        task('Adding a database import override flag for the current deployment.');
-        lagoon_run_cli(sprintf('update variable --environment %s --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global', escapeshellarg($deploy_branch)));
-        pass('Added the database import override flag.');
+        task('Adding a database import override flag for the current deployment.', 'Added the database import override flag.', function () use ($deploy_branch): void {
+          lagoon_run_cli(sprintf('update variable --environment %s --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global', escapeshellarg($deploy_branch)));
+        });
       }
 
       task(sprintf('Redeploying environment: project %s, branch: %s.', $lagoon_project, $deploy_branch));
@@ -268,14 +272,13 @@ else {
       $exit_code = lagoon_handle_environment_limit_exceeded($deploy_output, $exit_code);
 
       if ($deploy_action === 'deploy_override_db') {
-        task_progress('Waiting for deployment to be queued.', function (): void {
+        task('Waiting for deployment to be queued.', 'Waited for the deployment to be queued.', function (): void {
           sleep_progress(10);
         });
-        pass('Waited for the deployment to be queued.');
 
-        task('Removing a database import override flag for the current deployment.');
-        lagoon_run_cli(sprintf('update variable --environment %s --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global', escapeshellarg($deploy_branch)));
-        pass('Removed the database import override flag.');
+        task('Removing a database import override flag for the current deployment.', 'Removed the database import override flag.', function () use ($deploy_branch): void {
+          lagoon_run_cli(sprintf('update variable --environment %s --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global', escapeshellarg($deploy_branch)));
+        });
       }
     }
     // Fresh deployment.

--- a/.vortex/tooling/src/vortex-deploy-lagoon
+++ b/.vortex/tooling/src/vortex-deploy-lagoon
@@ -223,8 +223,9 @@ else {
       $exit_code = lagoon_handle_environment_limit_exceeded($deploy_output, $exit_code);
 
       if ($deploy_action === 'deploy_override_db') {
-        task('Waiting for deployment to be queued.');
-        sleep(10);
+        task_progress('Waiting for deployment to be queued.', function (): void {
+          sleep_progress(10);
+        });
         pass('Waited for the deployment to be queued.');
 
         task('Removing a database import override flag for the current deployment.');
@@ -267,8 +268,9 @@ else {
       $exit_code = lagoon_handle_environment_limit_exceeded($deploy_output, $exit_code);
 
       if ($deploy_action === 'deploy_override_db') {
-        task('Waiting for deployment to be queued.');
-        sleep(10);
+        task_progress('Waiting for deployment to be queued.', function (): void {
+          sleep_progress(10);
+        });
         pass('Waited for the deployment to be queued.');
 
         task('Removing a database import override flag for the current deployment.');

--- a/.vortex/tooling/src/vortex-export-db-image
+++ b/.vortex/tooling/src/vortex-export-db-image
@@ -50,29 +50,34 @@ note(sprintf('Found %s service container with id %s.', $service_name, $cid));
 
 $new_image = $registry . '/' . $image;
 
-task('Locking and unlocking tables before upgrade.');
-passthru_or_fail(sprintf('docker compose exec -T %s mysql -e %s', $service_escaped, escapeshellarg('FLUSH TABLES WITH READ LOCK;')), 'Failed to lock tables for service %s.', $service_name);
+task('Locking and unlocking tables before upgrade.', 'Locked and unlocked tables before upgrade.', function () use ($service_escaped, $service_name): void {
+  passthru_or_fail(sprintf('docker compose exec -T %s mysql -e %s', $service_escaped, escapeshellarg('FLUSH TABLES WITH READ LOCK;')), 'Failed to lock tables for service %s.', $service_name);
 
-sleep(5);
+  sleep(5);
 
-passthru_or_fail(sprintf('docker compose exec -T %s mysql -e %s', $service_escaped, escapeshellarg('UNLOCK TABLES;')), 'Failed to unlock tables for service %s.', $service_name);
-pass('Locked and unlocked tables before upgrade.');
+  passthru_or_fail(sprintf('docker compose exec -T %s mysql -e %s', $service_escaped, escapeshellarg('UNLOCK TABLES;')), 'Failed to unlock tables for service %s.', $service_name);
+});
 
-task('Running forced service upgrade.');
-passthru_or_fail(sprintf('docker compose exec -T %s sh -c %s', $service_escaped, escapeshellarg('mariadb-upgrade --force || mariadb-upgrade --force')), 'Failed to run service upgrade for %s.', $service_name);
-pass('Ran the forced service upgrade.');
+task('Running forced service upgrade.', 'Ran the forced service upgrade.', function () use ($service_escaped, $service_name): void {
+  passthru_or_fail(sprintf('docker compose exec -T %s sh -c %s', $service_escaped, escapeshellarg('mariadb-upgrade --force || mariadb-upgrade --force')), 'Failed to run service upgrade for %s.', $service_name);
+});
 
-task('Locking tables after upgrade.');
-passthru_or_fail(sprintf('docker compose exec -T %s mysql -e %s', $service_escaped, escapeshellarg('FLUSH TABLES WITH READ LOCK;')), 'Failed to lock tables after upgrade for service %s.', $service_name);
-pass('Locked tables after upgrade.');
+task('Locking tables after upgrade.', 'Locked tables after upgrade.', function () use ($service_escaped, $service_name): void {
+  passthru_or_fail(sprintf('docker compose exec -T %s mysql -e %s', $service_escaped, escapeshellarg('FLUSH TABLES WITH READ LOCK;')), 'Failed to lock tables after upgrade for service %s.', $service_name);
+});
 
-task(sprintf('Committing exported container image with name %s.', $new_image));
-$iid = trim((string) shell_exec(sprintf('docker commit %s %s', escapeshellarg($cid), escapeshellarg($new_image))));
-if ($iid === '') {
-  fail('Failed to commit container image %s.', $new_image);
-}
-$iid = str_starts_with($iid, 'sha256:') ? substr($iid, 7) : $iid;
-pass(sprintf('Committed exported container image with id %s.', $iid));
+task(
+  sprintf('Committing exported container image with name %s.', $new_image),
+  fn(string $iid): string => sprintf('Committed exported container image with id %s.', $iid),
+  function () use ($cid, $new_image): string {
+    $iid = trim((string) shell_exec(sprintf('docker commit %s %s', escapeshellarg($cid), escapeshellarg($new_image))));
+    if ($iid === '') {
+      throw new \RuntimeException(sprintf('Failed to commit container image %s.', $new_image));
+    }
+
+    return str_starts_with($iid, 'sha256:') ? substr($iid, 7) : $iid;
+  },
+);
 
 // Create directory to store database dump.
 if (!is_dir($image_dir)) {
@@ -88,16 +93,13 @@ else {
   $archive = $image_dir . '/export_db_' . date('Ymd_His') . '.tar';
 }
 
-task(sprintf('Exporting database image archive to file %s.', $archive));
+task(sprintf('Exporting database image archive to file %s.', $archive), sprintf('Exported database image saved to archive file %s.', $archive), function () use ($archive, $new_image): void {
+  passthru_or_fail(sprintf('docker save -o %s %s', escapeshellarg($archive), escapeshellarg($new_image)), 'Unable to save database image archive file %s.', $archive);
 
-passthru_or_fail(sprintf('docker save -o %s %s', escapeshellarg($archive), escapeshellarg($new_image)), 'Unable to save database image archive file %s.', $archive);
-
-// Check that file was saved and output saved dump file name.
-if (file_exists($archive) && filesize($archive) > 0) {
-  pass(sprintf('Exported database image saved to archive file %s.', $archive));
-}
-else {
-  fail(sprintf('Unable to save database image archive file %s.', $archive));
-}
+  // Check that file was saved and output saved dump file name.
+  if (!file_exists($archive) || filesize($archive) <= 0) {
+    throw new \RuntimeException(sprintf('Unable to save database image archive file %s.', $archive));
+  }
+});
 
 pass('Finished database data container image export.');

--- a/.vortex/tooling/src/vortex-export-db-image
+++ b/.vortex/tooling/src/vortex-export-db-image
@@ -56,12 +56,15 @@ passthru_or_fail(sprintf('docker compose exec -T %s mysql -e %s', $service_escap
 sleep(5);
 
 passthru_or_fail(sprintf('docker compose exec -T %s mysql -e %s', $service_escaped, escapeshellarg('UNLOCK TABLES;')), 'Failed to unlock tables for service %s.', $service_name);
+pass('Locked and unlocked tables before upgrade.');
 
 task('Running forced service upgrade.');
 passthru_or_fail(sprintf('docker compose exec -T %s sh -c %s', $service_escaped, escapeshellarg('mariadb-upgrade --force || mariadb-upgrade --force')), 'Failed to run service upgrade for %s.', $service_name);
+pass('Ran the forced service upgrade.');
 
 task('Locking tables after upgrade.');
 passthru_or_fail(sprintf('docker compose exec -T %s mysql -e %s', $service_escaped, escapeshellarg('FLUSH TABLES WITH READ LOCK;')), 'Failed to lock tables after upgrade for service %s.', $service_name);
+pass('Locked tables after upgrade.');
 
 task(sprintf('Committing exported container image with name %s.', $new_image));
 $iid = trim((string) shell_exec(sprintf('docker commit %s %s', escapeshellarg($cid), escapeshellarg($new_image))));
@@ -69,7 +72,7 @@ if ($iid === '') {
   fail('Failed to commit container image %s.', $new_image);
 }
 $iid = str_starts_with($iid, 'sha256:') ? substr($iid, 7) : $iid;
-note(sprintf('Committed exported container image with id %s.', $iid));
+pass(sprintf('Committed exported container image with id %s.', $iid));
 
 // Create directory to store database dump.
 if (!is_dir($image_dir)) {
@@ -91,7 +94,7 @@ passthru_or_fail(sprintf('docker save -o %s %s', escapeshellarg($archive), escap
 
 // Check that file was saved and output saved dump file name.
 if (file_exists($archive) && filesize($archive) > 0) {
-  note(sprintf('Exported database image saved to archive file %s.', $archive));
+  pass(sprintf('Exported database image saved to archive file %s.', $archive));
 }
 else {
   fail(sprintf('Unable to save database image archive file %s.', $archive));

--- a/.vortex/tooling/src/vortex-export-db-image
+++ b/.vortex/tooling/src/vortex-export-db-image
@@ -53,7 +53,7 @@ $new_image = $registry . '/' . $image;
 task('Locking and unlocking tables before upgrade.', 'Locked and unlocked tables before upgrade.', function () use ($service_escaped, $service_name): void {
   passthru_or_fail(sprintf('docker compose exec -T %s mysql -e %s', $service_escaped, escapeshellarg('FLUSH TABLES WITH READ LOCK;')), 'Failed to lock tables for service %s.', $service_name);
 
-  sleep(5);
+  sleep_progress(5);
 
   passthru_or_fail(sprintf('docker compose exec -T %s mysql -e %s', $service_escaped, escapeshellarg('UNLOCK TABLES;')), 'Failed to unlock tables for service %s.', $service_name);
 });

--- a/.vortex/tooling/src/vortex-fetch-db-acquia
+++ b/.vortex/tooling/src/vortex-fetch-db-acquia
@@ -230,6 +230,43 @@ function acquia_backup_download_url(string $json): string {
   return (string) ($data['_links']['download']['href'] ?? '');
 }
 
+/**
+ * Poll until a completed backup exists, emitting a progress dot each second.
+ *
+ * @param string $bin
+ *   The Acquia CLI binary.
+ * @param array{home: string, key: string, secret: string} $ctx
+ *   Execution context threaded to the CLI.
+ * @param string $env_id
+ *   The environment id to poll.
+ * @param string $db_name
+ *   The database name to poll.
+ * @param int $max_wait
+ *   Maximum time to wait, in seconds.
+ * @param int $interval
+ *   Seconds between backup status checks.
+ *
+ * @return bool
+ *   TRUE when a completed backup appeared within the wait window.
+ */
+function acquia_wait_for_backup(string $bin, array $ctx, string $env_id, string $db_name, int $max_wait, int $interval): bool {
+  $elapsed = 0;
+
+  while ($elapsed < $max_wait) {
+    for ($second = 0; $second < $interval; $second++) {
+      sleep(1);
+      progress_dot();
+    }
+    $elapsed += $interval;
+
+    if (acquia_latest_backup_id(acli_exec($bin, sprintf('api:environments:database-backup-list %s %s', escapeshellarg($env_id), escapeshellarg($db_name)), $ctx)) !== '') {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
 info('Started database backup download from Acquia.');
 
 $bin = acli_resolve();
@@ -278,21 +315,7 @@ if ($fresh === '1') {
   acli_exec($bin, sprintf('api:environments:database-backup-create %s %s', escapeshellarg($env_id), escapeshellarg($db_name)), $ctx);
   pass('Requested a new database backup.');
 
-  task('Waiting for the backup to complete.');
-  $elapsed = 0;
-  $completed = FALSE;
-  while ($elapsed < $backup_max_wait) {
-    sleep($backup_wait_interval);
-    $elapsed += $backup_wait_interval;
-
-    if (acquia_latest_backup_id(acli_exec($bin, sprintf('api:environments:database-backup-list %s %s', escapeshellarg($env_id), escapeshellarg($db_name)), $ctx)) !== '') {
-      $completed = TRUE;
-      break;
-    }
-
-    note(sprintf('Backup in progress (%ds elapsed).', $elapsed));
-  }
-
+  $completed = task_progress('Waiting for the backup to complete.', fn(): bool => acquia_wait_for_backup($bin, $ctx, $env_id, $db_name, $backup_max_wait, $backup_wait_interval));
   if (!$completed) {
     fail('Backup creation timed out after %d seconds.', $backup_max_wait);
   }
@@ -326,8 +349,7 @@ else {
     }
     pass('Discovered the backup download URL.');
 
-    task(sprintf('Downloading the backup into "%s".', $file_name_compressed));
-    $response = request($download_url, ['method' => 'GET', 'save_to' => $file_name_compressed, 'timeout' => 1800]);
+    $response = task_progress(sprintf('Downloading the backup into "%s".', $file_name_compressed), fn(): array => request($download_url, ['method' => 'GET', 'save_to' => $file_name_compressed, 'timeout' => 1800, 'progress' => TRUE]));
     if (!$response['ok']) {
       @unlink($file_name_compressed);
       fail('Unable to download database "%s" backup "%s": %s', $db_name, $backup_id, $response['error'] ?? 'Unknown error');

--- a/.vortex/tooling/src/vortex-fetch-db-acquia
+++ b/.vortex/tooling/src/vortex-fetch-db-acquia
@@ -276,56 +276,74 @@ $ctx = [
 ];
 
 // Surface the CLI version so the run is observable.
-task('Checking Acquia CLI version.');
-echo acli_exec($bin, '--version', $ctx);
-pass('Checked Acquia CLI version.');
+task('Checking Acquia CLI version.', 'Checked Acquia CLI version.', function () use ($bin, $ctx): void {
+  echo acli_exec($bin, '--version', $ctx);
+});
 
 if (!is_dir($db_dir)) {
-  task('Creating directory for database dumps.');
-  mkdir($db_dir, 0755, TRUE);
-  pass('Created directory for database dumps.');
+  task('Creating directory for database dumps.', 'Created directory for database dumps.', function () use ($db_dir): void {
+    if (!mkdir($db_dir, 0755, TRUE)) {
+      throw new \RuntimeException(sprintf('Unable to create directory "%s".', $db_dir));
+    }
+  });
 }
 
-task($app_name === '' ? 'Auto-discovering the Acquia application.' : sprintf('Discovering the "%s" application.', $app_name));
-$apps = acquia_items(acli_exec($bin, 'api:applications:list', $ctx));
-$app = acquia_select_app($apps, $app_name);
-if ($app === []) {
-  if ($app_name !== '') {
-    fail('Unable to find an Acquia application matching "%s". Accessible applications: %s', $app_name, acquia_app_labels($apps));
-  }
-  fail('Unable to auto-discover a single Acquia application (found %d). Set VORTEX_FETCH_DB_ACQUIA_APP_NAME to one of: %s', count($apps), acquia_app_labels($apps));
-}
-$app_uuid = (string) ($app['uuid'] ?? '');
-pass(sprintf('Using application "%s" (%s).', $app['name'] ?? $app_uuid, $app_uuid));
+$app = task(
+  $app_name === '' ? 'Auto-discovering the Acquia application.' : sprintf('Discovering the "%s" application.', $app_name),
+  fn(array $app): string => sprintf('Using application "%s" (%s).', $app['name'] ?? '', $app['uuid'] ?? ''),
+  function () use ($bin, $ctx, $app_name): array {
+    $apps = acquia_items(acli_exec($bin, 'api:applications:list', $ctx));
+    $app = acquia_select_app($apps, $app_name);
+    if ($app !== []) {
+      return $app;
+    }
 
-task(sprintf('Discovering the "%s" environment.', $environment));
-$env = acquia_find_item(acli_exec($bin, sprintf('api:applications:environment-list %s', escapeshellarg($app_uuid)), $ctx), $environment);
-$env_id = (string) ($env['id'] ?? '');
-if ($env_id === '') {
-  fail('Unable to find the Acquia environment "%s".', $environment);
-}
-pass(sprintf('Found environment "%s".', $env_id));
+    throw new \RuntimeException($app_name !== ''
+      ? sprintf('Unable to find an Acquia application matching "%s". Accessible applications: %s', $app_name, acquia_app_labels($apps))
+      : sprintf('Unable to auto-discover a single Acquia application (found %d). Set VORTEX_FETCH_DB_ACQUIA_APP_NAME to one of: %s', count($apps), acquia_app_labels($apps)));
+  },
+);
+$app_uuid = is_array($app) ? (string) ($app['uuid'] ?? '') : '';
+
+$env_id = (string) task(
+  sprintf('Discovering the "%s" environment.', $environment),
+  fn(string $env_id): string => sprintf('Found environment "%s".', $env_id),
+  function () use ($bin, $ctx, $app_uuid, $environment): string {
+    $env = acquia_find_item(acli_exec($bin, sprintf('api:applications:environment-list %s', escapeshellarg($app_uuid)), $ctx), $environment);
+    $env_id = (string) ($env['id'] ?? '');
+    if ($env_id === '') {
+      throw new \RuntimeException(sprintf('Unable to find the Acquia environment "%s".', $environment));
+    }
+
+    return $env_id;
+  },
+);
 
 // Optionally trigger a fresh backup and wait for it to complete.
 if ($fresh === '1') {
-  task(sprintf('Creating a new database backup for "%s".', $db_name));
-  acli_exec($bin, sprintf('api:environments:database-backup-create %s %s', escapeshellarg($env_id), escapeshellarg($db_name)), $ctx);
-  pass('Requested a new database backup.');
+  task(sprintf('Creating a new database backup for "%s".', $db_name), 'Requested a new database backup.', function () use ($bin, $ctx, $env_id, $db_name): void {
+    acli_exec($bin, sprintf('api:environments:database-backup-create %s %s', escapeshellarg($env_id), escapeshellarg($db_name)), $ctx);
+  });
 
-  $completed = task_progress('Waiting for the backup to complete.', fn(): bool => acquia_wait_for_backup($bin, $ctx, $env_id, $db_name, $backup_max_wait, $backup_wait_interval));
-  if (!$completed) {
-    fail('Backup creation timed out after %d seconds.', $backup_max_wait);
-  }
-
-  pass('Backup completed.');
+  task('Waiting for the backup to complete.', 'Backup completed.', function () use ($bin, $ctx, $env_id, $db_name, $backup_max_wait, $backup_wait_interval): void {
+    if (!acquia_wait_for_backup($bin, $ctx, $env_id, $db_name, $backup_max_wait, $backup_wait_interval)) {
+      throw new \RuntimeException(sprintf('Backup creation timed out after %d seconds.', $backup_max_wait));
+    }
+  });
 }
 
-task(sprintf('Discovering the latest backup for "%s".', $db_name));
-$backup_id = acquia_latest_backup_id(acli_exec($bin, sprintf('api:environments:database-backup-list %s %s', escapeshellarg($env_id), escapeshellarg($db_name)), $ctx));
-if ($backup_id === '') {
-  fail('No completed backups found for database "%s" in environment "%s".', $db_name, $environment);
-}
-pass(sprintf('Selected backup "%s".', $backup_id));
+$backup_id = (string) task(
+  sprintf('Discovering the latest backup for "%s".', $db_name),
+  fn(string $id): string => sprintf('Selected backup "%s".', $id),
+  function () use ($bin, $ctx, $env_id, $db_name, $environment): string {
+    $id = acquia_latest_backup_id(acli_exec($bin, sprintf('api:environments:database-backup-list %s %s', escapeshellarg($env_id), escapeshellarg($db_name)), $ctx));
+    if ($id === '') {
+      throw new \RuntimeException(sprintf('No completed backups found for database "%s" in environment "%s".', $db_name, $environment));
+    }
+
+    return $id;
+  },
+);
 
 // Build cached file names (keyed by backup id, decompressed and gzipped).
 $file_extension = pathinfo($db_file, PATHINFO_EXTENSION);
@@ -339,69 +357,72 @@ else {
   if (!file_exists($file_name_compressed)) {
     // The download action returns a short-lived, pre-signed URL; fetch it and
     // stream it straight to disk to avoid buffering a large dump in memory.
-    task(sprintf('Discovering the download URL for backup "%s".', $backup_id));
-    $download_url = acquia_backup_download_url(acli_exec($bin, sprintf('api:environments:database-backup-download %s %s %s', escapeshellarg($env_id), escapeshellarg($db_name), escapeshellarg($backup_id)), $ctx));
-    if ($download_url === '') {
-      fail('Unable to discover the download URL for backup "%s".', $backup_id);
-    }
-    pass('Discovered the backup download URL.');
+    $download_url = (string) task(
+      sprintf('Discovering the download URL for backup "%s".', $backup_id),
+      'Discovered the backup download URL.',
+      function () use ($bin, $ctx, $env_id, $db_name, $backup_id): string {
+        $url = acquia_backup_download_url(acli_exec($bin, sprintf('api:environments:database-backup-download %s %s %s', escapeshellarg($env_id), escapeshellarg($db_name), escapeshellarg($backup_id)), $ctx));
+        if ($url === '') {
+          throw new \RuntimeException(sprintf('Unable to discover the download URL for backup "%s".', $backup_id));
+        }
 
-    $response = task_progress(sprintf('Downloading the backup into "%s".', $file_name_compressed), fn(): array => request($download_url, ['method' => 'GET', 'save_to' => $file_name_compressed, 'timeout' => 1800, 'progress' => TRUE]));
-    if (!$response['ok']) {
-      @unlink($file_name_compressed);
-      fail('Unable to download database "%s" backup "%s": %s', $db_name, $backup_id, $response['error'] ?? 'Unknown error');
-    }
+        return $url;
+      },
+    );
 
-    if (!file_exists($file_name_compressed) || filesize($file_name_compressed) === 0) {
-      fail('Downloaded file is empty or missing: %s', $file_name_compressed);
-    }
+    task(sprintf('Downloading the backup into "%s".', $file_name_compressed), 'Downloaded the database backup.', function () use ($download_url, $file_name_compressed, $db_name, $backup_id): void {
+      $response = request($download_url, ['method' => 'GET', 'save_to' => $file_name_compressed, 'timeout' => 1800, 'on_progress' => progress_dot(...)]);
+      if (!$response['ok']) {
+        @unlink($file_name_compressed);
+        throw new \RuntimeException(sprintf('Unable to download database "%s" backup "%s": %s', $db_name, $backup_id, $response['error'] ?? 'Unknown error'));
+      }
 
-    pass('Downloaded the database backup.');
+      if (!file_exists($file_name_compressed) || filesize($file_name_compressed) === 0) {
+        throw new \RuntimeException(sprintf('Downloaded file is empty or missing: %s', $file_name_compressed));
+      }
+    });
   }
   else {
     pass(sprintf('Found existing cached gzipped DB file "%s" for DB "%s".', $file_name_compressed, $db_name));
   }
 
-  task(sprintf('Expanding "%s" into "%s".', $file_name_compressed, $file_name));
+  task(sprintf('Expanding "%s" into "%s".', $file_name_compressed, $file_name), 'Expanded the database dump.', function () use ($file_name_compressed, $file_name): void {
+    // Validate the gzip header, then stream-decompress via the zlib wrapper.
+    $header = file_get_contents($file_name_compressed, FALSE, NULL, 0, 2);
+    if ($header === FALSE || $header !== "\x1f\x8b") {
+      throw new \RuntimeException(sprintf('Downloaded file is not a valid gzip archive: %s', $file_name_compressed));
+    }
 
-  // Validate the gzip header, then stream-decompress via the zlib wrapper.
-  $header = file_get_contents($file_name_compressed, FALSE, NULL, 0, 2);
-  if ($header === FALSE || $header !== "\x1f\x8b") {
-    fail('Downloaded file is not a valid gzip archive: %s', $file_name_compressed);
-  }
+    $gz_in = @fopen('compress.zlib://' . $file_name_compressed, 'rb');
+    if ($gz_in === FALSE) {
+      // @codeCoverageIgnoreStart
+      throw new \RuntimeException(sprintf('Unable to read compressed file "%s".', $file_name_compressed));
+      // @codeCoverageIgnoreEnd
+    }
 
-  $gz_in = @fopen('compress.zlib://' . $file_name_compressed, 'rb');
-  if ($gz_in === FALSE) {
-    // @codeCoverageIgnoreStart
-    fail('Unable to read compressed file "%s".', $file_name_compressed);
-    // @codeCoverageIgnoreEnd
-  }
+    $out = @fopen($file_name, 'wb');
+    if ($out === FALSE) {
+      // @codeCoverageIgnoreStart
+      fclose($gz_in);
+      throw new \RuntimeException(sprintf('Unable to write decompressed file "%s".', $file_name));
+      // @codeCoverageIgnoreEnd
+    }
 
-  $out = @fopen($file_name, 'wb');
-  if ($out === FALSE) {
-    // @codeCoverageIgnoreStart
+    $bytes = stream_copy_to_stream($gz_in, $out);
     fclose($gz_in);
-    fail('Unable to write decompressed file "%s".', $file_name);
-    // @codeCoverageIgnoreEnd
-  }
+    fclose($out);
 
-  $bytes = stream_copy_to_stream($gz_in, $out);
-  fclose($gz_in);
-  fclose($out);
+    if ($bytes === FALSE || $bytes === 0) {
+      throw new \RuntimeException(sprintf('Downloaded file is not a valid gzip archive: %s', $file_name_compressed));
+    }
 
-  if ($bytes === FALSE || $bytes === 0) {
-    fail('Downloaded file is not a valid gzip archive: %s', $file_name_compressed);
-  }
-
-  @unlink($file_name_compressed);
-
-  pass('Expanded the database dump.');
+    @unlink($file_name_compressed);
+  });
 }
 
-task(sprintf('Renaming "%s" to "%s/%s".', $file_name, $db_dir, $db_file));
-$final_path = $db_dir . '/' . $db_file;
-if (!@rename($file_name, $final_path)) {
-  fail('Unable to rename file from "%s" to "%s".', $file_name, $final_path);
-}
-
-pass('Finished database backup download from Acquia.');
+task(sprintf('Renaming "%s" to "%s/%s".', $file_name, $db_dir, $db_file), 'Finished database backup download from Acquia.', function () use ($file_name, $db_dir, $db_file): void {
+  $final_path = $db_dir . '/' . $db_file;
+  if (!@rename($file_name, $final_path)) {
+    throw new \RuntimeException(sprintf('Unable to rename file from "%s" to "%s".', $file_name, $final_path));
+  }
+});

--- a/.vortex/tooling/src/vortex-fetch-db-acquia
+++ b/.vortex/tooling/src/vortex-fetch-db-acquia
@@ -250,6 +250,9 @@ function acquia_backup_download_url(string $json): string {
  *   TRUE when a completed backup appeared within the wait window.
  */
 function acquia_wait_for_backup(string $bin, array $ctx, string $env_id, string $db_name, int $max_wait, int $interval): bool {
+  // Guard against a misconfigured non-positive interval that would never let
+  // $elapsed advance, spinning the poll loop and hammering the API.
+  $interval = max(1, $interval);
   $elapsed = 0;
 
   while ($elapsed < $max_wait) {

--- a/.vortex/tooling/src/vortex-fetch-db-acquia
+++ b/.vortex/tooling/src/vortex-fetch-db-acquia
@@ -3,11 +3,15 @@
 
 /**
  * @file
- * Download DB dump from the latest Acquia Cloud backup.
+ * Download a database backup from Acquia Cloud using the Acquia CLI.
  *
- * This script will discover the latest available backup in the specified
- * Acquia Cloud environment using Acquia Cloud API 2.0, download and decompress
- * it into specified directory.
+ * Wraps the provider-native 'acli': it discovers the application and
+ * environment, optionally creates a fresh backup and waits for it, then
+ * downloads the latest backup and decompresses it. Because it relies on the CLI
+ * rather than bespoke Cloud API calls, acli is resolved on demand (used from
+ * PATH or downloaded to a cache directory) and authenticated headlessly via
+ * 'ACLI_KEY'/'ACLI_SECRET' against an isolated 'ACLI_HOME', so a developer's
+ * global '~/.acquia' configuration is never read or written.
  *
  * IMPORTANT! This script runs outside the container on the host system.
  */
@@ -29,13 +33,13 @@ $acquia_key = getenv_required(...array_values(array_unique(['VORTEX_FETCH_DB' . 
 // Acquia Cloud API secret.
 $acquia_secret = getenv_required(...array_values(array_unique(['VORTEX_FETCH_DB' . $db_index . '_ACQUIA_SECRET', 'VORTEX_FETCH_DB_ACQUIA_SECRET', 'VORTEX_ACQUIA_SECRET'])));
 
-// Application name. Used to discover UUID.
+// Application name. Used to discover the application UUID.
 $app_name = getenv_required(...array_values(array_unique(['VORTEX_FETCH_DB' . $db_index . '_ACQUIA_APP_NAME', 'VORTEX_FETCH_DB_ACQUIA_APP_NAME', 'VORTEX_ACQUIA_APP_NAME'])));
 
-// Source environment name used to download the database dump from.
+// Source environment name to download the database from.
 $environment = getenv_required(...array_values(array_unique(['VORTEX_FETCH_DB' . $db_index . '_ENVIRONMENT', 'VORTEX_FETCH_DB_ENVIRONMENT'])));
 
-// Database name within source environment.
+// Database name within the source environment.
 $db_name = getenv_required(...array_values(array_unique(['VORTEX_FETCH_DB' . $db_index . '_ACQUIA_DB_NAME', 'VORTEX_FETCH_DB_ACQUIA_DB_NAME'])));
 
 // Directory where DB dumps are stored.
@@ -55,229 +59,227 @@ $backup_max_wait = (int) getenv_default(...array_values(array_unique(['VORTEX_FE
 
 // -----------------------------------------------------------------------------
 
-// Inlined Acquia API helpers.
-function dl_acquia_api_get_token(string $key, string $secret): string {
-  $response = request_post('https://accounts.acquia.com/api/auth/oauth/token', http_build_query(['client_id' => $key, 'client_secret' => $secret, 'grant_type' => 'client_credentials']), ['Content-Type: application/x-www-form-urlencoded']);
+/**
+ * Find an Acquia resource item by name in an API list response.
+ *
+ * The Acquia Cloud API (which the CLI wraps) returns collections under
+ * '_embedded.items'; this returns the first item whose 'name' matches.
+ *
+ * @param string $json
+ *   The JSON list response.
+ * @param string $name
+ *   The item name to match.
+ *
+ * @return array<string, mixed>
+ *   The matched item, or an empty array when none matches.
+ */
+function acquia_find_item(string $json, string $name): array {
+  $items = acquia_items($json);
 
-  if (!$response['ok']) {
-    fail('Unable to retrieve a token.');
+  foreach ($items as $item) {
+    if (is_array($item) && ($item['name'] ?? '') === $name) {
+      return $item;
+    }
   }
 
-  $data = json_decode((string) $response['body'], TRUE);
-  $token = $data['access_token'] ?? '';
-  if ($token === '') {
-    fail('Unable to retrieve a token.');
-  }
-
-  return $token;
+  return [];
 }
 
-function dl_acquia_api_headers(string $token): array {
-  return [
-    'Accept: application/json, version=2',
-    'Authorization: Bearer ' . $token,
-  ];
+/**
+ * Extract the collection items from an Acquia API list response.
+ *
+ * @param string $json
+ *   The JSON list response, wrapped in '_embedded.items' or a bare array.
+ *
+ * @return array<int, mixed>
+ *   The list items.
+ */
+function acquia_items(string $json): array {
+  $data = json_decode($json, TRUE);
+
+  if (is_array($data) && isset($data['_embedded']['items']) && is_array($data['_embedded']['items'])) {
+    return array_values($data['_embedded']['items']);
+  }
+
+  // Some CLI versions return a bare list of items.
+  return is_array($data) ? array_values($data) : [];
 }
 
-function dl_acquia_api_get_app_uuid(string $token, string $app_name): string {
-  $url = 'https://cloud.acquia.com/api/applications?filter=name%3D' . rawurlencode($app_name);
-  $response = request_get($url, dl_acquia_api_headers($token));
+/**
+ * Return the newest completed backup id from a backups list response.
+ *
+ * @param string $json
+ *   The database-backup-list JSON response.
+ *
+ * @return string
+ *   The newest completed backup id, or an empty string when there is none.
+ */
+function acquia_latest_backup_id(string $json): string {
+  $backups = array_filter(acquia_items($json), fn($backup): bool => is_array($backup) && ($backup['id'] ?? '') !== '' && ($backup['completedAt'] ?? $backup['completed'] ?? '') !== '');
 
-  if (!$response['ok']) {
-    fail('Unable to retrieve an application UUID.');
-  }
+  usort($backups, fn($a, $b): int => strcmp((string) ($b['completedAt'] ?? $b['startedAt'] ?? ''), (string) ($a['completedAt'] ?? $a['startedAt'] ?? '')));
 
-  $data = json_decode((string) $response['body'], TRUE);
-  $items = $data['_embedded']['items'] ?? [];
-  $last = end($items);
-  $uuid = $last['uuid'] ?? '';
+  $latest = reset($backups);
 
-  if ($uuid === '') {
-    fail(sprintf('Unable to retrieve an application UUID for \'%s\'.', $app_name));
-  }
-
-  return $uuid;
+  return is_array($latest) ? (string) ($latest['id'] ?? '') : '';
 }
 
-function dl_acquia_api_get_env_id(string $token, string $app_uuid, string $env_name): string {
-  $url = sprintf('https://cloud.acquia.com/api/applications/%s/environments?filter=name%%3D%s', $app_uuid, $env_name);
-  $response = request_get($url, dl_acquia_api_headers($token));
+/**
+ * Extract the backup download URL from a download command response.
+ *
+ * The Cloud API's backup download action returns a short-lived, pre-signed URL
+ * rather than the file bytes; this reads that URL from the JSON, tolerating the
+ * top-level 'url' field and the HAL '_links.download.href' shape.
+ *
+ * @param string $json
+ *   The database-backup-download JSON response.
+ *
+ * @return string
+ *   The download URL, or an empty string when none is present.
+ */
+function acquia_backup_download_url(string $json): string {
+  $data = json_decode($json, TRUE);
 
-  if (!$response['ok']) {
-    fail(sprintf('Unable to retrieve environment ID for \'%s\'.', $env_name));
+  if (!is_array($data)) {
+    return '';
   }
 
-  $data = json_decode((string) $response['body'], TRUE);
-  $items = $data['_embedded']['items'] ?? [];
-  $last = end($items);
-  $env_id = $last['id'] ?? '';
-
-  if ($env_id === '') {
-    fail(sprintf('Unable to retrieve an environment ID for \'%s\'.', $env_name));
+  if (($data['url'] ?? '') !== '') {
+    return (string) $data['url'];
   }
 
-  return (string) $env_id;
+  return (string) ($data['_links']['download']['href'] ?? '');
 }
 
-// -----------------------------------------------------------------------------
+info('Started database backup download from Acquia.');
 
-info('Started database dump download from Acquia.');
+$bin = acli_resolve();
+$home = acli_home();
+
+$ctx = [
+  'home' => $home,
+  'key' => $acquia_key,
+  'secret' => $acquia_secret,
+];
+
+// Surface the CLI version so the run is observable.
+task('Checking Acquia CLI version.');
+echo acli_exec($bin, '--version', $ctx);
+pass('Checked Acquia CLI version.');
 
 if (!is_dir($db_dir)) {
+  task('Creating directory for database dumps.');
   mkdir($db_dir, 0755, TRUE);
+  pass('Created directory for database dumps.');
 }
 
-task('Retrieving authentication token.');
-$token = dl_acquia_api_get_token($acquia_key, $acquia_secret);
+task(sprintf('Discovering the "%s" application.', $app_name));
+$app = acquia_find_item(acli_exec($bin, 'api:applications:list', $ctx), $app_name);
+$app_uuid = (string) ($app['uuid'] ?? '');
+if ($app_uuid === '') {
+  fail('Unable to find the Acquia application "%s".', $app_name);
+}
+pass(sprintf('Found application "%s".', $app_uuid));
 
-task(sprintf('Retrieving %s application UUID.', $app_name));
-$app_uuid = dl_acquia_api_get_app_uuid($token, $app_name);
+task(sprintf('Discovering the "%s" environment.', $environment));
+$env = acquia_find_item(acli_exec($bin, sprintf('api:applications:environment-list %s', escapeshellarg($app_uuid)), $ctx), $environment);
+$env_id = (string) ($env['id'] ?? '');
+if ($env_id === '') {
+  fail('Unable to find the Acquia environment "%s".', $environment);
+}
+pass(sprintf('Found environment "%s".', $env_id));
 
-task(sprintf('Retrieving %s environment ID.', $environment));
-$env_id = dl_acquia_api_get_env_id($token, $app_uuid, $environment);
-
-// If fresh backup requested, create a new backup and wait for completion.
+// Optionally trigger a fresh backup and wait for it to complete.
 if ($fresh === '1') {
-  task(sprintf('Creating new database backup for %s.', $db_name));
+  task(sprintf('Creating a new database backup for "%s".', $db_name));
+  acli_exec($bin, sprintf('api:environments:database-backup-create %s %s', escapeshellarg($env_id), escapeshellarg($db_name)), $ctx);
+  pass('Requested a new database backup.');
 
-  $create_response = request_post(sprintf('https://cloud.acquia.com/api/environments/%s/databases/%s/backups', $env_id, $db_name), NULL, dl_acquia_api_headers($token));
-
-  if (!$create_response['ok']) {
-    fail('Failed to create database backup for %s.', $db_name);
-  }
-
-  $create_data = json_decode((string) $create_response['body'], TRUE);
-  $notification_url = $create_data['_links']['notification']['href'] ?? '';
-
-  if ($notification_url === '') {
-    fail('Unable to get notification URL for backup creation.');
-  }
-
-  task('Waiting for backup to complete.');
+  task('Waiting for the backup to complete.');
   $elapsed = 0;
-  $backup_completed = FALSE;
-
+  $completed = FALSE;
   while ($elapsed < $backup_max_wait) {
     sleep($backup_wait_interval);
     $elapsed += $backup_wait_interval;
 
-    $status_response = request_get($notification_url, dl_acquia_api_headers($token));
-    if ($status_response['ok']) {
-      $status_data = json_decode((string) $status_response['body'], TRUE);
-      $status = $status_data['status'] ?? '';
-
-      if ($status === 'completed') {
-        pass('Backup completed successfully.');
-        $backup_completed = TRUE;
-        break;
-      }
-
-      if ($status === 'failed') {
-        fail('Backup creation failed.');
-      }
+    if (acquia_latest_backup_id(acli_exec($bin, sprintf('api:environments:database-backup-list %s %s', escapeshellarg($env_id), escapeshellarg($db_name)), $ctx)) !== '') {
+      $completed = TRUE;
+      break;
     }
 
-    note(sprintf('Backup in progress (%ds elapsed)...', $elapsed));
+    note(sprintf('Backup in progress (%ds elapsed).', $elapsed));
   }
 
-  if (!$backup_completed) {
-    fail(sprintf('Backup creation timed out after %d seconds.', $backup_max_wait));
+  if (!$completed) {
+    fail('Backup creation timed out after %d seconds.', $backup_max_wait);
   }
 
-  note('Fresh backup will be downloaded.');
+  pass('Backup completed.');
 }
 
-task(sprintf('Discovering latest backup ID for DB %s.', $db_name));
-$backups_response = request_get(sprintf('https://cloud.acquia.com/api/environments/%s/databases/%s/backups?sort=created', $env_id, $db_name), dl_acquia_api_headers($token));
-
-if (!$backups_response['ok']) {
-  fail(sprintf('Failed to retrieve backups for database \'%s\'.', $db_name));
-}
-
-$backups_data = json_decode((string) $backups_response['body'], TRUE);
-$backup_items = $backups_data['_embedded']['items'] ?? [];
-
-if (empty($backup_items)) {
-  fail(sprintf('No backups found for database \'%s\' in environment \'%s\'.', $db_name, $environment));
-}
-
-$last_backup = end($backup_items);
-$backup_id = $last_backup['id'] ?? '';
-
+task(sprintf('Discovering the latest backup for "%s".', $db_name));
+$backup_id = acquia_latest_backup_id(acli_exec($bin, sprintf('api:environments:database-backup-list %s %s', escapeshellarg($env_id), escapeshellarg($db_name)), $ctx));
 if ($backup_id === '') {
-  fail(sprintf('Unable to discover backup ID for DB \'%s\'.', $db_name));
+  fail('No completed backups found for database "%s" in environment "%s".', $db_name, $environment);
 }
+pass(sprintf('Selected backup "%s".', $backup_id));
 
-// Build file names.
+// Build cached file names (keyed by backup id, decompressed and gzipped).
 $file_extension = pathinfo($db_file, PATHINFO_EXTENSION);
-$file_prefix = $db_name . '_backup_';
-$file_name = sprintf('%s/%s%s.%s', $db_dir, $file_prefix, $backup_id, $file_extension);
+$file_name = sprintf('%s/%s_backup_%s.%s', $db_dir, $db_name, $backup_id, $file_extension);
 $file_name_compressed = $file_name . '.gz';
 
 if (file_exists($file_name)) {
   note(sprintf('Found existing cached DB file "%s" for DB "%s".', $file_name, $db_name));
 }
 else {
-  // If the gzipped version exists, skip download.
   if (!file_exists($file_name_compressed)) {
-    note(sprintf('Using the latest backup ID %s for DB %s.', $backup_id, $db_name));
+    // The download action returns a short-lived, pre-signed URL; fetch it and
+    // stream it straight to disk to avoid buffering a large dump in memory.
+    task(sprintf('Discovering the download URL for backup "%s".', $backup_id));
+    $download_url = acquia_backup_download_url(acli_exec($bin, sprintf('api:environments:database-backup-download %s %s %s', escapeshellarg($env_id), escapeshellarg($db_name), escapeshellarg($backup_id)), $ctx));
+    if ($download_url === '') {
+      fail('Unable to discover the download URL for backup "%s".', $backup_id);
+    }
+    pass('Discovered the backup download URL.');
 
-    task('Discovering backup URL.');
-    // The Acquia API responds with a 200 and a JSON body containing the
-    // temporary, pre-signed S3 download URL under the "url" key. Fetch the
-    // body and extract that URL. The Authorization header is required only to
-    // query the Acquia API; the returned S3 URL is pre-signed and is fetched
-    // later without it.
-    $backup_url_response = request_get(sprintf('https://cloud.acquia.com/api/environments/%s/databases/%s/backups/%s/actions/download', $env_id, $db_name, $backup_id), dl_acquia_api_headers($token));
-
-    if (!$backup_url_response['ok']) {
-      fail(sprintf('Unable to discover backup URL for backup ID \'%s\' (status: %s).', $backup_id, (string) $backup_url_response['status']));
+    task(sprintf('Downloading the backup into "%s".', $file_name_compressed));
+    $response = request($download_url, ['method' => 'GET', 'save_to' => $file_name_compressed, 'timeout' => 1800]);
+    if (!$response['ok']) {
+      @unlink($file_name_compressed);
+      fail('Unable to download database "%s" backup "%s": %s', $db_name, $backup_id, $response['error'] ?? 'Unknown error');
     }
 
-    $backup_url_data = json_decode((string) $backup_url_response['body'], TRUE);
-    $backup_url = is_array($backup_url_data) ? (string) ($backup_url_data['url'] ?? '') : '';
-
-    if ($backup_url === '') {
-      fail(sprintf('Unable to discover backup URL for backup ID \'%s\'.', $backup_id));
-    }
-
-    task(sprintf('Downloading DB dump into file %s.', $file_name_compressed));
-    $dl_response = request($backup_url, ['method' => 'GET', 'save_to' => $file_name_compressed, 'timeout' => 600]);
-    if (!$dl_response['ok']) {
-      fail('Unable to download database %s.', $db_name);
-    }
-
-    // Check if the downloaded file exists and has content. Leave the file in
-    // place on failure so it can be inspected.
     if (!file_exists($file_name_compressed) || filesize($file_name_compressed) === 0) {
-      fail(sprintf('Downloaded file is empty or missing: %s', $file_name_compressed));
+      fail('Downloaded file is empty or missing: %s', $file_name_compressed);
     }
+
+    pass('Downloaded the database backup.');
   }
   else {
-    pass(sprintf('Found existing cached gzipped DB file %s for DB %s.', $file_name_compressed, $db_name));
+    pass(sprintf('Found existing cached gzipped DB file "%s" for DB "%s".', $file_name_compressed, $db_name));
   }
 
-  task(sprintf('Expanding DB file %s into %s.', $file_name_compressed, $file_name));
+  task(sprintf('Expanding "%s" into "%s".', $file_name_compressed, $file_name));
 
-  // Test the gzip file first to ensure it's valid. Leave the file in place
-  // on failure so it can be inspected.
+  // Validate the gzip header, then stream-decompress via the zlib wrapper.
   $header = file_get_contents($file_name_compressed, FALSE, NULL, 0, 2);
   if ($header === FALSE || $header !== "\x1f\x8b") {
-    fail(sprintf('Downloaded file is not a valid gzip archive: %s', $file_name_compressed));
+    fail('Downloaded file is not a valid gzip archive: %s', $file_name_compressed);
   }
 
   $gz_in = @fopen('compress.zlib://' . $file_name_compressed, 'rb');
   if ($gz_in === FALSE) {
     // @codeCoverageIgnoreStart
-    fail(sprintf('Unable to read compressed file %s.', $file_name_compressed));
+    fail('Unable to read compressed file "%s".', $file_name_compressed);
     // @codeCoverageIgnoreEnd
   }
 
   $out = @fopen($file_name, 'wb');
   if ($out === FALSE) {
-    fclose($gz_in);
     // @codeCoverageIgnoreStart
-    fail(sprintf('Unable to write decompressed file %s.', $file_name));
+    fclose($gz_in);
+    fail('Unable to write decompressed file "%s".', $file_name);
     // @codeCoverageIgnoreEnd
   }
 
@@ -285,23 +287,17 @@ else {
   fclose($gz_in);
   fclose($out);
 
-  // Check decompression result and file validity. Leave both files in place
-  // on failure so they can be inspected.
   if ($bytes === FALSE || $bytes === 0) {
-    fail(sprintf('Downloaded file is not a valid gzip archive: %s', $file_name_compressed));
-  }
-
-  if (!file_exists($file_name) || filesize($file_name) === 0) {
-    fail(sprintf('Unable to process DB dump file "%s".', $file_name));
+    fail('Downloaded file is not a valid gzip archive: %s', $file_name_compressed);
   }
 
   @unlink($file_name_compressed);
 }
 
-task(sprintf('Renaming file "%s" to "%s/%s".', $file_name, $db_dir, $db_file));
+task(sprintf('Renaming "%s" to "%s/%s".', $file_name, $db_dir, $db_file));
 $final_path = $db_dir . '/' . $db_file;
-if (!rename($file_name, $final_path)) {
-  fail(sprintf('Unable to rename file from \'%s\' to \'%s\'.', $file_name, $final_path));
+if (!@rename($file_name, $final_path)) {
+  fail('Unable to rename file from "%s" to "%s".', $file_name, $final_path);
 }
 
-pass('Finished database dump download from Acquia.');
+pass('Finished database backup download from Acquia.');

--- a/.vortex/tooling/src/vortex-fetch-db-acquia
+++ b/.vortex/tooling/src/vortex-fetch-db-acquia
@@ -33,8 +33,10 @@ $acquia_key = getenv_required(...array_values(array_unique(['VORTEX_FETCH_DB' . 
 // Acquia Cloud API secret.
 $acquia_secret = getenv_required(...array_values(array_unique(['VORTEX_FETCH_DB' . $db_index . '_ACQUIA_SECRET', 'VORTEX_FETCH_DB_ACQUIA_SECRET', 'VORTEX_ACQUIA_SECRET'])));
 
-// Application name. Used to discover the application UUID.
-$app_name = getenv_required(...array_values(array_unique(['VORTEX_FETCH_DB' . $db_index . '_ACQUIA_APP_NAME', 'VORTEX_FETCH_DB_ACQUIA_APP_NAME', 'VORTEX_ACQUIA_APP_NAME'])));
+// Optional application hint. When empty, the application is auto-discovered as
+// long as the credentials expose exactly one. When set, it matches an
+// application by uuid, name, hosting id or hosting machine name.
+$app_name = getenv_default(...array_values(array_unique(['VORTEX_FETCH_DB' . $db_index . '_ACQUIA_APP_NAME', 'VORTEX_FETCH_DB_ACQUIA_APP_NAME', 'VORTEX_ACQUIA_APP_NAME', ''])));
 
 // Source environment name to download the database from.
 $environment = getenv_required(...array_values(array_unique(['VORTEX_FETCH_DB' . $db_index . '_ENVIRONMENT', 'VORTEX_FETCH_DB_ENVIRONMENT'])));
@@ -77,7 +79,7 @@ function acquia_find_item(string $json, string $name): array {
   $items = acquia_items($json);
 
   foreach ($items as $item) {
-    if (is_array($item) && ($item['name'] ?? '') === $name) {
+    if (is_array($item) && strcasecmp((string) ($item['name'] ?? ''), $name) === 0) {
       return $item;
     }
   }
@@ -115,13 +117,90 @@ function acquia_items(string $json): array {
  *   The newest completed backup id, or an empty string when there is none.
  */
 function acquia_latest_backup_id(string $json): string {
-  $backups = array_filter(acquia_items($json), fn($backup): bool => is_array($backup) && ($backup['id'] ?? '') !== '' && ($backup['completedAt'] ?? $backup['completed'] ?? '') !== '');
+  $backups = array_filter(acquia_items($json), fn($backup): bool => is_array($backup) && ($backup['id'] ?? '') !== '' && ($backup['completed_at'] ?? '') !== '');
 
-  usort($backups, fn($a, $b): int => strcmp((string) ($b['completedAt'] ?? $b['startedAt'] ?? ''), (string) ($a['completedAt'] ?? $a['startedAt'] ?? '')));
+  usort($backups, fn($a, $b): int => strcmp((string) ($b['completed_at'] ?? $b['started_at'] ?? ''), (string) ($a['completed_at'] ?? $a['started_at'] ?? '')));
 
   $latest = reset($backups);
 
   return is_array($latest) ? (string) ($latest['id'] ?? '') : '';
+}
+
+/**
+ * Select an Acquia application by hint, or auto-discover the only one.
+ *
+ * When a hint is given it matches an application by uuid, name, hosting id, or
+ * hosting machine name (the segment after the ':' in a 'prod:machine' id), all
+ * case-insensitively. When no hint is given, the single accessible application
+ * is returned; an empty array is returned when the choice is ambiguous.
+ *
+ * @param array<int, mixed> $apps
+ *   The applications from an 'api:applications:list' response.
+ * @param string $hint
+ *   The optional application hint.
+ *
+ * @return array<string, mixed>
+ *   The selected application, or an empty array when none is selected.
+ */
+function acquia_select_app(array $apps, string $hint): array {
+  if ($hint === '') {
+    return count($apps) === 1 && isset($apps[0]) && is_array($apps[0]) ? $apps[0] : [];
+  }
+
+  foreach ($apps as $app) {
+    if (is_array($app) && acquia_app_matches($app, $hint)) {
+      return $app;
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Whether an application matches a hint across its identifying fields.
+ *
+ * @param array<string, mixed> $app
+ *   An application record.
+ * @param string $hint
+ *   The hint to match.
+ *
+ * @return bool
+ *   TRUE when the hint matches the uuid, name, hosting id or machine name.
+ */
+function acquia_app_matches(array $app, string $hint): bool {
+  $hosting = strtolower((string) ($app['hosting']['id'] ?? ''));
+  // The hosting id looks like 'prod:machinename'; accept the bare machine name.
+  $machine = str_contains($hosting, ':') ? substr($hosting, (int) strrpos($hosting, ':') + 1) : $hosting;
+
+  $candidates = [
+    strtolower((string) ($app['uuid'] ?? '')),
+    strtolower((string) ($app['name'] ?? '')),
+    $hosting,
+    $machine,
+  ];
+
+  return in_array(strtolower($hint), array_filter($candidates), TRUE);
+}
+
+/**
+ * Human-readable labels for a list of applications, for disambiguation errors.
+ *
+ * @param array<int, mixed> $apps
+ *   The applications from an 'api:applications:list' response.
+ *
+ * @return string
+ *   A comma-separated list of 'name (hosting id)' labels.
+ */
+function acquia_app_labels(array $apps): string {
+  $labels = [];
+
+  foreach ($apps as $app) {
+    if (is_array($app)) {
+      $labels[] = sprintf('%s (%s)', $app['name'] ?? '?', $app['hosting']['id'] ?? ($app['uuid'] ?? '?'));
+    }
+  }
+
+  return $labels === [] ? '(none)' : implode(', ', $labels);
 }
 
 /**
@@ -173,13 +252,17 @@ if (!is_dir($db_dir)) {
   pass('Created directory for database dumps.');
 }
 
-task(sprintf('Discovering the "%s" application.', $app_name));
-$app = acquia_find_item(acli_exec($bin, 'api:applications:list', $ctx), $app_name);
-$app_uuid = (string) ($app['uuid'] ?? '');
-if ($app_uuid === '') {
-  fail('Unable to find the Acquia application "%s".', $app_name);
+task($app_name === '' ? 'Auto-discovering the Acquia application.' : sprintf('Discovering the "%s" application.', $app_name));
+$apps = acquia_items(acli_exec($bin, 'api:applications:list', $ctx));
+$app = acquia_select_app($apps, $app_name);
+if ($app === []) {
+  if ($app_name !== '') {
+    fail('Unable to find an Acquia application matching "%s". Accessible applications: %s', $app_name, acquia_app_labels($apps));
+  }
+  fail('Unable to auto-discover a single Acquia application (found %d). Set VORTEX_FETCH_DB_ACQUIA_APP_NAME to one of: %s', count($apps), acquia_app_labels($apps));
 }
-pass(sprintf('Found application "%s".', $app_uuid));
+$app_uuid = (string) ($app['uuid'] ?? '');
+pass(sprintf('Using application "%s" (%s).', $app['name'] ?? $app_uuid, $app_uuid));
 
 task(sprintf('Discovering the "%s" environment.', $environment));
 $env = acquia_find_item(acli_exec($bin, sprintf('api:applications:environment-list %s', escapeshellarg($app_uuid)), $ctx), $environment);

--- a/.vortex/tooling/src/vortex-fetch-db-acquia
+++ b/.vortex/tooling/src/vortex-fetch-db-acquia
@@ -253,10 +253,7 @@ function acquia_wait_for_backup(string $bin, array $ctx, string $env_id, string 
   $elapsed = 0;
 
   while ($elapsed < $max_wait) {
-    for ($second = 0; $second < $interval; $second++) {
-      sleep(1);
-      progress_dot();
-    }
+    sleep_progress($interval);
     $elapsed += $interval;
 
     if (acquia_latest_backup_id(acli_exec($bin, sprintf('api:environments:database-backup-list %s %s', escapeshellarg($env_id), escapeshellarg($db_name)), $ctx)) !== '') {
@@ -397,6 +394,8 @@ else {
   }
 
   @unlink($file_name_compressed);
+
+  pass('Expanded the database dump.');
 }
 
 task(sprintf('Renaming "%s" to "%s/%s".', $file_name, $db_dir, $db_file));

--- a/.vortex/tooling/src/vortex-fetch-db-lagoon
+++ b/.vortex/tooling/src/vortex-fetch-db-lagoon
@@ -159,8 +159,12 @@ function lagoon_create_dump_task(string $bin, array $ctx, string $environment): 
  *   Number of status checks before timing out.
  * @param int $interval
  *   Seconds to wait between status checks.
+ *
+ * @return string
+ *   The terminal status: 'complete', a failure status ('failed', 'cancelled'
+ *   or 'error'), or 'timeout' when it never completed within the retries.
  */
-function lagoon_wait_dump_task(string $bin, array $ctx, string $task_id, int $retries, int $interval): void {
+function lagoon_wait_dump_task(string $bin, array $ctx, string $task_id, int $retries, int $interval): string {
   for ($i = 1; $i <= $retries; $i++) {
     $json = lagoon_exec($bin, sprintf('get task-by-id --id %s --output-json', escapeshellarg($task_id)), $ctx);
 
@@ -168,20 +172,17 @@ function lagoon_wait_dump_task(string $bin, array $ctx, string $task_id, int $re
     $status = (is_array($data) && isset($data['data'][0]['status'])) ? (string) $data['data'][0]['status'] : '';
 
     if ($status === 'complete') {
-      return;
+      return 'complete';
     }
 
     if (in_array($status, ['failed', 'cancelled', 'error'], TRUE)) {
-      fail('Database dump task "%s" %s.', $task_id, $status);
+      return $status;
     }
 
-    for ($second = 0; $second < $interval; $second++) {
-      sleep(1);
-      progress_dot();
-    }
+    sleep_progress($interval);
   }
 
-  fail('Timed out waiting for the database dump task "%s".', $task_id);
+  return 'timeout';
 }
 
 /**
@@ -323,9 +324,13 @@ if (!$reused) {
   $task_id = lagoon_create_dump_task($bin, $ctx, $environment);
   pass(sprintf('Requested database dump task "%s".', $task_id));
 
-  task_progress('Waiting for the database dump to complete.', function () use ($bin, $ctx, $task_id, $status_retries, $status_interval): void {
-    lagoon_wait_dump_task($bin, $ctx, $task_id, $status_retries, $status_interval);
-  });
+  $status = task_progress('Waiting for the database dump to complete.', fn(): string => lagoon_wait_dump_task($bin, $ctx, $task_id, $status_retries, $status_interval));
+  if ($status === 'timeout') {
+    fail('Timed out waiting for the database dump task "%s".', $task_id);
+  }
+  if ($status !== 'complete') {
+    fail('Database dump task "%s" %s.', $task_id, $status);
+  }
   pass('Database dump completed.');
 
   $download_url = lagoon_dump_task_url($bin, $ctx, $task_id);

--- a/.vortex/tooling/src/vortex-fetch-db-lagoon
+++ b/.vortex/tooling/src/vortex-fetch-db-lagoon
@@ -232,7 +232,7 @@ function lagoon_dump_task_url(string $bin, array $ctx, string $task_id): string 
 function lagoon_download_dump(string $url, string $dest, int $timeout): bool {
   $archive = $dest . '.gz';
 
-  $response = request($url, ['method' => 'GET', 'save_to' => $archive, 'timeout' => $timeout, 'progress' => TRUE]);
+  $response = request($url, ['method' => 'GET', 'save_to' => $archive, 'timeout' => $timeout, 'on_progress' => progress_dot(...)]);
   $valid_gzip = $response['ok'] && is_file($archive) && file_get_contents($archive, FALSE, NULL, 0, 2) === "\x1f\x8b";
 
   if (!$valid_gzip) {

--- a/.vortex/tooling/src/vortex-fetch-db-lagoon
+++ b/.vortex/tooling/src/vortex-fetch-db-lagoon
@@ -274,9 +274,9 @@ if ($ssh_file !== 'false') {
 
 $config_file = lagoon_config_file();
 
-task('Configuring Lagoon instance.');
-lagoon_config($bin, $config_file, $instance, $instance_graphql, $ssh_host, $ssh_port);
-pass('Configured Lagoon instance.');
+task('Configuring Lagoon instance.', 'Configured Lagoon instance.', function () use ($bin, $config_file, $instance, $instance_graphql, $ssh_host, $ssh_port): void {
+  lagoon_config($bin, $config_file, $instance, $instance_graphql, $ssh_host, $ssh_port);
+});
 
 $ctx = [
   'instance' => $instance,
@@ -288,61 +288,70 @@ $ctx = [
 // Surface the CLI version and authenticated identity so the run is observable.
 lagoon_print_version($bin, $config_file);
 
-task('Checking Lagoon authenticated identity.');
-echo lagoon_exec($bin, 'whoami', $ctx);
-pass('Checked Lagoon authenticated identity.');
+task('Checking Lagoon authenticated identity.', 'Checked Lagoon authenticated identity.', function () use ($bin, $ctx): void {
+  echo lagoon_exec($bin, 'whoami', $ctx);
+});
 
 if (!is_dir($db_dir)) {
-  task('Creating directory for database dumps.');
-  mkdir($db_dir, 0755, TRUE);
-  pass('Created directory for database dumps.');
+  task('Creating directory for database dumps.', 'Created directory for database dumps.', function () use ($db_dir): void {
+    if (!mkdir($db_dir, 0755, TRUE)) {
+      throw new \RuntimeException(sprintf('Unable to create directory "%s".', $db_dir));
+    }
+  });
 }
 
 $dest = $db_dir . '/' . $db_file;
 
 // Reuse a recent dump when possible; a fresh dump is always the fallback.
-$reused = FALSE;
+$reuse_id = '';
 if ($fresh === '1') {
   note('Fresh dump requested; skipping reuse of a previous dump.');
 }
 else {
-  task('Looking for a recent database dump to reuse.');
-  $reuse_id = lagoon_reusable_dump_task($bin, $ctx, $environment, $reuse_max_age);
-  $reuse_url = $reuse_id === '' ? '' : lagoon_dump_task_url($bin, $ctx, $reuse_id);
-  $reused = $reuse_url !== '' && lagoon_download_dump($reuse_url, $dest, $download_timeout);
+  $reuse_id = (string) task(
+    'Looking for a recent database dump to reuse.',
+    fn(string $id): string => $id !== '' ? sprintf('Reused the database dump from task "%s".', $id) : 'No reusable database dump; a fresh one will be created.',
+    function () use ($bin, $ctx, $environment, $reuse_max_age, $dest, $download_timeout): string {
+      $id = lagoon_reusable_dump_task($bin, $ctx, $environment, $reuse_max_age);
+      if ($id === '') {
+        return '';
+      }
 
-  if ($reused) {
-    pass(sprintf('Reused the database dump from task "%s".', $reuse_id));
-  }
-  else {
-    pass('No reusable database dump; a fresh one will be created.');
-  }
+      $url = lagoon_dump_task_url($bin, $ctx, $id);
+
+      return ($url !== '' && lagoon_download_dump($url, $dest, $download_timeout)) ? $id : '';
+    },
+  );
 }
+$reused = $reuse_id !== '';
 
 if (!$reused) {
-  task('Requesting a fresh database dump.');
-  $task_id = lagoon_create_dump_task($bin, $ctx, $environment);
-  pass(sprintf('Requested database dump task "%s".', $task_id));
+  $task_id = (string) task(
+    'Requesting a fresh database dump.',
+    fn(string $id): string => sprintf('Requested database dump task "%s".', $id),
+    fn(): string => lagoon_create_dump_task($bin, $ctx, $environment),
+  );
 
-  $status = task_progress('Waiting for the database dump to complete.', fn(): string => lagoon_wait_dump_task($bin, $ctx, $task_id, $status_retries, $status_interval));
-  if ($status === 'timeout') {
-    fail('Timed out waiting for the database dump task "%s".', $task_id);
-  }
-  if ($status !== 'complete') {
-    fail('Database dump task "%s" %s.', $task_id, $status);
-  }
-  pass('Database dump completed.');
+  task('Waiting for the database dump to complete.', 'Database dump completed.', function () use ($bin, $ctx, $task_id, $status_retries, $status_interval): void {
+    $status = lagoon_wait_dump_task($bin, $ctx, $task_id, $status_retries, $status_interval);
+    if ($status === 'timeout') {
+      throw new \RuntimeException(sprintf('Timed out waiting for the database dump task "%s".', $task_id));
+    }
+    if ($status !== 'complete') {
+      throw new \RuntimeException(sprintf('Database dump task "%s" %s.', $task_id, $status));
+    }
+  });
 
   $download_url = lagoon_dump_task_url($bin, $ctx, $task_id);
   if ($download_url === '') {
     fail('The database dump task "%s" produced no downloadable file.', $task_id);
   }
 
-  $downloaded = task_progress('Downloading the database dump.', fn(): bool => lagoon_download_dump($download_url, $dest, $download_timeout));
-  if (!$downloaded) {
-    fail('Failed to download the database dump from Lagoon.');
-  }
-  pass('Downloaded the database dump.');
+  task('Downloading the database dump.', 'Downloaded the database dump.', function () use ($download_url, $dest, $download_timeout): void {
+    if (!lagoon_download_dump($download_url, $dest, $download_timeout)) {
+      throw new \RuntimeException('Failed to download the database dump from Lagoon.');
+    }
+  });
 }
 
 pass('Finished database dump download from Lagoon.');

--- a/.vortex/tooling/src/vortex-fetch-db-lagoon
+++ b/.vortex/tooling/src/vortex-fetch-db-lagoon
@@ -175,7 +175,10 @@ function lagoon_wait_dump_task(string $bin, array $ctx, string $task_id, int $re
       fail('Database dump task "%s" %s.', $task_id, $status);
     }
 
-    sleep($interval);
+    for ($second = 0; $second < $interval; $second++) {
+      sleep(1);
+      progress_dot();
+    }
   }
 
   fail('Timed out waiting for the database dump task "%s".', $task_id);
@@ -228,7 +231,7 @@ function lagoon_dump_task_url(string $bin, array $ctx, string $task_id): string 
 function lagoon_download_dump(string $url, string $dest, int $timeout): bool {
   $archive = $dest . '.gz';
 
-  $response = request($url, ['method' => 'GET', 'save_to' => $archive, 'timeout' => $timeout]);
+  $response = request($url, ['method' => 'GET', 'save_to' => $archive, 'timeout' => $timeout, 'progress' => TRUE]);
   $valid_gzip = $response['ok'] && is_file($archive) && file_get_contents($archive, FALSE, NULL, 0, 2) === "\x1f\x8b";
 
   if (!$valid_gzip) {
@@ -320,8 +323,9 @@ if (!$reused) {
   $task_id = lagoon_create_dump_task($bin, $ctx, $environment);
   pass(sprintf('Requested database dump task "%s".', $task_id));
 
-  task('Waiting for the database dump to complete.');
-  lagoon_wait_dump_task($bin, $ctx, $task_id, $status_retries, $status_interval);
+  task_progress('Waiting for the database dump to complete.', function () use ($bin, $ctx, $task_id, $status_retries, $status_interval): void {
+    lagoon_wait_dump_task($bin, $ctx, $task_id, $status_retries, $status_interval);
+  });
   pass('Database dump completed.');
 
   $download_url = lagoon_dump_task_url($bin, $ctx, $task_id);
@@ -329,8 +333,8 @@ if (!$reused) {
     fail('The database dump task "%s" produced no downloadable file.', $task_id);
   }
 
-  task('Downloading the database dump.');
-  if (!lagoon_download_dump($download_url, $dest, $download_timeout)) {
+  $downloaded = task_progress('Downloading the database dump.', fn(): bool => lagoon_download_dump($download_url, $dest, $download_timeout));
+  if (!$downloaded) {
     fail('Failed to download the database dump from Lagoon.');
   }
   pass('Downloaded the database dump.');

--- a/.vortex/tooling/src/vortex-notify-email
+++ b/.vortex/tooling/src/vortex-notify-email
@@ -204,12 +204,14 @@ task(
     // Send a single message addressed to all TO recipients at once.
     $to_combined = implode(', ', $to_list);
 
+    if (!mail($to_combined, $email_subject, $email_message, $headers)) {
+      throw new \RuntimeException('Failed to send email notification via mail().');
+    }
+
     $sent = [];
-    if (mail($to_combined, $email_subject, $email_message, $headers)) {
-      foreach ($to_list as $to) {
-        // Extract just the email address from formatted string for tracking.
-        $sent[] = preg_match('/<(.+?)>/', $to, $matches) ? $matches[1] : $to;
-      }
+    foreach ($to_list as $to) {
+      // Extract just the email address from formatted string for tracking.
+      $sent[] = preg_match('/<(.+?)>/', $to, $matches) ? $matches[1] : $to;
     }
 
     return $sent;

--- a/.vortex/tooling/src/vortex-notify-email
+++ b/.vortex/tooling/src/vortex-notify-email
@@ -166,49 +166,54 @@ if (!empty($email_bcc)) {
 note('Subject        : ' . $email_subject);
 note('Content        : ' . $email_message);
 
-task('Sending email notification');
+task(
+  'Sending email notification',
+  function (array $sent): string {
+    if (!empty($sent)) {
+      return sprintf('Email notification sent successfully to %d recipient(s).', count($sent));
+    }
 
-// Parse recipients.
-$to_list = parse_email_recipients($email_recipients);
-$cc_list = parse_email_recipients($email_cc);
-$bcc_list = parse_email_recipients($email_bcc);
+    // @codeCoverageIgnoreStart
+    return 'No notification emails were sent.';
+    // @codeCoverageIgnoreEnd
+  },
+  function () use ($email_recipients, $email_cc, $email_bcc, $email_from, $email_subject, $email_message): array {
+    // Parse recipients.
+    $to_list = parse_email_recipients($email_recipients);
+    $cc_list = parse_email_recipients($email_cc);
+    $bcc_list = parse_email_recipients($email_bcc);
 
-// Build headers once. The CC and BCC headers must appear a single time on the
-// one outgoing message; adding them per TO recipient would deliver a duplicate
-// copy to every CC and BCC address for each TO recipient.
-$headers = [
-  'From: ' . $email_from,
-  'Content-Type: text/plain; charset=UTF-8',
-];
+    // Build headers once. The CC and BCC headers must appear only once on the
+    // one outgoing message; adding them per TO recipient would deliver a
+    // duplicate copy to every CC and BCC address for each TO recipient.
+    $headers = [
+      'From: ' . $email_from,
+      'Content-Type: text/plain; charset=UTF-8',
+    ];
 
-// Add CC header if there are CC recipients.
-if (!empty($cc_list)) {
-  $headers[] = 'Cc: ' . implode(', ', $cc_list);
-}
+    // Add CC header if there are CC recipients.
+    if (!empty($cc_list)) {
+      $headers[] = 'Cc: ' . implode(', ', $cc_list);
+    }
 
-// Add BCC header if there are BCC recipients.
-if (!empty($bcc_list)) {
-  $headers[] = 'Bcc: ' . implode(', ', $bcc_list);
-}
+    // Add BCC header if there are BCC recipients.
+    if (!empty($bcc_list)) {
+      $headers[] = 'Bcc: ' . implode(', ', $bcc_list);
+    }
 
-// Send a single message addressed to all TO recipients at once.
-$to_combined = implode(', ', $to_list);
+    // Send a single message addressed to all TO recipients at once.
+    $to_combined = implode(', ', $to_list);
 
-$sent = [];
-if (mail($to_combined, $email_subject, $email_message, $headers)) {
-  foreach ($to_list as $to) {
-    // Extract just the email address from formatted string for tracking.
-    $sent[] = preg_match('/<(.+?)>/', $to, $matches) ? $matches[1] : $to;
-  }
-}
+    $sent = [];
+    if (mail($to_combined, $email_subject, $email_message, $headers)) {
+      foreach ($to_list as $to) {
+        // Extract just the email address from formatted string for tracking.
+        $sent[] = preg_match('/<(.+?)>/', $to, $matches) ? $matches[1] : $to;
+      }
+    }
 
-if (!empty($sent)) {
-  pass('Email notification sent successfully to %d recipient(s).', count($sent));
-}
-else {
-  // @codeCoverageIgnoreStart
-  pass('No notification emails were sent.');
-  // @codeCoverageIgnoreEnd
-}
+    return $sent;
+  },
+);
 
 info('Finished email notification.');

--- a/.vortex/tooling/src/vortex-notify-github
+++ b/.vortex/tooling/src/vortex-notify-github
@@ -126,7 +126,7 @@ if ($notify_event === 'pre_deployment') {
 else {
   $env_url = getenv_required('VORTEX_NOTIFY_GITHUB_ENVIRONMENT_URL', 'VORTEX_NOTIFY_ENVIRONMENT_URL');
 
-  task('Finding latest deployment for ref %s', $notify_branch);
+  task(sprintf('Finding latest deployment for ref %s', $notify_branch));
 
   $url = sprintf('https://api.github.com/repos/%s/deployments?ref=%s', $github_repository, urlencode($notify_branch));
   $response = request_get($url, [

--- a/.vortex/tooling/src/vortex-notify-github
+++ b/.vortex/tooling/src/vortex-notify-github
@@ -95,61 +95,69 @@ if ($notify_event === 'pre_deployment') {
   note('Environment Type: ' . $github_env_type);
   note('Event           : ' . $notify_event);
 
-  task('Creating deployment');
+  task(
+    'Creating deployment',
+    fn(string $deployment_id): string => sprintf('Created deployment with ID %s.', $deployment_id),
+    function () use ($notify_branch, $github_env_type, $github_repository, $github_token, $notify_event): string {
+      $payload_data = [
+        'ref' => $notify_branch,
+        'environment' => $github_env_type,
+        'auto_merge' => FALSE,
+        'required_contexts' => [],
+      ];
 
-  $payload_data = [
-    'ref' => $notify_branch,
-    'environment' => $github_env_type,
-    'auto_merge' => FALSE,
-    'required_contexts' => [],
-  ];
+      $url = sprintf('https://api.github.com/repos/%s/deployments', $github_repository);
+      $response = request_post($url, json_encode($payload_data), [
+        'Authorization: token ' . $github_token,
+        'Accept: application/vnd.github.v3+json',
+      ]);
 
-  $url = sprintf('https://api.github.com/repos/%s/deployments', $github_repository);
-  $response = request_post($url, json_encode($payload_data), [
-    'Authorization: token ' . $github_token,
-    'Accept: application/vnd.github.v3+json',
-  ]);
+      $deployment_id = NULL;
+      if ($response['ok'] && $response['body']) {
+        $payload = json_decode((string) $response['body'], TRUE);
+        $deployment_id = $payload['id'] ?? NULL;
+      }
 
-  $deployment_id = NULL;
-  if ($response['ok'] && $response['body']) {
-    $payload = json_decode((string) $response['body'], TRUE);
-    $deployment_id = $payload['id'] ?? NULL;
-  }
+      // Check deployment ID.
+      if (!deployment_id_is_valid($deployment_id)) {
+        throw new \RuntimeException(sprintf('Failed to get a deployment ID for a %s event. Payload: %s. Wait for GitHub checks to finish and try again.', $notify_event, $response['body'] ?: 'empty'));
+      }
 
-  // Check deployment ID.
-  if (!deployment_id_is_valid($deployment_id)) {
-    fail('Failed to get a deployment ID for a %s event. Payload: %s. Wait for GitHub checks to finish and try again.', $notify_event, $response['body'] ?: 'empty');
-  }
-
-  pass('Created deployment with ID %s.', $deployment_id);
+      return (string) $deployment_id;
+    },
+  );
 }
 else {
   $env_url = getenv_required('VORTEX_NOTIFY_GITHUB_ENVIRONMENT_URL', 'VORTEX_NOTIFY_ENVIRONMENT_URL');
 
-  task(sprintf('Finding latest deployment for ref %s', $notify_branch));
+  $deployment_id = (string) task(
+    sprintf('Finding latest deployment for ref %s', $notify_branch),
+    fn(string $deployment_id): string => sprintf('Found deployment with ID %s.', $deployment_id),
+    function () use ($github_repository, $notify_branch, $github_token): string {
+      $url = sprintf('https://api.github.com/repos/%s/deployments?ref=%s', $github_repository, urlencode($notify_branch));
+      $response = request_get($url, [
+        'Authorization: token ' . $github_token,
+        'Accept: application/vnd.github.v3+json',
+      ]);
 
-  $url = sprintf('https://api.github.com/repos/%s/deployments?ref=%s', $github_repository, urlencode($notify_branch));
-  $response = request_get($url, [
-    'Authorization: token ' . $github_token,
-    'Accept: application/vnd.github.v3+json',
-  ]);
+      // Get first (latest) deployment ID.
+      $deployment_id = NULL;
+      if ($response['ok'] && $response['body']) {
+        $payload = json_decode((string) $response['body'], TRUE);
+        if (is_array($payload) && !empty($payload)) {
+          $first = reset($payload);
+          $deployment_id = $first['id'] ?? NULL;
+        }
+      }
 
-  // Get first (latest) deployment ID.
-  $deployment_id = NULL;
-  if ($response['ok'] && $response['body']) {
-    $payload = json_decode((string) $response['body'], TRUE);
-    if (is_array($payload) && !empty($payload)) {
-      $first = reset($payload);
-      $deployment_id = $first['id'] ?? NULL;
-    }
-  }
+      // Check deployment ID.
+      if (!deployment_id_is_valid($deployment_id)) {
+        throw new \RuntimeException(sprintf('Failed to find a previous deployment for ref %s. Payload: %s', $notify_branch, $response['body'] ?: 'empty'));
+      }
 
-  // Check deployment ID.
-  if (!deployment_id_is_valid($deployment_id)) {
-    fail('Failed to find a previous deployment for ref %s. Payload: %s', $notify_branch, $response['body'] ?: 'empty');
-  }
-
-  pass('Found deployment with ID %s.', $deployment_id);
+      return (string) $deployment_id;
+    },
+  );
 
   note('GitHub post-deployment notification summary:');
   note('Repository         : ' . $github_repository);
@@ -159,30 +167,28 @@ else {
   note('Deployment ID      : ' . $deployment_id);
   note('Event              : ' . $notify_event);
 
-  task('Marking deployment as finished');
+  task('Marking deployment as finished', 'Marked deployment as finished.', function () use ($github_repository, $deployment_id, $env_url, $github_token): void {
+    $status_data = [
+      'state' => 'success',
+      'environment_url' => $env_url,
+    ];
 
-  $status_data = [
-    'state' => 'success',
-    'environment_url' => $env_url,
-  ];
+    $url = sprintf('https://api.github.com/repos/%s/deployments/%s/statuses', $github_repository, $deployment_id);
+    $response = request_post($url, json_encode($status_data), [
+      'Accept: application/vnd.github.v3+json',
+      'Authorization: token ' . $github_token,
+    ]);
 
-  $url = sprintf('https://api.github.com/repos/%s/deployments/%s/statuses', $github_repository, $deployment_id);
-  $response = request_post($url, json_encode($status_data), [
-    'Accept: application/vnd.github.v3+json',
-    'Authorization: token ' . $github_token,
-  ]);
+    $status = NULL;
+    if ($response['ok'] && $response['body']) {
+      $payload = json_decode((string) $response['body'], TRUE);
+      $status = $payload['state'] ?? NULL;
+    }
 
-  $status = NULL;
-  if ($response['ok'] && $response['body']) {
-    $payload = json_decode((string) $response['body'], TRUE);
-    $status = $payload['state'] ?? NULL;
-  }
-
-  if ($status !== 'success') {
-    fail('Previous deployment was found, but was unable to update the deployment status. Payload: %s', $response['body'] ?: 'empty');
-  }
-
-  pass('Marked deployment as finished.');
+    if ($status !== 'success') {
+      throw new \RuntimeException(sprintf('Previous deployment was found, but was unable to update the deployment status. Payload: %s', $response['body'] ?: 'empty'));
+    }
+  });
 }
 
 info('Finished GitHub notification for %s event.', $notify_event);

--- a/.vortex/tooling/src/vortex-notify-jira
+++ b/.vortex/tooling/src/vortex-notify-jira
@@ -157,29 +157,28 @@ $jira_issue = $matches[2];
 
 pass('Found issue %s.', $jira_issue);
 
-task('Checking API access');
-
 $token = base64_encode(sprintf('%s:%s', $jira_user_email, $jira_api_token));
-$url = sprintf('%s/rest/api/3/myself', $jira_endpoint);
 
-$response = request_get($url, [
-  'Authorization: Basic ' . $token,
-  'Content-Type: application/json',
-]);
+task('Checking API access', fn(string $account_id): string => sprintf('Authenticated as user with account ID %s.', $account_id), function () use ($token, $jira_endpoint): string {
+  $url = sprintf('%s/rest/api/3/myself', $jira_endpoint);
 
-$account_id = 'error';
-if ($response['ok'] && $response['body']) {
-  $payload = json_decode((string) $response['body'], TRUE);
-  $account_id = $payload['accountId'] ?? 'error';
-}
+  $response = request_get($url, [
+    'Authorization: Basic ' . $token,
+    'Content-Type: application/json',
+  ]);
 
-if (strlen((string) $account_id) < 24) {
-  fail('Unable to authenticate');
-}
+  $account_id = 'error';
+  if ($response['ok'] && $response['body']) {
+    $payload = json_decode((string) $response['body'], TRUE);
+    $account_id = $payload['accountId'] ?? 'error';
+  }
 
-pass('Authenticated as user with account ID %s.', $account_id);
+  if (strlen((string) $account_id) < 24) {
+    throw new \RuntimeException('Unable to authenticate');
+  }
 
-task('Posting a comment');
+  return (string) $account_id;
+});
 
 $timestamp = date('d/m/Y H:i:s T');
 
@@ -196,113 +195,121 @@ note('User email     : ' . $jira_user_email);
 note('Transition     : ' . ($jira_transition ?: '<none>'));
 note('Assignee email : ' . ($jira_assignee_email ?: '<none>'));
 
-$payload_data = ['body' => $comment_body];
-$url = sprintf('%s/rest/api/3/issue/%s/comment', $jira_endpoint, $jira_issue);
-$response = request_post($url, json_encode($payload_data, JSON_UNESCAPED_SLASHES), [
-  'Authorization: Basic ' . $token,
-  'Content-Type: application/json',
-]);
-
-$comment_id = 'error';
-if ($response['ok'] && $response['body']) {
-  $payload = json_decode((string) $response['body'], TRUE);
-  $comment_id = $payload['id'] ?? 'error';
-}
-
-if (!ctype_digit((string) $comment_id)) {
-  fail('Unable to create a comment');
-}
-
-pass('Posted comment with ID %s.', $comment_id);
-
-if (!empty($jira_transition)) {
-  task(sprintf('Discovering transition ID for %s', $jira_transition));
-  $url = sprintf('%s/rest/api/3/issue/%s/transitions', $jira_endpoint, $jira_issue);
-  $response = request_get($url, [
+task('Posting a comment', fn(string $id): string => sprintf('Posted comment with ID %s.', $id), function () use ($token, $jira_endpoint, $jira_issue, $comment_body): string {
+  $payload_data = ['body' => $comment_body];
+  $url = sprintf('%s/rest/api/3/issue/%s/comment', $jira_endpoint, $jira_issue);
+  $response = request_post($url, json_encode($payload_data, JSON_UNESCAPED_SLASHES), [
     'Authorization: Basic ' . $token,
     'Content-Type: application/json',
   ]);
 
-  $transition_id = NULL;
+  $comment_id = 'error';
   if ($response['ok'] && $response['body']) {
     $payload = json_decode((string) $response['body'], TRUE);
-    if (isset($payload['transitions']) && is_array($payload['transitions'])) {
-      foreach ($payload['transitions'] as $t) {
-        if (isset($t['name']) && $t['name'] === $jira_transition) {
-          $transition_id = $t['id'] ?? NULL;
-          break;
+    $comment_id = $payload['id'] ?? 'error';
+  }
+
+  if (!ctype_digit((string) $comment_id)) {
+    throw new \RuntimeException('Unable to create a comment');
+  }
+
+  return (string) $comment_id;
+});
+
+if (!empty($jira_transition)) {
+  $transition_id = (string) task(
+    sprintf('Discovering transition ID for %s', $jira_transition),
+    fn(string $id): string => sprintf('Found transition ID %s', $id),
+    function () use ($token, $jira_endpoint, $jira_issue, $jira_transition): string {
+      $url = sprintf('%s/rest/api/3/issue/%s/transitions', $jira_endpoint, $jira_issue);
+      $response = request_get($url, [
+        'Authorization: Basic ' . $token,
+        'Content-Type: application/json',
+      ]);
+
+      $transition_id = NULL;
+      if ($response['ok'] && $response['body']) {
+        $payload = json_decode((string) $response['body'], TRUE);
+        if (isset($payload['transitions']) && is_array($payload['transitions'])) {
+          foreach ($payload['transitions'] as $t) {
+            if (isset($t['name']) && $t['name'] === $jira_transition) {
+              $transition_id = $t['id'] ?? NULL;
+              break;
+            }
+          }
         }
       }
+
+      if (!$transition_id || !ctype_digit((string) $transition_id)) {
+        throw new \RuntimeException('Unable to retrieve transition ID');
+      }
+
+      return (string) $transition_id;
+    },
+  );
+
+  task('Transitioning issue to ' . $jira_transition, sprintf('Transitioned issue to %s ', $jira_transition), function () use ($token, $jira_endpoint, $jira_issue, $transition_id, $jira_transition): void {
+    $payload_data = ['transition' => ['id' => $transition_id]];
+    $url = sprintf('%s/rest/api/3/issue/%s/transitions', $jira_endpoint, $jira_issue);
+    $response = request_post($url, json_encode($payload_data), [
+      'Authorization: Basic ' . $token,
+      'Content-Type: application/json',
+    ]);
+
+    // JIRA returns HTTP 204 on a successful transition.
+    if ($response['status'] !== 204) {
+      throw new \RuntimeException(sprintf('Unable to transition issue to %s. HTTP status: %s', $jira_transition, $response['status']));
     }
-  }
-
-  if (!$transition_id || !ctype_digit((string) $transition_id)) {
-    fail('Unable to retrieve transition ID');
-  }
-
-  pass('Found transition ID %s', $transition_id);
-
-  task('Transitioning issue to ' . $jira_transition);
-
-  $payload_data = ['transition' => ['id' => $transition_id]];
-  $url = sprintf('%s/rest/api/3/issue/%s/transitions', $jira_endpoint, $jira_issue);
-  $response = request_post($url, json_encode($payload_data), [
-    'Authorization: Basic ' . $token,
-    'Content-Type: application/json',
-  ]);
-
-  // JIRA returns HTTP 204 on a successful transition.
-  if ($response['status'] !== 204) {
-    fail('Unable to transition issue to %s. HTTP status: %s', $jira_transition, $response['status']);
-  }
-
-  pass('Transitioned issue to %s ', $jira_transition);
+  });
 }
 
 if (!empty($jira_assignee_email)) {
   task('Assigning issue to ' . $jira_assignee_email);
 
-  task(sprintf('Discovering assignee user ID for %s', $jira_assignee_email));
-  $url = sprintf('%s/rest/api/3/user/assignable/search?query=%s&issueKey=%s', $jira_endpoint, urlencode($jira_assignee_email), urlencode($jira_issue));
-  $response = request_get($url, [
-    'Authorization: Basic ' . $token,
-    'Content-Type: application/json',
-  ]);
+  $assignee_account_id = (string) task(
+    sprintf('Discovering assignee user ID for %s', $jira_assignee_email),
+    fn(string $id): string => sprintf('Found assignee account ID %s', $id),
+    function () use ($token, $jira_endpoint, $jira_issue, $jira_assignee_email): string {
+      $url = sprintf('%s/rest/api/3/user/assignable/search?query=%s&issueKey=%s', $jira_endpoint, urlencode($jira_assignee_email), urlencode($jira_issue));
+      $response = request_get($url, [
+        'Authorization: Basic ' . $token,
+        'Content-Type: application/json',
+      ]);
 
-  $assignee_account_id = NULL;
-  if ($response['ok'] && $response['body']) {
-    $payload = json_decode((string) $response['body'], TRUE);
-    if (is_array($payload) && !empty($payload)) {
-      $first = reset($payload);
-      $assignee_account_id = $first['accountId'] ?? NULL;
+      $assignee_account_id = NULL;
+      if ($response['ok'] && $response['body']) {
+        $payload = json_decode((string) $response['body'], TRUE);
+        if (is_array($payload) && !empty($payload)) {
+          $first = reset($payload);
+          $assignee_account_id = $first['accountId'] ?? NULL;
+        }
+      }
+
+      if (!$assignee_account_id || strlen((string) $assignee_account_id) < 24) {
+        throw new \RuntimeException('Unable to retrieve assignee account ID');
+      }
+
+      return (string) $assignee_account_id;
+    },
+  );
+
+  task('Assigning issue to user ID ' . $assignee_account_id, 'Assigned issue to ' . $jira_assignee_email, function () use ($token, $jira_endpoint, $jira_issue, $assignee_account_id, $jira_assignee_email): void {
+    $payload_data = ['accountId' => $assignee_account_id];
+    $url = sprintf('%s/rest/api/3/issue/%s/assignee', $jira_endpoint, $jira_issue);
+    $response = request($url, [
+      'method' => 'PUT',
+      'body' => json_encode($payload_data),
+      'headers' => [
+        'Authorization: Basic ' . $token,
+        'Content-Type: application/json',
+      ],
+    ]);
+
+    // JIRA returns HTTP 204 on a successful assignee update.
+    if ($response['status'] !== 204) {
+      throw new \RuntimeException(sprintf('Unable to assign issue to %s. HTTP status: %s', $jira_assignee_email, $response['status']));
     }
-  }
-
-  if (!$assignee_account_id || strlen((string) $assignee_account_id) < 24) {
-    fail('Unable to retrieve assignee account ID');
-  }
-
-  pass('Found assignee account ID %s', $assignee_account_id);
-
-  task('Assigning issue to user ID ' . $assignee_account_id);
-
-  $payload_data = ['accountId' => $assignee_account_id];
-  $url = sprintf('%s/rest/api/3/issue/%s/assignee', $jira_endpoint, $jira_issue);
-  $response = request($url, [
-    'method' => 'PUT',
-    'body' => json_encode($payload_data),
-    'headers' => [
-      'Authorization: Basic ' . $token,
-      'Content-Type: application/json',
-    ],
-  ]);
-
-  // JIRA returns HTTP 204 on a successful assignee update.
-  if ($response['status'] !== 204) {
-    fail('Unable to assign issue to %s. HTTP status: %s', $jira_assignee_email, $response['status']);
-  }
-
-  pass('Assigned issue to ' . $jira_assignee_email);
+  });
 }
 
 info('Finished JIRA notification.');

--- a/.vortex/tooling/src/vortex-notify-jira
+++ b/.vortex/tooling/src/vortex-notify-jira
@@ -216,7 +216,7 @@ if (!ctype_digit((string) $comment_id)) {
 pass('Posted comment with ID %s.', $comment_id);
 
 if (!empty($jira_transition)) {
-  task('Discovering transition ID for %s', $jira_transition);
+  task(sprintf('Discovering transition ID for %s', $jira_transition));
   $url = sprintf('%s/rest/api/3/issue/%s/transitions', $jira_endpoint, $jira_issue);
   $response = request_get($url, [
     'Authorization: Basic ' . $token,
@@ -262,7 +262,7 @@ if (!empty($jira_transition)) {
 if (!empty($jira_assignee_email)) {
   task('Assigning issue to ' . $jira_assignee_email);
 
-  task('Discovering assignee user ID for %s', $jira_assignee_email);
+  task(sprintf('Discovering assignee user ID for %s', $jira_assignee_email));
   $url = sprintf('%s/rest/api/3/user/assignable/search?query=%s&issueKey=%s', $jira_endpoint, urlencode($jira_assignee_email), urlencode($jira_issue));
   $response = request_get($url, [
     'Authorization: Basic ' . $token,

--- a/.vortex/tooling/src/vortex-notify-newrelic
+++ b/.vortex/tooling/src/vortex-notify-newrelic
@@ -181,7 +181,7 @@ note('User             : ' . $newrelic_user);
 note('Endpoint         : ' . $newrelic_endpoint);
 note('Description      : ' . $newrelic_description);
 
-task('Creating a deployment notification for application %s with ID %s.', $newrelic_app_name, $newrelic_appid);
+task(sprintf('Creating a deployment notification for application %s with ID %s.', $newrelic_app_name, $newrelic_appid));
 
 $payload_data = [
   'deployment' => [

--- a/.vortex/tooling/src/vortex-notify-newrelic
+++ b/.vortex/tooling/src/vortex-notify-newrelic
@@ -181,8 +181,6 @@ note('User             : ' . $newrelic_user);
 note('Endpoint         : ' . $newrelic_endpoint);
 note('Description      : ' . $newrelic_description);
 
-task(sprintf('Creating a deployment notification for application %s with ID %s.', $newrelic_app_name, $newrelic_appid));
-
 $payload_data = [
   'deployment' => [
     'revision' => $newrelic_revision,
@@ -193,15 +191,20 @@ $payload_data = [
 ];
 
 $url = sprintf('%s/applications/%s/deployments.json', $newrelic_endpoint, $newrelic_appid);
-$response = request_post($url, json_encode($payload_data, JSON_UNESCAPED_SLASHES), [
-  'Api-Key: ' . $newrelic_user_key,
-  'Content-Type: application/json',
-]);
 
-if ($response['status'] !== 201) {
-  fail('Failed to create a deployment notification for application %s with ID %s', $newrelic_app_name, $newrelic_appid);
-}
+task(
+  sprintf('Creating a deployment notification for application %s with ID %s.', $newrelic_app_name, $newrelic_appid),
+  sprintf('Created deployment notification for application %s with ID %s.', $newrelic_app_name, $newrelic_appid),
+  function () use ($url, $payload_data, $newrelic_user_key, $newrelic_app_name, $newrelic_appid): void {
+    $response = request_post($url, json_encode($payload_data, JSON_UNESCAPED_SLASHES), [
+      'Api-Key: ' . $newrelic_user_key,
+      'Content-Type: application/json',
+    ]);
 
-pass('Created deployment notification for application %s with ID %s.', $newrelic_app_name, $newrelic_appid);
+    if ($response['status'] !== 201) {
+      throw new \RuntimeException(sprintf('Failed to create a deployment notification for application %s with ID %s', $newrelic_app_name, $newrelic_appid));
+    }
+  },
+);
 
 info('Finished New Relic notification.');

--- a/.vortex/tooling/src/vortex-notify-slack
+++ b/.vortex/tooling/src/vortex-notify-slack
@@ -152,16 +152,14 @@ note('Channel        : ' . ($slack_channel ?: '<default>'));
 note('Username       : ' . $slack_username);
 note('Event          : ' . $event_label);
 
-task('Sending notification to Slack');
+task('Sending notification to Slack', 'Slack notification sent successfully.', function () use ($slack_webhook, $payload): void {
+  $response = request_post($slack_webhook, $payload, [
+    'Content-Type: application/json',
+  ]);
 
-$response = request_post($slack_webhook, $payload, [
-  'Content-Type: application/json',
-]);
-
-if ($response['status'] !== 200) {
-  fail('Unable to send notification to Slack. HTTP status: %s', $response['status']);
-}
-
-pass('Slack notification sent successfully.');
+  if ($response['status'] !== 200) {
+    throw new \RuntimeException(sprintf('Unable to send notification to Slack. HTTP status: %s', $response['status']));
+  }
+});
 
 info('Finished Slack notification.');

--- a/.vortex/tooling/src/vortex-notify-webhook
+++ b/.vortex/tooling/src/vortex-notify-webhook
@@ -110,19 +110,23 @@ note('Headers            : ' . $webhook_headers);
 note('Expected Status    : ' . $webhook_expected_status);
 note('Payload (first 200): ' . substr($webhook_payload, 0, 200) . '...');
 
-task(sprintf('Sending webhook notification to %s', $webhook_domain));
+task(
+  sprintf('Sending webhook notification to %s', $webhook_domain),
+  fn(int $status): string => sprintf('Webhook notification sent successfully with status %s.', $status),
+  function () use ($webhook_url, $webhook_method, $webhook_headers, $webhook_payload, $webhook_expected_status): int {
+    // Send webhook notification.
+    $response = request($webhook_url, [
+      'method' => $webhook_method,
+      'headers' => array_map(trim(...), explode('|', $webhook_headers)),
+      'body' => $webhook_payload,
+    ]);
 
-// Send webhook notification.
-$response = request($webhook_url, [
-  'method' => $webhook_method,
-  'headers' => array_map(trim(...), explode('|', $webhook_headers)),
-  'body' => $webhook_payload,
-]);
+    if ($response['status'] !== (int) $webhook_expected_status) {
+      throw new \RuntimeException(sprintf('Webhook notification failed. Expected status %s but got %s.', $webhook_expected_status, $response['status']));
+    }
 
-if ($response['status'] !== (int) $webhook_expected_status) {
-  fail('Webhook notification failed. Expected status %s but got %s.', $webhook_expected_status, $response['status']);
-}
-
-pass('Webhook notification sent successfully with status %s.', $response['status']);
+    return $response['status'];
+  },
+);
 
 pass('Finished webhook notification.');

--- a/.vortex/tooling/src/vortex-notify-webhook
+++ b/.vortex/tooling/src/vortex-notify-webhook
@@ -110,7 +110,7 @@ note('Headers            : ' . $webhook_headers);
 note('Expected Status    : ' . $webhook_expected_status);
 note('Payload (first 200): ' . substr($webhook_payload, 0, 200) . '...');
 
-task('Sending webhook notification to %s', $webhook_domain);
+task(sprintf('Sending webhook notification to %s', $webhook_domain));
 
 // Send webhook notification.
 $response = request($webhook_url, [

--- a/.vortex/tooling/src/vortex-provision
+++ b/.vortex/tooling/src/vortex-provision
@@ -543,7 +543,9 @@ task('Enabling site modules.', 'Enabled site modules.', function () use ($webroo
   drush('pm:install deploy_steps');
   $module_paths = array_merge((array) glob($webroot . '/modules/custom/*_base', GLOB_ONLYDIR), (array) glob($webroot . '/modules/custom/*_migrate', GLOB_ONLYDIR));
   foreach ($module_paths as $module_path) {
-    drush('pm:install ' . escapeshellarg(basename((string) $module_path)));
+    $module_name = basename((string) $module_path);
+    drush('pm:install ' . escapeshellarg($module_name));
+    note('Installed module %s.', $module_name);
   }
 });
 echo PHP_EOL;

--- a/.vortex/tooling/src/vortex-provision
+++ b/.vortex/tooling/src/vortex-provision
@@ -433,9 +433,9 @@ if ($provision_post_operations_skip === '1') {
 }
 
 if ($provision_use_maintenance_mode === '1') {
-  task('Enabling maintenance mode.');
-  drush('maint:set 1');
-  pass('Enabled maintenance mode.');
+  task('Enabling maintenance mode.', 'Enabled maintenance mode.', function (): void {
+    drush('maint:set 1');
+  });
   echo PHP_EOL;
 }
 
@@ -493,9 +493,9 @@ pass('Completed running database updates.');
 echo PHP_EOL;
 
 if ($provision_cache_rebuild_after_db_update_skip !== '1') {
-  task('Clearing cache after database updates.');
-  drush('cache:rebuild');
-  pass('Cache was cleared.');
+  task('Clearing cache after database updates.', 'Cache was cleared.', function (): void {
+    drush('cache:rebuild');
+  });
   echo PHP_EOL;
 }
 else {
@@ -505,15 +505,15 @@ else {
 
 // Import configuration if config files are present.
 if ($site_has_config_files) {
-  task('Importing configuration.');
-  drush('config:import');
-  pass('Completed configuration import.');
+  task('Importing configuration.', 'Completed configuration import.', function (): void {
+    drush('config:import');
+  });
   echo PHP_EOL;
 
   if ($provision_config_import_repeat === '1') {
-    task('Repeating configuration import.');
-    drush('config:import');
-    pass('Completed repeated configuration import.');
+    task('Repeating configuration import.', 'Completed repeated configuration import.', function (): void {
+      drush('config:import');
+    });
     echo PHP_EOL;
   }
 
@@ -523,34 +523,34 @@ if ($site_has_config_files) {
   // @see https://www.drupal.org/project/drupal/issues/3241439
   $pm_list_output = drush('pm:list --status=enabled', $pm_list_exit_code);
   if (str_contains($pm_list_output, 'config_split')) {
-    task('Importing config_split configuration.');
-    drush('config:import');
-    pass('Completed config_split configuration import.');
+    task('Importing config_split configuration.', 'Completed config_split configuration import.', function (): void {
+      drush('config:import');
+    });
     echo PHP_EOL;
   }
 }
 
-task('Rebuilding cache.');
-drush('cache:rebuild');
-pass('Cache was rebuilt.');
+task('Rebuilding cache.', 'Cache was rebuilt.', function (): void {
+  drush('cache:rebuild');
+});
 echo PHP_EOL;
 
 // Enable the deploy_steps runner and the always-on site modules before deploy
 // hooks, so their deploy step plugins and run-once deploy hooks run on this
 // provision. Site module names are project-specific (the installer renames
 // them), so resolve them by glob. Idempotent in every environment.
-task('Enabling site modules.');
-drush('pm:install deploy_steps');
-$module_paths = array_merge((array) glob($webroot . '/modules/custom/*_base', GLOB_ONLYDIR), (array) glob($webroot . '/modules/custom/*_migrate', GLOB_ONLYDIR));
-foreach ($module_paths as $module_path) {
-  drush('pm:install ' . escapeshellarg(basename((string) $module_path)));
-}
-pass('Enabled site modules.');
+task('Enabling site modules.', 'Enabled site modules.', function () use ($webroot): void {
+  drush('pm:install deploy_steps');
+  $module_paths = array_merge((array) glob($webroot . '/modules/custom/*_base', GLOB_ONLYDIR), (array) glob($webroot . '/modules/custom/*_migrate', GLOB_ONLYDIR));
+  foreach ($module_paths as $module_path) {
+    drush('pm:install ' . escapeshellarg(basename((string) $module_path)));
+  }
+});
 echo PHP_EOL;
 
-task('Running deployment hooks.');
-drush('deploy:hook');
-pass('Completed deployment hooks.');
+task('Running deployment hooks.', 'Completed deployment hooks.', function (): void {
+  drush('deploy:hook');
+});
 echo PHP_EOL;
 
 // Sanitize database.
@@ -569,9 +569,9 @@ else {
 }
 
 if ($provision_use_maintenance_mode === '1') {
-  task('Disabling maintenance mode.');
-  drush('maint:set 0');
-  pass('Disabled maintenance mode.');
+  task('Disabling maintenance mode.', 'Disabled maintenance mode.', function (): void {
+    drush('maint:set 0');
+  });
   echo PHP_EOL;
 }
 

--- a/.vortex/tooling/src/vortex-task-copy-db-acquia
+++ b/.vortex/tooling/src/vortex-task-copy-db-acquia
@@ -110,7 +110,7 @@ function acquia_api_poll_notification(string $key, string $secret, string $notif
   $token = acquia_api_get_token($key, $secret);
 
   for ($i = 1; $i <= $retries; $i++) {
-    sleep($interval);
+    sleep_progress($interval);
 
     $response = request_get($notification_url, acquia_api_headers($token));
 
@@ -137,15 +137,19 @@ info('Started database copying between environments in Acquia.');
 
 task('Retrieving authentication token.');
 $token = acquia_api_get_token($acquia_key, $acquia_secret);
+pass('Retrieved authentication token.');
 
 task(sprintf('Retrieving %s application UUID.', $app_name));
 $app_uuid = acquia_api_get_app_uuid($token, $app_name);
+pass('Retrieved the application UUID.');
 
 task('Retrieving source environment ID.');
 $src_env_id = acquia_api_get_env_id($token, $app_uuid, $src_env);
+pass('Retrieved source environment ID.');
 
 task('Retrieving destination environment ID.');
 $dst_env_id = acquia_api_get_env_id($token, $app_uuid, $dst_env);
+pass('Retrieved destination environment ID.');
 
 task(sprintf('Copying DB from %s to %s environment.', $src_env, $dst_env));
 $copy_response = request_post(sprintf('https://cloud.acquia.com/api/environments/%s/databases', $dst_env_id), json_encode(['source' => $src_env_id, 'name' => $db_name]), array_merge(acquia_api_headers($token), ['Content-Type: application/json']));
@@ -161,12 +165,14 @@ if ($notification_url === '') {
   fail('Unable to get notification URL for DB copy operation.');
 }
 
-$task_completed = acquia_api_poll_notification($acquia_key, $acquia_secret, $notification_url, $status_retries, $status_interval);
+pass('Requested the database copy.');
+
+$task_completed = task_progress('Waiting for the database copy to complete.', fn(): bool => acquia_api_poll_notification($acquia_key, $acquia_secret, $notification_url, $status_retries, $status_interval));
 
 if (!$task_completed) {
   fail(sprintf('Unable to copy DB from %s to %s environment.', $src_env, $dst_env));
 }
 
-note(sprintf('Copied DB from %s to %s environment.', $src_env, $dst_env));
+pass(sprintf('Copied DB from %s to %s environment.', $src_env, $dst_env));
 
 pass('Finished database copying between environments in Acquia.');

--- a/.vortex/tooling/src/vortex-task-copy-db-acquia
+++ b/.vortex/tooling/src/vortex-task-copy-db-acquia
@@ -135,44 +135,59 @@ function acquia_api_poll_notification(string $key, string $secret, string $notif
 
 info('Started database copying between environments in Acquia.');
 
-task('Retrieving authentication token.');
-$token = acquia_api_get_token($acquia_key, $acquia_secret);
-pass('Retrieved authentication token.');
+$token = (string) task(
+  'Retrieving authentication token.',
+  'Retrieved authentication token.',
+  fn(): string => acquia_api_get_token($acquia_key, $acquia_secret),
+);
 
-task(sprintf('Retrieving %s application UUID.', $app_name));
-$app_uuid = acquia_api_get_app_uuid($token, $app_name);
-pass('Retrieved the application UUID.');
+$app_uuid = (string) task(
+  sprintf('Retrieving %s application UUID.', $app_name),
+  'Retrieved the application UUID.',
+  fn(): string => acquia_api_get_app_uuid($token, $app_name),
+);
 
-task('Retrieving source environment ID.');
-$src_env_id = acquia_api_get_env_id($token, $app_uuid, $src_env);
-pass('Retrieved source environment ID.');
+$src_env_id = (string) task(
+  'Retrieving source environment ID.',
+  'Retrieved source environment ID.',
+  fn(): string => acquia_api_get_env_id($token, $app_uuid, $src_env),
+);
 
-task('Retrieving destination environment ID.');
-$dst_env_id = acquia_api_get_env_id($token, $app_uuid, $dst_env);
-pass('Retrieved destination environment ID.');
+$dst_env_id = (string) task(
+  'Retrieving destination environment ID.',
+  'Retrieved destination environment ID.',
+  fn(): string => acquia_api_get_env_id($token, $app_uuid, $dst_env),
+);
 
-task(sprintf('Copying DB from %s to %s environment.', $src_env, $dst_env));
-$copy_response = request_post(sprintf('https://cloud.acquia.com/api/environments/%s/databases', $dst_env_id), json_encode(['source' => $src_env_id, 'name' => $db_name]), array_merge(acquia_api_headers($token), ['Content-Type: application/json']));
+$notification_url = (string) task(
+  sprintf('Copying DB from %s to %s environment.', $src_env, $dst_env),
+  'Requested the database copy.',
+  function () use ($dst_env_id, $src_env_id, $db_name, $token, $src_env, $dst_env): string {
+    $copy_response = request_post(sprintf('https://cloud.acquia.com/api/environments/%s/databases', $dst_env_id), json_encode(['source' => $src_env_id, 'name' => $db_name]), array_merge(acquia_api_headers($token), ['Content-Type: application/json']));
 
-if (!$copy_response['ok']) {
-  fail('Failed to copy DB from %s to %s environment.', $src_env, $dst_env);
-}
+    if (!$copy_response['ok']) {
+      throw new \RuntimeException(sprintf('Failed to copy DB from %s to %s environment.', $src_env, $dst_env));
+    }
 
-$copy_data = json_decode((string) $copy_response['body'], TRUE);
-$notification_url = $copy_data['_links']['notification']['href'] ?? '';
+    $copy_data = json_decode((string) $copy_response['body'], TRUE);
+    $notification_url = $copy_data['_links']['notification']['href'] ?? '';
 
-if ($notification_url === '') {
-  fail('Unable to get notification URL for DB copy operation.');
-}
+    if ($notification_url === '') {
+      throw new \RuntimeException('Unable to get notification URL for DB copy operation.');
+    }
 
-pass('Requested the database copy.');
+    return $notification_url;
+  },
+);
 
-$task_completed = task_progress('Waiting for the database copy to complete.', fn(): bool => acquia_api_poll_notification($acquia_key, $acquia_secret, $notification_url, $status_retries, $status_interval));
-
-if (!$task_completed) {
-  fail(sprintf('Unable to copy DB from %s to %s environment.', $src_env, $dst_env));
-}
-
-pass(sprintf('Copied DB from %s to %s environment.', $src_env, $dst_env));
+task(
+  'Waiting for the database copy to complete.',
+  sprintf('Copied DB from %s to %s environment.', $src_env, $dst_env),
+  function () use ($acquia_key, $acquia_secret, $notification_url, $status_retries, $status_interval, $src_env, $dst_env): void {
+    if (!acquia_api_poll_notification($acquia_key, $acquia_secret, $notification_url, $status_retries, $status_interval)) {
+      throw new \RuntimeException(sprintf('Unable to copy DB from %s to %s environment.', $src_env, $dst_env));
+    }
+  },
+);
 
 pass('Finished database copying between environments in Acquia.');

--- a/.vortex/tooling/src/vortex-task-copy-files-acquia
+++ b/.vortex/tooling/src/vortex-task-copy-files-acquia
@@ -107,7 +107,7 @@ function files_acquia_api_poll_notification(string $key, string $secret, string 
   $token = files_acquia_api_get_token($key, $secret);
 
   for ($i = 1; $i <= $retries; $i++) {
-    sleep($interval);
+    sleep_progress($interval);
 
     $response = request_get($notification_url, files_acquia_api_headers($token));
 
@@ -134,15 +134,19 @@ info('Started files copying between environments in Acquia.');
 
 task('Retrieving authentication token.');
 $token = files_acquia_api_get_token($acquia_key, $acquia_secret);
+pass('Retrieved authentication token.');
 
 task(sprintf('Retrieving %s application UUID.', $app_name));
 $app_uuid = files_acquia_api_get_app_uuid($token, $app_name);
+pass('Retrieved the application UUID.');
 
 task('Retrieving source environment ID.');
 $src_env_id = files_acquia_api_get_env_id($token, $app_uuid, $src_env);
+pass('Retrieved source environment ID.');
 
 task('Retrieving destination environment ID.');
 $dst_env_id = files_acquia_api_get_env_id($token, $app_uuid, $dst_env);
+pass('Retrieved destination environment ID.');
 
 task(sprintf('Copying files from %s to %s environment.', $src_env, $dst_env));
 $copy_response = request_post(sprintf('https://cloud.acquia.com/api/environments/%s/files', $dst_env_id), json_encode(['source' => $src_env_id]), array_merge(files_acquia_api_headers($token), ['Content-Type: application/json']));
@@ -158,12 +162,14 @@ if ($notification_url === '') {
   fail('Unable to get notification URL for files copy operation.');
 }
 
-$task_completed = files_acquia_api_poll_notification($acquia_key, $acquia_secret, $notification_url, $status_retries, $status_interval);
+pass('Requested the files copy.');
+
+$task_completed = task_progress('Waiting for the files copy to complete.', fn(): bool => files_acquia_api_poll_notification($acquia_key, $acquia_secret, $notification_url, $status_retries, $status_interval));
 
 if (!$task_completed) {
   fail(sprintf('Unable to copy files from %s to %s environment.', $src_env, $dst_env));
 }
 
-note(sprintf('Copied files from %s to %s environment.', $src_env, $dst_env));
+pass(sprintf('Copied files from %s to %s environment.', $src_env, $dst_env));
 
 pass('Finished files copying between environments in Acquia.');

--- a/.vortex/tooling/src/vortex-task-copy-files-acquia
+++ b/.vortex/tooling/src/vortex-task-copy-files-acquia
@@ -132,44 +132,51 @@ function files_acquia_api_poll_notification(string $key, string $secret, string 
 
 info('Started files copying between environments in Acquia.');
 
-task('Retrieving authentication token.');
-$token = files_acquia_api_get_token($acquia_key, $acquia_secret);
-pass('Retrieved authentication token.');
+$token = (string) task(
+  'Retrieving authentication token.',
+  'Retrieved authentication token.',
+  fn(): string => files_acquia_api_get_token($acquia_key, $acquia_secret),
+);
 
-task(sprintf('Retrieving %s application UUID.', $app_name));
-$app_uuid = files_acquia_api_get_app_uuid($token, $app_name);
-pass('Retrieved the application UUID.');
+$app_uuid = (string) task(
+  sprintf('Retrieving %s application UUID.', $app_name),
+  'Retrieved the application UUID.',
+  fn(): string => files_acquia_api_get_app_uuid($token, $app_name),
+);
 
-task('Retrieving source environment ID.');
-$src_env_id = files_acquia_api_get_env_id($token, $app_uuid, $src_env);
-pass('Retrieved source environment ID.');
+$src_env_id = (string) task(
+  'Retrieving source environment ID.',
+  'Retrieved source environment ID.',
+  fn(): string => files_acquia_api_get_env_id($token, $app_uuid, $src_env),
+);
 
-task('Retrieving destination environment ID.');
-$dst_env_id = files_acquia_api_get_env_id($token, $app_uuid, $dst_env);
-pass('Retrieved destination environment ID.');
+$dst_env_id = (string) task(
+  'Retrieving destination environment ID.',
+  'Retrieved destination environment ID.',
+  fn(): string => files_acquia_api_get_env_id($token, $app_uuid, $dst_env),
+);
 
-task(sprintf('Copying files from %s to %s environment.', $src_env, $dst_env));
-$copy_response = request_post(sprintf('https://cloud.acquia.com/api/environments/%s/files', $dst_env_id), json_encode(['source' => $src_env_id]), array_merge(files_acquia_api_headers($token), ['Content-Type: application/json']));
+$notification_url = (string) task(sprintf('Copying files from %s to %s environment.', $src_env, $dst_env), 'Requested the files copy.', function () use ($token, $dst_env_id, $src_env_id, $src_env, $dst_env): string {
+  $copy_response = request_post(sprintf('https://cloud.acquia.com/api/environments/%s/files', $dst_env_id), json_encode(['source' => $src_env_id]), array_merge(files_acquia_api_headers($token), ['Content-Type: application/json']));
 
-if (!$copy_response['ok']) {
-  fail('Failed to copy files from %s to %s environment.', $src_env, $dst_env);
-}
+  if (!$copy_response['ok']) {
+    throw new \RuntimeException(sprintf('Failed to copy files from %s to %s environment.', $src_env, $dst_env));
+  }
 
-$copy_data = json_decode((string) $copy_response['body'], TRUE);
-$notification_url = $copy_data['_links']['notification']['href'] ?? '';
+  $copy_data = json_decode((string) $copy_response['body'], TRUE);
+  $notification_url = (string) ($copy_data['_links']['notification']['href'] ?? '');
 
-if ($notification_url === '') {
-  fail('Unable to get notification URL for files copy operation.');
-}
+  if ($notification_url === '') {
+    throw new \RuntimeException('Unable to get notification URL for files copy operation.');
+  }
 
-pass('Requested the files copy.');
+  return $notification_url;
+});
 
-$task_completed = task_progress('Waiting for the files copy to complete.', fn(): bool => files_acquia_api_poll_notification($acquia_key, $acquia_secret, $notification_url, $status_retries, $status_interval));
-
-if (!$task_completed) {
-  fail(sprintf('Unable to copy files from %s to %s environment.', $src_env, $dst_env));
-}
-
-pass(sprintf('Copied files from %s to %s environment.', $src_env, $dst_env));
+task('Waiting for the files copy to complete.', sprintf('Copied files from %s to %s environment.', $src_env, $dst_env), function () use ($acquia_key, $acquia_secret, $notification_url, $status_retries, $status_interval, $src_env, $dst_env): void {
+  if (!files_acquia_api_poll_notification($acquia_key, $acquia_secret, $notification_url, $status_retries, $status_interval)) {
+    throw new \RuntimeException(sprintf('Unable to copy files from %s to %s environment.', $src_env, $dst_env));
+  }
+});
 
 pass('Finished files copying between environments in Acquia.');

--- a/.vortex/tooling/src/vortex-task-purge-cache-acquia
+++ b/.vortex/tooling/src/vortex-task-purge-cache-acquia
@@ -181,39 +181,53 @@ function purge_acquia_api_poll_notification(string $key, string $secret, string 
 
 info('Started cache purging in Acquia.');
 
-task('Retrieving authentication token.');
-$token = purge_acquia_api_get_token($acquia_key, $acquia_secret);
-pass('Retrieved authentication token.');
+$token = (string) task(
+  'Retrieving authentication token.',
+  'Retrieved authentication token.',
+  fn(): string => purge_acquia_api_get_token($acquia_key, $acquia_secret),
+);
 
-task(sprintf('Retrieving %s application UUID.', $app_name));
-$app_uuid = purge_acquia_api_get_app_uuid($token, $app_name);
-pass('Retrieved the application UUID.');
+$app_uuid = (string) task(
+  sprintf('Retrieving %s application UUID.', $app_name),
+  'Retrieved the application UUID.',
+  fn(): string => purge_acquia_api_get_app_uuid($token, $app_name),
+);
 
-task('Retrieving environment ID.');
-$env_id = purge_acquia_api_get_env_id($token, $app_uuid, $target_env);
-pass('Retrieved environment ID.');
+$env_id = (string) task(
+  'Retrieving environment ID.',
+  'Retrieved environment ID.',
+  fn(): string => purge_acquia_api_get_env_id($token, $app_uuid, $target_env),
+);
 
-task('Compiling a list of domains.');
+$domain_list = task(
+  'Compiling a list of domains.',
+  fn(array $domain_list): string => sprintf('Compiled a list of %d domain(s).', count($domain_list)),
+  function () use ($domains_file, $target_env): array {
+    if (!file_exists($domains_file)) {
+      throw new \RuntimeException(sprintf('Domains file %s does not exist.', $domains_file));
+    }
 
-if (!file_exists($domains_file)) {
-  fail(sprintf('Domains file %s does not exist.', $domains_file));
+    $lines = file($domains_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    $domain_list = [];
+    foreach ($lines as $line) {
+      $line = trim($line);
+      if ($line === '' || str_starts_with($line, '#')) {
+        continue;
+      }
+
+      $interpolated = purge_interpolate_domain($line, $target_env);
+      if ($interpolated !== NULL) {
+        $domain_list[] = $interpolated;
+      }
+    }
+
+    return $domain_list;
+  },
+);
+
+if (!is_array($domain_list)) {
+  $domain_list = [];
 }
-
-$lines = file($domains_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-$domain_list = [];
-foreach ($lines as $line) {
-  $line = trim($line);
-  if ($line === '' || str_starts_with($line, '#')) {
-    continue;
-  }
-
-  $interpolated = purge_interpolate_domain($line, $target_env);
-  if ($interpolated !== NULL) {
-    $domain_list[] = $interpolated;
-  }
-}
-
-pass(sprintf('Compiled a list of %d domain(s).', count($domain_list)));
 
 if ($domain_list === []) {
   note(sprintf('No domains to purge cache for %s environment.', $target_env));

--- a/.vortex/tooling/src/vortex-task-purge-cache-acquia
+++ b/.vortex/tooling/src/vortex-task-purge-cache-acquia
@@ -234,36 +234,30 @@ if ($domain_list === []) {
 }
 
 foreach ($domain_list as $domain) {
-  $result = task_progress(sprintf('Purging cache for %s environment domain %s.', $target_env, $domain), function () use ($env_id, $token, $domain, $acquia_key, $acquia_secret, $status_retries, $status_interval): string {
-    $purge_response = request_post(sprintf('https://cloud.acquia.com/api/environments/%s/domains/actions/clear-varnish', $env_id), json_encode(['domains' => [$domain]]), array_merge(purge_acquia_api_headers($token), ['Content-Type: application/json']));
+  task(
+    sprintf('Purging cache for %s environment domain %s.', $target_env, $domain),
+    sprintf('Purged cache for %s environment domain %s.', $target_env, $domain),
+    function () use ($env_id, $token, $domain, $acquia_key, $acquia_secret, $status_retries, $status_interval, $target_env): void {
+      $purge_response = request_post(sprintf('https://cloud.acquia.com/api/environments/%s/domains/actions/clear-varnish', $env_id), json_encode(['domains' => [$domain]]), array_merge(purge_acquia_api_headers($token), ['Content-Type: application/json']));
 
-    if (!$purge_response['ok']) {
-      return 'error:' . ($purge_response['error'] ?? 'HTTP ' . ($purge_response['status'] ?? 'unknown'));
-    }
+      if (!$purge_response['ok']) {
+        throw new \RuntimeException(sprintf('Failed to purge cache for %s environment domain %s: %s', $target_env, $domain, $purge_response['error'] ?? 'HTTP ' . ($purge_response['status'] ?? 'unknown')));
+      }
 
-    $purge_data = json_decode((string) $purge_response['body'], TRUE);
-    $notification_url = $purge_data['_links']['notification']['href'] ?? '';
+      $purge_data = json_decode((string) $purge_response['body'], TRUE);
+      $notification_url = $purge_data['_links']['notification']['href'] ?? '';
 
-    // If the domain does not exist the notification URL is empty.
-    if ($notification_url === '') {
-      return 'missing';
-    }
+      // If the domain does not exist the notification URL is empty.
+      if ($notification_url === '') {
+        throw new \RuntimeException(sprintf('Unable to purge cache for %s environment domain %s as it does not exist.', $target_env, $domain));
+      }
 
-    return purge_acquia_api_poll_notification($acquia_key, $acquia_secret, $token, $notification_url, $status_retries, $status_interval) ? 'completed' : 'timeout';
-  });
-
-  if ($result === 'completed') {
-    pass(sprintf('Purged cache for %s environment domain %s.', $target_env, $domain));
-  }
-  elseif ($result === 'missing') {
-    fail_no_exit('Unable to purge cache for %s environment domain %s as it does not exist.', $target_env, $domain);
-  }
-  elseif (str_starts_with($result, 'error:')) {
-    fail_no_exit('Failed to purge cache for %s environment domain %s: %s', $target_env, $domain, substr($result, 6));
-  }
-  else {
-    fail_no_exit('Unable to purge cache for %s environment domain %s.', $target_env, $domain);
-  }
+      if (!purge_acquia_api_poll_notification($acquia_key, $acquia_secret, $token, $notification_url, $status_retries, $status_interval)) {
+        throw new \RuntimeException(sprintf('Unable to purge cache for %s environment domain %s.', $target_env, $domain));
+      }
+    },
+    fatal: FALSE,
+  );
 }
 
 pass('Finished cache purging in Acquia.');

--- a/.vortex/tooling/src/vortex-task-purge-cache-acquia
+++ b/.vortex/tooling/src/vortex-task-purge-cache-acquia
@@ -136,18 +136,62 @@ function purge_interpolate_domain(string $domain, string $target_env): ?string {
   return $domain;
 }
 
+/**
+ * Poll a cache-purge notification until it completes.
+ *
+ * @param string $key
+ *   The Acquia Cloud API key.
+ * @param string $secret
+ *   The Acquia Cloud API secret.
+ * @param string $token
+ *   The current API access token; refreshed internally on a 401.
+ * @param string $notification_url
+ *   The notification URL returned by the purge request.
+ * @param int $retries
+ *   Number of status checks before giving up.
+ * @param int $interval
+ *   Seconds to wait between status checks.
+ *
+ * @return bool
+ *   TRUE when the purge completed within the retries.
+ */
+function purge_acquia_api_poll_notification(string $key, string $secret, string $token, string $notification_url, int $retries, int $interval): bool {
+  for ($i = 1; $i <= $retries; $i++) {
+    sleep_progress($interval);
+
+    $response = request_get($notification_url, purge_acquia_api_headers($token));
+
+    if (!$response['ok'] && ($response['status'] ?? 0) === 401) {
+      $token = purge_acquia_api_get_token($key, $secret);
+      $response = request_get($notification_url, purge_acquia_api_headers($token));
+    }
+
+    if ($response['ok']) {
+      $data = json_decode((string) $response['body'], TRUE);
+      if (($data['status'] ?? '') === 'completed') {
+        return TRUE;
+      }
+    }
+  }
+
+  return FALSE;
+}
+
 // -----------------------------------------------------------------------------
 
 info('Started cache purging in Acquia.');
 
 task('Retrieving authentication token.');
 $token = purge_acquia_api_get_token($acquia_key, $acquia_secret);
+pass('Retrieved authentication token.');
 
 task(sprintf('Retrieving %s application UUID.', $app_name));
 $app_uuid = purge_acquia_api_get_app_uuid($token, $app_name);
+pass('Retrieved the application UUID.');
 
 task('Retrieving environment ID.');
 $env_id = purge_acquia_api_get_env_id($token, $app_uuid, $target_env);
+pass('Retrieved environment ID.');
 
 task('Compiling a list of domains.');
 
@@ -169,58 +213,43 @@ foreach ($lines as $line) {
   }
 }
 
-if (count($domain_list) > 0) {
-  foreach ($domain_list as $domain) {
-    task(sprintf('Purging cache for %s environment domain %s.', $target_env, $domain));
+pass(sprintf('Compiled a list of %d domain(s).', count($domain_list)));
 
+if ($domain_list === []) {
+  note(sprintf('No domains to purge cache for %s environment.', $target_env));
+}
+
+foreach ($domain_list as $domain) {
+  $result = task_progress(sprintf('Purging cache for %s environment domain %s.', $target_env, $domain), function () use ($env_id, $token, $domain, $acquia_key, $acquia_secret, $status_retries, $status_interval): string {
     $purge_response = request_post(sprintf('https://cloud.acquia.com/api/environments/%s/domains/actions/clear-varnish', $env_id), json_encode(['domains' => [$domain]]), array_merge(purge_acquia_api_headers($token), ['Content-Type: application/json']));
 
     if (!$purge_response['ok']) {
-      note(sprintf('Warning: Failed to purge cache for %s environment domain %s: %s', $target_env, $domain, $purge_response['error'] ?? 'HTTP ' . $purge_response['status']));
-      continue;
+      return 'error:' . ($purge_response['error'] ?? 'HTTP ' . $purge_response['status']);
     }
 
     $purge_data = json_decode((string) $purge_response['body'], TRUE);
     $notification_url = $purge_data['_links']['notification']['href'] ?? '';
 
-    // If domain does not exist - notification will be empty.
+    // If the domain does not exist the notification URL is empty.
     if ($notification_url === '') {
-      note(sprintf('Warning: Unable to purge cache for %s environment domain %s as it does not exist.', $target_env, $domain));
-      continue;
+      return 'missing';
     }
 
-    // Poll notification status.
-    $task_completed = FALSE;
-    $poll_token = $token;
-    for ($i = 1; $i <= $status_retries; $i++) {
-      sleep($status_interval);
+    return purge_acquia_api_poll_notification($acquia_key, $acquia_secret, $token, $notification_url, $status_retries, $status_interval) ? 'completed' : 'timeout';
+  });
 
-      $status_response = request_get($notification_url, purge_acquia_api_headers($poll_token));
-
-      // Refresh token on 401 and retry.
-      if (!$status_response['ok'] && ($status_response['status'] ?? 0) === 401) {
-        $poll_token = purge_acquia_api_get_token($acquia_key, $acquia_secret);
-        $status_response = request_get($notification_url, purge_acquia_api_headers($poll_token));
-      }
-
-      if ($status_response['ok']) {
-        $status_data = json_decode((string) $status_response['body'], TRUE);
-        $task_state = $status_data['status'] ?? '';
-        if ($task_state === 'completed') {
-          note(sprintf('Purged cache for %s environment domain %s.', $target_env, $domain));
-          $task_completed = TRUE;
-          break;
-        }
-      }
-    }
-
-    if (!$task_completed) {
-      note(sprintf('Warning: Unable to purge cache for %s environment domain %s.', $target_env, $domain));
-    }
+  if ($result === 'completed') {
+    pass(sprintf('Purged cache for %s environment domain %s.', $target_env, $domain));
   }
-}
-else {
-  note(sprintf('Unable to find domains to purge cache for %s environment.', $target_env));
+  elseif ($result === 'missing') {
+    fail_no_exit('Unable to purge cache for %s environment domain %s as it does not exist.', $target_env, $domain);
+  }
+  elseif (str_starts_with($result, 'error:')) {
+    fail_no_exit('Failed to purge cache for %s environment domain %s: %s', $target_env, $domain, substr($result, 6));
+  }
+  else {
+    fail_no_exit('Unable to purge cache for %s environment domain %s.', $target_env, $domain);
+  }
 }
 
 pass('Finished cache purging in Acquia.');

--- a/.vortex/tooling/src/vortex-task-purge-cache-acquia
+++ b/.vortex/tooling/src/vortex-task-purge-cache-acquia
@@ -238,7 +238,7 @@ foreach ($domain_list as $domain) {
     $purge_response = request_post(sprintf('https://cloud.acquia.com/api/environments/%s/domains/actions/clear-varnish', $env_id), json_encode(['domains' => [$domain]]), array_merge(purge_acquia_api_headers($token), ['Content-Type: application/json']));
 
     if (!$purge_response['ok']) {
-      return 'error:' . ($purge_response['error'] ?? 'HTTP ' . $purge_response['status']);
+      return 'error:' . ($purge_response['error'] ?? 'HTTP ' . ($purge_response['status'] ?? 'unknown'));
     }
 
     $purge_data = json_decode((string) $purge_response['body'], TRUE);

--- a/.vortex/tooling/src/vortex-task-purge-cache-acquia
+++ b/.vortex/tooling/src/vortex-task-purge-cache-acquia
@@ -238,7 +238,17 @@ foreach ($domain_list as $domain) {
     sprintf('Purging cache for %s environment domain %s.', $target_env, $domain),
     sprintf('Purged cache for %s environment domain %s.', $target_env, $domain),
     function () use ($env_id, $token, $domain, $acquia_key, $acquia_secret, $status_retries, $status_interval, $target_env): void {
-      $purge_response = request_post(sprintf('https://cloud.acquia.com/api/environments/%s/domains/actions/clear-varnish', $env_id), json_encode(['domains' => [$domain]]), array_merge(purge_acquia_api_headers($token), ['Content-Type: application/json']));
+      $purge_url = sprintf('https://cloud.acquia.com/api/environments/%s/domains/actions/clear-varnish', $env_id);
+      $purge_body = json_encode(['domains' => [$domain]]);
+
+      $purge_response = request_post($purge_url, $purge_body, array_merge(purge_acquia_api_headers($token), ['Content-Type: application/json']));
+
+      // The access token expires after five minutes, so a long multi-domain run
+      // can outlive it; refresh once on a 401 and retry, as the poller does.
+      if (!$purge_response['ok'] && ($purge_response['status'] ?? 0) === 401) {
+        $token = purge_acquia_api_get_token($acquia_key, $acquia_secret);
+        $purge_response = request_post($purge_url, $purge_body, array_merge(purge_acquia_api_headers($token), ['Content-Type: application/json']));
+      }
 
       if (!$purge_response['ok']) {
         throw new \RuntimeException(sprintf('Failed to purge cache for %s environment domain %s: %s', $target_env, $domain, $purge_response['error'] ?? 'HTTP ' . ($purge_response['status'] ?? 'unknown')));

--- a/.vortex/tooling/tests/Unit/FetchDbAcquiaTest.php
+++ b/.vortex/tooling/tests/Unit/FetchDbAcquiaTest.php
@@ -14,15 +14,20 @@ class FetchDbAcquiaTest extends UnitTestCase {
   protected function setUp(): void {
     parent::setUp();
 
-    $this->envSet('VORTEX_FETCH_DB_ACQUIA_KEY', 'test-key');
-    $this->envSet('VORTEX_FETCH_DB_ACQUIA_SECRET', 'test-secret');
-    $this->envSet('VORTEX_FETCH_DB_ACQUIA_APP_NAME', 'myapp');
-    $this->envSet('VORTEX_FETCH_DB_ENVIRONMENT', 'prod');
-    $this->envSet('VORTEX_FETCH_DB_ACQUIA_DB_NAME', 'mydb');
-    $this->envSet('VORTEX_FETCH_DB_ACQUIA_DB_DIR', self::$tmp . '/data');
-    $this->envSet('VORTEX_FETCH_DB_ACQUIA_DB_FILE', 'db.sql');
-    $this->envSet('VORTEX_FETCH_DB_ACQUIA_BACKUP_WAIT_INTERVAL', '1');
-    $this->envSet('VORTEX_FETCH_DB_ACQUIA_BACKUP_MAX_WAIT', '3');
+    $this->envSetMultiple([
+      'VORTEX_FETCH_DB_ACQUIA_KEY' => 'test-key',
+      'VORTEX_FETCH_DB_ACQUIA_SECRET' => 'test-secret',
+      'VORTEX_FETCH_DB_ACQUIA_APP_NAME' => 'myapp',
+      'VORTEX_FETCH_DB_ENVIRONMENT' => 'prod',
+      'VORTEX_FETCH_DB_ACQUIA_DB_NAME' => 'mydb',
+      'VORTEX_FETCH_DB_ACQUIA_DB_DIR' => self::$tmp . '/data',
+      'VORTEX_FETCH_DB_ACQUIA_DB_FILE' => 'db.sql',
+      'VORTEX_FETCH_DB_ACQUIA_BACKUP_WAIT_INTERVAL' => '1',
+      'VORTEX_FETCH_DB_ACQUIA_BACKUP_MAX_WAIT' => '3',
+      'VORTEX_ACLI_PATH' => self::$tmp,
+    ]);
+
+    mkdir(self::$tmp . '/data', 0755, TRUE);
   }
 
   public function testMissingKey(): void {
@@ -58,381 +63,346 @@ class FetchDbAcquiaTest extends UnitTestCase {
     $this->runScriptError('src/vortex-fetch-db-acquia', 'Missing required value for VORTEX_FETCH_DB_ACQUIA_DB_NAME');
   }
 
-  public function testCachedDecompressedFile(): void {
-    $db_dir = self::$tmp . '/data';
-    mkdir($db_dir, 0755, TRUE);
+  public function testApplicationNotFound(): void {
+    $this->mockCommandExists();
 
-    // Pre-create the decompressed file with backup_id=12345.
-    file_put_contents($db_dir . '/mydb_backup_12345.sql', 'SQL DUMP');
-
-    $this->mockRequestMultiple([
-      // Token.
-      [
-        'url' => 'https://accounts.acquia.com/api/auth/oauth/token',
-        'response' => ['body' => json_encode(['access_token' => 'test-token'])],
-      ],
-      // App UUID.
-      [
-        'url' => 'https://cloud.acquia.com/api/applications?filter=name%3Dmyapp',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['uuid' => 'app-uuid-123']]]])],
-      ],
-      // Env ID.
-      [
-        'url' => 'https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => 'env-id-prod']]]])],
-      ],
-      // Backups list.
-      [
-        'url' => 'https://cloud.acquia.com/api/environments/env-id-prod/databases/mydb/backups?sort=created',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => '12345']]]])],
-      ],
+    $this->mockPassthruMultiple([
+      ['cmd' => $this->versionCmd(), 'output' => 'Acquia CLI 2.61.3', 'result_code' => 0],
+      ['cmd' => $this->appsListCmd(), 'output' => $this->appsJson([]), 'result_code' => 0],
     ]);
+
+    $this->runScriptError('src/vortex-fetch-db-acquia', 'Unable to find the Acquia application "myapp".');
+  }
+
+  public function testEnvironmentNotFound(): void {
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple([
+      ['cmd' => $this->versionCmd(), 'output' => 'Acquia CLI 2.61.3', 'result_code' => 0],
+      ['cmd' => $this->appsListCmd(), 'output' => $this->appsJson([['name' => 'myapp', 'uuid' => 'app-uuid-123']]), 'result_code' => 0],
+      ['cmd' => $this->envListCmd(), 'output' => $this->envsJson([]), 'result_code' => 0],
+    ]);
+
+    $this->runScriptError('src/vortex-fetch-db-acquia', 'Unable to find the Acquia environment "prod".');
+  }
+
+  public function testNoBackups(): void {
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson([]), 'result_code' => 0],
+    ]));
+
+    $this->runScriptError('src/vortex-fetch-db-acquia', 'No completed backups found for database "mydb" in environment "prod".');
+  }
+
+  public function testCachedDecompressedFile(): void {
+    file_put_contents(self::$tmp . '/data/mydb_backup_12345.sql', 'SQL DUMP');
+
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+    ]));
 
     $output = $this->runScript('src/vortex-fetch-db-acquia');
 
     $this->assertStringContainsString('Found existing cached DB file', $output);
-    $this->assertStringContainsString('Finished database dump download from Acquia.', $output);
-    // The file should be renamed to the final path.
-    $this->assertFileExists($db_dir . '/db.sql');
+    $this->assertStringContainsString('Finished database backup download from Acquia.', $output);
+    $this->assertFileExists(self::$tmp . '/data/db.sql');
   }
 
   public function testCachedGzFile(): void {
-    $db_dir = self::$tmp . '/data';
-    mkdir($db_dir, 0755, TRUE);
+    file_put_contents(self::$tmp . '/data/mydb_backup_12345.sql.gz', $this->gzipBody('SQL DUMP FROM ACQUIA'));
 
-    // Pre-create the gz file with valid gzip content.
-    $gzipped = gzencode('SQL DUMP FROM ACQUIA');
-    file_put_contents($db_dir . '/mydb_backup_12345.sql.gz', $gzipped);
+    $this->mockCommandExists();
 
-    $this->mockRequestMultiple([
-      [
-        'url' => 'https://accounts.acquia.com/api/auth/oauth/token',
-        'response' => ['body' => json_encode(['access_token' => 'test-token'])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications?filter=name%3Dmyapp',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['uuid' => 'app-uuid-123']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => 'env-id-prod']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/environments/env-id-prod/databases/mydb/backups?sort=created',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => '12345']]]])],
-      ],
-    ]);
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+    ]));
 
     $output = $this->runScript('src/vortex-fetch-db-acquia');
 
     $this->assertStringContainsString('Found existing cached gzipped DB file', $output);
-    $this->assertStringContainsString('Expanding DB file', $output);
-    $this->assertStringContainsString('Finished database dump download from Acquia.', $output);
-    // Final renamed file should exist.
-    $this->assertFileExists($db_dir . '/db.sql');
-    $this->assertEquals('SQL DUMP FROM ACQUIA', file_get_contents($db_dir . '/db.sql'));
-    // Gz file should be cleaned up.
-    $this->assertFileDoesNotExist($db_dir . '/mydb_backup_12345.sql.gz');
+    $this->assertStringContainsString('Expanding', $output);
+    $this->assertStringContainsString('Finished database backup download from Acquia.', $output);
+    $this->assertStringEqualsFile(self::$tmp . '/data/db.sql', 'SQL DUMP FROM ACQUIA');
+    $this->assertFileDoesNotExist(self::$tmp . '/data/mydb_backup_12345.sql.gz');
+  }
+
+  public function testDownloadAndDecompress(): void {
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+      ['cmd' => $this->backupDownloadCmd('12345'), 'output' => $this->downloadJson('https://acquia-backup.s3.amazonaws.com/backup.sql.gz'), 'result_code' => 0],
+    ]));
+
+    $this->mockRequest('https://acquia-backup.s3.amazonaws.com/backup.sql.gz', ['method' => 'GET'], ['status' => 200, 'ok' => TRUE, 'body' => $this->gzipBody('DOWNLOADED SQL DUMP')]);
+
+    $output = $this->runScript('src/vortex-fetch-db-acquia');
+
+    $this->assertStringContainsString('Discovered the backup download URL.', $output);
+    $this->assertStringContainsString('Downloaded the database backup.', $output);
+    $this->assertStringContainsString('Expanding', $output);
+    $this->assertStringContainsString('Finished database backup download from Acquia.', $output);
+    $this->assertStringEqualsFile(self::$tmp . '/data/db.sql', 'DOWNLOADED SQL DUMP');
+  }
+
+  public function testDownloadUrlEmpty(): void {
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+      ['cmd' => $this->backupDownloadCmd('12345'), 'output' => '{}', 'result_code' => 0],
+    ]));
+
+    $this->runScriptError('src/vortex-fetch-db-acquia', 'Unable to discover the download URL for backup "12345".');
   }
 
   public function testDownloadRequestFails(): void {
-    $db_dir = self::$tmp . '/data';
-    mkdir($db_dir, 0755, TRUE);
+    $this->mockCommandExists();
 
-    $this->mockRequestMultiple([
-      [
-        'url' => 'https://accounts.acquia.com/api/auth/oauth/token',
-        'response' => ['body' => json_encode(['access_token' => 'test-token'])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications?filter=name%3Dmyapp',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['uuid' => 'app-uuid-123']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => 'env-id-prod']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/environments/env-id-prod/databases/mydb/backups?sort=created',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => '12345']]]])],
-      ],
-      // Backup download URL: 200 response with the URL in the JSON body.
-      [
-        'url' => 'https://cloud.acquia.com/api/environments/env-id-prod/databases/mydb/backups/12345/actions/download',
-        'response' => ['body' => json_encode(['url' => 'https://acquia-backup.s3.amazonaws.com/backup.sql.gz'])],
-      ],
-      // Download request fails.
-      [
-        'url' => 'https://acquia-backup.s3.amazonaws.com/backup.sql.gz',
-        'method' => 'GET',
-        'response' => ['ok' => FALSE, 'status' => 500, 'body' => ''],
-      ],
-    ]);
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+      ['cmd' => $this->backupDownloadCmd('12345'), 'output' => $this->downloadJson('https://acquia-backup.s3.amazonaws.com/backup.sql.gz'), 'result_code' => 0],
+    ]));
 
-    $this->runScriptError('src/vortex-fetch-db-acquia', 'Unable to download database mydb');
+    $this->mockRequest('https://acquia-backup.s3.amazonaws.com/backup.sql.gz', ['method' => 'GET'], ['status' => 500, 'ok' => FALSE, 'body' => '', 'error' => 'Server error']);
+
+    $this->runScriptError('src/vortex-fetch-db-acquia', 'Unable to download database "mydb" backup "12345"');
+  }
+
+  public function testDownloadEmptyFile(): void {
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+      ['cmd' => $this->backupDownloadCmd('12345'), 'output' => $this->downloadJson('https://acquia-backup.s3.amazonaws.com/backup.sql.gz'), 'result_code' => 0],
+    ]));
+
+    $this->mockRequest('https://acquia-backup.s3.amazonaws.com/backup.sql.gz', ['method' => 'GET'], ['status' => 200, 'ok' => TRUE, 'body' => '']);
+
+    $this->runScriptError('src/vortex-fetch-db-acquia', 'Downloaded file is empty or missing');
   }
 
   public function testInvalidGzip(): void {
-    $db_dir = self::$tmp . '/data';
-    mkdir($db_dir, 0755, TRUE);
-
-    // Pre-create an invalid gz file.
-    $invalid_gz = $db_dir . '/mydb_backup_12345.sql.gz';
+    $invalid_gz = self::$tmp . '/data/mydb_backup_12345.sql.gz';
     file_put_contents($invalid_gz, 'NOT VALID GZIP DATA');
 
-    $this->mockRequestMultiple([
-      [
-        'url' => 'https://accounts.acquia.com/api/auth/oauth/token',
-        'response' => ['body' => json_encode(['access_token' => 'test-token'])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications?filter=name%3Dmyapp',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['uuid' => 'app-uuid-123']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => 'env-id-prod']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/environments/env-id-prod/databases/mydb/backups?sort=created',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => '12345']]]])],
-      ],
-    ]);
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+    ]));
 
     $this->runScriptError('src/vortex-fetch-db-acquia', 'Downloaded file is not a valid gzip archive');
 
-    // Invalid file is left in place for inspection.
+    // The invalid file is left in place for inspection.
     $this->assertFileExists($invalid_gz);
   }
 
-  public function testNoBackups(): void {
-    mkdir(self::$tmp . '/data', 0755, TRUE);
+  public function testEmptyGzipDecompressesToNothing(): void {
+    file_put_contents(self::$tmp . '/data/mydb_backup_12345.sql.gz', $this->gzipBody(''));
 
-    $this->mockRequestMultiple([
-      [
-        'url' => 'https://accounts.acquia.com/api/auth/oauth/token',
-        'response' => ['body' => json_encode(['access_token' => 'test-token'])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications?filter=name%3Dmyapp',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['uuid' => 'app-uuid-123']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => 'env-id-prod']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/environments/env-id-prod/databases/mydb/backups?sort=created',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => []]])],
-      ],
-    ]);
+    $this->mockCommandExists();
 
-    $this->runScriptError('src/vortex-fetch-db-acquia', 'No backups found for database');
-  }
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+    ]));
 
-  public function testBackupUrlEmpty(): void {
-    mkdir(self::$tmp . '/data', 0755, TRUE);
-
-    $this->mockRequestMultiple([
-      [
-        'url' => 'https://accounts.acquia.com/api/auth/oauth/token',
-        'response' => ['body' => json_encode(['access_token' => 'test-token'])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications?filter=name%3Dmyapp',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['uuid' => 'app-uuid-123']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => 'env-id-prod']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/environments/env-id-prod/databases/mydb/backups?sort=created',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => '12345']]]])],
-      ],
-      // Backup download URL: API responds with 200 but no URL in the body.
-      [
-        'url' => 'https://cloud.acquia.com/api/environments/env-id-prod/databases/mydb/backups/12345/actions/download',
-        'response' => ['body' => json_encode([])],
-      ],
-    ]);
-
-    $this->runScriptError('src/vortex-fetch-db-acquia', 'Unable to discover backup URL');
+    $this->runScriptError('src/vortex-fetch-db-acquia', 'Downloaded file is not a valid gzip archive');
   }
 
   public function testFreshBackup(): void {
     $this->mockSleep();
     $this->envSet('VORTEX_FETCH_DB_FRESH', '1');
 
-    $db_dir = self::$tmp . '/data';
-    mkdir($db_dir, 0755, TRUE);
+    file_put_contents(self::$tmp . '/data/mydb_backup_99999.sql.gz', $this->gzipBody('FRESH SQL DUMP'));
 
-    // Pre-create the gz file to test decompress path (skip download).
-    $gzipped = gzencode('FRESH SQL DUMP');
-    file_put_contents($db_dir . '/mydb_backup_99999.sql.gz', $gzipped);
+    $this->mockCommandExists();
 
-    $this->mockRequestMultiple([
-      // Token.
-      [
-        'url' => 'https://accounts.acquia.com/api/auth/oauth/token',
-        'response' => ['body' => json_encode(['access_token' => 'test-token'])],
-      ],
-      // App UUID.
-      [
-        'url' => 'https://cloud.acquia.com/api/applications?filter=name%3Dmyapp',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['uuid' => 'app-uuid-123']]]])],
-      ],
-      // Env ID.
-      [
-        'url' => 'https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => 'env-id-prod']]]])],
-      ],
-      // Create backup.
-      [
-        'url' => 'https://cloud.acquia.com/api/environments/env-id-prod/databases/mydb/backups',
-        'response' => ['body' => json_encode(['_links' => ['notification' => ['href' => 'https://cloud.acquia.com/api/notifications/backup-create']]])],
-      ],
-      // Backup creation polling: status completed.
-      [
-        'url' => 'https://cloud.acquia.com/api/notifications/backup-create',
-        'response' => ['body' => json_encode(['status' => 'completed'])],
-      ],
-      // List backups (after creation).
-      [
-        'url' => 'https://cloud.acquia.com/api/environments/env-id-prod/databases/mydb/backups?sort=created',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => '99999']]]])],
-      ],
-    ]);
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupCreateCmd(), 'output' => '', 'result_code' => 0],
+      // Poll: the new backup is already listed as completed.
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['99999']), 'result_code' => 0],
+      // Latest-backup lookup after the fresh block.
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['99999']), 'result_code' => 0],
+    ]));
 
     $output = $this->runScript('src/vortex-fetch-db-acquia');
 
-    $this->assertStringContainsString('Creating new database backup for mydb.', $output);
-    $this->assertStringContainsString('Backup completed successfully.', $output);
-    $this->assertStringContainsString('Expanding DB file', $output);
-    $this->assertStringContainsString('Finished database dump download from Acquia.', $output);
-    $this->assertFileExists($db_dir . '/db.sql');
-    $this->assertEquals('FRESH SQL DUMP', file_get_contents($db_dir . '/db.sql'));
+    $this->assertStringContainsString('Requested a new database backup.', $output);
+    $this->assertStringContainsString('Backup completed.', $output);
+    $this->assertStringContainsString('Expanding', $output);
+    $this->assertStringContainsString('Finished database backup download from Acquia.', $output);
+    $this->assertStringEqualsFile(self::$tmp . '/data/db.sql', 'FRESH SQL DUMP');
   }
 
   public function testFreshBackupTimeout(): void {
     $this->mockSleep();
     $this->envSet('VORTEX_FETCH_DB_FRESH', '1');
 
-    mkdir(self::$tmp . '/data', 0755, TRUE);
+    $this->mockCommandExists();
 
-    $this->mockRequestMultiple([
-      [
-        'url' => 'https://accounts.acquia.com/api/auth/oauth/token',
-        'response' => ['body' => json_encode(['access_token' => 'test-token'])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications?filter=name%3Dmyapp',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['uuid' => 'app-uuid-123']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => 'env-id-prod']]]])],
-      ],
-      // Create backup.
-      [
-        'url' => 'https://cloud.acquia.com/api/environments/env-id-prod/databases/mydb/backups',
-        'response' => ['body' => json_encode(['_links' => ['notification' => ['href' => 'https://cloud.acquia.com/api/notifications/backup-create']]])],
-      ],
-      // Polling: in_progress for all iterations.
-      [
-        'url' => 'https://cloud.acquia.com/api/notifications/backup-create',
-        'response' => ['body' => json_encode(['status' => 'in_progress'])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/notifications/backup-create',
-        'response' => ['body' => json_encode(['status' => 'in_progress'])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/notifications/backup-create',
-        'response' => ['body' => json_encode(['status' => 'in_progress'])],
-      ],
-    ]);
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupCreateCmd(), 'output' => '', 'result_code' => 0],
+      // No completed backup ever appears within the max wait window.
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson([]), 'result_code' => 0],
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson([]), 'result_code' => 0],
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson([]), 'result_code' => 0],
+    ]));
 
-    $this->runScriptError('src/vortex-fetch-db-acquia', 'Backup creation timed out');
-  }
-
-  public function testFreshBackupFailed(): void {
-    $this->mockSleep();
-    $this->envSet('VORTEX_FETCH_DB_FRESH', '1');
-
-    mkdir(self::$tmp . '/data', 0755, TRUE);
-
-    $this->mockRequestMultiple([
-      [
-        'url' => 'https://accounts.acquia.com/api/auth/oauth/token',
-        'response' => ['body' => json_encode(['access_token' => 'test-token'])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications?filter=name%3Dmyapp',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['uuid' => 'app-uuid-123']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => 'env-id-prod']]]])],
-      ],
-      // Create backup.
-      [
-        'url' => 'https://cloud.acquia.com/api/environments/env-id-prod/databases/mydb/backups',
-        'response' => ['body' => json_encode(['_links' => ['notification' => ['href' => 'https://cloud.acquia.com/api/notifications/backup-create']]])],
-      ],
-      // Polling: failed.
-      [
-        'url' => 'https://cloud.acquia.com/api/notifications/backup-create',
-        'response' => ['body' => json_encode(['status' => 'failed'])],
-      ],
-    ]);
-
-    $this->runScriptError('src/vortex-fetch-db-acquia', 'Backup creation failed');
-  }
-
-  public function testTokenError(): void {
-    $this->mockRequestMultiple([
-      [
-        'url' => 'https://accounts.acquia.com/api/auth/oauth/token',
-        'response' => ['ok' => FALSE, 'status' => 401, 'body' => ''],
-      ],
-    ]);
-
-    $this->runScriptError('src/vortex-fetch-db-acquia', 'Unable to retrieve a token');
+    $this->runScriptError('src/vortex-fetch-db-acquia', 'Backup creation timed out after 3 seconds.');
   }
 
   public function testDirectoryCreation(): void {
-    // Don't pre-create directory - it should be auto-created.
     $db_dir = self::$tmp . '/new-data-dir';
     $this->envSet('VORTEX_FETCH_DB_ACQUIA_DB_DIR', $db_dir);
 
-    // Pre-create the decompressed file (need directory first).
-    mkdir($db_dir, 0755, TRUE);
-    file_put_contents($db_dir . '/mydb_backup_12345.sql', 'SQL DUMP');
+    $this->mockCommandExists();
 
-    $this->mockRequestMultiple([
-      [
-        'url' => 'https://accounts.acquia.com/api/auth/oauth/token',
-        'response' => ['body' => json_encode(['access_token' => 'test-token'])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications?filter=name%3Dmyapp',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['uuid' => 'app-uuid-123']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Dprod',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => 'env-id-prod']]]])],
-      ],
-      [
-        'url' => 'https://cloud.acquia.com/api/environments/env-id-prod/databases/mydb/backups?sort=created',
-        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => '12345']]]])],
-      ],
-    ]);
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+      ['cmd' => $this->backupDownloadCmd('12345'), 'output' => $this->downloadJson('https://acquia-backup.s3.amazonaws.com/backup.sql.gz'), 'result_code' => 0],
+    ]));
+
+    $this->mockRequest('https://acquia-backup.s3.amazonaws.com/backup.sql.gz', ['method' => 'GET'], ['status' => 200, 'ok' => TRUE, 'body' => $this->gzipBody('DOWNLOADED SQL DUMP')]);
 
     $output = $this->runScript('src/vortex-fetch-db-acquia');
 
+    $this->assertStringContainsString('Creating directory for database dumps.', $output);
     $this->assertTrue(is_dir($db_dir));
-    $this->assertStringContainsString('Finished database dump download from Acquia.', $output);
+    $this->assertStringContainsString('Finished database backup download from Acquia.', $output);
+  }
+
+  public function testBareArrayBackupList(): void {
+    // Some CLI versions return a bare list instead of an '_embedded' envelope.
+    file_put_contents(self::$tmp . '/data/mydb_backup_12345.sql', 'SQL DUMP');
+
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupListCmd(), 'output' => json_encode([['id' => '12345', 'completedAt' => '2026-07-07T00:00:00Z']]) ?: '', 'result_code' => 0],
+    ]));
+
+    $output = $this->runScript('src/vortex-fetch-db-acquia');
+
+    $this->assertStringContainsString('Found existing cached DB file', $output);
+    $this->assertStringContainsString('Finished database backup download from Acquia.', $output);
+  }
+
+  public function testDownloadUrlMalformedResponse(): void {
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+      ['cmd' => $this->backupDownloadCmd('12345'), 'output' => 'not-json-at-all', 'result_code' => 0],
+    ]));
+
+    $this->runScriptError('src/vortex-fetch-db-acquia', 'Unable to discover the download URL for backup "12345".');
+  }
+
+  public function testRenameFailure(): void {
+    // A cached decompressed dump goes straight to the rename step.
+    file_put_contents(self::$tmp . '/data/mydb_backup_12345.sql', 'SQL DUMP');
+    // Make the destination a non-empty directory so the rename cannot succeed.
+    mkdir(self::$tmp . '/data/db.sql', 0755, TRUE);
+    file_put_contents(self::$tmp . '/data/db.sql/blocker', 'x');
+
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+    ]));
+
+    $this->runScriptError('src/vortex-fetch-db-acquia', 'Unable to rename file');
+  }
+
+  /**
+   * The version and application/environment discovery command mocks.
+   *
+   * @return array<int, array{cmd: string, output: string, result_code: int}>
+   *   The ordered passthru mocks shared by the discovery phase.
+   */
+  protected function discoveryMocks(): array {
+    return [
+      ['cmd' => $this->versionCmd(), 'output' => 'Acquia CLI 2.61.3', 'result_code' => 0],
+      ['cmd' => $this->appsListCmd(), 'output' => $this->appsJson([['name' => 'myapp', 'uuid' => 'app-uuid-123']]), 'result_code' => 0],
+      ['cmd' => $this->envListCmd(), 'output' => $this->envsJson([['name' => 'prod', 'id' => 'env-id-prod']]), 'result_code' => 0],
+    ];
+  }
+
+  protected function acliHome(): string {
+    return self::$tmp . '/acli-home-' . getmypid();
+  }
+
+  protected function acliCmd(string $subcommand): string {
+    return sprintf('ACLI_HOME=%s ACLI_KEY=%s ACLI_SECRET=%s ACLI_NO_TELEMETRY=1 %s %s --no-interaction 2>&1', escapeshellarg($this->acliHome()), escapeshellarg('test-key'), escapeshellarg('test-secret'), escapeshellarg('acli'), $subcommand);
+  }
+
+  protected function versionCmd(): string {
+    return $this->acliCmd('--version');
+  }
+
+  protected function appsListCmd(): string {
+    return $this->acliCmd('api:applications:list');
+  }
+
+  protected function envListCmd(string $uuid = 'app-uuid-123'): string {
+    return $this->acliCmd('api:applications:environment-list ' . escapeshellarg($uuid));
+  }
+
+  protected function backupCreateCmd(string $env = 'env-id-prod', string $db = 'mydb'): string {
+    return $this->acliCmd('api:environments:database-backup-create ' . escapeshellarg($env) . ' ' . escapeshellarg($db));
+  }
+
+  protected function backupListCmd(string $env = 'env-id-prod', string $db = 'mydb'): string {
+    return $this->acliCmd('api:environments:database-backup-list ' . escapeshellarg($env) . ' ' . escapeshellarg($db));
+  }
+
+  protected function backupDownloadCmd(string $id, string $env = 'env-id-prod', string $db = 'mydb'): string {
+    return $this->acliCmd('api:environments:database-backup-download ' . escapeshellarg($env) . ' ' . escapeshellarg($db) . ' ' . escapeshellarg($id));
+  }
+
+  /**
+   * Encodes an application list response.
+   *
+   * @param array<int, array<string, string>> $apps
+   *   The application records.
+   */
+  protected function appsJson(array $apps): string {
+    return json_encode(['_embedded' => ['items' => $apps]]) ?: '';
+  }
+
+  /**
+   * Encodes an environment list response.
+   *
+   * @param array<int, array<string, string>> $envs
+   *   The environment records.
+   */
+  protected function envsJson(array $envs): string {
+    return json_encode(['_embedded' => ['items' => $envs]]) ?: '';
+  }
+
+  /**
+   * Encodes a backup list response from completed backup ids.
+   *
+   * @param array<int, string> $ids
+   *   The completed backup ids.
+   */
+  protected function backupsJson(array $ids): string {
+    $items = array_map(fn(string $id): array => ['id' => $id, 'completedAt' => '2026-07-07T00:00:00Z'], $ids);
+
+    return json_encode(['_embedded' => ['items' => $items]]) ?: '';
+  }
+
+  protected function downloadJson(string $url): string {
+    return json_encode(['url' => $url]) ?: '';
+  }
+
+  protected function gzipBody(string $content): string {
+    return gzencode($content) ?: '';
   }
 
 }

--- a/.vortex/tooling/tests/Unit/FetchDbAcquiaTest.php
+++ b/.vortex/tooling/tests/Unit/FetchDbAcquiaTest.php
@@ -406,12 +406,8 @@ class FetchDbAcquiaTest extends UnitTestCase {
     ];
   }
 
-  protected function acliHome(): string {
-    return self::$tmp . '/acli-home-' . getmypid();
-  }
-
   protected function acliCmd(string $subcommand): string {
-    return sprintf('ACLI_HOME=%s ACLI_KEY=%s ACLI_SECRET=%s ACLI_NO_TELEMETRY=1 %s %s --no-interaction 2>&1', escapeshellarg($this->acliHome()), escapeshellarg('test-key'), escapeshellarg('test-secret'), escapeshellarg('acli'), $subcommand);
+    return sprintf('%s %s --no-interaction 2>&1', escapeshellarg('acli'), $subcommand);
   }
 
   protected function versionCmd(): string {

--- a/.vortex/tooling/tests/Unit/FetchDbAcquiaTest.php
+++ b/.vortex/tooling/tests/Unit/FetchDbAcquiaTest.php
@@ -44,13 +44,6 @@ class FetchDbAcquiaTest extends UnitTestCase {
     $this->runScriptError('src/vortex-fetch-db-acquia', 'Missing required value for VORTEX_FETCH_DB_ACQUIA_SECRET');
   }
 
-  public function testMissingAppName(): void {
-    $this->envSet('VORTEX_FETCH_DB_ACQUIA_APP_NAME', '');
-    $this->envUnset('VORTEX_ACQUIA_APP_NAME');
-
-    $this->runScriptError('src/vortex-fetch-db-acquia', 'Missing required value for VORTEX_FETCH_DB_ACQUIA_APP_NAME');
-  }
-
   public function testMissingEnvironment(): void {
     $this->envSet('VORTEX_FETCH_DB_ENVIRONMENT', '');
 
@@ -63,7 +56,7 @@ class FetchDbAcquiaTest extends UnitTestCase {
     $this->runScriptError('src/vortex-fetch-db-acquia', 'Missing required value for VORTEX_FETCH_DB_ACQUIA_DB_NAME');
   }
 
-  public function testApplicationNotFound(): void {
+  public function testApplicationHintNotFound(): void {
     $this->mockCommandExists();
 
     $this->mockPassthruMultiple([
@@ -71,7 +64,87 @@ class FetchDbAcquiaTest extends UnitTestCase {
       ['cmd' => $this->appsListCmd(), 'output' => $this->appsJson([]), 'result_code' => 0],
     ]);
 
-    $this->runScriptError('src/vortex-fetch-db-acquia', 'Unable to find the Acquia application "myapp".');
+    $this->runScriptError('src/vortex-fetch-db-acquia', 'Unable to find an Acquia application matching "myapp".');
+  }
+
+  public function testAutoDiscoverSingleApplication(): void {
+    // With no hint and exactly one accessible application, it is auto-selected.
+    $this->envSet('VORTEX_FETCH_DB_ACQUIA_APP_NAME', '');
+    $this->envUnset('VORTEX_ACQUIA_APP_NAME');
+
+    file_put_contents(self::$tmp . '/data/mydb_backup_12345.sql', 'SQL DUMP');
+
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple([
+      ['cmd' => $this->versionCmd(), 'output' => 'Acquia CLI 2.61.3', 'result_code' => 0],
+      ['cmd' => $this->appsListCmd(), 'output' => $this->appsJson([['name' => 'NSWSES', 'uuid' => 'app-uuid-123', 'hosting' => ['id' => 'prod:nswses']]]), 'result_code' => 0],
+      ['cmd' => $this->envListCmd(), 'output' => $this->envsJson([['name' => 'prod', 'id' => 'env-id-prod']]), 'result_code' => 0],
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+    ]);
+
+    $output = $this->runScript('src/vortex-fetch-db-acquia');
+
+    $this->assertStringContainsString('Auto-discovering the Acquia application.', $output);
+    $this->assertStringContainsString('Using application "NSWSES"', $output);
+    $this->assertStringContainsString('Finished database backup download from Acquia.', $output);
+  }
+
+  public function testAutoDiscoverAmbiguousApplications(): void {
+    // With no hint and more than one application, the choice is ambiguous.
+    $this->envSet('VORTEX_FETCH_DB_ACQUIA_APP_NAME', '');
+    $this->envUnset('VORTEX_ACQUIA_APP_NAME');
+
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple([
+      ['cmd' => $this->versionCmd(), 'output' => 'Acquia CLI 2.61.3', 'result_code' => 0],
+      ['cmd' => $this->appsListCmd(), 'output' => $this->appsJson([['name' => 'One', 'uuid' => 'u1', 'hosting' => ['id' => 'prod:one']], ['name' => 'Two', 'uuid' => 'u2']]), 'result_code' => 0],
+    ]);
+
+    $this->runScriptError('src/vortex-fetch-db-acquia', 'Unable to auto-discover a single Acquia application (found 2)');
+  }
+
+  public function testApplicationMatchedByMachineName(): void {
+    // The hint 'mymachine' matches only the hosting machine name.
+    $this->envSet('VORTEX_FETCH_DB_ACQUIA_APP_NAME', 'mymachine');
+
+    file_put_contents(self::$tmp . '/data/mydb_backup_12345.sql', 'SQL DUMP');
+
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple([
+      ['cmd' => $this->versionCmd(), 'output' => 'Acquia CLI 2.61.3', 'result_code' => 0],
+      ['cmd' => $this->appsListCmd(), 'output' => $this->appsJson([['name' => 'Human Label', 'uuid' => 'app-uuid-123', 'hosting' => ['id' => 'prod:mymachine']]]), 'result_code' => 0],
+      ['cmd' => $this->envListCmd(), 'output' => $this->envsJson([['name' => 'prod', 'id' => 'env-id-prod']]), 'result_code' => 0],
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+    ]);
+
+    $output = $this->runScript('src/vortex-fetch-db-acquia');
+
+    $this->assertStringContainsString('Using application "Human Label"', $output);
+    $this->assertStringContainsString('Finished database backup download from Acquia.', $output);
+  }
+
+  public function testApplicationMatchedByUuid(): void {
+    // The hint is the application uuid; the application carries no hosting id.
+    $this->envSet('VORTEX_FETCH_DB_ACQUIA_APP_NAME', 'app-uuid-123');
+
+    file_put_contents(self::$tmp . '/data/mydb_backup_12345.sql', 'SQL DUMP');
+
+    $this->mockCommandExists();
+
+    $this->mockPassthruMultiple([
+      ['cmd' => $this->versionCmd(), 'output' => 'Acquia CLI 2.61.3', 'result_code' => 0],
+      ['cmd' => $this->appsListCmd(), 'output' => $this->appsJson([['name' => 'Human Label', 'uuid' => 'app-uuid-123']]), 'result_code' => 0],
+      ['cmd' => $this->envListCmd(), 'output' => $this->envsJson([['name' => 'prod', 'id' => 'env-id-prod']]), 'result_code' => 0],
+      ['cmd' => $this->backupListCmd(), 'output' => $this->backupsJson(['12345']), 'result_code' => 0],
+    ]);
+
+    $output = $this->runScript('src/vortex-fetch-db-acquia');
+
+    $this->assertStringContainsString('Using application "Human Label"', $output);
+    $this->assertStringContainsString('Finished database backup download from Acquia.', $output);
   }
 
   public function testEnvironmentNotFound(): void {
@@ -283,7 +356,7 @@ class FetchDbAcquiaTest extends UnitTestCase {
     $this->mockCommandExists();
 
     $this->mockPassthruMultiple(array_merge($this->discoveryMocks(), [
-      ['cmd' => $this->backupListCmd(), 'output' => json_encode([['id' => '12345', 'completedAt' => '2026-07-07T00:00:00Z']]) ?: '', 'result_code' => 0],
+      ['cmd' => $this->backupListCmd(), 'output' => json_encode([['id' => '12345', 'completed_at' => '2026-07-07T00:00:00Z']]) ?: '', 'result_code' => 0],
     ]));
 
     $output = $this->runScript('src/vortex-fetch-db-acquia');
@@ -368,7 +441,7 @@ class FetchDbAcquiaTest extends UnitTestCase {
   /**
    * Encodes an application list response.
    *
-   * @param array<int, array<string, string>> $apps
+   * @param array<int, array<string, mixed>> $apps
    *   The application records.
    */
   protected function appsJson(array $apps): string {
@@ -392,7 +465,7 @@ class FetchDbAcquiaTest extends UnitTestCase {
    *   The completed backup ids.
    */
   protected function backupsJson(array $ids): string {
-    $items = array_map(fn(string $id): array => ['id' => $id, 'completedAt' => '2026-07-07T00:00:00Z'], $ids);
+    $items = array_map(fn(string $id): array => ['id' => $id, 'completed_at' => '2026-07-07T00:00:00Z'], $ids);
 
     return json_encode(['_embedded' => ['items' => $items]]) ?: '';
   }

--- a/.vortex/tooling/tests/Unit/HelpersAcquiaTest.php
+++ b/.vortex/tooling/tests/Unit/HelpersAcquiaTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\VortexTooling\Tests\Unit;
+
+use DrevOps\VortexTooling\Tests\Exceptions\QuitErrorException;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests for shared Acquia CLI helper functions.
+ *
+ * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ */
+#[CoversFunction('DrevOps\VortexTooling\acli_resolve')]
+#[CoversFunction('DrevOps\VortexTooling\acli_home')]
+#[CoversFunction('DrevOps\VortexTooling\acli_exec')]
+#[Group('helpers')]
+#[RunTestsInSeparateProcesses]
+class HelpersAcquiaTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+
+    require_once __DIR__ . '/../../src/helpers.php';
+  }
+
+  public function testResolveUsesPath(): void {
+    $this->mockCommandExists();
+
+    $result = '';
+    $output = $this->captureOutput(function () use (&$result): void {
+      $result = \DrevOps\VortexTooling\acli_resolve();
+    });
+
+    $this->assertSame('acli', $result);
+    $this->assertStringContainsString('Using the Acquia CLI found on PATH.', $output);
+  }
+
+  public function testResolveReusesCached(): void {
+    $this->mockCommandExists();
+    $this->mockCommandMissing('acli');
+    $dir = self::$tmp . '/cli';
+    mkdir($dir, 0755, TRUE);
+    $bin = $dir . '/acli';
+    file_put_contents($bin, "#!/bin/sh\n");
+    chmod($bin, 0755);
+    $this->envSet('VORTEX_ACLI_PATH', $dir);
+
+    $result = '';
+    $output = $this->captureOutput(function () use (&$result): void {
+      $result = \DrevOps\VortexTooling\acli_resolve();
+    });
+
+    $this->assertSame($bin, $result);
+    $this->assertStringContainsString('Reusing the Acquia CLI', $output);
+  }
+
+  public function testResolveDownloads(): void {
+    $this->mockCommandExists();
+    $this->mockCommandMissing('acli');
+    $dir = self::$tmp . '/cli';
+    $this->envSetMultiple([
+      'VORTEX_ACLI_PATH' => $dir,
+      'VORTEX_ACLI_VERSION' => '2.61.3',
+    ]);
+
+    $url = 'https://github.com/acquia/cli/releases/download/2.61.3/acli.phar';
+    $this->mockRequest($url, ['method' => 'GET'], ['status' => 200, 'ok' => TRUE, 'body' => '']);
+
+    $result = '';
+    $output = $this->captureOutput(function () use (&$result): void {
+      $result = \DrevOps\VortexTooling\acli_resolve();
+    });
+
+    $this->assertSame($dir . '/acli', $result);
+    $this->assertStringContainsString('Downloading the Acquia CLI', $output);
+    $this->assertFileExists($dir . '/acli');
+  }
+
+  public function testResolveDownloadFails(): void {
+    $this->mockCommandExists();
+    $this->mockCommandMissing('acli');
+    $this->envSetMultiple([
+      'VORTEX_ACLI_PATH' => self::$tmp . '/cli',
+      'VORTEX_ACLI_VERSION' => '2.61.3',
+    ]);
+
+    $url = 'https://github.com/acquia/cli/releases/download/2.61.3/acli.phar';
+    $this->mockRequest($url, ['method' => 'GET'], ['status' => 404, 'ok' => FALSE, 'body' => '', 'error' => 'Not Found']);
+
+    $this->mockQuit(1);
+
+    ob_start();
+    try {
+      \DrevOps\VortexTooling\acli_resolve();
+      $this->fail('Expected QuitErrorException to be thrown.');
+    }
+    catch (QuitErrorException $e) {
+      $this->assertEquals(1, $e->getCode());
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertStringContainsString('Failed to download the Acquia CLI', (string) $output);
+    }
+  }
+
+  public function testHomeCreatesIsolatedDir(): void {
+    $this->envSet('VORTEX_ACLI_PATH', self::$tmp);
+
+    $result = \DrevOps\VortexTooling\acli_home();
+
+    $this->assertSame(self::$tmp . '/acli-home-' . getmypid(), $result);
+    $this->assertDirectoryExists($result);
+  }
+
+  public function testHomeReusesExistingDir(): void {
+    $this->envSet('VORTEX_ACLI_PATH', self::$tmp);
+    $home = self::$tmp . '/acli-home-' . getmypid();
+    mkdir($home, 0755, TRUE);
+
+    $result = \DrevOps\VortexTooling\acli_home();
+
+    $this->assertSame($home, $result);
+    $this->assertDirectoryExists($result);
+  }
+
+  public function testExecSuccess(): void {
+    $ctx = ['home' => self::$tmp . '/home', 'key' => 'k', 'secret' => 's'];
+    $this->mockPassthru([
+      'cmd' => $this->acliExecCmd($ctx, 'api:applications:list'),
+      'output' => '{"_embedded":{"items":[]}}',
+      'result_code' => 0,
+    ]);
+
+    $result = \DrevOps\VortexTooling\acli_exec('acli', 'api:applications:list', $ctx);
+
+    $this->assertSame('{"_embedded":{"items":[]}}', $result);
+  }
+
+  public function testExecSoftFailureCapturesExitCode(): void {
+    $ctx = ['home' => self::$tmp . '/home', 'key' => 'k', 'secret' => 's'];
+    $this->mockPassthru([
+      'cmd' => $this->acliExecCmd($ctx, 'api:applications:list'),
+      'output' => 'not authenticated',
+      'result_code' => 3,
+    ]);
+
+    $exit_code = 0;
+    $result = \DrevOps\VortexTooling\acli_exec('acli', 'api:applications:list', $ctx, $exit_code);
+
+    $this->assertSame(3, $exit_code);
+    $this->assertSame('not authenticated', $result);
+  }
+
+  public function testExecPreservesZeroOutput(): void {
+    $ctx = ['home' => self::$tmp . '/home', 'key' => 'k', 'secret' => 's'];
+    $this->mockPassthru([
+      'cmd' => $this->acliExecCmd($ctx, '--version'),
+      'output' => '0',
+      'result_code' => 0,
+    ]);
+
+    $result = \DrevOps\VortexTooling\acli_exec('acli', '--version', $ctx);
+
+    $this->assertSame('0', $result);
+  }
+
+  public function testExecHardFailure(): void {
+    $ctx = ['home' => self::$tmp . '/home', 'key' => 'k', 'secret' => 's'];
+    $this->mockPassthru([
+      'cmd' => $this->acliExecCmd($ctx, 'api:applications:list'),
+      'output' => 'boom',
+      'result_code' => 2,
+    ]);
+
+    $this->mockQuit(1);
+
+    ob_start();
+    try {
+      \DrevOps\VortexTooling\acli_exec('acli', 'api:applications:list', $ctx);
+      $this->fail('Expected QuitErrorException to be thrown.');
+    }
+    catch (QuitErrorException $e) {
+      $this->assertEquals(1, $e->getCode());
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertStringContainsString('Acquia CLI command "api:applications:list" failed with exit code 2', (string) $output);
+    }
+  }
+
+  /**
+   * Builds the expected shell command produced by acli_exec().
+   *
+   * @param array{home: string, key: string, secret: string} $ctx
+   *   The execution context threaded into the environment prefix.
+   * @param string $subcommand
+   *   The subcommand with its command-specific arguments.
+   */
+  protected function acliExecCmd(array $ctx, string $subcommand): string {
+    return sprintf('ACLI_HOME=%s ACLI_KEY=%s ACLI_SECRET=%s ACLI_NO_TELEMETRY=1 %s %s --no-interaction 2>&1', escapeshellarg($ctx['home']), escapeshellarg($ctx['key']), escapeshellarg($ctx['secret']), escapeshellarg('acli'), $subcommand);
+  }
+
+}

--- a/.vortex/tooling/tests/Unit/HelpersAcquiaTest.php
+++ b/.vortex/tooling/tests/Unit/HelpersAcquiaTest.php
@@ -130,7 +130,7 @@ class HelpersAcquiaTest extends UnitTestCase {
   public function testExecSuccess(): void {
     $ctx = ['home' => self::$tmp . '/home', 'key' => 'k', 'secret' => 's'];
     $this->mockPassthru([
-      'cmd' => $this->acliExecCmd($ctx, 'api:applications:list'),
+      'cmd' => $this->acliExecCmd('api:applications:list'),
       'output' => '{"_embedded":{"items":[]}}',
       'result_code' => 0,
     ]);
@@ -143,7 +143,7 @@ class HelpersAcquiaTest extends UnitTestCase {
   public function testExecSoftFailureCapturesExitCode(): void {
     $ctx = ['home' => self::$tmp . '/home', 'key' => 'k', 'secret' => 's'];
     $this->mockPassthru([
-      'cmd' => $this->acliExecCmd($ctx, 'api:applications:list'),
+      'cmd' => $this->acliExecCmd('api:applications:list'),
       'output' => 'not authenticated',
       'result_code' => 3,
     ]);
@@ -158,7 +158,7 @@ class HelpersAcquiaTest extends UnitTestCase {
   public function testExecPreservesZeroOutput(): void {
     $ctx = ['home' => self::$tmp . '/home', 'key' => 'k', 'secret' => 's'];
     $this->mockPassthru([
-      'cmd' => $this->acliExecCmd($ctx, '--version'),
+      'cmd' => $this->acliExecCmd('--version'),
       'output' => '0',
       'result_code' => 0,
     ]);
@@ -171,7 +171,7 @@ class HelpersAcquiaTest extends UnitTestCase {
   public function testExecHardFailure(): void {
     $ctx = ['home' => self::$tmp . '/home', 'key' => 'k', 'secret' => 's'];
     $this->mockPassthru([
-      'cmd' => $this->acliExecCmd($ctx, 'api:applications:list'),
+      'cmd' => $this->acliExecCmd('api:applications:list'),
       'output' => 'boom',
       'result_code' => 2,
     ]);
@@ -195,13 +195,11 @@ class HelpersAcquiaTest extends UnitTestCase {
   /**
    * Builds the expected shell command produced by acli_exec().
    *
-   * @param array{home: string, key: string, secret: string} $ctx
-   *   The execution context threaded into the environment prefix.
    * @param string $subcommand
    *   The subcommand with its command-specific arguments.
    */
-  protected function acliExecCmd(array $ctx, string $subcommand): string {
-    return sprintf('ACLI_HOME=%s ACLI_KEY=%s ACLI_SECRET=%s ACLI_NO_TELEMETRY=1 %s %s --no-interaction 2>&1', escapeshellarg($ctx['home']), escapeshellarg($ctx['key']), escapeshellarg($ctx['secret']), escapeshellarg('acli'), $subcommand);
+  protected function acliExecCmd(string $subcommand): string {
+    return sprintf('%s %s --no-interaction 2>&1', escapeshellarg('acli'), $subcommand);
   }
 
 }

--- a/.vortex/tooling/tests/Unit/HelpersAcquiaTest.php
+++ b/.vortex/tooling/tests/Unit/HelpersAcquiaTest.php
@@ -116,15 +116,20 @@ class HelpersAcquiaTest extends UnitTestCase {
     $this->assertDirectoryExists($result);
   }
 
-  public function testHomeReusesExistingDir(): void {
+  public function testHomeClearsStaleDir(): void {
     $this->envSet('VORTEX_ACLI_PATH', self::$tmp);
     $home = self::$tmp . '/acli-home-' . getmypid();
-    mkdir($home, 0755, TRUE);
+    mkdir($home . '/subdir', 0755, TRUE);
+    file_put_contents($home . '/subdir/token.json', 'stale');
+    file_put_contents($home . '/state', 'stale');
 
     $result = \DrevOps\VortexTooling\acli_home();
 
     $this->assertSame($home, $result);
     $this->assertDirectoryExists($result);
+    // A leftover home is cleared so stale credentials never reach acli.
+    $this->assertFileDoesNotExist($home . '/state');
+    $this->assertDirectoryDoesNotExist($home . '/subdir');
   }
 
   public function testExecSuccess(): void {

--- a/.vortex/tooling/tests/Unit/HelpersFormatterTest.php
+++ b/.vortex/tooling/tests/Unit/HelpersFormatterTest.php
@@ -52,9 +52,10 @@ class HelpersFormatterTest extends UnitTestCase {
     return [
       // Note - does not use term_supports_color, always plain output.
       'note' => ['note', NULL, "       Test message arg\n"],
-      // Task - blue (34m).
-      'task, no color' => ['task', FALSE, "[TASK] Test message arg\n"],
-      'task, with color' => ['task', TRUE, "\033[34m[TASK] Test message arg\033[0m\n"],
+      // Task - blue (34m). Announces only (no body), so the message is printed
+      // verbatim and the extra argument is the ignored done message.
+      'task, no color' => ['task', FALSE, "[TASK] Test message %s\n"],
+      'task, with color' => ['task', TRUE, "\033[34m[TASK] Test message %s\033[0m\n"],
       // Info - cyan (36m).
       'info, no color' => ['info', FALSE, "[INFO] Test message arg\n"],
       'info, with color' => ['info', TRUE, "\033[36m[INFO] Test message arg\033[0m\n"],

--- a/.vortex/tooling/tests/Unit/HelpersFormatterTest.php
+++ b/.vortex/tooling/tests/Unit/HelpersFormatterTest.php
@@ -68,6 +68,64 @@ class HelpersFormatterTest extends UnitTestCase {
     ];
   }
 
+  public function testTaskBodySuccess(): void {
+    $this->envSet('TERM', 'dumb');
+
+    require_once __DIR__ . '/../../src/helpers.php';
+
+    // A string done message reports [ OK ] verbatim and returns the body value.
+    ob_start();
+    $result = \DrevOps\VortexTooling\task('Doing the thing.', 'Did the thing.', fn(): string => 'value');
+    $output = ob_get_clean();
+
+    $this->assertSame('value', $result);
+    $this->assertEquals("[TASK] Doing the thing.\n[ OK ] Did the thing.\n", $output);
+
+    // A closure done receives the body's return value to build the message.
+    ob_start();
+    $result = \DrevOps\VortexTooling\task('Doing the thing.', fn(string $value): string => sprintf('Did the thing with %s.', $value), fn(): string => 'value');
+    $output = ob_get_clean();
+
+    $this->assertSame('value', $result);
+    $this->assertEquals("[TASK] Doing the thing.\n[ OK ] Did the thing with value.\n", $output);
+  }
+
+  public function testTaskBodyNonFatalFailure(): void {
+    $this->envSet('TERM', 'dumb');
+
+    require_once __DIR__ . '/../../src/helpers.php';
+
+    ob_start();
+    $result = \DrevOps\VortexTooling\task('Doing the thing.', 'Did the thing.', function (): void {
+      throw new \RuntimeException('Something went wrong.');
+    }, fatal: FALSE);
+    $output = ob_get_clean();
+
+    $this->assertNull($result);
+    $this->assertEquals("[TASK] Doing the thing.\n[FAIL] Something went wrong.\n", $output);
+  }
+
+  public function testTaskBodyFatalFailure(): void {
+    $this->envSet('TERM', 'dumb');
+    $this->mockQuit(1);
+
+    require_once __DIR__ . '/../../src/helpers.php';
+
+    $this->expectException(QuitErrorException::class);
+    $this->expectExceptionCode(1);
+
+    try {
+      ob_start();
+      \DrevOps\VortexTooling\task('Doing the thing.', 'Did the thing.', function (): void {
+        throw new \RuntimeException('Something went wrong.');
+      });
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertEquals("[TASK] Doing the thing.\n[FAIL] Something went wrong.\n", $output);
+    }
+  }
+
   #[DataProvider('dataProviderFail')]
   public function testFail(bool $is_tty, string $expected_output): void {
     // Set TERM to a valid terminal type and mock posix_isatty BEFORE loading.

--- a/.vortex/tooling/tests/Unit/NotifyEmailTest.php
+++ b/.vortex/tooling/tests/Unit/NotifyEmailTest.php
@@ -57,6 +57,17 @@ class NotifyEmailTest extends UnitTestCase {
     $this->assertStringContainsString('Finished email notification', $output);
   }
 
+  public function testFailedNotification(): void {
+    $this->mockMail([
+      'to' => 'to@example.com',
+      'subject' => 'test-project deployment notification of main',
+      'message' => $this->defaultMessageMatcher(),
+      'result' => FALSE,
+    ]);
+
+    $this->runScriptError('src/vortex-notify-email', 'Failed to send email notification via mail().');
+  }
+
   public function testSuccessfulNotificationMultipleRecipients(): void {
     $this->envSet('VORTEX_NOTIFY_EMAIL_RECIPIENTS', 'to1@example.com|Jane Doe, to2@example.com|John Doe');
 

--- a/.vortex/tooling/tests/Unit/TaskPurgeCacheAcquiaTest.php
+++ b/.vortex/tooling/tests/Unit/TaskPurgeCacheAcquiaTest.php
@@ -271,7 +271,7 @@ class TaskPurgeCacheAcquiaTest extends UnitTestCase {
 
     $output = $this->runScript('src/vortex-task-purge-cache-acquia');
 
-    $this->assertStringContainsString('Unable to find domains to purge cache for dev environment.', $output);
+    $this->assertStringContainsString('No domains to purge cache for dev environment.', $output);
     $this->assertStringContainsString('Finished cache purging in Acquia.', $output);
   }
 

--- a/.vortex/tooling/tests/Unit/TaskPurgeCacheAcquiaTest.php
+++ b/.vortex/tooling/tests/Unit/TaskPurgeCacheAcquiaTest.php
@@ -248,6 +248,52 @@ class TaskPurgeCacheAcquiaTest extends UnitTestCase {
     $this->assertStringContainsString('Finished cache purging in Acquia.', $output);
   }
 
+  public function testDomainPurgeRefreshesTokenOn401(): void {
+    $this->mockSleep();
+
+    file_put_contents(self::$tmp . '/domains.txt', '$target_env.example.com' . "\n");
+
+    $this->mockRequestMultiple([
+      [
+        'url' => 'https://accounts.acquia.com/api/auth/oauth/token',
+        'response' => ['body' => json_encode(['access_token' => 'test-token'])],
+      ],
+      [
+        'url' => 'https://cloud.acquia.com/api/applications?filter=name%3Dmyapp',
+        'response' => ['body' => json_encode(['_embedded' => ['items' => [['uuid' => 'app-uuid-123']]]])],
+      ],
+      [
+        'url' => 'https://cloud.acquia.com/api/applications/app-uuid-123/environments?filter=name%3Ddev',
+        'response' => ['body' => json_encode(['_embedded' => ['items' => [['id' => 'env-id-dev']]]])],
+      ],
+      // First purge POST fails with an expired-token 401.
+      [
+        'url' => 'https://cloud.acquia.com/api/environments/env-id-dev/domains/actions/clear-varnish',
+        'response' => ['ok' => FALSE, 'status' => 401, 'body' => ''],
+      ],
+      // Token is refreshed.
+      [
+        'url' => 'https://accounts.acquia.com/api/auth/oauth/token',
+        'response' => ['body' => json_encode(['access_token' => 'test-token-refreshed'])],
+      ],
+      // Retry purge POST succeeds with the fresh token.
+      [
+        'url' => 'https://cloud.acquia.com/api/environments/env-id-dev/domains/actions/clear-varnish',
+        'response' => ['body' => json_encode(['_links' => ['notification' => ['href' => 'https://cloud.acquia.com/api/notifications/purge-1']]])],
+      ],
+      // Polling: status completed.
+      [
+        'url' => 'https://cloud.acquia.com/api/notifications/purge-1',
+        'response' => ['body' => json_encode(['status' => 'completed'])],
+      ],
+    ]);
+
+    $output = $this->runScript('src/vortex-task-purge-cache-acquia');
+
+    $this->assertStringContainsString('Purged cache for dev environment domain dev.example.com.', $output);
+    $this->assertStringContainsString('Finished cache purging in Acquia.', $output);
+  }
+
   public function testNoDomains(): void {
     $this->mockSleep();
 


### PR DESCRIPTION
Closes #1384

## Summary

The Acquia database fetch (`vortex-fetch-db-acquia`) has been rebuilt on the provider-native Acquia CLI (`acli`) in place of bespoke Cloud API HTTP calls. `acli` is resolved on demand - used from `PATH` or downloaded once into a cache directory - and authenticated headlessly against an isolated `ACLI_HOME`, with the API key and secret passed through the process environment rather than the command line, so a developer's own `~/.acquia` configuration is never read or written and credentials never appear in the process list. The source application is auto-discovered from the credentials, matched by name, hosting ID, machine name or UUID when more than one application is accessible. The rework was validated live end to end against a real Acquia account, fetching, decompressing and writing a 1.5 GB production database. Landing this also drove a tooling-wide output overhaul: `task()` is now the single task primitive - it takes a callback body and reports `[ OK ]`/`[FAIL]` from it (the body throws to fail), fatal by default or non-fatal for best-effort loops - long waits and downloads tick a per-second progress dot in the task's own colour, and every task across the tooling now ends with an explicit OK/FAIL status.

## Changes

**Acquia fetch rebuilt on `acli`**
- Rewrote `vortex-fetch-db-acquia` to discover the application and environment, optionally trigger and await a fresh backup, then discover and stream-download the latest backup via `acli` subcommands instead of raw Acquia Cloud API HTTP calls.
- Added `acli_resolve()`, `acli_home()`, `acli_home_remove()` and `acli_exec()` to `helpers.php`: on-demand CLI resolution (`PATH` or a cached download) and headless execution with `ACLI_KEY`/`ACLI_SECRET` passed through the process environment so credentials are never exposed on the command line.
- Isolated, self-cleaning authentication: `acli_home()` points `ACLI_HOME` at an ephemeral per-process directory, clears any stale copy left behind by a crashed run before use, and removes it on shutdown, so no cached token or state lingers on disk after a run.
- Added application auto-discovery and hint matching (`acquia_select_app()`, `acquia_app_matches()`, `acquia_app_labels()`) - a hint matches by UUID, name, hosting ID or hosting machine name, and the single accessible application is used automatically when no hint is given.
- Rewrote `tests/Unit/FetchDbAcquiaTest.php` around `acli` subprocess mocks and added `tests/Unit/HelpersAcquiaTest.php` for the new helpers.
- Added `playground/fetch-db-acquia.php`, a manual runner for exercising the script end to end against a real Acquia Cloud environment.
- Documented the new flow in `docs/content/hosting/acquia.mdx` (cache directory, `VORTEX_ACLI_PATH`, isolated auth, application auto-discovery) and added `acli` to `docs/cspell.json`.

**`task()` is the single callback-based task primitive**
- Reworked `task()` in `helpers.php` to `task(string $doing, string|\Closure|null $done = NULL, ?callable $body = NULL, bool $fatal = TRUE)`: given a body, it prints `[TASK]`, runs the body, then reports `[ OK ]` with the done message, or `[FAIL]` with the thrown exception's message. A fatal task then exits the script; a non-fatal one (`fatal: FALSE`) reports `[FAIL]` and returns `NULL` so a best-effort loop carries on to its next item.
- Added `progress_dot()` and `sleep_progress()` so long-running steps tick a dot once a second in the task's own colour instead of appearing to hang; `task()`'s body keeps the `[TASK]` line open so those dots render inline. The former `task_progress()` helper is subsumed by `task()`'s non-fatal mode, keeping every task in one place.
- Gave `request()` an `on_progress` callback option so downloads can report progress while the request layer itself stays output-agnostic.
- Updated `tests/Unit/HelpersFormatterTest.php` with body-form coverage for `task()` across its success, non-fatal and fatal outcomes.

**Every tooling script migrated to `task()`**
- Converted `vortex-deploy-artifact`, `vortex-deploy-lagoon`, `vortex-export-db-image`, `vortex-fetch-db-lagoon`, `vortex-notify-email`, `vortex-notify-github`, `vortex-notify-jira`, `vortex-notify-newrelic`, `vortex-notify-slack`, `vortex-notify-webhook`, `vortex-provision`, `vortex-task-copy-db-acquia`, `vortex-task-copy-files-acquia` and `vortex-task-purge-cache-acquia` to the callback-based `task()`, so every step now ends with an explicit OK/FAIL status.
- The Acquia cache-purge loop runs each domain under `task(..., fatal: FALSE)` so a missing or failing domain reports `[FAIL]` and the run continues to the next domain, and its `clear-varnish` POST now refreshes the access token once on a 401 and retries (matching the notification poller), so a long multi-domain purge no longer fails on an expired token.
- Updated `tests/Unit/TaskPurgeCacheAcquiaTest.php`, including coverage for the token-refresh path.

## Screenshots

N/A

## Before / After

```
┌──────────────────────────────────────────────────────────────────────┐
│ BEFORE - flat task() / pass() / fail()                               │
└──────────────────────────────────────────────────────────────────────┘
task('Sending notification to Slack');

$response = request_post($slack_webhook, $payload, ['Content-Type: application/json']);
if ($response['status'] !== 200) {
  fail('Unable to send notification to Slack. HTTP status: %s', $response['status']);
}

pass('Slack notification sent successfully.');

┌──────────────────────────────────────────────────────────────────────┐
│ AFTER - callback-based task(), body throws to fail                   │
└──────────────────────────────────────────────────────────────────────┘
task('Sending notification to Slack', 'Slack notification sent successfully.', function () use ($slack_webhook, $payload): void {
  $response = request_post($slack_webhook, $payload, ['Content-Type: application/json']);
  if ($response['status'] !== 200) {
    throw new \RuntimeException(sprintf('Unable to send notification to Slack. HTTP status: %s', $response['status']));
  }
});
```

```
┌──────────────────────────────────────────────────────────────────────┐
│ BEFORE - a best-effort loop dispatched on status strings             │
└──────────────────────────────────────────────────────────────────────┘
$result = task_progress(sprintf('Purging cache for %s domain %s.', $env, $domain), function () {
  ...
  return $ok ? 'completed' : 'missing';
});

if ($result === 'completed') {
  pass(sprintf('Purged cache for %s domain %s.', $env, $domain));
}
elseif ($result === 'missing') {
  fail_no_exit('Unable to purge cache for %s domain %s as it does not exist.', $env, $domain);
}

┌──────────────────────────────────────────────────────────────────────┐
│ AFTER - one task(), non-fatal so the loop carries on                 │
└──────────────────────────────────────────────────────────────────────┘
task(
  sprintf('Purging cache for %s domain %s.', $env, $domain),
  sprintf('Purged cache for %s domain %s.', $env, $domain),
  function () use (...): void {
    ...
    if ($notification_url === '') {
      throw new \RuntimeException(sprintf('Unable to purge cache for %s domain %s as it does not exist.', $env, $domain));
    }
  },
  fatal: FALSE,
);
```

```
┌──────────────────────────────────────────────────────────────────────┐
│ BEFORE - bespoke Acquia Cloud API HTTP calls                         │
└──────────────────────────────────────────────────────────────────────┘
task('Retrieving authentication token.');
$token = dl_acquia_api_get_token($acquia_key, $acquia_secret);

task(sprintf('Retrieving %s application UUID.', $app_name));
$app_uuid = dl_acquia_api_get_app_uuid($token, $app_name);

$backups_response = request_get(sprintf('https://cloud.acquia.com/api/environments/%s/databases/%s/backups?sort=created', $env_id, $db_name), ...);

┌──────────────────────────────────────────────────────────────────────┐
│ AFTER - provider-native acli, isolated env-passed auth, discovery    │
└──────────────────────────────────────────────────────────────────────┘
$bin = acli_resolve();                // PATH, or downloaded to a cache dir
$home = acli_home();                  // isolated ACLI_HOME, cleared + removed
$ctx = ['home' => $home, 'key' => $acquia_key, 'secret' => $acquia_secret];

$app = task('Auto-discovering the Acquia application.', ..., function () use ($bin, $ctx, $app_name): array {
  return acquia_select_app(acquia_items(acli_exec($bin, 'api:applications:list', $ctx)), $app_name);
});
```
