### PR TITLE
[#2775] Replaced third-party tool usage in tooling scripts with PHP-native implementations.

### DIFF
--- a/.vortex/tooling/README.md
+++ b/.vortex/tooling/README.md
@@ -16,6 +16,29 @@ composer require drevops/vortex-tooling
 Once installed, you run the shipped scripts as Composer binaries from
 `vendor/bin/vortex-<script-name>`.
 
+## Host requirements
+
+The scripts are PHP and use PHP internals wherever possible: HTTP requests go
+through the PHP `curl` extension, gzip archives are decompressed with the
+`zlib` stream wrapper, and file discovery, comparison and removal are native
+PHP. The remaining external commands are the tools whose job cannot be done
+in-process:
+
+- `docker` (with the `compose` plugin) - all container operations.
+- `git` - repository reset and artifact deployment.
+- `ssh-keygen`, `ssh-agent`, `ssh-add` - SSH key loading for deployments and
+  database downloads.
+- `unzip` - only when fetching a database dump from a `.zip` URL.
+- `pygmy`, `ahoy`, `lsof` - local development stack checks in `vortex-doctor`
+  (`lsof` is used only for the port check on macOS).
+- Hosting provider CLIs (`lagoon`, `acli`) - downloaded automatically when not
+  already installed on the host.
+
+Scripts that run inside the CLI container (`vortex-login`, `vortex-logout`,
+`vortex-info`, `vortex-provision`, database import/export) additionally rely on
+the project's `vendor/bin/drush` and the database client provided by the
+container image.
+
 ## Read-only mirror
 
 > [!IMPORTANT]

--- a/.vortex/tooling/src/helpers.php
+++ b/.vortex/tooling/src/helpers.php
@@ -1219,7 +1219,7 @@ function remove_dir(string $dir): void {
     return;
   }
 
-  $items = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
+  $items = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST, \RecursiveIteratorIterator::CATCH_GET_CHILD);
   foreach ($items as $item) {
     // @codeCoverageIgnoreStart
     if (!$item instanceof \SplFileInfo) {

--- a/.vortex/tooling/src/helpers.php
+++ b/.vortex/tooling/src/helpers.php
@@ -1156,6 +1156,40 @@ function copy_dir(string $src, string $dst): void {
 }
 
 /**
+ * Recursively walk a directory, invoking a visitor for every entry.
+ *
+ * Entries are visited top-down in alphabetical order. Symbolic links are
+ * visited as entries but never followed. Returning FALSE from the visitor for
+ * a directory entry prevents descending into that directory; any other return
+ * value continues the walk.
+ *
+ * @param string $dir
+ *   Directory to walk; a no-op when it does not exist or is not a directory.
+ * @param \Closure $visitor
+ *   Visitor receiving an \SplFileInfo for each entry.
+ */
+function walk_dir(string $dir, \Closure $visitor): void {
+  if (is_link($dir) || !is_dir($dir)) {
+    return;
+  }
+
+  $entries = scandir($dir) ?: [];
+
+  foreach ($entries as $entry) {
+    if ($entry === '.' || $entry === '..') {
+      continue;
+    }
+
+    $item = new \SplFileInfo($dir . '/' . $entry);
+    $descend = $visitor($item);
+
+    if ($descend !== FALSE && !$item->isLink() && $item->isDir()) {
+      walk_dir($item->getPathname(), $visitor);
+    }
+  }
+}
+
+/**
  * Recursively remove a directory and all of its contents.
  *
  * Best-effort, mirroring 'rm -rf': individual failures are suppressed rather

--- a/.vortex/tooling/src/helpers.php
+++ b/.vortex/tooling/src/helpers.php
@@ -772,48 +772,18 @@ function acli_home(): string {
 
   // A home left behind by a crashed run that reused this PID would hand acli
   // stale cached credentials; clear it so every run starts from a clean home.
-  acli_home_remove($home);
+  remove_dir($home);
   mkdir($home, 0755, TRUE);
 
   // The isolated home caches acli's token and state; remove it when the run
   // ends so no credentials linger on disk afterwards.
   register_shutdown_function(static function () use ($home): void {
     // @codeCoverageIgnoreStart
-    acli_home_remove($home);
+    remove_dir($home);
     // @codeCoverageIgnoreEnd
   });
 
   return $home;
-}
-
-/**
- * Recursively remove an isolated Acquia CLI home directory.
- *
- * @param string $home
- *   Path to the directory to remove; a no-op when it does not exist.
- */
-function acli_home_remove(string $home): void {
-  if (!is_dir($home)) {
-    return;
-  }
-
-  $items = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($home, \RecursiveDirectoryIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
-  foreach ($items as $item) {
-    // @codeCoverageIgnoreStart
-    if (!$item instanceof \SplFileInfo) {
-      continue;
-    }
-    // @codeCoverageIgnoreEnd
-
-    if ($item->isDir()) {
-      rmdir($item->getPathname());
-    }
-    else {
-      unlink($item->getPathname());
-    }
-  }
-
-  rmdir($home);
 }
 
 /**
@@ -1183,6 +1153,47 @@ function copy_dir(string $src, string $dst): void {
       copy($item->getPathname(), $target);
     }
   }
+}
+
+/**
+ * Recursively remove a directory and all of its contents.
+ *
+ * Best-effort, mirroring 'rm -rf': individual failures are suppressed rather
+ * than thrown, and a missing path is a no-op. Symbolic links are removed as
+ * links without following them, so a link into a tree outside the directory
+ * never triggers deletions there.
+ *
+ * @param string $dir
+ *   Path to the directory to remove.
+ */
+function remove_dir(string $dir): void {
+  if (is_link($dir)) {
+    @unlink($dir);
+
+    return;
+  }
+
+  if (!is_dir($dir)) {
+    return;
+  }
+
+  $items = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
+  foreach ($items as $item) {
+    // @codeCoverageIgnoreStart
+    if (!$item instanceof \SplFileInfo) {
+      continue;
+    }
+    // @codeCoverageIgnoreEnd
+
+    if (!$item->isLink() && $item->isDir()) {
+      @rmdir($item->getPathname());
+    }
+    else {
+      @unlink($item->getPathname());
+    }
+  }
+
+  @rmdir($dir);
 }
 
 /**

--- a/.vortex/tooling/src/helpers.php
+++ b/.vortex/tooling/src/helpers.php
@@ -773,7 +773,15 @@ function acli_home(): string {
   // A home left behind by a crashed run that reused this PID would hand acli
   // stale cached credentials; clear it so every run starts from a clean home.
   remove_dir($home);
-  mkdir($home, 0755, TRUE);
+  if (file_exists($home) || is_link($home)) {
+    FAIL('Unable to clear the acli home directory %s.', $home);
+  }
+
+  if (!mkdir($home, 0755, TRUE)) {
+    // @codeCoverageIgnoreStart
+    FAIL('Unable to create the acli home directory %s.', $home);
+    // @codeCoverageIgnoreEnd
+  }
 
   // The isolated home caches acli's token and state; remove it when the run
   // ends so no credentials linger on disk afterwards.

--- a/.vortex/tooling/src/vortex-deploy-artifact
+++ b/.vortex/tooling/src/vortex-deploy-artifact
@@ -71,8 +71,6 @@ $git_artifact_sha256 = getenv_default('VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_SHA25
 
 INFO('Started artifact deployment.');
 
-command_must_exist('curl');
-
 // Configure global git settings, if they do not exist.
 $global_git_name = trim((string) shell_exec('git config --global user.name'));
 if (empty($global_git_name)) {

--- a/.vortex/tooling/src/vortex-doctor
+++ b/.vortex/tooling/src/vortex-doctor
@@ -115,8 +115,13 @@ if ($check_tools === '1') {
 
 if ($check_port === '1' && PHP_OS_FAMILY !== 'Linux') {
   TASK('Checking port 80 availability.', 'Port 80 is available.', function (): void {
-    passthru("lsof -i :80 2>/dev/null | grep -v 'CLOSED' | grep 'LISTEN' | grep -vq 'om.docke'", $exit_code);
-    if ($exit_code === 0) {
+    $lsof_output = (string) shell_exec('lsof -i :80 2>/dev/null');
+
+    foreach (explode("\n", $lsof_output) as $line) {
+      if (str_contains($line, 'CLOSED') || !str_contains($line, 'LISTEN') || str_contains($line, 'om.docke')) {
+        continue;
+      }
+
       throw new \RuntimeException("Port 80 is occupied by a service other than Docker. Stop this service and run 'pygmy up'.");
     }
   });
@@ -143,10 +148,11 @@ if ($check_pygmy === '1') {
 
 if ($check_containers === '1') {
   TASK('Checking that containers are running.', 'All containers are running.', function (): void {
+    $running_services = array_map(trim(...), explode("\n", (string) shell_exec('docker compose ps --status=running --services 2>/dev/null')));
+
     $container_services = ['cli', 'appserver', 'webserver', 'database'];
     foreach ($container_services as $service) {
-      passthru(sprintf('docker compose ps --status=running --services 2>/dev/null | grep -q %s', escapeshellarg($service)), $exit_code);
-      if ($exit_code !== 0) {
+      if (!in_array($service, $running_services, TRUE)) {
         NOTE("Run 'ahoy up'.");
         NOTE("Run 'ahoy logs %s' to see error logs.", $service);
         throw new \RuntimeException(sprintf('%s container is not running.', $service));
@@ -158,8 +164,8 @@ if ($check_containers === '1') {
 if ($check_ssh === '1') {
   // Check that the key is injected into pygmy ssh-agent container.
   $ssh_key_added_to_pygmy = (bool) TASK('Checking that the SSH key is added to pygmy.', 'SSH key is added to pygmy.', function () use ($ssh_file): bool {
-    passthru(sprintf('pygmy status 2>&1 | grep -q %s', escapeshellarg($ssh_file)), $exit_code);
-    if ($exit_code !== 0) {
+    $status = str_replace("\0", '', (string) shell_exec('pygmy status 2>&1'));
+    if (!str_contains($status, $ssh_file)) {
       NOTE("The SSH key will not be available in the CLI container. Run 'pygmy restart' and then 'ahoy up'.");
       throw new \RuntimeException('SSH key is not added to pygmy.');
     }
@@ -230,7 +236,11 @@ echo PHP_EOL;
  * Sanitize system information output to remove PII data.
  */
 function sanitize_system_info(string $input): string {
-  $username = trim((string) shell_exec('whoami'));
+  $username = (string) getenv('USER');
+
+  if ($username === '' && function_exists('posix_getpwuid') && function_exists('posix_geteuid')) {
+    $username = (string) (posix_getpwuid(posix_geteuid())['name'] ?? '');
+  }
 
   $input = str_replace('/Users/' . $username . '/', '/Users/[USERNAME_REDACTED]/', $input);
   $input = str_replace('/home/' . $username . '/', '/home/[USERNAME_REDACTED]/', $input);

--- a/.vortex/tooling/src/vortex-fetch-db-container-registry
+++ b/.vortex/tooling/src/vortex-fetch-db-container-registry
@@ -54,9 +54,9 @@ command_must_exist('docker');
  *   TRUE when the image exists on the host.
  */
 function image_exists_on_host(string $image): bool {
-  $inspect_result = shell_exec(sprintf('docker image inspect %s >/dev/null 2>&1 && echo 1 || echo 0', escapeshellarg($image)));
+  passthru(sprintf('docker image inspect %s >/dev/null 2>&1', escapeshellarg($image)), $exit_code);
 
-  return trim((string) $inspect_result) === '1';
+  return $exit_code === 0;
 }
 
 INFO('Started database data container image download.');

--- a/.vortex/tooling/src/vortex-fetch-db-url
+++ b/.vortex/tooling/src/vortex-fetch-db-url
@@ -83,7 +83,7 @@ if (str_ends_with($url, '.zip')) {
     NOTE('Discovering database file in archive.');
     $extracted_files = [];
     walk_dir($temp_dir, function (\SplFileInfo $item) use (&$extracted_files): void {
-      if ($item->isFile()) {
+      if ($item->isFile() && !$item->isLink()) {
         $extracted_files[] = $item->getPathname();
       }
     });

--- a/.vortex/tooling/src/vortex-fetch-db-url
+++ b/.vortex/tooling/src/vortex-fetch-db-url
@@ -81,14 +81,13 @@ if (str_ends_with($url, '.zip')) {
 
     // Find the first regular file in the extracted content.
     NOTE('Discovering database file in archive.');
-    $extracted_file = '';
-    $items = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($temp_dir, \RecursiveDirectoryIterator::SKIP_DOTS));
-    foreach ($items as $item) {
-      if ($item instanceof \SplFileInfo && $item->isFile()) {
-        $extracted_file = $item->getPathname();
-        break;
+    $extracted_files = [];
+    walk_dir($temp_dir, function (\SplFileInfo $item) use (&$extracted_files): void {
+      if ($item->isFile()) {
+        $extracted_files[] = $item->getPathname();
       }
-    }
+    });
+    $extracted_file = $extracted_files[0] ?? '';
 
     if ($extracted_file === '') {
       remove_dir($temp_dir);

--- a/.vortex/tooling/src/vortex-fetch-db-url
+++ b/.vortex/tooling/src/vortex-fetch-db-url
@@ -74,18 +74,24 @@ if (str_ends_with($url, '.zip')) {
 
     if ($exit_code !== 0) {
       // Clean up on failure.
-      shell_exec('rm -rf ' . escapeshellarg($temp_dir));
+      remove_dir($temp_dir);
       @unlink($zip_file);
       throw new \RuntimeException('Failed to extract zip file.');
     }
 
     // Find the first regular file in the extracted content.
     NOTE('Discovering database file in archive.');
-    $extracted_file = shell_exec('find ' . escapeshellarg($temp_dir) . ' -type f -print | head -n 1');
-    $extracted_file = $extracted_file !== NULL ? trim($extracted_file) : '';
+    $extracted_file = '';
+    $items = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($temp_dir, \RecursiveDirectoryIterator::SKIP_DOTS));
+    foreach ($items as $item) {
+      if ($item instanceof \SplFileInfo && $item->isFile()) {
+        $extracted_file = $item->getPathname();
+        break;
+      }
+    }
 
     if ($extracted_file === '') {
-      shell_exec('rm -rf ' . escapeshellarg($temp_dir));
+      remove_dir($temp_dir);
       @unlink($zip_file);
       throw new \RuntimeException('No files found in the zip archive.');
     }
@@ -94,7 +100,7 @@ if (str_ends_with($url, '.zip')) {
     rename($extracted_file, $dest);
 
     NOTE('Cleaning up temporary files.');
-    shell_exec('rm -rf ' . escapeshellarg($temp_dir));
+    remove_dir($temp_dir);
     @unlink($zip_file);
   });
 }

--- a/.vortex/tooling/src/vortex-info
+++ b/.vortex/tooling/src/vortex-info
@@ -57,8 +57,8 @@ if ($selenium_vnc_port !== '') {
 NOTE('Mailhog URL                 : http://mailhog.docker.amazee.io/');
 
 // Check Xdebug status.
-passthru('php -v 2>/dev/null | grep -q Xdebug', $exit_code);
-$xdebug_status = $exit_code === 0
+$php_version = (string) shell_exec('php -v 2>/dev/null');
+$xdebug_status = str_contains($php_version, 'Xdebug')
   ? "Enabled ('ahoy up cli' to disable)"
   : "Disabled ('ahoy debug' to enable)";
 NOTE('Xdebug                      : %s', $xdebug_status);

--- a/.vortex/tooling/src/vortex-login
+++ b/.vortex/tooling/src/vortex-login
@@ -23,13 +23,18 @@ $unblock_admin = getenv_default('VORTEX_LOGIN_UNBLOCK_ADMIN', 'VORTEX_UNBLOCK_AD
 
 if ($unblock_admin === '1') {
   // Check if the password_policy module is enabled.
-  passthru('./vendor/bin/drush -y pm:list --status=enabled 2>/dev/null | grep -q password_policy', $exit_code);
-  if ($exit_code === 0) {
+  $enabled_modules = (string) shell_exec('./vendor/bin/drush -y pm:list --status=enabled 2>/dev/null');
+  if (str_contains($enabled_modules, 'password_policy')) {
     passthru('./vendor/bin/drush -y sql:query \'UPDATE `user__field_password_expiration` SET `field_password_expiration_value` = 0 WHERE `bundle` = "user" AND `entity_id` = 1;\' >/dev/null', $exit_code);
   }
 
   // Unblock the admin user.
-  passthru('./vendor/bin/drush -y sql:query "SELECT name FROM \\`users_field_data\\` WHERE \\`uid\\` = \'1\';" | head -n 1 | xargs ./vendor/bin/drush -y -- user:unblock 2>/dev/null', $exit_code);
+  $admin_name_output = (string) shell_exec('./vendor/bin/drush -y sql:query "SELECT name FROM \\`users_field_data\\` WHERE \\`uid\\` = \'1\';"');
+  $admin_name = trim(explode("\n", trim($admin_name_output))[0]);
+
+  if ($admin_name !== '') {
+    passthru(sprintf('./vendor/bin/drush -y -- user:unblock %s 2>/dev/null', escapeshellarg($admin_name)), $exit_code);
+  }
 }
 
 passthru_or_fail('./vendor/bin/drush -y user:login');

--- a/.vortex/tooling/src/vortex-logout
+++ b/.vortex/tooling/src/vortex-logout
@@ -22,5 +22,10 @@ $block_admin = getenv_default('VORTEX_LOGOUT_BLOCK_ADMIN', 'VORTEX_UNBLOCK_ADMIN
 // -----------------------------------------------------------------------------
 
 if ($block_admin === '1') {
-  passthru_or_fail('./vendor/bin/drush -y sql:query "SELECT name FROM \\`users_field_data\\` WHERE \\`uid\\` = \'1\';" | head -n 1 | xargs ./vendor/bin/drush -y -- user:block', 'Failed to block admin user.');
+  $admin_name_output = (string) shell_exec('./vendor/bin/drush -y sql:query "SELECT name FROM \\`users_field_data\\` WHERE \\`uid\\` = \'1\';"');
+  $admin_name = trim(explode("\n", trim($admin_name_output))[0]);
+
+  if ($admin_name !== '') {
+    passthru_or_fail(sprintf('./vendor/bin/drush -y -- user:block %s', escapeshellarg($admin_name)), 'Failed to block admin user.');
+  }
 }

--- a/.vortex/tooling/src/vortex-provision
+++ b/.vortex/tooling/src/vortex-provision
@@ -116,6 +116,58 @@ function yesno(string $value): string {
 }
 
 /**
+ * Compare two directories recursively and describe the differences.
+ *
+ * Mirrors the 'diff -rq' report: entries present on one side only and files
+ * whose contents differ.
+ *
+ * @param string $dir1
+ *   First directory.
+ * @param string $dir2
+ *   Second directory.
+ *
+ * @return array<int,string>
+ *   Human-readable difference lines; empty when the directories match.
+ */
+function compare_dirs(string $dir1, string $dir2): array {
+  $list_files = function (string $dir): array {
+    $files = [];
+
+    $items = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS));
+    foreach ($items as $item) {
+      if ($item instanceof \SplFileInfo && $item->isFile()) {
+        $files[] = substr($item->getPathname(), strlen($dir) + 1);
+      }
+    }
+
+    sort($files);
+
+    return $files;
+  };
+
+  $files1 = $list_files($dir1);
+  $files2 = $list_files($dir2);
+
+  $differences = [];
+
+  foreach (array_diff($files1, $files2) as $file) {
+    $differences[] = sprintf('Only in %s: %s', $dir1, $file);
+  }
+
+  foreach (array_diff($files2, $files1) as $file) {
+    $differences[] = sprintf('Only in %s: %s', $dir2, $file);
+  }
+
+  foreach (array_intersect($files1, $files2) as $file) {
+    if (filesize($dir1 . '/' . $file) !== filesize($dir2 . '/' . $file) || file_get_contents($dir1 . '/' . $file) !== file_get_contents($dir2 . '/' . $file)) {
+      $differences[] = sprintf('Files %s and %s differ', $dir1 . '/' . $file, $dir2 . '/' . $file);
+    }
+  }
+
+  return $differences;
+}
+
+/**
  * Provision site from database dump file.
  *
  * @param string $provision_db
@@ -322,10 +374,6 @@ NOTE('Verify config after update     : %s', yesno($provision_verify_config));
 NOTE('Use maintenance mode           : %s', yesno($provision_use_maintenance_mode));
 echo PHP_EOL;
 
-if ($provision_verify_config === '1') {
-  command_must_exist('diff');
-}
-
 // Provision site from DB dump or profile.
 //
 // The code block below has explicit if-else conditions and verbose output to
@@ -474,7 +522,9 @@ if ($provision_verify_config === '1' && $site_has_config_files) {
   $config_after = $config_tmp_dir . '/config_after_' . uniqid();
 
   TASK('Exporting configuration before database updates.', 'Exported configuration before database updates.', function () use ($config_before): void {
-    mkdir($config_before, 0755, TRUE);
+    if (!is_dir($config_before)) {
+      mkdir($config_before, 0755, TRUE);
+    }
     drush('config:export --destination=' . escapeshellarg($config_before));
   });
 
@@ -483,23 +533,26 @@ if ($provision_verify_config === '1' && $site_has_config_files) {
   });
 
   TASK('Exporting configuration after database updates.', 'Exported configuration after database updates.', function () use ($config_after): void {
-    mkdir($config_after, 0755, TRUE);
+    if (!is_dir($config_after)) {
+      mkdir($config_after, 0755, TRUE);
+    }
     drush('config:export --destination=' . escapeshellarg($config_after));
   });
 
   TASK('Verifying that database updates did not change configuration.', 'Verified that database updates did not change configuration.', function () use ($config_before, $config_after): void {
-    $config_diff = (string) shell_exec('diff -rq ' . escapeshellarg($config_before) . ' ' . escapeshellarg($config_after) . ' 2>&1');
+    $config_diff = compare_dirs($config_before, $config_after);
 
-    if (!empty(trim($config_diff))) {
+    if ($config_diff !== []) {
       NOTE('The following configuration files were changed:');
-      echo $config_diff . PHP_EOL;
+      echo implode(PHP_EOL, $config_diff) . PHP_EOL;
       NOTE('Configuration before updates: %s', $config_before);
       NOTE('Configuration after updates:  %s', $config_after);
       NOTE('Review the update hooks and manually export updated configuration.');
       throw new \RuntimeException('Configuration was changed by database updates.');
     }
 
-    shell_exec('rm -rf ' . escapeshellarg($config_before) . ' ' . escapeshellarg($config_after));
+    remove_dir($config_before);
+    remove_dir($config_after);
   });
 }
 else {

--- a/.vortex/tooling/src/vortex-provision
+++ b/.vortex/tooling/src/vortex-provision
@@ -133,12 +133,11 @@ function compare_dirs(string $dir1, string $dir2): array {
   $list_files = function (string $dir): array {
     $files = [];
 
-    $items = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS));
-    foreach ($items as $item) {
-      if ($item instanceof \SplFileInfo && $item->isFile()) {
+    walk_dir($dir, function (\SplFileInfo $item) use (&$files, $dir): void {
+      if ($item->isFile()) {
         $files[] = substr($item->getPathname(), strlen($dir) + 1);
       }
-    }
+    });
 
     sort($files);
 

--- a/.vortex/tooling/src/vortex-reset
+++ b/.vortex/tooling/src/vortex-reset
@@ -28,19 +28,50 @@ $is_hard_reset = in_array('--hard', array_slice($GLOBALS['argv'], 1), TRUE);
 INFO('Started reset.');
 
 TASK('Removing dependencies and built assets.', 'Removed dependencies and built assets.', function () use ($webroot): void {
-  passthru(sprintf('rm -rf "./vendor" "./%s/core" "./%s/profiles/contrib" "./%s/modules/contrib" "./%s/themes/contrib" "./%s/themes/custom/*/build" "./%s/themes/custom/*/scss/_components.scss"', $webroot, $webroot, $webroot, $webroot, $webroot, $webroot));
+  $patterns = ['./vendor', sprintf('./%s/core', $webroot), sprintf('./%s/profiles/contrib', $webroot), sprintf('./%s/modules/contrib', $webroot), sprintf('./%s/themes/contrib', $webroot), sprintf('./%s/themes/custom/*/build', $webroot), sprintf('./%s/themes/custom/*/scss/_components.scss', $webroot)];
+
+  foreach ($patterns as $pattern) {
+    foreach (glob($pattern) ?: [] as $path) {
+      if (is_dir($path) && !is_link($path)) {
+        remove_dir($path);
+      }
+      else {
+        @unlink($path);
+      }
+    }
+  }
 });
 
 TASK('Removing node_modules directories.', 'Removed node_modules directories.', function (): void {
-  passthru('find . -type d -name node_modules -prune -exec rm -Rf -- {} +', $exit_code);
-  if ($exit_code !== 0) {
-    throw new \RuntimeException('Failed to remove node_modules directories.');
-  }
+  walk_dir('.', function (\SplFileInfo $item): bool {
+    if (!$item->isLink() && $item->isDir() && $item->getFilename() === 'node_modules') {
+      remove_dir($item->getPathname());
+
+      return FALSE;
+    }
+
+    return TRUE;
+  });
 });
 
 if ($is_hard_reset) {
   TASK('Changing permissions and removing all other untracked files.', 'Changed permissions and removed all other untracked files.', function (): void {
-    passthru('git ls-files --others -i --exclude-from=.gitignore -z | xargs -0 -r sh -c \'for f in "$@"; do chmod 777 "$f" 2>/dev/null; rm -rf "$f" 2>/dev/null; done\' _');
+    $ignored_files = (string) shell_exec('git ls-files --others -i --exclude-from=.gitignore -z');
+
+    foreach (explode("\0", $ignored_files) as $file) {
+      if ($file === '') {
+        continue;
+      }
+
+      @chmod($file, 0777);
+
+      if (is_dir($file) && !is_link($file)) {
+        remove_dir($file);
+      }
+      else {
+        @unlink($file);
+      }
+    }
   });
 
   TASK('Resetting repository files.', 'Reset repository files.', function (): void {
@@ -58,7 +89,31 @@ if ($is_hard_reset) {
   });
 
   TASK('Removing empty directories.', 'Removed empty directories.', function (): void {
-    passthru('find . -type d -not -path "./.git/*" -empty -delete');
+    $dirs = [];
+
+    walk_dir('.', function (\SplFileInfo $item) use (&$dirs): bool {
+      if ($item->isLink() || !$item->isDir()) {
+        return TRUE;
+      }
+
+      if ($item->getPathname() === './.git') {
+        return FALSE;
+      }
+
+      $dirs[] = $item->getPathname();
+
+      return TRUE;
+    });
+
+    // Bottom-up so that directories which only contained empty directories
+    // become empty themselves and are removed in the same pass.
+    usort($dirs, static fn(string $a, string $b): int => substr_count($b, '/') <=> substr_count($a, '/'));
+
+    foreach ($dirs as $dir) {
+      if (scandir($dir) === ['.', '..']) {
+        @rmdir($dir);
+      }
+    }
   });
 }
 

--- a/.vortex/tooling/src/vortex-reset
+++ b/.vortex/tooling/src/vortex-reset
@@ -28,7 +28,7 @@ $is_hard_reset = in_array('--hard', array_slice($GLOBALS['argv'], 1), TRUE);
 INFO('Started reset.');
 
 TASK('Removing dependencies and built assets.', 'Removed dependencies and built assets.', function () use ($webroot): void {
-  $patterns = ['./vendor', sprintf('./%s/core', $webroot), sprintf('./%s/profiles/contrib', $webroot), sprintf('./%s/modules/contrib', $webroot), sprintf('./%s/themes/contrib', $webroot), sprintf('./%s/themes/custom/*/build', $webroot), sprintf('./%s/themes/custom/*/scss/_components.scss', $webroot)];
+  $patterns = ['./vendor', sprintf('./%s/core', $webroot), sprintf('./%s/profiles/contrib', $webroot), sprintf('./%s/modules/contrib', $webroot), sprintf('./%s/themes/contrib', $webroot), sprintf('./%s/themes/custom/*/build', $webroot)];
 
   foreach ($patterns as $pattern) {
     foreach (glob($pattern) ?: [] as $path) {

--- a/.vortex/tooling/tests/Unit/DoctorTest.php
+++ b/.vortex/tooling/tests/Unit/DoctorTest.php
@@ -78,18 +78,11 @@ class DoctorTest extends UnitTestCase {
 
     $os_cmd = PHP_OS === 'Darwin' ? 'sw_vers' : 'lsb_release -a 2>/dev/null';
 
-    // shell_exec calls in order:
-    // 1. whoami (sanitize docker_path), 2. docker info,
-    // 3. whoami (sanitize docker_info), 4. whoami (sanitize dc_path),
-    // 5. whoami (sanitize pygmy_path), 6. whoami (sanitize ahoy_path).
-    $this->mockShellExecMultiple([
-      ['value' => 'testuser'],
-      ['value' => 'Docker Server Version: 20.10.0'],
-      ['value' => 'testuser'],
-      ['value' => 'testuser'],
-      ['value' => 'testuser'],
-      ['value' => 'testuser'],
-    ]);
+    $this->envSet('USER', 'testuser');
+
+    // The only shell_exec call is 'docker info'; its output must have the
+    // username redacted by sanitize_system_info().
+    $this->mockShellExec('Docker Server Version: 20.10.0 at /Users/testuser/docker');
 
     // Passthru calls in order.
     $this->mockPassthru(['cmd' => $os_cmd, 'result_code' => 0]);
@@ -112,6 +105,8 @@ class DoctorTest extends UnitTestCase {
         '* DOCKER-COMPOSE V1',
         '* PYGMY',
         '* AHOY',
+        '* at /Users/[USERNAME_REDACTED]/docker',
+        '! /Users/testuser/',
         '! Docker is not running',
       ]);
 
@@ -124,15 +119,10 @@ class DoctorTest extends UnitTestCase {
 
     $os_cmd = PHP_OS === 'Darwin' ? 'sw_vers' : 'lsb_release -a 2>/dev/null';
 
-    // shell_exec calls — docker info returns empty (docker not running).
-    // No whoami call for docker_info since sanitize_system_info is not called.
-    $this->mockShellExecMultiple([
-      ['value' => 'testuser'],
-      ['value' => ''],
-      ['value' => 'testuser'],
-      ['value' => 'testuser'],
-      ['value' => 'testuser'],
-    ]);
+    $this->envSet('USER', 'testuser');
+
+    // The 'docker info' shell_exec call returns empty (docker not running).
+    $this->mockShellExec('');
 
     $this->mockPassthru(['cmd' => $os_cmd, 'result_code' => 0]);
     $this->mockPassthru(['cmd' => 'docker -v', 'result_code' => 0]);
@@ -155,13 +145,43 @@ class DoctorTest extends UnitTestCase {
     }
   }
 
+  public function testDoctorInfoUsernameFromPosix(): void {
+    $GLOBALS['argv'] = ['doctor', 'info'];
+
+    $os_cmd = PHP_OS === 'Darwin' ? 'sw_vers' : 'lsb_release -a 2>/dev/null';
+
+    // With no USER in the environment, the username comes from posix.
+    $this->envSet('USER', '');
+    $this->registerMock('posix_geteuid', 'DrevOps\\VortexTooling', static fn(): int => 501);
+    $this->registerMock('posix_getpwuid', 'DrevOps\\VortexTooling', static fn(int $euid): array => ['name' => 'posixuser']);
+
+    $this->mockShellExec('Docker Server Version: 20.10.0 at /home/posixuser/docker');
+
+    $this->mockPassthru(['cmd' => $os_cmd, 'result_code' => 0]);
+    $this->mockPassthru(['cmd' => 'docker -v', 'result_code' => 0]);
+    $this->mockPassthru(['cmd' => 'docker compose version 2>/dev/null || echo "Docker Compose V2 is not installed."', 'result_code' => 0]);
+    $this->mockPassthru(['cmd' => 'docker-compose version 2>/dev/null || echo "Docker Compose V1 is not installed."', 'result_code' => 0]);
+    $this->mockPassthru(['cmd' => 'pygmy version 2>/dev/null || echo "Pygmy is not installed."', 'result_code' => 0]);
+    $this->mockPassthru(['cmd' => 'ahoy --version 2>/dev/null || echo "Ahoy is not installed."', 'result_code' => 0]);
+
+    try {
+      $this->runScript('src/vortex-doctor', 0);
+    }
+    catch (QuitSuccessException $e) {
+      $this->assertStringContainsOrNot($e->getOutput(), [
+        '* at /home/[USERNAME_REDACTED]/docker',
+        '! /home/posixuser/',
+      ]);
+
+      throw $e;
+    }
+  }
+
   public static function dataProviderDoctor(): array {
-    $container_cmd = fn(string $s): array => ['cmd' => sprintf("docker compose ps --status=running --services 2>/dev/null | grep -q '%s'", $s), 'result_code' => 0];
-    $container_fail = fn(string $s): array => ['cmd' => sprintf("docker compose ps --status=running --services 2>/dev/null | grep -q '%s'", $s), 'result_code' => 1];
-    $containers_running = fn(): array => [$container_cmd('cli'), $container_cmd('appserver'), $container_cmd('webserver'), $container_cmd('database')];
+    $containers_running = fn(): array => [['shell_exec' => "cli\nappserver\nwebserver\ndatabase"]];
 
     $ssh_file = '/home/testuser/.ssh/id_rsa';
-    $ssh_pygmy_cmd = fn(int $code): array => ['cmd' => sprintf("pygmy status 2>&1 | grep -q '%s'", $ssh_file), 'result_code' => $code];
+    $ssh_pygmy_status = fn(bool $added): array => ['shell_exec' => 'amazeeio-ssh-agent: Running' . ($added ? "\nssh-key: " . $ssh_file : '')];
     $ssh_volume_cmd = fn(int $code): array => ['cmd' => 'docker compose exec -T cli bash -c \'grep "^/dev" /etc/mtab | grep -q /tmp/amazeeio_ssh-agent\'', 'result_code' => $code];
     $ssh_key_cmd = fn(int $code): array => ['cmd' => 'docker compose exec -T cli bash -c "ssh-add -L | grep -q \'ssh-rsa\'"', 'result_code' => $code];
 
@@ -209,12 +229,22 @@ class DoctorTest extends UnitTestCase {
 
       'container not running' => [
         ['VORTEX_DOCTOR_CHECK_CONTAINERS' => '1'],
-        [$container_fail('cli')],
+        [['shell_exec' => "appserver\nwebserver\ndatabase"]],
         [
           '* [INFO] Checking project requirements.',
           '* [FAIL] cli container is not running.',
           "* Run 'ahoy up'.",
           "* Run 'ahoy logs cli' to see error logs.",
+        ],
+        TRUE,
+      ],
+
+      'container name is not matched as a substring' => [
+        ['VORTEX_DOCTOR_CHECK_CONTAINERS' => '1'],
+        [['shell_exec' => "clix\nappserver\nwebserver\ndatabase"]],
+        [
+          '* [INFO] Checking project requirements.',
+          '* [FAIL] cli container is not running.',
         ],
         TRUE,
       ],
@@ -246,7 +276,7 @@ class DoctorTest extends UnitTestCase {
           'VORTEX_DOCTOR_CHECK_SSH' => '1',
           'VORTEX_SSH_FILE' => $ssh_file,
         ],
-        [$ssh_pygmy_cmd(0), $ssh_volume_cmd(0), $ssh_key_cmd(0)],
+        [$ssh_pygmy_status(TRUE), $ssh_volume_cmd(0), $ssh_key_cmd(0)],
         [
           '* [INFO] Checking project requirements.',
           '* [ OK ] SSH key is available within the CLI container.',
@@ -260,7 +290,7 @@ class DoctorTest extends UnitTestCase {
           'VORTEX_DOCTOR_CHECK_SSH' => '1',
           'VORTEX_SSH_FILE' => $ssh_file,
         ],
-        [$ssh_pygmy_cmd(1), $ssh_volume_cmd(0)],
+        [$ssh_pygmy_status(FALSE), $ssh_volume_cmd(0)],
         [
           '* [INFO] Checking project requirements.',
           '* [FAIL] SSH key is not added to pygmy.',
@@ -275,7 +305,7 @@ class DoctorTest extends UnitTestCase {
           'VORTEX_DOCTOR_CHECK_SSH' => '1',
           'VORTEX_SSH_FILE' => $ssh_file,
         ],
-        [$ssh_pygmy_cmd(0), $ssh_volume_cmd(1)],
+        [$ssh_pygmy_status(TRUE), $ssh_volume_cmd(1)],
         [
           '* [INFO] Checking project requirements.',
           '* [FAIL] SSH key volume is not mounted into CLI container.',
@@ -293,7 +323,7 @@ class DoctorTest extends UnitTestCase {
           'VORTEX_DOCTOR_CHECK_SSH' => '1',
           'VORTEX_SSH_FILE' => $ssh_file,
         ],
-        [$ssh_pygmy_cmd(0), $ssh_volume_cmd(0), $ssh_key_cmd(1)],
+        [$ssh_pygmy_status(TRUE), $ssh_volume_cmd(0), $ssh_key_cmd(1)],
         [
           '* [INFO] Checking project requirements.',
           "* [FAIL] SSH key was not added to the container. Run 'pygmy restart'.",

--- a/.vortex/tooling/tests/Unit/ExportDbTest.php
+++ b/.vortex/tooling/tests/Unit/ExportDbTest.php
@@ -37,7 +37,7 @@ class ExportDbTest extends UnitTestCase {
    * only available in the global scope. When require'd inside a function,
    * we need to define it as a local variable.
    */
-  protected function runScript(string $script_path, ?int $early_exit_code = NULL): string {
+  protected function runScript(string $script_path, ?int $early_exit_code = NULL, ?string $cwd = NULL): string {
     // @phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UnusedVariable
     $argv = $GLOBALS['argv'] ?? [];
 
@@ -57,7 +57,7 @@ class ExportDbTest extends UnitTestCase {
       // @codeCoverageIgnoreEnd
     }
 
-    chdir($root);
+    chdir($cwd ?? $root);
 
     if (!is_null($early_exit_code)) {
       if ($early_exit_code > 0) {

--- a/.vortex/tooling/tests/Unit/FetchDbContainerRegistryTest.php
+++ b/.vortex/tooling/tests/Unit/FetchDbContainerRegistryTest.php
@@ -55,14 +55,10 @@ class FetchDbContainerRegistryTest extends UnitTestCase {
     file_put_contents($db_dir . '/db.tar', 'fake-tar-data');
 
     // Initial inspect: not found. After docker load: found.
-    $this->mockShellExecMultiple([
-      ['value' => '0'],
-      ['value' => '1'],
-    ]);
-
-    $this->mockPassthru([
-      'cmd' => sprintf('docker load -q --input %s', escapeshellarg($db_dir . '/db.tar')),
-      'result_code' => 0,
+    $this->mockPassthruMultiple([
+      ['cmd' => 'docker image inspect ' . escapeshellarg('myorg/mydb') . ' >/dev/null 2>&1', 'result_code' => 1],
+      ['cmd' => sprintf('docker load -q --input %s', escapeshellarg($db_dir . '/db.tar')), 'result_code' => 0],
+      ['cmd' => 'docker image inspect ' . escapeshellarg('myorg/mydb') . ' >/dev/null 2>&1', 'result_code' => 0],
     ]);
 
     $output = $this->runScript('src/vortex-fetch-db-container-registry');
@@ -78,15 +74,18 @@ class FetchDbContainerRegistryTest extends UnitTestCase {
     file_put_contents($db_dir . '/db.tar', 'fake-tar-data');
 
     // Initial inspect: not found. After docker load: still not found.
-    $this->mockShellExecMultiple([
-      ['value' => '0'],
-      ['value' => '0'],
-    ]);
-
     $this->mockPassthruMultiple([
+      [
+        'cmd' => 'docker image inspect ' . escapeshellarg('myorg/mydb') . ' >/dev/null 2>&1',
+        'result_code' => 1,
+      ],
       [
         'cmd' => sprintf('docker load -q --input %s', escapeshellarg($db_dir . '/db.tar')),
         'result_code' => 0,
+      ],
+      [
+        'cmd' => 'docker image inspect ' . escapeshellarg('myorg/mydb') . ' >/dev/null 2>&1',
+        'result_code' => 1,
       ],
       [
         'cmd' => self::$srcDir . '/vortex-login-container-registry',
@@ -108,9 +107,11 @@ class FetchDbContainerRegistryTest extends UnitTestCase {
   public function testNoArchivePullFromRegistry(): void {
     mkdir(self::$tmp . '/data', 0755, TRUE);
 
-    $this->mockShellExec('0');
-
     $this->mockPassthruMultiple([
+      [
+        'cmd' => 'docker image inspect ' . escapeshellarg('myorg/mydb') . ' >/dev/null 2>&1',
+        'result_code' => 1,
+      ],
       [
         'cmd' => self::$srcDir . '/vortex-login-container-registry',
         'result_code' => 0,
@@ -131,9 +132,11 @@ class FetchDbContainerRegistryTest extends UnitTestCase {
     mkdir(self::$tmp . '/data', 0755, TRUE);
     $this->envSet('VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE_BASE', 'myorg/mydb-base');
 
-    $this->mockShellExec('0');
-
     $this->mockPassthruMultiple([
+      [
+        'cmd' => 'docker image inspect ' . escapeshellarg('myorg/mydb') . ' >/dev/null 2>&1',
+        'result_code' => 1,
+      ],
       [
         'cmd' => self::$srcDir . '/vortex-login-container-registry',
         'result_code' => 0,
@@ -154,9 +157,11 @@ class FetchDbContainerRegistryTest extends UnitTestCase {
     mkdir(self::$tmp . '/data', 0755, TRUE);
 
     // Initial inspect: found on host. Still pulls from registry (no archive).
-    $this->mockShellExec('1');
-
     $this->mockPassthruMultiple([
+      [
+        'cmd' => 'docker image inspect ' . escapeshellarg('myorg/mydb') . ' >/dev/null 2>&1',
+        'result_code' => 0,
+      ],
       [
         'cmd' => self::$srcDir . '/vortex-login-container-registry',
         'result_code' => 0,
@@ -176,9 +181,11 @@ class FetchDbContainerRegistryTest extends UnitTestCase {
   public function testPullFails(): void {
     mkdir(self::$tmp . '/data', 0755, TRUE);
 
-    $this->mockShellExec('0');
-
     $this->mockPassthruMultiple([
+      [
+        'cmd' => 'docker image inspect ' . escapeshellarg('myorg/mydb') . ' >/dev/null 2>&1',
+        'result_code' => 1,
+      ],
       [
         'cmd' => self::$srcDir . '/vortex-login-container-registry',
         'result_code' => 0,
@@ -195,11 +202,15 @@ class FetchDbContainerRegistryTest extends UnitTestCase {
   public function testLoginFails(): void {
     mkdir(self::$tmp . '/data', 0755, TRUE);
 
-    $this->mockShellExec('0');
-
-    $this->mockPassthru([
-      'cmd' => self::$srcDir . '/vortex-login-container-registry',
-      'result_code' => 1,
+    $this->mockPassthruMultiple([
+      [
+        'cmd' => 'docker image inspect ' . escapeshellarg('myorg/mydb') . ' >/dev/null 2>&1',
+        'result_code' => 1,
+      ],
+      [
+        'cmd' => self::$srcDir . '/vortex-login-container-registry',
+        'result_code' => 1,
+      ],
     ]);
 
     $this->runScriptError('src/vortex-fetch-db-container-registry', 'Failed to login to the container registry');

--- a/.vortex/tooling/tests/Unit/FetchDbUrlTest.php
+++ b/.vortex/tooling/tests/Unit/FetchDbUrlTest.php
@@ -71,6 +71,11 @@ class FetchDbUrlTest extends UnitTestCase {
           File::mkdir($temp_dir);
           File::dump($temp_dir . '/extracted_db.sql', 'SQL CONTENT');
 
+          // A symlink sorting before the dump file must be skipped by the
+          // discovery so the link itself is never moved as the dump.
+          File::dump(self::$tmp . '/outside.txt', 'OUTSIDE');
+          symlink(self::$tmp . '/outside.txt', $temp_dir . '/a_link');
+
           $test->mockRequestMultiple([
             ['url' => 'https://example.com/db.zip', 'method' => 'GET', 'response' => []],
           ]);
@@ -85,6 +90,7 @@ class FetchDbUrlTest extends UnitTestCase {
           $test->assertSame('SQL CONTENT', file_get_contents(self::$tmp . '/data/db.sql'));
           $test->assertDirectoryDoesNotExist(self::$tmp . '/data/tmp_extract_12345');
           $test->assertFileDoesNotExist(self::$tmp . '/data/db.sql.zip');
+          $test->assertFileExists(self::$tmp . '/outside.txt');
         },
       ],
       'zip extraction with password' => [

--- a/.vortex/tooling/tests/Unit/FetchDbUrlTest.php
+++ b/.vortex/tooling/tests/Unit/FetchDbUrlTest.php
@@ -78,13 +78,14 @@ class FetchDbUrlTest extends UnitTestCase {
             'cmd' => sprintf('unzip -o %s -d %s', escapeshellarg($db_dir . '/db.sql.zip'), escapeshellarg($temp_dir)),
             'result_code' => 0,
           ]);
-          $test->mockShellExecMultiple([
-            ['value' => $temp_dir . '/extracted_db.sql' . "\n"],
-            ['value' => ''],
-          ]);
         },
         'expected' => ['Extracting the database dump from the zip archive.', 'Finished database dump download from URL.'],
-        'after' => NULL,
+        'after' => function (self $test): void {
+          $test->assertFileExists(self::$tmp . '/data/db.sql');
+          $test->assertSame('SQL CONTENT', file_get_contents(self::$tmp . '/data/db.sql'));
+          $test->assertDirectoryDoesNotExist(self::$tmp . '/data/tmp_extract_12345');
+          $test->assertFileDoesNotExist(self::$tmp . '/data/db.sql.zip');
+        },
       ],
       'zip extraction with password' => [
         'before' => function (self $test): void {
@@ -107,13 +108,14 @@ class FetchDbUrlTest extends UnitTestCase {
             'cmd' => sprintf('unzip -o -P %s %s -d %s', escapeshellarg('secret'), escapeshellarg($db_dir . '/db.sql.zip'), escapeshellarg($temp_dir)),
             'result_code' => 0,
           ]);
-          $test->mockShellExecMultiple([
-            ['value' => $temp_dir . '/extracted_db.sql' . "\n"],
-            ['value' => ''],
-          ]);
         },
         'expected' => ['Unzipping password-protected', 'Finished database dump download from URL.'],
-        'after' => NULL,
+        'after' => function (self $test): void {
+          $test->assertFileExists(self::$tmp . '/data/db.sql');
+          $test->assertSame('SQL CONTENT', file_get_contents(self::$tmp . '/data/db.sql'));
+          $test->assertDirectoryDoesNotExist(self::$tmp . '/data/tmp_extract_12345');
+          $test->assertFileDoesNotExist(self::$tmp . '/data/db.sql.zip');
+        },
       ],
     ];
   }
@@ -160,7 +162,6 @@ class FetchDbUrlTest extends UnitTestCase {
             'cmd' => sprintf('unzip -o %s -d %s', escapeshellarg($db_dir . '/db.sql.zip'), escapeshellarg($temp_dir)),
             'result_code' => 1,
           ]);
-          $test->mockShellExec('');
         },
         'expected' => 'Failed to extract zip file',
       ],
@@ -182,10 +183,6 @@ class FetchDbUrlTest extends UnitTestCase {
           $test->mockPassthru([
             'cmd' => sprintf('unzip -o %s -d %s', escapeshellarg($db_dir . '/db.sql.zip'), escapeshellarg($temp_dir)),
             'result_code' => 0,
-          ]);
-          $test->mockShellExecMultiple([
-            ['value' => ''],
-            ['value' => ''],
           ]);
         },
         'expected' => 'No files found in the zip archive',

--- a/.vortex/tooling/tests/Unit/HelpersAcquiaTest.php
+++ b/.vortex/tooling/tests/Unit/HelpersAcquiaTest.php
@@ -132,6 +132,28 @@ class HelpersAcquiaTest extends UnitTestCase {
     $this->assertDirectoryDoesNotExist($home . '/subdir');
   }
 
+  public function testHomeFailsWhenPathIsFile(): void {
+    $this->envSet('VORTEX_ACLI_PATH', self::$tmp);
+    $home = self::$tmp . '/acli-home-' . getmypid();
+    file_put_contents($home, 'not a directory');
+
+    $this->mockQuit(1);
+
+    ob_start();
+    try {
+      \DrevOps\VortexTooling\acli_home();
+      $this->fail('Expected QuitErrorException to be thrown.');
+    }
+    catch (QuitErrorException $e) {
+      $this->assertEquals(1, $e->getCode());
+    }
+    finally {
+      $output = ob_get_clean();
+      $this->assertStringContainsString('Unable to clear the acli home directory', (string) $output);
+      unlink($home);
+    }
+  }
+
   public function testExecSuccess(): void {
     $ctx = ['home' => self::$tmp . '/home', 'key' => 'k', 'secret' => 's'];
     $this->mockPassthru([

--- a/.vortex/tooling/tests/Unit/HelpersCopyDirTest.php
+++ b/.vortex/tooling/tests/Unit/HelpersCopyDirTest.php
@@ -184,23 +184,4 @@ class HelpersCopyDirTest extends UnitTestCase {
     $this->assertEquals('new content', file_get_contents($dst . '/file.txt'));
   }
 
-  protected function createDirectoryStructure(string $base_path, array $structure): void {
-    if (!is_dir($base_path)) {
-      mkdir($base_path, 0755, TRUE);
-    }
-
-    foreach ($structure as $name => $content) {
-      $path = $base_path . '/' . $name;
-      if (is_array($content)) {
-        // It's a directory.
-        mkdir($path, 0755, TRUE);
-        $this->createDirectoryStructure($path, $content);
-      }
-      else {
-        // It's a file.
-        file_put_contents($path, $content);
-      }
-    }
-  }
-
 }

--- a/.vortex/tooling/tests/Unit/HelpersRemoveDirTest.php
+++ b/.vortex/tooling/tests/Unit/HelpersRemoveDirTest.php
@@ -149,23 +149,4 @@ class HelpersRemoveDirTest extends UnitTestCase {
     $this->assertDirectoryDoesNotExist($dir);
   }
 
-  protected function createDirectoryStructure(string $base_path, array $structure): void {
-    if (!is_dir($base_path)) {
-      mkdir($base_path, 0755, TRUE);
-    }
-
-    foreach ($structure as $name => $content) {
-      $path = $base_path . '/' . $name;
-      if (is_array($content)) {
-        // It's a directory.
-        mkdir($path, 0755, TRUE);
-        $this->createDirectoryStructure($path, $content);
-      }
-      else {
-        // It's a file.
-        file_put_contents($path, $content);
-      }
-    }
-  }
-
 }

--- a/.vortex/tooling/tests/Unit/HelpersRemoveDirTest.php
+++ b/.vortex/tooling/tests/Unit/HelpersRemoveDirTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\VortexTooling\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests for remove_dir() function.
+ *
+ * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ */
+#[CoversFunction('DrevOps\VortexTooling\remove_dir')]
+#[Group('helpers')]
+class HelpersRemoveDirTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+
+    require_once __DIR__ . '/../../src/helpers.php';
+  }
+
+  #[DataProvider('dataProviderRemoveDir')]
+  public function testRemoveDir(array $structure): void {
+    $dir = self::$tmp . '/remove_' . uniqid();
+
+    $this->createDirectoryStructure($dir, $structure);
+    $this->assertDirectoryExists($dir);
+
+    \DrevOps\VortexTooling\remove_dir($dir);
+
+    $this->assertDirectoryDoesNotExist($dir);
+  }
+
+  public static function dataProviderRemoveDir(): array {
+    return [
+      'empty directory' => [
+        'structure' => [],
+      ],
+      'single file' => [
+        'structure' => [
+          'file.txt' => 'content',
+        ],
+      ],
+      'nested directories' => [
+        'structure' => [
+          'root.txt' => 'root content',
+          'subdir1' => [
+            'file1.txt' => 'sub1 content',
+          ],
+          'subdir2' => [
+            'nested' => [
+              'file2.txt' => 'nested content',
+              'deep' => [
+                'file3.txt' => 'deep content',
+              ],
+            ],
+          ],
+        ],
+      ],
+      'empty subdirectories' => [
+        'structure' => [
+          'empty1' => [],
+          'empty2' => [
+            'empty3' => [],
+          ],
+        ],
+      ],
+      'hidden files' => [
+        'structure' => [
+          '.hidden' => 'hidden content',
+          '.hidden_dir' => [
+            '.another' => 'content',
+          ],
+        ],
+      ],
+    ];
+  }
+
+  public function testRemoveDirMissingPathIsNoop(): void {
+    $dir = self::$tmp . '/missing_' . uniqid();
+
+    \DrevOps\VortexTooling\remove_dir($dir);
+
+    $this->assertDirectoryDoesNotExist($dir);
+  }
+
+  public function testRemoveDirPathIsFile(): void {
+    $file = self::$tmp . '/file_' . uniqid();
+    file_put_contents($file, 'content');
+
+    // A plain file is not a directory: the call is a no-op and the file stays.
+    \DrevOps\VortexTooling\remove_dir($file);
+
+    $this->assertFileExists($file);
+    unlink($file);
+  }
+
+  public function testRemoveDirDoesNotFollowSymlinks(): void {
+    $target = self::$tmp . '/target_' . uniqid();
+    $dir = self::$tmp . '/remove_' . uniqid();
+
+    $this->createDirectoryStructure($target, ['kept.txt' => 'must survive']);
+    $this->createDirectoryStructure($dir, ['file.txt' => 'content']);
+    symlink($target, $dir . '/link_to_dir');
+    symlink($target . '/kept.txt', $dir . '/link_to_file');
+
+    \DrevOps\VortexTooling\remove_dir($dir);
+
+    $this->assertDirectoryDoesNotExist($dir);
+    $this->assertFileExists($target . '/kept.txt');
+    $this->assertEquals('must survive', file_get_contents($target . '/kept.txt'));
+  }
+
+  public function testRemoveDirPathIsSymlink(): void {
+    $target = self::$tmp . '/target_' . uniqid();
+    $link = self::$tmp . '/link_' . uniqid();
+
+    $this->createDirectoryStructure($target, ['kept.txt' => 'must survive']);
+    symlink($target, $link);
+
+    // The link itself is removed; the tree it points to survives.
+    \DrevOps\VortexTooling\remove_dir($link);
+
+    $this->assertFalse(is_link($link));
+    $this->assertFileExists($target . '/kept.txt');
+  }
+
+  public function testRemoveDirSuppressesFailures(): void {
+    $dir = self::$tmp . '/remove_' . uniqid();
+
+    $this->createDirectoryStructure($dir, ['locked' => ['file.txt' => 'content']]);
+    chmod($dir . '/locked', 0555);
+
+    try {
+      // Must not throw: failures are suppressed, mirroring 'rm -rf'.
+      \DrevOps\VortexTooling\remove_dir($dir);
+
+      $this->assertFileExists($dir . '/locked/file.txt');
+    }
+    finally {
+      chmod($dir . '/locked', 0755);
+      \DrevOps\VortexTooling\remove_dir($dir);
+    }
+
+    $this->assertDirectoryDoesNotExist($dir);
+  }
+
+  protected function createDirectoryStructure(string $base_path, array $structure): void {
+    if (!is_dir($base_path)) {
+      mkdir($base_path, 0755, TRUE);
+    }
+
+    foreach ($structure as $name => $content) {
+      $path = $base_path . '/' . $name;
+      if (is_array($content)) {
+        // It's a directory.
+        mkdir($path, 0755, TRUE);
+        $this->createDirectoryStructure($path, $content);
+      }
+      else {
+        // It's a file.
+        file_put_contents($path, $content);
+      }
+    }
+  }
+
+}

--- a/.vortex/tooling/tests/Unit/HelpersRemoveDirTest.php
+++ b/.vortex/tooling/tests/Unit/HelpersRemoveDirTest.php
@@ -129,6 +129,26 @@ class HelpersRemoveDirTest extends UnitTestCase {
     $this->assertFileExists($target . '/kept.txt');
   }
 
+  public function testRemoveDirUnreadableSubdirectoryDoesNotThrow(): void {
+    $dir = self::$tmp . '/remove_' . uniqid();
+
+    $this->createDirectoryStructure($dir, ['unreadable' => ['file.txt' => 'content']]);
+    chmod($dir . '/unreadable', 0000);
+
+    try {
+      // Must not throw: an unreadable subdirectory is skipped, not fatal.
+      \DrevOps\VortexTooling\remove_dir($dir);
+    }
+    finally {
+      if (is_dir($dir . '/unreadable')) {
+        chmod($dir . '/unreadable', 0755);
+      }
+      \DrevOps\VortexTooling\remove_dir($dir);
+    }
+
+    $this->assertDirectoryDoesNotExist($dir);
+  }
+
   public function testRemoveDirSuppressesFailures(): void {
     $dir = self::$tmp . '/remove_' . uniqid();
 

--- a/.vortex/tooling/tests/Unit/HelpersWalkDirTest.php
+++ b/.vortex/tooling/tests/Unit/HelpersWalkDirTest.php
@@ -102,23 +102,4 @@ class HelpersWalkDirTest extends UnitTestCase {
     unlink($file);
   }
 
-  protected function createDirectoryStructure(string $base_path, array $structure): void {
-    if (!is_dir($base_path)) {
-      mkdir($base_path, 0755, TRUE);
-    }
-
-    foreach ($structure as $name => $content) {
-      $path = $base_path . '/' . $name;
-      if (is_array($content)) {
-        // It's a directory.
-        mkdir($path, 0755, TRUE);
-        $this->createDirectoryStructure($path, $content);
-      }
-      else {
-        // It's a file.
-        file_put_contents($path, $content);
-      }
-    }
-  }
-
 }

--- a/.vortex/tooling/tests/Unit/HelpersWalkDirTest.php
+++ b/.vortex/tooling/tests/Unit/HelpersWalkDirTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\VortexTooling\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests for walk_dir() function.
+ *
+ * @phpcs:disable Drupal.Classes.FullyQualifiedNamespace.UseStatementMissing
+ */
+#[CoversFunction('DrevOps\VortexTooling\walk_dir')]
+#[Group('helpers')]
+class HelpersWalkDirTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+
+    require_once __DIR__ . '/../../src/helpers.php';
+  }
+
+  public function testWalkDirVisitsAllEntries(): void {
+    $dir = self::$tmp . '/walk_' . uniqid();
+    $this->createDirectoryStructure($dir, [
+      'a.txt' => 'a',
+      'sub' => [
+        'b.txt' => 'b',
+        'nested' => [
+          'c.txt' => 'c',
+        ],
+      ],
+    ]);
+
+    $visited = [];
+    \DrevOps\VortexTooling\walk_dir($dir, function (\SplFileInfo $item) use (&$visited, $dir): void {
+      $visited[] = substr($item->getPathname(), strlen($dir) + 1);
+    });
+
+    $this->assertSame(['a.txt', 'sub', 'sub/b.txt', 'sub/nested', 'sub/nested/c.txt'], $visited);
+  }
+
+  public function testWalkDirPrunesOnFalse(): void {
+    $dir = self::$tmp . '/walk_' . uniqid();
+    $this->createDirectoryStructure($dir, [
+      'keep' => [
+        'a.txt' => 'a',
+      ],
+      'skip' => [
+        'b.txt' => 'b',
+      ],
+    ]);
+
+    $visited = [];
+    \DrevOps\VortexTooling\walk_dir($dir, function (\SplFileInfo $item) use (&$visited, $dir): bool {
+      $path = substr($item->getPathname(), strlen($dir) + 1);
+      $visited[] = $path;
+
+      return $path !== 'skip';
+    });
+
+    $this->assertSame(['keep', 'keep/a.txt', 'skip'], $visited);
+  }
+
+  public function testWalkDirDoesNotFollowSymlinks(): void {
+    $target = self::$tmp . '/target_' . uniqid();
+    $dir = self::$tmp . '/walk_' . uniqid();
+
+    $this->createDirectoryStructure($target, ['inside.txt' => 'x']);
+    $this->createDirectoryStructure($dir, ['a.txt' => 'a']);
+    symlink($target, $dir . '/link');
+
+    $visited = [];
+    \DrevOps\VortexTooling\walk_dir($dir, function (\SplFileInfo $item) use (&$visited, $dir): void {
+      $visited[] = substr($item->getPathname(), strlen($dir) + 1);
+    });
+
+    $this->assertSame(['a.txt', 'link'], $visited);
+  }
+
+  public function testWalkDirMissingPathIsNoop(): void {
+    $visited = [];
+    \DrevOps\VortexTooling\walk_dir(self::$tmp . '/missing_' . uniqid(), function (\SplFileInfo $item) use (&$visited): void {
+      $visited[] = $item->getPathname();
+    });
+
+    $this->assertSame([], $visited);
+  }
+
+  public function testWalkDirPathIsFileIsNoop(): void {
+    $file = self::$tmp . '/file_' . uniqid();
+    file_put_contents($file, 'content');
+
+    $visited = [];
+    \DrevOps\VortexTooling\walk_dir($file, function (\SplFileInfo $item) use (&$visited): void {
+      $visited[] = $item->getPathname();
+    });
+
+    $this->assertSame([], $visited);
+    unlink($file);
+  }
+
+  protected function createDirectoryStructure(string $base_path, array $structure): void {
+    if (!is_dir($base_path)) {
+      mkdir($base_path, 0755, TRUE);
+    }
+
+    foreach ($structure as $name => $content) {
+      $path = $base_path . '/' . $name;
+      if (is_array($content)) {
+        // It's a directory.
+        mkdir($path, 0755, TRUE);
+        $this->createDirectoryStructure($path, $content);
+      }
+      else {
+        // It's a file.
+        file_put_contents($path, $content);
+      }
+    }
+  }
+
+}

--- a/.vortex/tooling/tests/Unit/ImportDbTest.php
+++ b/.vortex/tooling/tests/Unit/ImportDbTest.php
@@ -34,7 +34,7 @@ class ImportDbTest extends UnitTestCase {
    * only available in the global scope. When require'd inside a function,
    * we need to define it as a local variable.
    */
-  protected function runScript(string $script_path, ?int $early_exit_code = NULL): string {
+  protected function runScript(string $script_path, ?int $early_exit_code = NULL, ?string $cwd = NULL): string {
     // @phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UnusedVariable
     $argv = $GLOBALS['argv'] ?? [];
 
@@ -54,7 +54,7 @@ class ImportDbTest extends UnitTestCase {
       // @codeCoverageIgnoreEnd
     }
 
-    chdir($root);
+    chdir($cwd ?? $root);
 
     if (!is_null($early_exit_code)) {
       if ($early_exit_code > 0) {

--- a/.vortex/tooling/tests/Unit/InfoTest.php
+++ b/.vortex/tooling/tests/Unit/InfoTest.php
@@ -33,10 +33,16 @@ class InfoTest extends UnitTestCase {
   }
 
   #[DataProvider('dataProviderInfo')]
-  public function testInfo(array $env_vars, array $mocks, array $expected): void {
+  public function testInfo(array $env_vars, array $mocks, array $expected, bool $xdebug_enabled = FALSE): void {
     if (!empty($env_vars)) {
       $this->envSetMultiple($env_vars);
     }
+
+    $php_version_output = 'PHP 8.3.10 (cli) (built: Aug  1 2024 10:00:00) (NTS)';
+    if ($xdebug_enabled) {
+      $php_version_output .= "\n    with Xdebug v3.3.2, Copyright (c) 2002-2024, by Derick Rethans";
+    }
+    $this->mockShellExec($php_version_output);
 
     foreach ($mocks as $mock) {
       $this->mockPassthru($mock);
@@ -51,7 +57,7 @@ class InfoTest extends UnitTestCase {
     return [
       'basic' => [
         [],
-        [['cmd' => 'php -v 2>/dev/null | grep -q Xdebug', 'result_code' => 1]],
+        [],
         [
           '* [INFO] Project information:',
           '* Project name                : test_project',
@@ -76,41 +82,41 @@ class InfoTest extends UnitTestCase {
 
       'xdebug enabled' => [
         [],
-        [['cmd' => 'php -v 2>/dev/null | grep -q Xdebug', 'result_code' => 0]],
+        [],
         [
           "* Xdebug                      : Enabled ('ahoy up cli' to disable)",
           "! Disabled ('ahoy debug' to enable)",
         ],
+        TRUE,
       ],
 
       'db image' => [
         ['VORTEX_DB_IMAGE' => 'myorg/db:latest'],
-        [['cmd' => 'php -v 2>/dev/null | grep -q Xdebug', 'result_code' => 1]],
+        [],
         ['* DB-in-image                 : myorg/db:latest'],
       ],
 
       'solr port' => [
         ['VORTEX_HOST_SOLR_PORT' => '8983'],
-        [['cmd' => 'php -v 2>/dev/null | grep -q Xdebug', 'result_code' => 1]],
+        [],
         ['* Solr URL on host            : http://127.0.0.1:8983'],
       ],
 
       'selenium vnc port' => [
         ['VORTEX_HOST_SELENIUM_VNC_PORT' => '7900'],
-        [['cmd' => 'php -v 2>/dev/null | grep -q Xdebug', 'result_code' => 1]],
+        [],
         ['* Selenium VNC URL on host    : http://localhost:7900/?autoconnect=1&password=secret'],
       ],
 
       'sequel ace' => [
         ['VORTEX_HOST_HAS_SEQUELACE' => '1'],
-        [['cmd' => 'php -v 2>/dev/null | grep -q Xdebug', 'result_code' => 1]],
+        [],
         ["* ('ahoy db' to start SequelAce)"],
       ],
 
       'show login' => [
         ['VORTEX_SHOW_LOGIN' => '1'],
         [
-          ['cmd' => 'php -v 2>/dev/null | grep -q Xdebug', 'result_code' => 1],
           ['cmd' => 'php ' . dirname(__DIR__, 2) . '/src/vortex-login', 'output' => 'http://example.com/user/reset/1/abc123/login', 'result_code' => 0],
         ],
         [
@@ -127,7 +133,7 @@ class InfoTest extends UnitTestCase {
           'VORTEX_HOST_SELENIUM_VNC_PORT' => '7900',
           'VORTEX_HOST_HAS_SEQUELACE' => '1',
         ],
-        [['cmd' => 'php -v 2>/dev/null | grep -q Xdebug', 'result_code' => 0]],
+        [],
         [
           '* DB-in-image                 : myorg/db:latest',
           '* Solr URL on host            : http://127.0.0.1:8983',
@@ -135,6 +141,7 @@ class InfoTest extends UnitTestCase {
           "* ('ahoy db' to start SequelAce)",
           "* Enabled ('ahoy up cli' to disable)",
         ],
+        TRUE,
       ],
     ];
   }

--- a/.vortex/tooling/tests/Unit/LoginTest.php
+++ b/.vortex/tooling/tests/Unit/LoginTest.php
@@ -17,9 +17,13 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 class LoginTest extends UnitTestCase {
 
   #[DataProvider('dataProviderLogin')]
-  public function testLogin(array $env_vars, array $mocks, array $expected, bool $expect_error = FALSE): void {
+  public function testLogin(array $env_vars, array $shell_mocks, array $mocks, array $expected, bool $expect_error = FALSE): void {
     if (!empty($env_vars)) {
       $this->envSetMultiple($env_vars);
+    }
+
+    if (!empty($shell_mocks)) {
+      $this->mockShellExecMultiple(array_map(static fn(string $value): array => ['value' => $value], $shell_mocks));
     }
 
     foreach ($mocks as $mock) {
@@ -50,17 +54,19 @@ class LoginTest extends UnitTestCase {
   }
 
   public static function dataProviderLogin(): array {
-    $password_policy_cmd = './vendor/bin/drush -y pm:list --status=enabled 2>/dev/null | grep -q password_policy';
+    $modules_without_policy = "admin_toolbar\nviews";
+    $modules_with_policy = "admin_toolbar\npassword_policy\nviews";
+    $admin_query_output = "admin\n";
     $password_reset_cmd = './vendor/bin/drush -y sql:query \'UPDATE `user__field_password_expiration` SET `field_password_expiration_value` = 0 WHERE `bundle` = "user" AND `entity_id` = 1;\' >/dev/null';
-    $unblock_cmd = './vendor/bin/drush -y sql:query "SELECT name FROM \\`users_field_data\\` WHERE \\`uid\\` = \'1\';" | head -n 1 | xargs ./vendor/bin/drush -y -- user:unblock 2>/dev/null';
+    $unblock_cmd = "./vendor/bin/drush -y -- user:unblock 'admin' 2>/dev/null";
     $login_cmd = './vendor/bin/drush -y user:login';
     $login_url = 'http://example.com/user/reset/1/abc123/login';
 
     return [
       'unblock admin' => [
         ['VORTEX_LOGIN_UNBLOCK_ADMIN' => '1'],
+        [$modules_without_policy, $admin_query_output],
         [
-          ['cmd' => $password_policy_cmd, 'result_code' => 1],
           ['cmd' => $unblock_cmd, 'result_code' => 0],
           ['cmd' => $login_cmd, 'output' => $login_url, 'result_code' => 0],
         ],
@@ -69,8 +75,8 @@ class LoginTest extends UnitTestCase {
 
       'unblock admin and password policy' => [
         ['VORTEX_LOGIN_UNBLOCK_ADMIN' => '1'],
+        [$modules_with_policy, $admin_query_output],
         [
-          ['cmd' => $password_policy_cmd, 'result_code' => 0],
           ['cmd' => $password_reset_cmd, 'result_code' => 0],
           ['cmd' => $unblock_cmd, 'result_code' => 0],
           ['cmd' => $login_cmd, 'output' => $login_url, 'result_code' => 0],
@@ -78,8 +84,28 @@ class LoginTest extends UnitTestCase {
         ['* ' . $login_url],
       ],
 
+      'unblock admin with multiline query result' => [
+        ['VORTEX_LOGIN_UNBLOCK_ADMIN' => '1'],
+        [$modules_without_policy, "admin\nextra_row\n"],
+        [
+          ['cmd' => $unblock_cmd, 'result_code' => 0],
+          ['cmd' => $login_cmd, 'output' => $login_url, 'result_code' => 0],
+        ],
+        ['* ' . $login_url],
+      ],
+
+      'unblock admin with empty admin name' => [
+        ['VORTEX_LOGIN_UNBLOCK_ADMIN' => '1'],
+        [$modules_without_policy, "\n"],
+        [
+          ['cmd' => $login_cmd, 'output' => $login_url, 'result_code' => 0],
+        ],
+        ['* ' . $login_url],
+      ],
+
       'without unblock admin' => [
         ['VORTEX_LOGIN_UNBLOCK_ADMIN' => '0'],
+        [],
         [
           ['cmd' => $login_cmd, 'output' => $login_url, 'result_code' => 0],
         ],
@@ -88,6 +114,7 @@ class LoginTest extends UnitTestCase {
 
       'fallback variable' => [
         ['VORTEX_UNBLOCK_ADMIN' => '0'],
+        [],
         [
           ['cmd' => $login_cmd, 'output' => $login_url, 'result_code' => 0],
         ],
@@ -96,6 +123,7 @@ class LoginTest extends UnitTestCase {
 
       'login failure' => [
         ['VORTEX_LOGIN_UNBLOCK_ADMIN' => '0'],
+        [],
         [
           ['cmd' => $login_cmd, 'result_code' => 1],
         ],
@@ -105,8 +133,8 @@ class LoginTest extends UnitTestCase {
 
       'default unblocks admin' => [
         [],
+        [$modules_without_policy, $admin_query_output],
         [
-          ['cmd' => $password_policy_cmd, 'result_code' => 1],
           ['cmd' => $unblock_cmd, 'result_code' => 0],
           ['cmd' => $login_cmd, 'output' => $login_url, 'result_code' => 0],
         ],

--- a/.vortex/tooling/tests/Unit/LogoutTest.php
+++ b/.vortex/tooling/tests/Unit/LogoutTest.php
@@ -16,9 +16,13 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 class LogoutTest extends UnitTestCase {
 
   #[DataProvider('dataProviderLogout')]
-  public function testLogout(array $env_vars, array $mocks, array $expected): void {
+  public function testLogout(array $env_vars, array $shell_mocks, array $mocks, array $expected): void {
     if (!empty($env_vars)) {
       $this->envSetMultiple($env_vars);
+    }
+
+    if (!empty($shell_mocks)) {
+      $this->mockShellExecMultiple(array_map(static fn(string $value): array => ['value' => $value], $shell_mocks));
     }
 
     foreach ($mocks as $mock) {
@@ -38,25 +42,40 @@ class LogoutTest extends UnitTestCase {
   public function testLogoutBlockAdminFails(): void {
     $this->envSet('VORTEX_LOGOUT_BLOCK_ADMIN', '1');
 
-    $block_cmd = './vendor/bin/drush -y sql:query "SELECT name FROM \\`users_field_data\\` WHERE \\`uid\\` = \'1\';" | head -n 1 | xargs ./vendor/bin/drush -y -- user:block';
-
-    $this->mockPassthru(['cmd' => $block_cmd, 'result_code' => 1]);
+    $this->mockShellExec("admin\n");
+    $this->mockPassthru(['cmd' => "./vendor/bin/drush -y -- user:block 'admin'", 'result_code' => 1]);
 
     $this->runScriptError('src/vortex-logout', 'Failed to block admin user.');
   }
 
   public static function dataProviderLogout(): array {
-    $block_cmd = './vendor/bin/drush -y sql:query "SELECT name FROM \\`users_field_data\\` WHERE \\`uid\\` = \'1\';" | head -n 1 | xargs ./vendor/bin/drush -y -- user:block';
+    $block_cmd = "./vendor/bin/drush -y -- user:block 'admin'";
 
     return [
       'block admin' => [
         ['VORTEX_LOGOUT_BLOCK_ADMIN' => '1'],
+        ["admin\n"],
         [['cmd' => $block_cmd, 'output' => 'Blocked user: admin', 'result_code' => 0]],
         ['* Blocked user: admin'],
       ],
 
+      'block admin with multiline query result' => [
+        ['VORTEX_LOGOUT_BLOCK_ADMIN' => '1'],
+        ["admin\nextra_row\n"],
+        [['cmd' => $block_cmd, 'output' => 'Blocked user: admin', 'result_code' => 0]],
+        ['* Blocked user: admin'],
+      ],
+
+      'block admin with empty admin name' => [
+        ['VORTEX_LOGOUT_BLOCK_ADMIN' => '1'],
+        ["\n"],
+        [],
+        [],
+      ],
+
       'without block admin' => [
         ['VORTEX_LOGOUT_BLOCK_ADMIN' => '0'],
+        [],
         [],
         [],
       ],
@@ -65,10 +84,12 @@ class LogoutTest extends UnitTestCase {
         ['VORTEX_UNBLOCK_ADMIN' => '0'],
         [],
         [],
+        [],
       ],
 
       'default blocks admin' => [
         [],
+        ["admin\n"],
         [['cmd' => $block_cmd, 'output' => 'Blocked user: admin', 'result_code' => 0]],
         ['* Blocked user: admin'],
       ],

--- a/.vortex/tooling/tests/Unit/ProvisionTest.php
+++ b/.vortex/tooling/tests/Unit/ProvisionTest.php
@@ -935,12 +935,6 @@ class ProvisionTest extends UnitTestCase {
     $config_before = $tmp . '/config_before_test1';
     $config_after = $tmp . '/config_after_test2';
 
-    // shell_exec: diff (no changes), rm -rf.
-    $this->mockShellExecMultiple([
-      ['value' => ''],
-      ['value' => ''],
-    ]);
-
     $this->mockDrushStartupSequenceWithConfig(TRUE);
 
     // Drush php:eval (environment).
@@ -1037,11 +1031,6 @@ class ProvisionTest extends UnitTestCase {
       return 'test' . (++$uniqid_counter);
     });
 
-    // shell_exec: diff returns changes.
-    $this->mockShellExecMultiple([
-      ['value' => 'Files config_before/system.site.yml and config_after/system.site.yml differ'],
-    ]);
-
     $this->mockDrushStartupSequenceWithConfig(TRUE);
 
     // Drush php:eval (environment).
@@ -1059,6 +1048,14 @@ class ProvisionTest extends UnitTestCase {
 
     $config_before = $tmp . '/config_before_test1';
     $config_after = $tmp . '/config_after_test2';
+
+    // Pre-seed the export directories with differing content: the mocked
+    // 'config:export' calls do not write files, and the comparison must
+    // report a difference.
+    mkdir($config_before, 0755, TRUE);
+    mkdir($config_after, 0755, TRUE);
+    file_put_contents($config_before . '/system.site.yml', 'name: before');
+    file_put_contents($config_after . '/system.site.yml', 'name: after');
 
     // Drush config:export (before).
     $this->mockPassthru([

--- a/.vortex/tooling/tests/Unit/ResetTest.php
+++ b/.vortex/tooling/tests/Unit/ResetTest.php
@@ -102,7 +102,9 @@ class ResetTest extends UnitTestCase {
           $test->assertDirectoryDoesNotExist($root . '/web/modules/contrib');
           $test->assertFileExists($root . '/web/modules/custom/keep/keep.info.yml');
           $test->assertDirectoryDoesNotExist($root . '/web/themes/custom/t1/build');
-          $test->assertFileDoesNotExist($root . '/web/themes/custom/t1/scss/_components.scss');
+          // Theme scss sources, including the committed '_components.scss',
+          // are not build artifacts and must survive the reset.
+          $test->assertFileExists($root . '/web/themes/custom/t1/scss/_components.scss');
           $test->assertFileExists($root . '/web/themes/custom/t1/scss/main.scss');
           $test->assertDirectoryDoesNotExist($root . '/sub/node_modules');
           // Soft reset does not sweep empty directories.

--- a/.vortex/tooling/tests/Unit/ResetTest.php
+++ b/.vortex/tooling/tests/Unit/ResetTest.php
@@ -7,23 +7,28 @@ namespace DrevOps\VortexTooling\Tests\Unit;
 use DrevOps\VortexTooling\Tests\Exceptions\QuitErrorException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for reset script.
+ *
+ * The script runs against a sandboxed project fixture directory: filesystem
+ * operations are real, while git commands are mocked.
  */
 #[Group('utility')]
-#[RunTestsInSeparateProcesses]
 class ResetTest extends UnitTestCase {
 
   protected function setUp(): void {
     parent::setUp();
 
     $this->envSet('WEBROOT', 'web');
+
+    // Tests share the process: reset argv so a '--hard' flag from a previous
+    // case does not leak into cases that expect the default soft reset.
+    $GLOBALS['argv'] = ['vortex-reset'];
   }
 
   #[DataProvider('dataProviderReset')]
-  public function testReset(array $env_vars, array $mocks, array $expected, ?array $argv = NULL, bool $expect_error = FALSE): void {
+  public function testReset(array $env_vars, ?\Closure $before, array $expected, ?array $argv = NULL, bool $expect_error = FALSE, ?\Closure $after = NULL): void {
     if (!empty($env_vars)) {
       $this->envSetMultiple($env_vars);
     }
@@ -32,44 +37,55 @@ class ResetTest extends UnitTestCase {
       $GLOBALS['argv'] = $argv;
     }
 
-    foreach ($mocks as $mock) {
-      $this->mockPassthru($mock);
+    $root = self::$tmp . '/project_' . uniqid();
+    mkdir($root, 0755, TRUE);
+
+    if ($before instanceof \Closure) {
+      $before($this, $root);
     }
 
     if ($expect_error) {
       try {
-        $this->runScript('src/vortex-reset', 1);
+        $this->runScript('src/vortex-reset', 1, $root);
       }
       catch (QuitErrorException $e) {
         if (!empty($expected)) {
           $this->assertStringContainsOrNot($e->getOutput(), $expected);
+        }
+
+        if ($after instanceof \Closure) {
+          $after($this, $root);
         }
         throw $e;
       }
       return;
     }
 
-    $output = $this->runScript('src/vortex-reset');
+    $output = $this->runScript('src/vortex-reset', NULL, $root);
 
     $this->assertStringContainsOrNot($output, $expected);
+
+    if ($after instanceof \Closure) {
+      $after($this, $root);
+    }
   }
 
   public static function dataProviderReset(): array {
-    $rm_web = 'rm -rf "./vendor" "./web/core" "./web/profiles/contrib" "./web/modules/contrib" "./web/themes/contrib" "./web/themes/custom/*/build" "./web/themes/custom/*/scss/_components.scss"';
-    $rm_docroot = 'rm -rf "./vendor" "./docroot/core" "./docroot/profiles/contrib" "./docroot/modules/contrib" "./docroot/themes/contrib" "./docroot/themes/custom/*/build" "./docroot/themes/custom/*/scss/_components.scss"';
-    $rm_node = 'find . -type d -name node_modules -prune -exec rm -Rf -- {} +';
-    $git_chmod = 'git ls-files --others -i --exclude-from=.gitignore -z | xargs -0 -r sh -c \'for f in "$@"; do chmod 777 "$f" 2>/dev/null; rm -rf "$f" 2>/dev/null; done\' _';
-    $git_reset = 'git reset --hard';
-    $git_clean = 'git clean -f -d';
-    $find_empty = 'find . -type d -not -path "./.git/*" -empty -delete';
-
     return [
       'soft default' => [
         [],
-        [
-          ['cmd' => $rm_web, 'result_code' => 0],
-          ['cmd' => $rm_node, 'result_code' => 0],
-        ],
+        static function (self $test, string $root): void {
+          static::createFileTree($root, [
+            'vendor/composer.json' => 'x',
+            'web/core/lib/core.txt' => 'x',
+            'web/modules/contrib/mod/mod.info.yml' => 'x',
+            'web/modules/custom/keep/keep.info.yml' => 'keep',
+            'web/themes/custom/t1/build/script.js' => 'x',
+            'web/themes/custom/t1/scss/_components.scss' => 'x',
+            'web/themes/custom/t1/scss/main.scss' => 'keep',
+            'sub/node_modules/pkg/index.js' => 'x',
+          ]);
+        },
         [
           '* [INFO] Started reset.',
           '* [ OK ] Finished reset.',
@@ -78,14 +94,25 @@ class ResetTest extends UnitTestCase {
           '! [TASK] Removing all untracked files.',
           '! [TASK] Removing empty directories.',
         ],
+        NULL,
+        FALSE,
+        static function (self $test, string $root): void {
+          $test->assertDirectoryDoesNotExist($root . '/vendor');
+          $test->assertDirectoryDoesNotExist($root . '/web/core');
+          $test->assertDirectoryDoesNotExist($root . '/web/modules/contrib');
+          $test->assertFileExists($root . '/web/modules/custom/keep/keep.info.yml');
+          $test->assertDirectoryDoesNotExist($root . '/web/themes/custom/t1/build');
+          $test->assertFileDoesNotExist($root . '/web/themes/custom/t1/scss/_components.scss');
+          $test->assertFileExists($root . '/web/themes/custom/t1/scss/main.scss');
+          $test->assertDirectoryDoesNotExist($root . '/sub/node_modules');
+          // Soft reset does not sweep empty directories.
+          $test->assertDirectoryExists($root . '/sub');
+        },
       ],
 
       'legacy hard positional is ignored' => [
         [],
-        [
-          ['cmd' => $rm_web, 'result_code' => 0],
-          ['cmd' => $rm_node, 'result_code' => 0],
-        ],
+        NULL,
         [
           '* [INFO] Started reset.',
           '* [ OK ] Finished reset.',
@@ -99,14 +126,19 @@ class ResetTest extends UnitTestCase {
 
       'hard' => [
         [],
-        [
-          ['cmd' => $rm_web, 'result_code' => 0],
-          ['cmd' => $rm_node, 'result_code' => 0],
-          ['cmd' => $git_chmod, 'result_code' => 0],
-          ['cmd' => $git_reset, 'result_code' => 0],
-          ['cmd' => $git_clean, 'result_code' => 0],
-          ['cmd' => $find_empty, 'result_code' => 0],
-        ],
+        static function (self $test, string $root): void {
+          static::createFileTree($root, [
+            'vendor/composer.json' => 'x',
+            'web/themes/custom/t1/build/script.js' => 'x',
+            'sub/node_modules/pkg/index.js' => 'x',
+            'ignored.txt' => 'x',
+            'empty_dir' => NULL,
+            '.git/refs' => NULL,
+          ]);
+          $test->mockShellExec("ignored.txt\0");
+          $test->mockPassthru(['cmd' => 'git reset --hard', 'result_code' => 0]);
+          $test->mockPassthru(['cmd' => 'git clean -f -d', 'result_code' => 0]);
+        },
         [
           '* [INFO] Started reset.',
           '* [TASK] Changing permissions and removing all other untracked files.',
@@ -116,16 +148,25 @@ class ResetTest extends UnitTestCase {
           '* [ OK ] Finished reset.',
         ],
         ['reset', '--hard'],
+        FALSE,
+        static function (self $test, string $root): void {
+          $test->assertDirectoryDoesNotExist($root . '/vendor');
+          $test->assertFileDoesNotExist($root . '/ignored.txt');
+          $test->assertDirectoryDoesNotExist($root . '/empty_dir');
+          // Directories that became empty are swept recursively.
+          $test->assertDirectoryDoesNotExist($root . '/sub');
+          $test->assertDirectoryDoesNotExist($root . '/web');
+          // Empty directories inside '.git' survive the sweep.
+          $test->assertDirectoryExists($root . '/.git/refs');
+        },
       ],
 
       'hard git reset fails' => [
         [],
-        [
-          ['cmd' => $rm_web, 'result_code' => 0],
-          ['cmd' => $rm_node, 'result_code' => 0],
-          ['cmd' => $git_chmod, 'result_code' => 0],
-          ['cmd' => $git_reset, 'result_code' => 1],
-        ],
+        static function (self $test, string $root): void {
+          $test->mockShellExec('');
+          $test->mockPassthru(['cmd' => 'git reset --hard', 'result_code' => 1]);
+        },
         [
           '* [INFO] Started reset.',
           '* [TASK] Resetting repository files.',
@@ -137,13 +178,11 @@ class ResetTest extends UnitTestCase {
 
       'hard git clean fails' => [
         [],
-        [
-          ['cmd' => $rm_web, 'result_code' => 0],
-          ['cmd' => $rm_node, 'result_code' => 0],
-          ['cmd' => $git_chmod, 'result_code' => 0],
-          ['cmd' => $git_reset, 'result_code' => 0],
-          ['cmd' => $git_clean, 'result_code' => 1],
-        ],
+        static function (self $test, string $root): void {
+          $test->mockShellExec('');
+          $test->mockPassthru(['cmd' => 'git reset --hard', 'result_code' => 0]);
+          $test->mockPassthru(['cmd' => 'git clean -f -d', 'result_code' => 1]);
+        },
         [
           '* [INFO] Started reset.',
           '* [TASK] Removing all untracked files.',
@@ -155,16 +194,42 @@ class ResetTest extends UnitTestCase {
 
       'custom webroot' => [
         ['WEBROOT' => 'docroot'],
-        [
-          ['cmd' => $rm_docroot, 'result_code' => 0],
-          ['cmd' => $rm_node, 'result_code' => 0],
-        ],
+        static function (self $test, string $root): void {
+          static::createFileTree($root, [
+            'docroot/core/lib/core.txt' => 'x',
+            'docroot/themes/custom/t1/build/script.js' => 'x',
+          ]);
+        },
         [
           '* [INFO] Started reset.',
           '* [ OK ] Finished reset.',
         ],
+        NULL,
+        FALSE,
+        static function (self $test, string $root): void {
+          $test->assertDirectoryDoesNotExist($root . '/docroot/core');
+          $test->assertDirectoryDoesNotExist($root . '/docroot/themes/custom/t1/build');
+        },
       ],
     ];
+  }
+
+  protected static function createFileTree(string $root, array $items): void {
+    foreach ($items as $path => $content) {
+      $full = $root . '/' . $path;
+
+      if ($content === NULL) {
+        mkdir($full, 0755, TRUE);
+        continue;
+      }
+
+      $dir = dirname($full);
+      if (!is_dir($dir)) {
+        mkdir($dir, 0755, TRUE);
+      }
+
+      file_put_contents($full, $content);
+    }
   }
 
 }

--- a/.vortex/tooling/tests/Unit/UnitTestCase.php
+++ b/.vortex/tooling/tests/Unit/UnitTestCase.php
@@ -156,6 +156,32 @@ abstract class UnitTestCase extends UpstreamUnitTestCase {
   }
 
   /**
+   * Create a directory structure from a nested array definition.
+   *
+   * @param string $base_path
+   *   Directory to create the structure under.
+   * @param array $structure
+   *   Nested array where a string value is a file with that content and an
+   *   array value is a subdirectory.
+   */
+  protected function createDirectoryStructure(string $base_path, array $structure): void {
+    if (!is_dir($base_path)) {
+      mkdir($base_path, 0755, TRUE);
+    }
+
+    foreach ($structure as $name => $content) {
+      $path = $base_path . '/' . $name;
+      if (is_array($content)) {
+        mkdir($path, 0755, TRUE);
+        $this->createDirectoryStructure($path, $content);
+      }
+      else {
+        file_put_contents($path, $content);
+      }
+    }
+  }
+
+  /**
    * Path to the isolated Lagoon CLI config file used in command assertions.
    *
    * Mirrors lagoon_config_file(): the file lives under VORTEX_LAGOONCLI_PATH

--- a/.vortex/tooling/tests/Unit/UnitTestCase.php
+++ b/.vortex/tooling/tests/Unit/UnitTestCase.php
@@ -45,10 +45,12 @@ abstract class UnitTestCase extends UpstreamUnitTestCase {
     parent::tearDown();
   }
 
-  protected function runScript(string $script_path, ?int $early_exit_code = NULL): string {
+  protected function runScript(string $script_path, ?int $early_exit_code = NULL, ?string $cwd = NULL): string {
     ob_start();
 
-    // Change to src directory so __DIR__ works correctly in the script.
+    // Change to the src directory by default so scripts resolve relative
+    // paths consistently; $cwd overrides it for scripts that operate on the
+    // current working directory (e.g. a sandboxed project fixture).
     $original_dir = getcwd();
     if ($original_dir === FALSE) {
       // @codeCoverageIgnoreStart
@@ -63,7 +65,7 @@ abstract class UnitTestCase extends UpstreamUnitTestCase {
       // @codeCoverageIgnoreEnd
     }
 
-    chdir($root);
+    chdir($cwd ?? $root);
 
     if (!is_null($early_exit_code)) {
       if ($early_exit_code > 0) {


### PR DESCRIPTION
Closes #2775

## Summary

This replaces shell pipelines built on `grep`, `find`, `xargs`, `diff`, `head`, `whoami`, and quoted `rm -rf` globs across the `drevops/vortex-tooling` scripts with PHP-native equivalents, cutting external process spawns and removing several fragile string-matching pipelines.
Two new helpers in `helpers.php`, `remove_dir()` and `walk_dir()`, provide a shared recursive-delete and recursive-traversal primitive that `vortex-reset`, `vortex-provision`, and `vortex-fetch-db-url` now share instead of each hand-rolling its own shell pipeline.
The `unzip` binary intentionally stays in `vortex-fetch-db-url`: replacing it with `ext-zip` would grow the package's dependency surface, which is a deliberate call documented in the new README section.
Two behavior changes ride along with the refactor: `vortex-reset` now actually deletes theme `build/` directories that the old quoted globs silently never matched (the stale `_components.scss` pattern from the same list was dropped instead, since that file is committed theme source), and `vortex-doctor` now matches container service names exactly instead of by substring.
The full PHPUnit suite (778 tests / 3704 assertions), lint (`phpcs`, `phpstan`, `rector`, `check-no-exit`), and the installer/test snapshot regeneration all pass with zero fixture churn.

## Changes

- **New filesystem helpers** (`helpers.php`): added `remove_dir()`, a best-effort recursive delete mirroring `rm -rf` (never follows symlinks, suppresses individual failures, skips unreadable subdirectories via `CATCH_GET_CHILD`, a missing path is a no-op), replacing every `shell_exec('rm -rf ...')` call site and the bespoke `acli_home_remove()`; `acli_home()` now fails explicitly via `FAIL()` when the home directory cannot be cleared or (re)created, instead of continuing silently.
- **New traversal helper** (`helpers.php`): added `walk_dir()`, a callback-based recursive directory walk (top-down, alphabetical, never follows symlinks; a visitor returning `FALSE` prunes further descent into that entry), used by `vortex-fetch-db-url`, `vortex-provision`, and `vortex-reset`.
- **`vortex-login` / `vortex-logout`**: replaced the `drush ... | grep -q password_policy` and `sql:query | head -n 1 | xargs drush ...` pipelines with output capture plus `str_contains()` and first-line parsing, adding an explicit guard for an empty admin name (the old `xargs` behavior on empty input differs between GNU and BSD, so the guard also removes that platform divergence).
- **`vortex-info`**: replaced `php -v | grep -q Xdebug` with a captured `php -v` output checked via `str_contains()`.
- **`vortex-doctor`**: the port-80 `lsof | grep -v | grep | grep -vq` chain, the per-service `docker compose ps | grep -q` loop, and the `pygmy status | grep -q` check now capture their command output once and filter it in PHP; the container loop goes from 8 spawned processes to 1, and now matches each service name exactly rather than as a substring (**behavior change**: a service named e.g. `cli-tools` no longer satisfies the `cli` check); `whoami` is replaced with `getenv('USER')`, falling back to `posix_getpwuid(posix_geteuid())` when available.
- **`vortex-fetch-db-url`**: replaced `find ... | head -n 1` file discovery with `walk_dir()` (skips symlinks so a symlinked entry is never mistaken for the dump file), and replaced `rm -rf` cleanup with `remove_dir()`.
- **`vortex-provision`**: replaced `diff -rq` with a local `compare_dirs()` function that reports only-in-before/only-in-after/differs lines the same way `diff -rq` does, dropped the `command_must_exist('diff')` check, and replaced `rm -rf` with `remove_dir()`.
- **`vortex-reset`**: full PHP-native filesystem rewrite - the removal patterns (previously a single quoted-glob string passed to `rm -rf`) are now expanded via `glob()` in PHP before removal (**behavior change**: the old quoted globs were never expanded by the shell, so `./web/themes/custom/*/build` directories were silently never deleted and now are); the list's stale `_components.scss` entry was dropped rather than made effective, because `scss/_components.scss` is committed theme source (not a build artifact) and deleting it broke every subsequent theme build; `find -name node_modules -prune -exec rm -Rf` and `find -empty -delete` are now `walk_dir()` traversals; the `git ls-files -z | xargs sh -c 'chmod; rm -rf'` loop keeps `git ls-files` for discovery but performs the `chmod`/delete in PHP, which also removes a GNU/BSD `xargs` empty-input divergence.
- **`vortex-deploy-artifact`**: dropped the stale `command_must_exist('curl')` check - its only download already goes through the PHP `curl` extension via the `request()` helper.
- **`vortex-fetch-db-container-registry`**: replaced `docker image inspect ... && echo 1 || echo 0` with a direct exit-code check via `passthru()`.
- **Documentation**: added a "Host requirements" section to `.vortex/tooling/README.md` enumerating the external tools the scripts still rely on (`docker`, `git`, `ssh-keygen`/`ssh-agent`/`ssh-add`, `unzip`, `pygmy`/`ahoy`/`lsof`, hosting-provider CLIs).
- **Tests**: added `HelpersRemoveDirTest` (including symlink, permission-failure, and unreadable-subdirectory regression cases) and `HelpersWalkDirTest`; `ResetTest` now runs the script against real sandboxed fixture trees instead of mocking shell pipeline strings, via a new optional `$cwd` parameter on `UnitTestCase::runScript()` (mirrored in the `ExportDbTest`/`ImportDbTest` overrides); `FetchDbUrlTest` and `ProvisionTest` assert real filesystem outcomes instead of mocked pipeline output; `DoctorTest` gained a posix-fallback username test and a regression test guarding against substring false positives in container-name matching; `createDirectoryStructure()` was deduplicated into the shared `UnitTestCase`.

## Before / After

```
helpers.php — shared filesystem primitives

┌─ Before (hand-rolled per call site) ───────────────────
│  shell_exec('find ' . $dir . ' -type f | head -n 1')
│  shell_exec('rm -rf ' . $dir)
│  RecursiveDirectoryIterator copy in acli_home_remove()
└─────────────────────────────────────────────────────────
                          │
                          ▼
┌─ After (shared helpers, one definition each) ──────────
│  walk_dir($dir, $visitor)   // top-down, symlink-safe
│  remove_dir($dir)           // rm -rf parity, best-effort
└─────────────────────────────────────────────────────────


vortex-doctor — container running check (4 services)

┌─ Before ────────────────────────────────────────────────
│  foreach ($services as $service) {
│    passthru("docker compose ps --status=running
│               | grep -q " . escapeshellarg($service));
│  }
└─ 8 processes spawned (1 docker + 1 grep, per service) ──
                          │
                          ▼
┌─ After ─────────────────────────────────────────────────
│  $running = explode("\n", shell_exec(
│    'docker compose ps --status=running'));
│  foreach ($services as $service) {
│    in_array($service, $running, TRUE);
│  }
└─ 1 process spawned, exact-name match [behavior change] ─


vortex-login / vortex-logout — admin user lookup

┌─ Before ────────────────────────────────────────────────
│  drush sql:query "SELECT name ..."
│    | head -n 1
│    | xargs drush -- user:unblock
└─ GNU/BSD xargs disagree on empty input ──────────────────
                          │
                          ▼
┌─ After ─────────────────────────────────────────────────
│  $out  = shell_exec('drush sql:query ...');
│  $name = trim(explode("\n", trim($out))[0]);
│  if ($name !== '') passthru('drush -- user:unblock ' .
│    escapeshellarg($name));
└─ empty-name guard removes the platform divergence ──────


vortex-reset — dependency and build-artifact removal

┌─ Before ────────────────────────────────────────────────
│  passthru('rm -rf "./vendor" ...
│    "./web/themes/custom/*/build"
│    "./web/themes/custom/*/scss/_components.scss"');
└─ quoted globs are never expanded by the shell ──────────
                          │
                          ▼
┌─ After ─────────────────────────────────────────────────
│  foreach ($patterns as $pattern) {
│    foreach (glob($pattern) as $path) {
│      is_dir($path) ? remove_dir($path) : @unlink($path);
│    }
│  }
└─ globs expand in PHP: build/ dirs are now actually ─────
   removed [behavior change]; the stale _components.scss
   entry was dropped (committed theme source, not a
   build artifact)


vortex-fetch-db-url — extracted dump file discovery

┌─ Before ────────────────────────────────────────────────
│  shell_exec('find ' . $temp_dir . ' -type f -print
│    | head -n 1')
└─ shells out, greedily matches the first file found ─────
                          │
                          ▼
┌─ After ─────────────────────────────────────────────────
│  walk_dir($temp_dir, function ($item) use (&$files) {
│    if ($item->isFile() && !$item->isLink()) {
│      $files[] = $item->getPathname();
│    }
│  });
└─ in-process walk, symlinked entries are skipped ────────
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expanded “Host requirements” documentation for the tooling environment.
  * Improved provisioning verification by comparing exported configuration contents directly.
* **Bug Fixes**
  * Hardened admin login/logout and doctor checks by reading command output reliably and adding stronger guards.
  * Improved safety for cleanup, directory traversal, and ZIP/database extraction using safer filesystem operations.
  * Refined Docker image/port/Xdebug detection for more consistent results.
* **Tests**
  * Updated and added unit tests covering safer filesystem utilities, provisioning verification, doctor/login/logout flows, and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
