### PR TITLE
[#2794] Added 'pull-requests: read' permission to CI deploy job for 'gh pr view'.

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -77,7 +77,7 @@ env:
   DOCKER_CONFIG: /tmp/.docker
 
 permissions:
-  contents: read # Minimal default for all jobs; jobs that need more override below.
+  contents: read
 
 jobs:
 
@@ -334,9 +334,9 @@ jobs:
     #;> !PROVISION_TYPE_PROFILE
 
     permissions:
-      contents: read # Check out the repository.
-      checks: write # Publish test results to the Checks tab.
-      pull-requests: write # Comment on the pull request.
+      contents: read
+      checks: write
+      pull-requests: write
 
     strategy:
       # A matrix to run multiple jobs in parallel.
@@ -625,8 +625,8 @@ jobs:
     #;> !PROVISION_TYPE_PROFILE
 
     permissions:
-      contents: read # Check out the repository.
-      pull-requests: read # 'gh pr view' resolves the PR head SHA and branch.
+      contents: read
+      pull-requests: read
 
     container:
       # https://hub.docker.com/r/drevops/ci-runner

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -624,6 +624,10 @@ jobs:
     if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
     #;> !PROVISION_TYPE_PROFILE
 
+    permissions:
+      contents: read # Check out the repository.
+      pull-requests: read # 'gh pr view' resolves the PR head SHA and branch.
+
     container:
       # https://hub.docker.com/r/drevops/ci-runner
       image: drevops/ci-runner:26.6.0@sha256:190027056cac7b7ce28c29a1e5494779ebadc4ee8e95d468b75bc56e7be5aabd

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -539,6 +539,10 @@ jobs:
     needs: [build, lint]
     if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
 
+    permissions:
+      contents: read # Check out the repository.
+      pull-requests: read # 'gh pr view' resolves the PR head SHA and branch.
+
     container:
       # https://hub.docker.com/r/drevops/ci-runner
       image: drevops/ci-runner:__VERSION__

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -66,7 +66,7 @@ env:
   DOCKER_CONFIG: /tmp/.docker
 
 permissions:
-  contents: read # Minimal default for all jobs; jobs that need more override below.
+  contents: read
 
 jobs:
 
@@ -289,9 +289,9 @@ jobs:
     if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
 
     permissions:
-      contents: read # Check out the repository.
-      checks: write # Publish test results to the Checks tab.
-      pull-requests: write # Comment on the pull request.
+      contents: read
+      checks: write
+      pull-requests: write
 
     strategy:
       # A matrix to run multiple jobs in parallel.
@@ -540,8 +540,8 @@ jobs:
     if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
 
     permissions:
-      contents: read # Check out the repository.
-      pull-requests: read # 'gh pr view' resolves the PR head SHA and branch.
+      contents: read
+      pull-requests: read
 
     container:
       # https://hub.docker.com/r/drevops/ci-runner

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -9,8 +9,8 @@
 -    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
 -
 -    permissions:
--      contents: read # Check out the repository.
--      pull-requests: read # 'gh pr view' resolves the PR head SHA and branch.
+-      contents: read
+-      pull-requests: read
 -
 -    container:
 -      # https://hub.docker.com/r/drevops/ci-runner

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -533,100 +533,3 @@
+@@ -533,104 +533,3 @@
          timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
          with:
            detached: true
@@ -7,6 +7,10 @@
 -    runs-on: ubuntu-latest
 -    needs: [build, lint]
 -    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
+-
+-    permissions:
+-      contents: read # Check out the repository.
+-      pull-requests: read # 'gh pr view' resolves the PR head SHA and branch.
 -
 -    container:
 -      # https://hub.docker.com/r/drevops/ci-runner

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -185,5 +185,5 @@
      needs: [build, lint]
 -    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
  
-     container:
-       # https://hub.docker.com/r/drevops/ci-runner
+     permissions:
+       contents: read # Check out the repository.

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -133,7 +133,7 @@
 -    if: ${{ !inputs.deploy_target && github.event_name != 'schedule' && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
  
      permissions:
-       contents: read # Check out the repository.
+       contents: read
 @@ -312,14 +199,6 @@
          VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"
          VORTEX_SSH_REMOVE_ALL_KEYS: "1"
@@ -186,4 +186,4 @@
 -    if: ${{ !cancelled() && (inputs.deploy_target || (success() && github.event_name != 'schedule' && !startsWith(github.head_ref || github.ref_name, 'deps/') && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')))) }}
  
      permissions:
-       contents: read # Check out the repository.
+       contents: read


### PR DESCRIPTION
Closes #2794

## Summary

The `deploy` job in `.github/workflows/build-test-deploy.yml` declared no `permissions:` block and inherited the repo-wide least-privilege `contents: read` default.
Its "Resolve deploy target" step runs `gh pr view` to resolve the PR head SHA and branch, which requires `pull-requests: read`, so a manual `workflow_dispatch` run with `deploy_target=pr-<number>` failed on private repos with `Resource not accessible by integration`.
This adds a job-level `permissions:` block granting `contents: read` (restated because a job-level block replaces rather than merges the inherited default, so checkout and artifact download keep their access) and `pull-requests: read`.
This mirrors the established pattern already used in `.github/workflows/test-vr.yml`, which declares `pull-requests: read` next to its own `gh pr view` call.

## Changes

- Added a job-level `permissions:` block (`contents: read` + `pull-requests: read`) to the `deploy` job in `.github/workflows/build-test-deploy.yml`.
- Regenerated installer test fixtures (`_baseline`, `deploy_types_none_gha`, `provision_profile`) that snapshot this workflow.

## Screenshots

N/A - non-visual CI configuration change.

## Before / After

```
BEFORE                                       AFTER
┌──────────────────────────────────┐         ┌──────────────────────────────────┐
│ deploy:                          │         │ deploy:                          │
│   # no permissions: block        │         │   permissions:                   │
│   # -> inherits repo default     │         │     contents: read               │
│                                   │         │     pull-requests: read         │
├──────────────────────────────────┤         ├──────────────────────────────────┤
│ effective permissions:            │         │ effective permissions:            │
│   contents: read                 │         │   contents: read                  │
│   pull-requests: (none)          │         │   pull-requests: read            │
├──────────────────────────────────┤         ├──────────────────────────────────┤
│ Resolve deploy target step:      │         │ Resolve deploy target step:      │
│   gh pr view <number>            │         │   gh pr view <number>            │
│   -> 403 Resource not accessible │         │   -> 200 OK, PR head SHA and     │
│      by integration              │         │      branch resolved             │
│      (private repos only)        │         │                                   │
└──────────────────────────────────┘         └──────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow permissions to follow least-privilege access.
  * Set global workflow access to read-only repository contents.
  * Refined job-level permissions: the build job now explicitly allows writing checks and pull requests; the deploy job is restricted to read-only repository contents and pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->