### PR TITLE
[#2784] Added Drupal logo to the Drupal version shield.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/README.md
@@ -11,7 +11,7 @@ Drupal 11 implementation of star wars for star wars Org
 
 [![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 
-![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
 
 ![Automated updates](https://img.shields.io/badge/Automated%20updates-RenovateBot-brightgreen.svg)
 

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/README.md
@@ -1,6 +1,6 @@
 @@ -13,6 +13,8 @@
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  
 +[![codecov](https://codecov.io/gh/star_wars_org/star_wars/graph/badge.svg)](https://codecov.io/gh/star_wars_org/star_wars)
 +

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/README.md
@@ -5,7 +5,7 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
 +
 +[![codecov](https://codecov.io/gh/star_wars_org/star_wars/graph/badge.svg)](https://codecov.io/gh/star_wars_org/star_wars)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_none/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_none/README.md
@@ -1,6 +1,6 @@
 @@ -13,8 +13,6 @@
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  
 -![Automated updates](https://img.shields.io/badge/Automated%20updates-RenovateBot-brightgreen.svg)
 -

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/names/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/names/README.md
@@ -16,7 +16,7 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![Database, Build, Test and Deploy](https://github.com/the_jedi_order/the_new_hope/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/the_jedi_order/the_new_hope/actions/workflows/build-test-deploy.yml)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  
 @@ -23,9 +23,9 @@
  

--- a/.vortex/installer/tests/Fixtures/handler_process/non_interactive_config_file/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/non_interactive_config_file/README.md
@@ -8,5 +8,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![Database, Build, Test and Deploy](https://github.com/my_custom_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/my_custom_org/star_wars/actions/workflows/build-test-deploy.yml)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/non_interactive_config_string/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/non_interactive_config_string/README.md
@@ -8,5 +8,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![Database, Build, Test and Deploy](https://github.com/my_other_custom_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/my_other_custom_org/star_wars/actions/workflows/build-test-deploy.yml)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/README.md
@@ -14,5 +14,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/README.md
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/README.md
@@ -5,5 +5,5 @@
 -[![Database, Build, Test and Deploy](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml/badge.svg)](https://github.com/star_wars_org/star_wars/actions/workflows/build-test-deploy.yml)
 +[![CircleCI](https://circleci.com/gh/star_wars_org/star_wars.svg?style=shield)](https://circleci.com/gh/star_wars_org/star_wars)
  
- ![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+ ![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
  

--- a/README.dist.md
+++ b/README.dist.md
@@ -25,7 +25,7 @@ Drupal 11 implementation of YOURSITE for YOURORG
 
 [//]: # (#;> CI_PROVIDER_GHA)
 
-![Drupal 11](https://img.shields.io/badge/Drupal-11-blue.svg)
+![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
 
 [//]: # (#;< CODE_COVERAGE_PROVIDER_CODECOV)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![Test](https://github.com/drevops/vortex/actions/workflows/vortex-test-common.yml/badge.svg)](https://github.com/drevops/vortex/actions/workflows/vortex-test-common.yml)
 [![Test docs](https://github.com/drevops/vortex/actions/workflows/vortex-test-docs.yml/badge.svg)](https://github.com/drevops/vortex/actions/workflows/vortex-test-docs.yml)
 [![codecov](https://codecov.io/gh/drevops/vortex/graph/badge.svg?token=YDTAEWWT5H)](https://codecov.io/gh/drevops/vortex)
+![Drupal 11](https://img.shields.io/badge/Drupal-11-0678BE?logo=drupal&logoColor=white)
 ![GitHub release](https://img.shields.io/github/v/release/drevops/vortex?logo=github)
 ![LICENSE](https://img.shields.io/github/license/drevops/vortex?cachebust=123)
 


### PR DESCRIPTION
Closes #2784

## Summary

The Drupal version shield now uses Drupal's brand blue (`#0678BE`) and embeds the Drupal logo, replacing the previous plain blue badge. Applied to the shipped template README, added as a new badge to the project's own README before the release badge, and propagated to the installer test fixtures.

## Changes

- `README.dist.md`: updated the Drupal shield badge to the brand-blue + logo variant.
- `README.md`: added the Drupal shield badge before the GitHub release badge.
- `.vortex/installer/tests/Fixtures/handler_process/*/README.md`: regenerated 27 snapshots via `ahoy update-snapshots` to reflect the template change.

## Before / After

```
BEFORE                                    AFTER
┌──────────────────────────┐              ┌────────────────────────────────────┐
│         Drupal 11         │              │  (drupal-logo)   Drupal 11         │
└──────────────────────────┘              └────────────────────────────────────┘
color : blue (shields.io default)         color : 0678BE (Drupal brand blue)
logo  : none                              logo  : drupal (logoColor: white)
url   : badge/Drupal-11-blue.svg          url   : badge/Drupal-11-0678BE?logo=drupal&logoColor=white
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Drupal 11 badges in the project README files with improved branding and display styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->