### PR TITLE
[#2795] Added 'issues: write' permission to the Renovate dependency updates job.

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -31,6 +31,7 @@ jobs:
 
     permissions:
       contents: write # Renovate creates branches and pushes commits.
+      issues: write
       pull-requests: write # Renovate opens and updates dependency PRs.
 
     steps:

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.github/workflows/update-dependencies.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.github/workflows/update-dependencies.yml
@@ -31,6 +31,7 @@ jobs:
 
     permissions:
       contents: write # Renovate creates branches and pushes commits.
+      issues: write
       pull-requests: write # Renovate opens and updates dependency PRs.
 
     steps:

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_gha/.github/workflows/update-dependencies.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_gha/.github/workflows/update-dependencies.yml
@@ -31,6 +31,7 @@ jobs:
 
     permissions:
       contents: write # Renovate creates branches and pushes commits.
+      issues: write
       pull-requests: write # Renovate opens and updates dependency PRs.
 
     steps:

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_none/.github/workflows/update-dependencies.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_none/.github/workflows/update-dependencies.yml
@@ -31,6 +31,7 @@ jobs:
 
     permissions:
       contents: write # Renovate creates branches and pushes commits.
+      issues: write
       pull-requests: write # Renovate opens and updates dependency PRs.
 
     steps:


### PR DESCRIPTION
Closes #2795

## Summary

The `update-dependencies` Renovate job was missing the `issues: write` permission, so any consumer whose `renovate.json` relies on the `config:recommended` preset (the default) had Renovate silently fail to create or update its Dependency Dashboard issue, since that preset enables the Dependency Dashboard, which GitHub represents as a regular issue.

## Changes

- Added `issues: write` to the `update-dependencies` job's `permissions` block in `.github/workflows/update-dependencies.yml`, inserted alphabetically between `contents: write` and `pull-requests: write`.
- Scoped the permission to the single job only, so the workflow-level default of `contents: read` is unchanged and least-privilege still holds.
- Regenerated the three installer snapshot fixtures affected by the change under `.vortex/installer/tests/Fixtures/handler_process/`: `deps_updates_provider_ci_gha`, `deps_updates_provider_ci_circleci`, and `deps_updates_provider_none`.

## Before / After

```
.github/workflows/update-dependencies.yml
└─ update-dependencies job (Renovate)
   └─ permissions:

        BEFORE                          AFTER
        ───────────────────────         ───────────────────────
        contents: write                 contents: write
        pull-requests: write            issues: write        ← added
                                         pull-requests: write

                                                 │
                                                 ▼
                       Renovate can now create/update its
                          Dependency Dashboard issue
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency maintenance by enabling issue creation and updates alongside dependency commits and pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->