### PR TITLE
[#2820] Surfaced Lagoon deploy output in debug mode and per-task status.

### DIFF
--- a/.vortex/tooling/src/vortex-deploy-lagoon
+++ b/.vortex/tooling/src/vortex-deploy-lagoon
@@ -99,8 +99,15 @@ is_lagoon_env_limit_exceeded() {
 # environment-limit error into a controlled outcome. The captured output is
 # printed so a failing deploy shows the reason instead of only "[FAIL]".
 run_lagoon_deploy() {
-  deploy_output=$(lagoon "$@" 2>&1) || exit_code=$?
-  exit_code="${exit_code:-0}"
+  local deploy_output
+
+  # Assign ${exit_code} on both paths so it always reflects this deploy's
+  # status rather than only being touched when the command fails.
+  if deploy_output=$(lagoon "$@" 2>&1); then
+    exit_code=0
+  else
+    exit_code=$?
+  fi
 
   [ -n "${deploy_output}" ] && printf '%s\n' "${deploy_output}"
 
@@ -191,8 +198,8 @@ else
       fi
     done
 
-    [ "${is_redeploy}" = "0" ] && note "No existing environment found for PR \"${VORTEX_DEPLOY_LAGOON_PR}\"."
-    pass "Discovered existing environments."
+    [ "${is_redeploy:-}" = "0" ] && note "No existing environment found for PR \"${VORTEX_DEPLOY_LAGOON_PR}\"."
+    pass "Completed environment discovery."
 
     # Re-deployment of the existing environment.
     if [ "${is_redeploy:-}" = "1" ]; then
@@ -248,8 +255,8 @@ else
       fi
     done
 
-    [ "${is_redeploy}" = "0" ] && note "No existing environment found for branch \"${VORTEX_DEPLOY_LAGOON_BRANCH}\"."
-    pass "Discovered existing environments."
+    [ "${is_redeploy:-}" = "0" ] && note "No existing environment found for branch \"${VORTEX_DEPLOY_LAGOON_BRANCH}\"."
+    pass "Completed environment discovery."
 
     # Re-deployment of the existing environment.
     if [ "${is_redeploy:-}" = "1" ]; then

--- a/.vortex/tooling/src/vortex-deploy-lagoon
+++ b/.vortex/tooling/src/vortex-deploy-lagoon
@@ -95,6 +95,26 @@ is_lagoon_env_limit_exceeded() {
 }
 # @formatter:on
 
+# Run a Lagoon deploy command, surface its output, and translate an
+# environment-limit error into a controlled outcome. The captured output is
+# printed so a failing deploy shows the reason instead of only "[FAIL]".
+run_lagoon_deploy() {
+  deploy_output=$(lagoon "$@" 2>&1) || exit_code=$?
+  exit_code="${exit_code:-0}"
+
+  [ -n "${deploy_output}" ] && printf '%s\n' "${deploy_output}"
+
+  if is_lagoon_env_limit_exceeded "${deploy_output}"; then
+    note "Lagoon environment limit exceeded."
+    [ "${VORTEX_DEPLOY_LAGOON_FAIL_ENV_LIMIT_EXCEEDED}" = "0" ] && exit_code=0
+  fi
+
+  # Always succeed: the outcome is carried in ${exit_code}. Leaking the status
+  # of the check above would trip 'set -e' at the call site and skip the final
+  # deployment status line.
+  return 0
+}
+
 # Track exit status to return at the end.
 exit_code=0
 
@@ -127,6 +147,8 @@ if ! command -v lagoon >/dev/null || [ -n "${VORTEX_DEPLOY_LAGOON_LAGOONCLI_FORC
   note "Installing Lagoon CLI to ${VORTEX_DEPLOY_LAGOON_LAGOONCLI_PATH}/lagoon."
   chmod +x "${VORTEX_DEPLOY_LAGOON_LAGOONCLI_PATH}/lagoon"
   export PATH="${PATH}:${VORTEX_DEPLOY_LAGOON_LAGOONCLI_PATH}"
+
+  pass "Installed Lagoon CLI."
 fi
 
 for cmd in lagoon curl; do command -v "${cmd}" >/dev/null || {
@@ -137,6 +159,7 @@ for cmd in lagoon curl; do command -v "${cmd}" >/dev/null || {
 task "Configuring Lagoon instance."
 #shellcheck disable=SC2218
 lagoon config add --force --lagoon "${VORTEX_DEPLOY_LAGOON_INSTANCE}" --graphql "${VORTEX_DEPLOY_LAGOON_INSTANCE_GRAPHQL}" --hostname "${VORTEX_DEPLOY_LAGOON_INSTANCE_HOSTNAME}" --port "${VORTEX_DEPLOY_LAGOON_INSTANCE_PORT}"
+pass "Configured Lagoon instance."
 
 lagoon() { command lagoon --force --skip-update-check --ssh-key "${VORTEX_DEPLOY_LAGOON_SSH_FILE}" --lagoon "${VORTEX_DEPLOY_LAGOON_INSTANCE}" --project "${VORTEX_DEPLOY_LAGOON_PROJECT}" "$@"; }
 
@@ -145,6 +168,7 @@ lagoon() { command lagoon --force --skip-update-check --ssh-key "${VORTEX_DEPLOY
 if [ "${VORTEX_DEPLOY_LAGOON_ACTION}" = "destroy" ]; then
   task "Destroying environment: project: ${VORTEX_DEPLOY_LAGOON_PROJECT}, branch: ${VORTEX_DEPLOY_LAGOON_BRANCH}."
   lagoon delete environment --environment "${VORTEX_DEPLOY_LAGOON_BRANCH}" || true
+  pass "Destroyed environment: project: ${VORTEX_DEPLOY_LAGOON_PROJECT}, branch: ${VORTEX_DEPLOY_LAGOON_BRANCH}."
 
 # ACTION: 'deploy' OR 'deploy_override_db'
 else
@@ -167,47 +191,44 @@ else
       fi
     done
 
+    [ "${is_redeploy}" = "0" ] && note "No existing environment found for PR \"${VORTEX_DEPLOY_LAGOON_PR}\"."
+    pass "Discovered existing environments."
+
     # Re-deployment of the existing environment.
     if [ "${is_redeploy:-}" = "1" ]; then
       # Explicitly set DB overwrite flag to 0 due to a bug in Lagoon.
       # @see https://github.com/uselagoon/lagoon/issues/1922
       task "Setting a database overwrite flag to 0."
       lagoon update variable --environment "${deploy_pr_full}" --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global || true
+      pass "Set a database overwrite flag to 0."
 
       # Override DB during re-deployment.
       if [ "${VORTEX_DEPLOY_LAGOON_ACTION}" = "deploy_override_db" ]; then
         task "Adding a database import override flag for the current deployment."
         # To update variable value, we need to remove it and add again.
         lagoon update variable --environment "${deploy_pr_full}" --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global || true
+        pass "Added a database import override flag for the current deployment."
       fi
 
       task "Redeploying environment: project: ${VORTEX_DEPLOY_LAGOON_PROJECT}, PR: ${VORTEX_DEPLOY_LAGOON_PR}."
-      deploy_output=$(lagoon deploy pullrequest --number "${VORTEX_DEPLOY_LAGOON_PR}" --base-branch-name "${VORTEX_DEPLOY_LAGOON_PR_BASE_BRANCH}" --base-branch-ref "origin/${VORTEX_DEPLOY_LAGOON_PR_BASE_BRANCH}" --head-branch-name "${VORTEX_DEPLOY_LAGOON_BRANCH}" --head-branch-ref "${VORTEX_DEPLOY_LAGOON_PR_HEAD}" --title "${deploy_pr_full}" 2>&1) || exit_code=$?
-      exit_code=${exit_code:-0}
-      if is_lagoon_env_limit_exceeded "${deploy_output}"; then
-        note "Lagoon environment limit exceeded."
-        [ "${VORTEX_DEPLOY_LAGOON_FAIL_ENV_LIMIT_EXCEEDED}" = "0" ] && exit_code=0
-      fi
+      run_lagoon_deploy deploy pullrequest --number "${VORTEX_DEPLOY_LAGOON_PR}" --base-branch-name "${VORTEX_DEPLOY_LAGOON_PR_BASE_BRANCH}" --base-branch-ref "origin/${VORTEX_DEPLOY_LAGOON_PR_BASE_BRANCH}" --head-branch-name "${VORTEX_DEPLOY_LAGOON_BRANCH}" --head-branch-ref "${VORTEX_DEPLOY_LAGOON_PR_HEAD}" --title "${deploy_pr_full}"
 
       if [ "${VORTEX_DEPLOY_LAGOON_ACTION:-}" = "deploy_override_db" ]; then
         task "Waiting for deployment to be queued."
         sleep 10
+        pass "Waited for deployment to be queued."
 
         task "Removing a database import override flag for the current deployment."
         # Note that a variable will be read by Lagoon during queuing of the build.
         lagoon update variable --environment "${deploy_pr_full}" --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global || true
+        pass "Removed a database import override flag for the current deployment."
       fi
 
     # Deployment of the fresh environment.
     else
       # If PR deployments are not configured in Lagoon - it will filter it out and will not deploy.
       task "Deploying environment: project: ${VORTEX_DEPLOY_LAGOON_PROJECT}, PR: ${VORTEX_DEPLOY_LAGOON_PR}."
-      deploy_output=$(lagoon deploy pullrequest --number "${VORTEX_DEPLOY_LAGOON_PR}" --base-branch-name "${VORTEX_DEPLOY_LAGOON_PR_BASE_BRANCH}" --base-branch-ref "origin/${VORTEX_DEPLOY_LAGOON_PR_BASE_BRANCH}" --head-branch-name "${VORTEX_DEPLOY_LAGOON_BRANCH}" --head-branch-ref "${VORTEX_DEPLOY_LAGOON_PR_HEAD}" --title "${deploy_pr_full}" 2>&1) || exit_code=$?
-      exit_code=${exit_code:-0}
-      if is_lagoon_env_limit_exceeded "${deploy_output}"; then
-        note "Lagoon environment limit exceeded."
-        [ "${VORTEX_DEPLOY_LAGOON_FAIL_ENV_LIMIT_EXCEEDED}" = "0" ] && exit_code=0
-      fi
+      run_lagoon_deploy deploy pullrequest --number "${VORTEX_DEPLOY_LAGOON_PR}" --base-branch-name "${VORTEX_DEPLOY_LAGOON_PR_BASE_BRANCH}" --base-branch-ref "origin/${VORTEX_DEPLOY_LAGOON_PR_BASE_BRANCH}" --head-branch-name "${VORTEX_DEPLOY_LAGOON_BRANCH}" --head-branch-ref "${VORTEX_DEPLOY_LAGOON_PR_HEAD}" --title "${deploy_pr_full}"
     fi
 
   # Deploy branch.
@@ -227,47 +248,44 @@ else
       fi
     done
 
+    [ "${is_redeploy}" = "0" ] && note "No existing environment found for branch \"${VORTEX_DEPLOY_LAGOON_BRANCH}\"."
+    pass "Discovered existing environments."
+
     # Re-deployment of the existing environment.
     if [ "${is_redeploy:-}" = "1" ]; then
       # Explicitly set DB overwrite flag to 0 due to a bug in Lagoon.
       # @see https://github.com/uselagoon/lagoon/issues/1922
       task "Setting a database overwrite flag to 0."
       lagoon update variable --environment "${VORTEX_DEPLOY_LAGOON_BRANCH}" --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global || true
+      pass "Set a database overwrite flag to 0."
 
       # Override DB during re-deployment.
       if [ "${VORTEX_DEPLOY_LAGOON_ACTION:-}" = "deploy_override_db" ]; then
         task "Adding a database import override flag for the current deployment."
         # To update variable value, we need to remove it and add again.
         lagoon update variable --environment "${VORTEX_DEPLOY_LAGOON_BRANCH}" --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global || true
+        pass "Added a database import override flag for the current deployment."
       fi
 
       task "Redeploying environment: project: ${VORTEX_DEPLOY_LAGOON_PROJECT}, branch: ${VORTEX_DEPLOY_LAGOON_BRANCH}."
-      deploy_output=$(lagoon deploy latest --environment "${VORTEX_DEPLOY_LAGOON_BRANCH}" 2>&1) || exit_code=$?
-      exit_code=${exit_code:-0}
-      if is_lagoon_env_limit_exceeded "${deploy_output}"; then
-        note "Lagoon environment limit exceeded."
-        [ "${VORTEX_DEPLOY_LAGOON_FAIL_ENV_LIMIT_EXCEEDED}" = "0" ] && exit_code=0
-      fi
+      run_lagoon_deploy deploy latest --environment "${VORTEX_DEPLOY_LAGOON_BRANCH}"
 
       if [ "${VORTEX_DEPLOY_LAGOON_ACTION:-}" = "deploy_override_db" ]; then
         task "Waiting for deployment to be queued."
         sleep 10
+        pass "Waited for deployment to be queued."
 
         task "Removing a database import override flag for the current deployment."
         # Note that a variable will be read by Lagoon during queuing of the build.
         lagoon update variable --environment "${VORTEX_DEPLOY_LAGOON_BRANCH}" --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global || true
+        pass "Removed a database import override flag for the current deployment."
       fi
 
     # Deployment of the fresh environment.
     else
       # If current branch deployments does not match a regex in Lagoon - it will filter it out and will not deploy.
       task "Deploying environment: project: ${VORTEX_DEPLOY_LAGOON_PROJECT}, branch: ${VORTEX_DEPLOY_LAGOON_BRANCH}."
-      deploy_output=$(lagoon deploy branch --branch "${VORTEX_DEPLOY_LAGOON_BRANCH}" 2>&1) || exit_code=$?
-      exit_code=${exit_code:-0}
-      if is_lagoon_env_limit_exceeded "${deploy_output}"; then
-        note "Lagoon environment limit exceeded."
-        [ "${VORTEX_DEPLOY_LAGOON_FAIL_ENV_LIMIT_EXCEEDED}" = "0" ] && exit_code=0
-      fi
+      run_lagoon_deploy deploy branch --branch "${VORTEX_DEPLOY_LAGOON_BRANCH}"
     fi
   fi
 fi

--- a/.vortex/tooling/src/vortex-deploy-lagoon
+++ b/.vortex/tooling/src/vortex-deploy-lagoon
@@ -95,9 +95,9 @@ is_lagoon_env_limit_exceeded() {
 }
 # @formatter:on
 
-# Run a Lagoon deploy command, surface its output, and translate an
-# environment-limit error into a controlled outcome. The captured output is
-# printed so a failing deploy shows the reason instead of only "[FAIL]".
+# Run a Lagoon deploy command, surface its output in debug mode, and translate
+# an environment-limit error into a controlled outcome. The captured output is
+# printed only when VORTEX_DEBUG=1 so a debugged deploy shows the CLI reason.
 run_lagoon_deploy() {
   local deploy_output
 
@@ -109,7 +109,8 @@ run_lagoon_deploy() {
     exit_code=$?
   fi
 
-  [ -n "${deploy_output}" ] && printf '%s\n' "${deploy_output}"
+  # Surface the raw CLI output only in debug mode.
+  [ "${VORTEX_DEBUG-}" = "1" ] && [ -n "${deploy_output}" ] && printf '%s\n' "${deploy_output}"
 
   if is_lagoon_env_limit_exceeded "${deploy_output}"; then
     note "Lagoon environment limit exceeded."

--- a/.vortex/tooling/tests/unit/deploy-lagoon.bats
+++ b/.vortex/tooling/tests/unit/deploy-lagoon.bats
@@ -77,7 +77,7 @@ load ../_helper.bash
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
     'No existing environment found for branch "test-branch".'
-    "Discovered existing environments."
+    "Completed environment discovery."
     "Deploying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 0 # Deployment of branch test-branch triggered."
     "Deployment of branch test-branch triggered."
@@ -115,7 +115,7 @@ load ../_helper.bash
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # ${existing_env_json}"
     'Found already deployed environment for branch "test-branch".'
-    "Discovered existing environments."
+    "Completed environment discovery."
     "Setting a database overwrite flag to 0."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
     "Set a database overwrite flag to 0."
@@ -157,7 +157,7 @@ load ../_helper.bash
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # ${existing_env_json}"
     'Found already deployed environment for branch "test-branch".'
-    "Discovered existing environments."
+    "Completed environment discovery."
     "Setting a database overwrite flag to 0."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
     "Set a database overwrite flag to 0."
@@ -209,7 +209,7 @@ load ../_helper.bash
     "Discovering existing environments for PR deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
     'No existing environment found for PR "123".'
-    "Discovered existing environments."
+    "Completed environment discovery."
     "Deploying environment: project: test_project, PR: 123."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 123 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-123 # 0 # Deployment of pr-123 triggered."
     "Deployment of pr-123 triggered."
@@ -252,7 +252,7 @@ load ../_helper.bash
     "Discovering existing environments for PR deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # ${existing_pr_env_json}"
     'Found already deployed environment for PR "123".'
-    "Discovered existing environments."
+    "Completed environment discovery."
     "Setting a database overwrite flag to 0."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment pr-123 --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
     "Set a database overwrite flag to 0."
@@ -299,7 +299,7 @@ load ../_helper.bash
     "Discovering existing environments for PR deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # ${existing_pr_env_json}"
     'Found already deployed environment for PR "456".'
-    "Discovered existing environments."
+    "Completed environment discovery."
     "Setting a database overwrite flag to 0."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment pr-456 --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
     "Set a database overwrite flag to 0."
@@ -385,7 +385,7 @@ load ../_helper.bash
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
     'No existing environment found for branch "test-branch".'
-    "Discovered existing environments."
+    "Completed environment discovery."
     "Deploying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 1 # ${limit_error}"
     "would exceed the configured limit"
@@ -425,7 +425,7 @@ load ../_helper.bash
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
     'No existing environment found for branch "test-branch".'
-    "Discovered existing environments."
+    "Completed environment discovery."
     "Deploying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 1 # ${limit_error}"
     "would exceed the configured limit"
@@ -469,7 +469,7 @@ load ../_helper.bash
     "Discovering existing environments for PR deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
     'No existing environment found for PR "133".'
-    "Discovered existing environments."
+    "Completed environment discovery."
     "Deploying environment: project: test_project, PR: 133."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 133 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-133 # 1 # ${limit_error}"
     "would exceed the configured limit"

--- a/.vortex/tooling/tests/unit/deploy-lagoon.bats
+++ b/.vortex/tooling/tests/unit/deploy-lagoon.bats
@@ -79,8 +79,7 @@ load ../_helper.bash
     'No existing environment found for branch "test-branch".'
     "Completed environment discovery."
     "Deploying environment: project: test_project, branch: test-branch."
-    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 0 # Deployment of branch test-branch triggered."
-    "Deployment of branch test-branch triggered."
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch"
     "Finished Lagoon deployment."
   )
 
@@ -120,8 +119,7 @@ load ../_helper.bash
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
     "Set a database overwrite flag to 0."
     "Redeploying environment: project: test_project, branch: test-branch."
-    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy latest --environment test-branch # 0 # Redeployment of branch test-branch triggered."
-    "Redeployment of branch test-branch triggered."
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy latest --environment test-branch"
     "Finished Lagoon deployment."
   )
 
@@ -165,8 +163,7 @@ load ../_helper.bash
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global"
     "Added a database import override flag for the current deployment."
     "Redeploying environment: project: test_project, branch: test-branch."
-    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy latest --environment test-branch # 0 # Redeployment of branch test-branch triggered."
-    "Redeployment of branch test-branch triggered."
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy latest --environment test-branch"
     "Waiting for deployment to be queued."
     "@sleep 10"
     "Waited for deployment to be queued."
@@ -211,8 +208,7 @@ load ../_helper.bash
     'No existing environment found for PR "123".'
     "Completed environment discovery."
     "Deploying environment: project: test_project, PR: 123."
-    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 123 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-123 # 0 # Deployment of pr-123 triggered."
-    "Deployment of pr-123 triggered."
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 123 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-123"
     "Finished Lagoon deployment."
   )
 
@@ -257,8 +253,7 @@ load ../_helper.bash
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment pr-123 --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
     "Set a database overwrite flag to 0."
     "Redeploying environment: project: test_project, PR: 123."
-    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 123 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-123 # 0 # Redeployment of pr-123 triggered."
-    "Redeployment of pr-123 triggered."
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 123 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-123"
     "Finished Lagoon deployment."
   )
 
@@ -307,8 +302,7 @@ load ../_helper.bash
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment pr-456 --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global"
     "Added a database import override flag for the current deployment."
     "Redeploying environment: project: test_project, PR: 456."
-    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 456 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-456 # 0 # Redeployment of pr-456 triggered."
-    "Redeployment of pr-456 triggered."
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 456 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-456"
     "Waiting for deployment to be queued."
     "@sleep 10"
     "Waited for deployment to be queued."
@@ -388,7 +382,7 @@ load ../_helper.bash
     "Completed environment discovery."
     "Deploying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 1 # ${limit_error}"
-    "would exceed the configured limit"
+    "- would exceed the configured limit"
     "Lagoon environment limit exceeded."
     "Finished Lagoon deployment."
   )
@@ -428,7 +422,7 @@ load ../_helper.bash
     "Completed environment discovery."
     "Deploying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 1 # ${limit_error}"
-    "would exceed the configured limit"
+    "- would exceed the configured limit"
     "Lagoon environment limit exceeded."
     "[FAIL] Lagoon deployment completed with errors."
   )
@@ -459,7 +453,6 @@ load ../_helper.bash
   # Mock lagoon command to return environment limit exceeded error
   local limit_error="Error: graphql: 'pr-133' would exceed the configured limit of 5 development environments for project website"
 
-  # shellcheck disable=SC2034
   declare -a STEPS=(
     "Started Lagoon deployment."
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
@@ -472,7 +465,7 @@ load ../_helper.bash
     "Completed environment discovery."
     "Deploying environment: project: test_project, PR: 133."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 133 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-133 # 1 # ${limit_error}"
-    "would exceed the configured limit"
+    "- would exceed the configured limit"
     "Lagoon environment limit exceeded."
     "Finished Lagoon deployment."
   )
@@ -481,6 +474,68 @@ load ../_helper.bash
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_success
+  run_steps "assert" "${mocks[@]}"
+
+  popd >/dev/null
+}
+
+@test "Debug: deploy output is surfaced when VORTEX_DEBUG is enabled" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  fixture_ssh_key_prepare
+  fixture_ssh_key
+
+  export LAGOON_PROJECT="test_project"
+  export VORTEX_DEPLOY_BRANCH="test-branch"
+  export VORTEX_DEPLOY_LAGOON_INSTANCE="amazeeio"
+  export VORTEX_DEBUG=1
+
+  declare -a STEPS=(
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
+    "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 0 # Deployment of branch test-branch triggered."
+    "Deployment of branch test-branch triggered."
+    "Finished Lagoon deployment."
+  )
+
+  mocks="$(run_steps "setup")"
+
+  run .vortex/tooling/src/vortex-deploy-lagoon
+  assert_success
+  run_steps "assert" "${mocks[@]}"
+
+  popd >/dev/null
+}
+
+@test "Debug: failed deploy surfaces its error when VORTEX_DEBUG is enabled" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  fixture_ssh_key_prepare
+  fixture_ssh_key
+
+  export LAGOON_PROJECT="test_project"
+  export VORTEX_DEPLOY_BRANCH="test-branch"
+  export VORTEX_DEPLOY_LAGOON_INSTANCE="amazeeio"
+  export VORTEX_DEBUG=1
+
+  # Mock a deploy failure unrelated to environment limits.
+  local deploy_error="Error: deployment rejected by policy."
+
+  # shellcheck disable=SC2034
+  declare -a STEPS=(
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
+    "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 1 # ${deploy_error}"
+    "Error: deployment rejected by policy."
+    "[FAIL] Lagoon deployment completed with errors."
+  )
+
+  mocks="$(run_steps "setup")"
+
+  run .vortex/tooling/src/vortex-deploy-lagoon
+  assert_failure
   run_steps "assert" "${mocks[@]}"
 
   popd >/dev/null

--- a/.vortex/tooling/tests/unit/deploy-lagoon.bats
+++ b/.vortex/tooling/tests/unit/deploy-lagoon.bats
@@ -73,10 +73,14 @@ load ../_helper.bash
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "Configured Lagoon instance."
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
+    'No existing environment found for branch "test-branch".'
+    "Discovered existing environments."
     "Deploying environment: project: test_project, branch: test-branch."
-    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 0 # Deployment of branch test-branch triggered."
+    "Deployment of branch test-branch triggered."
     "Finished Lagoon deployment."
   )
 
@@ -107,13 +111,17 @@ load ../_helper.bash
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "Configured Lagoon instance."
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # ${existing_env_json}"
     'Found already deployed environment for branch "test-branch".'
+    "Discovered existing environments."
     "Setting a database overwrite flag to 0."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
+    "Set a database overwrite flag to 0."
     "Redeploying environment: project: test_project, branch: test-branch."
-    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy latest --environment test-branch"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy latest --environment test-branch # 0 # Redeployment of branch test-branch triggered."
+    "Redeployment of branch test-branch triggered."
     "Finished Lagoon deployment."
   )
 
@@ -145,19 +153,26 @@ load ../_helper.bash
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "Configured Lagoon instance."
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # ${existing_env_json}"
     'Found already deployed environment for branch "test-branch".'
+    "Discovered existing environments."
     "Setting a database overwrite flag to 0."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
+    "Set a database overwrite flag to 0."
     "Adding a database import override flag for the current deployment."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global"
+    "Added a database import override flag for the current deployment."
     "Redeploying environment: project: test_project, branch: test-branch."
-    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy latest --environment test-branch"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy latest --environment test-branch # 0 # Redeployment of branch test-branch triggered."
+    "Redeployment of branch test-branch triggered."
     "Waiting for deployment to be queued."
     "@sleep 10"
+    "Waited for deployment to be queued."
     "Removing a database import override flag for the current deployment."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
+    "Removed a database import override flag for the current deployment."
     "Finished Lagoon deployment."
   )
 
@@ -190,10 +205,14 @@ load ../_helper.bash
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "Configured Lagoon instance."
     "Discovering existing environments for PR deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
+    'No existing environment found for PR "123".'
+    "Discovered existing environments."
     "Deploying environment: project: test_project, PR: 123."
-    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 123 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-123"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 123 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-123 # 0 # Deployment of pr-123 triggered."
+    "Deployment of pr-123 triggered."
     "Finished Lagoon deployment."
   )
 
@@ -229,13 +248,17 @@ load ../_helper.bash
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "Configured Lagoon instance."
     "Discovering existing environments for PR deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # ${existing_pr_env_json}"
     'Found already deployed environment for PR "123".'
+    "Discovered existing environments."
     "Setting a database overwrite flag to 0."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment pr-123 --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
+    "Set a database overwrite flag to 0."
     "Redeploying environment: project: test_project, PR: 123."
-    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 123 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-123"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 123 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-123 # 0 # Redeployment of pr-123 triggered."
+    "Redeployment of pr-123 triggered."
     "Finished Lagoon deployment."
   )
 
@@ -272,19 +295,26 @@ load ../_helper.bash
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "Configured Lagoon instance."
     "Discovering existing environments for PR deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # ${existing_pr_env_json}"
     'Found already deployed environment for PR "456".'
+    "Discovered existing environments."
     "Setting a database overwrite flag to 0."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment pr-456 --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
+    "Set a database overwrite flag to 0."
     "Adding a database import override flag for the current deployment."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment pr-456 --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global"
+    "Added a database import override flag for the current deployment."
     "Redeploying environment: project: test_project, PR: 456."
-    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 456 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-456"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 456 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-456 # 0 # Redeployment of pr-456 triggered."
+    "Redeployment of pr-456 triggered."
     "Waiting for deployment to be queued."
     "@sleep 10"
+    "Waited for deployment to be queued."
     "Removing a database import override flag for the current deployment."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment pr-456 --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
+    "Removed a database import override flag for the current deployment."
     "Finished Lagoon deployment."
   )
 
@@ -314,8 +344,10 @@ load ../_helper.bash
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "Configured Lagoon instance."
     "Destroying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project delete environment --environment test-branch"
+    "Destroyed environment: project: test_project, branch: test-branch."
     "Finished Lagoon deployment."
   )
 
@@ -349,10 +381,14 @@ load ../_helper.bash
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "Configured Lagoon instance."
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
+    'No existing environment found for branch "test-branch".'
+    "Discovered existing environments."
     "Deploying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 1 # ${limit_error}"
+    "would exceed the configured limit"
     "Lagoon environment limit exceeded."
     "Finished Lagoon deployment."
   )
@@ -385,10 +421,14 @@ load ../_helper.bash
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "Configured Lagoon instance."
     "Discovering existing environments for branch deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
+    'No existing environment found for branch "test-branch".'
+    "Discovered existing environments."
     "Deploying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 1 # ${limit_error}"
+    "would exceed the configured limit"
     "Lagoon environment limit exceeded."
     "[FAIL] Lagoon deployment completed with errors."
   )
@@ -425,10 +465,14 @@ load ../_helper.bash
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "Configuring Lagoon instance."
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "Configured Lagoon instance."
     "Discovering existing environments for PR deployments."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
+    'No existing environment found for PR "133".'
+    "Discovered existing environments."
     "Deploying environment: project: test_project, PR: 133."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy pullrequest --number 133 --base-branch-name develop --base-branch-ref origin/develop --head-branch-name feature-branch --head-branch-ref origin/feature-branch --title pr-133 # 1 # ${limit_error}"
+    "would exceed the configured limit"
     "Lagoon environment limit exceeded."
     "Finished Lagoon deployment."
   )


### PR DESCRIPTION
Closes #2820

## Summary

The Lagoon deploy script captured the `lagoon deploy` CLI output into `deploy_output` only to grep it for the environment-limit-exceeded case, then discarded it, so a failed deploy printed only `[FAIL] Lagoon deployment completed with errors.` with no reason. Because the output was captured via command substitution, even `VORTEX_DEBUG=1` (which enables `set -x`) never surfaced it. This extracts the four near-identical deploy call sites into a single `run_lagoon_deploy` helper that prints the captured output when debug mode is enabled, and closes each `[TASK]` with a matching `[ OK ]` status line so the deploy's own progress is fully visible.

## Changes

- Added a `run_lagoon_deploy` helper in `.vortex/tooling/src/vortex-deploy-lagoon` that runs `lagoon "$@"`, prints the captured CLI output when `VORTEX_DEBUG=1`, and applies the existing `is_lagoon_env_limit_exceeded` translation. The environment-limit note and exit-code handling still run in every mode; only the raw CLI output is gated on debug.
- Replaced the four duplicated `deploy_output=$(lagoon deploy ... 2>&1) || exit_code=$?` blocks (PR redeploy, PR fresh deploy, branch redeploy, branch fresh deploy) with calls to `run_lagoon_deploy`.
- `run_lagoon_deploy` assigns `exit_code` on both the success and failure paths and always `return 0`, so the outcome is carried in `${exit_code}` without tripping `set -e` at the call site and skipping the final status line.
- Added `pass` status lines after each `task` block (Lagoon CLI install, instance config, environment destroy, environment discovery, DB overwrite flag set/add/remove, deploy-queue wait) so every task is explicitly closed with an `[ OK ]`; the deploy task itself is closed by the terminal `[ OK ]`/`[FAIL]`.
- Added a "No existing environment found ..." `note` for the fresh-deploy paths (PR and branch), symmetric to the existing "Found already deployed environment ..." note, so new-vs-redeploy is explicit in the output.
- Extended `.vortex/tooling/tests/unit/deploy-lagoon.bats`: the flow scenarios assert the new discovery notes and `[ OK ]` lines; the environment-limit scenarios assert the raw CLI error is not printed without debug (while the limit note still shows); and two new debug-mode scenarios assert the deploy output, and a failing deploy's reason, are surfaced under `VORTEX_DEBUG=1`.

## Before / After

```
Before                                     After (VORTEX_DEBUG=1)
-------------------------------------      -------------------------------------
[TASK] Deploying environment...            [TASK] Deploying environment...
[FAIL] Lagoon deployment                   <full lagoon CLI output, incl reason>
       completed with errors.              [FAIL] Lagoon deployment
                                                  completed with errors.
deploy_output was captured, grepped
for the limit case, then discarded -       run_lagoon_deploy prints deploy_output
so the reason never printed, even          when VORTEX_DEBUG=1; every [TASK] is
with VORTEX_DEBUG=1.                        closed with a matching [ OK ]. Without
                                           debug, output stays quiet by design.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer deployment status updates throughout environment discovery, configuration, redeployment, waiting, and destruction steps.
  - Improved handling of Lagoon environment-limit errors, including an option to continue successfully when limits are exceeded.

- **Bug Fixes**
  - Deployment results and error messages are now reported consistently for pull request and branch deployments.
  - Added clearer confirmation messages for triggered, queued, completed, and destroyed deployment actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
