### PR TITLE
[#2821] Fixed database fetch skip message to name the indexed force variable.

### DIFF
--- a/.vortex/tooling/src/vortex-fetch-db
+++ b/.vortex/tooling/src/vortex-fetch-db
@@ -69,7 +69,7 @@ if [ "${VORTEX_FETCH_DB_SOURCE}" != "container_registry" ]; then
     if [ "${VORTEX_FETCH_DB_FORCE}" != "1" ]; then
       note "Using existing database dump file(s)."
       note "Fetch will not proceed."
-      note "Remove existing database file or set VORTEX_FETCH_DB_FORCE value to 1 to force fetch."
+      note "Remove existing database file or set VORTEX_FETCH_DB${_db_index}_FORCE value to 1 to force fetch."
       exit 0
     else
       note "Will fetch a fresh copy of the database."

--- a/.vortex/tooling/tests/unit/fetch-db.bats
+++ b/.vortex/tooling/tests/unit/fetch-db.bats
@@ -210,6 +210,9 @@ EOF
   # plain VORTEX_DB_DIR fallback and found the existing dump there.
   assert_output_contains "Found existing database dump file(s)."
   assert_output_contains "Using existing database dump file(s)."
+  # The force hint must name the indexed variable that controls this fetch
+  # (VORTEX_FETCH_DB2_FORCE), not the non-indexed VORTEX_FETCH_DB_FORCE.
+  assert_output_contains "Remove existing database file or set VORTEX_FETCH_DB2_FORCE value to 1 to force fetch."
 
   popd >/dev/null
 }


### PR DESCRIPTION
Closes #2821

## Summary

`vortex-fetch-db` resolves every DB variable through a `VORTEX_DB_INDEX` suffix, so the force-refetch flag for a given DB comes from `VORTEX_FETCH_DB${_db_index}_FORCE` (e.g. `VORTEX_FETCH_DB2_FORCE` for the migration DB). The message shown when an existing dump is found hardcoded the non-indexed `VORTEX_FETCH_DB_FORCE`, so for the migration DB it told users to set a variable that has no effect on that fetch. This interpolates `${_db_index}` into the message so it names the variable that actually controls the current DB's fetch.

## Changes

- Interpolated `${_db_index}` into the skip message in `.vortex/tooling/src/vortex-fetch-db`, so it reads `VORTEX_FETCH_DB_FORCE` for the primary DB (index empty, unchanged) and `VORTEX_FETCH_DB2_FORCE` for the migration DB (index `2`).
- Extended the existing indexed BATS scenario `Resolve indexed dir from plain VORTEX_DB_DIR fallback` in `.vortex/tooling/tests/unit/fetch-db.bats` with an assertion that the message names `VORTEX_FETCH_DB2_FORCE`.

## Before / After

```
┌──────────────────────────────────────────────────┐
│ BEFORE - migration DB fetch, existing dump found │
│                                                  │
│ Remove existing database file or set             │
│ VORTEX_FETCH_DB_FORCE value to 1 to force fetch. │
│                                                  │
│ Wrong: has no effect on the migration DB fetch - │
│ that flag only controls the primary DB.          │
└──────────────────────────────────────────────────┘

┌───────────────────────────────────────────────────┐
│ AFTER - migration DB fetch, existing dump found   │
│                                                   │
│ Remove existing database file or set              │
│ VORTEX_FETCH_DB2_FORCE value to 1 to force fetch. │
│                                                   │
│ Correct: this is the flag that actually forces    │
│ a fresh fetch of the migration DB.                │
└───────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the force-fetch guidance for indexed database dumps to reference the appropriate environment variable.
  * Updated the related validation to ensure the displayed instructions are accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->