### PR TITLE
[#2696] Bumped git-artifact to 1.7.0 and add an option for stale deployment branch cleanup.

### DIFF
--- a/.vortex/docs/content/tools/git-artifact.mdx
+++ b/.vortex/docs/content/tools/git-artifact.mdx
@@ -43,7 +43,7 @@ with a SHA256 checksum before execution.
 
 The version and checksum are controlled by:
 
-- `VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_VERSION`: Version to download (default: `1.4.0`).
+- `VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_VERSION`: Version to download (default: `1.7.0`).
 - `VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_SHA256`: Expected SHA256 checksum of the binary.
 
 It is required to set the following environment variables in the continuous
@@ -53,3 +53,23 @@ integration environment:
   committing to a remote repository.
 - `VORTEX_DEPLOY_ARTIFACT_GIT_USER_EMAIL`: Name of the user who will be
   committing to a remote repository.
+
+## Stale branch cleanup
+
+Each source branch is deployed to a same-named branch in the destination
+repository, so over time the destination accumulates branches for source
+branches that no longer exist. **Vortex** can prune these stale branches after
+each successful push.
+
+Cleanup is opt-in and controlled by:
+
+- `VORTEX_DEPLOY_ARTIFACT_CLEANUP_PATTERN`: branches eligible for pruning.
+  Setting a non-empty value enables cleanup; leaving it empty (the default)
+  disables it. The value is a comma-separated list of globs
+  (e.g. `feature/*,bugfix/*`) or a single regex literal (e.g. `/^feature\/.+$/`).
+  A branch matching any pattern is eligible.
+- `VORTEX_DEPLOY_ARTIFACT_CLEANUP_AGE`: age in days after which a matching branch
+  is considered stale (default: `7`).
+
+The branch that was just pushed and the destination repository's default branch
+are never deleted, and cleanup never fails a deployment that already succeeded.

--- a/.vortex/tooling/src/vortex-deploy-artifact
+++ b/.vortex/tooling/src/vortex-deploy-artifact
@@ -52,10 +52,19 @@ VORTEX_DEPLOY_ARTIFACT_SSH_FINGERPRINT="${VORTEX_DEPLOY_ARTIFACT_SSH_FINGERPRINT
 VORTEX_DEPLOY_ARTIFACT_SSH_FILE="${VORTEX_DEPLOY_ARTIFACT_SSH_FILE:-${VORTEX_DEPLOY_SSH_FILE:-${HOME}/.ssh/id_rsa}}"
 
 # Version of git-artifact to download.
-VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_VERSION="${VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_VERSION:-1.4.0}"
+VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_VERSION="${VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_VERSION:-1.7.0}"
 
 # SHA256 checksum of the git-artifact binary.
-VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_SHA256="${VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_SHA256:-1fa99ff2a6f8dc6c1a42bcfc87ce75d04b2eab375216b0e3195a0e3b51a47646}"
+VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_SHA256="${VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_SHA256:-bff9d061fb757051366d650c35e367d9b024b7146e22fbd831c734ff88f4af4d}"
+
+# Remote branches eligible for stale branch cleanup after a successful push:
+# comma-separated globs (e.g. "feature/*,bugfix/*") or a single regex literal.
+# A branch matching any pattern is pruned. Setting this enables cleanup; empty
+# disables it. The just-pushed branch and the remote default branch are kept.
+VORTEX_DEPLOY_ARTIFACT_CLEANUP_PATTERN="${VORTEX_DEPLOY_ARTIFACT_CLEANUP_PATTERN:-}"
+
+# Age in days after which a matching remote branch is considered stale.
+VORTEX_DEPLOY_ARTIFACT_CLEANUP_AGE="${VORTEX_DEPLOY_ARTIFACT_CLEANUP_AGE:-7}"
 
 # ------------------------------------------------------------------------------
 
@@ -116,13 +125,22 @@ task "Copying deployment .gitignore as it may not exist in deploy code source fi
 cp -a "${VORTEX_DEPLOY_ARTIFACT_ROOT}"/.gitignore.artifact "${VORTEX_DEPLOY_ARTIFACT_SRC}" || true
 
 task "Running artifact builder."
+artifact_args=(
+  "${VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE}"
+  --root="${VORTEX_DEPLOY_ARTIFACT_ROOT}"
+  --src="${VORTEX_DEPLOY_ARTIFACT_SRC}"
+  --branch="${VORTEX_DEPLOY_ARTIFACT_DST_BRANCH}"
+  --gitignore="${VORTEX_DEPLOY_ARTIFACT_SRC}/.gitignore.artifact"
+  --log="${VORTEX_DEPLOY_ARTIFACT_LOG}"
+)
+
+# Prune stale remote branches only when a pattern is set: git-artifact requires
+# a pattern and errors without one.
+if [ -n "${VORTEX_DEPLOY_ARTIFACT_CLEANUP_PATTERN}" ]; then
+  artifact_args+=(--cleanup-stale --cleanup-pattern="${VORTEX_DEPLOY_ARTIFACT_CLEANUP_PATTERN}" --cleanup-age="${VORTEX_DEPLOY_ARTIFACT_CLEANUP_AGE}")
+fi
+
 # Add --debug to debug any deployment issues.
-"${TMPDIR:-/tmp}"/git-artifact "${VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE}" \
-  --root="${VORTEX_DEPLOY_ARTIFACT_ROOT}" \
-  --src="${VORTEX_DEPLOY_ARTIFACT_SRC}" \
-  --branch="${VORTEX_DEPLOY_ARTIFACT_DST_BRANCH}" \
-  --gitignore="${VORTEX_DEPLOY_ARTIFACT_SRC}"/.gitignore.artifact \
-  --log="${VORTEX_DEPLOY_ARTIFACT_LOG}" \
-  -vvv
+"${TMPDIR:-/tmp}"/git-artifact "${artifact_args[@]}" -vvv
 
 pass "Finished artifact deployment."

--- a/.vortex/tooling/tests/unit/deploy-artifact.bats
+++ b/.vortex/tooling/tests/unit/deploy-artifact.bats
@@ -120,6 +120,10 @@ load ../_helper.bash
   export VORTEX_DEPLOY_ARTIFACT_GIT_USER_EMAIL="test_user@example.com"
   local file=${HOME}/.ssh/id_rsa
 
+  # Ensure cleanup stays disabled regardless of any inherited environment.
+  unset VORTEX_DEPLOY_ARTIFACT_CLEANUP_PATTERN
+  unset VORTEX_DEPLOY_ARTIFACT_CLEANUP_AGE
+
   # Echo git-artifact's arguments so the absence of cleanup flags can be
   # asserted when no cleanup pattern is set.
   printf '#!/usr/bin/env bash\necho "ARTIFACT_ARGS: $*"\n' >"${TMPDIR:-/tmp}/git-artifact"
@@ -155,6 +159,8 @@ load ../_helper.bash
   assert_success
 
   assert_output_not_contains "--cleanup-stale"
+  assert_output_not_contains "--cleanup-pattern"
+  assert_output_not_contains "--cleanup-age"
 
   run_steps "assert" "${mocks[@]}"
   assert_equal "2" "$(mock_get_call_num "${mock_realpath}" 1)"

--- a/.vortex/tooling/tests/unit/deploy-artifact.bats
+++ b/.vortex/tooling/tests/unit/deploy-artifact.bats
@@ -90,7 +90,7 @@ load ../_helper.bash
     "@git config --global user.email #"
     "@git config --global user.email ${VORTEX_DEPLOY_ARTIFACT_GIT_USER_EMAIL} # 0 #"
     "@ssh-add -l # ${file}"
-    "@curl -sS -L https://github.com/drevops/git-artifact/releases/download/1.4.0/git-artifact -o ${TMPDIR:-/tmp}/git-artifact"
+    "@curl -sS -L https://github.com/drevops/git-artifact/releases/download/1.7.0/git-artifact -o ${TMPDIR:-/tmp}/git-artifact"
     "@sha256sum -c # 1"
     "SHA256 checksum verification failed for git-artifact binary."
     "- Finished artifact deployment."
@@ -120,6 +120,11 @@ load ../_helper.bash
   export VORTEX_DEPLOY_ARTIFACT_GIT_USER_EMAIL="test_user@example.com"
   local file=${HOME}/.ssh/id_rsa
 
+  # Echo git-artifact's arguments so the absence of cleanup flags can be
+  # asserted when no cleanup pattern is set.
+  printf '#!/usr/bin/env bash\necho "ARTIFACT_ARGS: $*"\n' >"${TMPDIR:-/tmp}/git-artifact"
+  chmod +x "${TMPDIR:-/tmp}/git-artifact"
+
   mock_realpath=$(mock_command "realpath")
 
   declare -a STEPS=(
@@ -136,7 +141,7 @@ load ../_helper.bash
     "@ssh-add -l # ${file}"
     "SSH agent already has ${file} key loaded."
     "Installing artifact builder."
-    "@curl -sS -L https://github.com/drevops/git-artifact/releases/download/1.4.0/git-artifact -o ${TMPDIR:-/tmp}/git-artifact"
+    "@curl -sS -L https://github.com/drevops/git-artifact/releases/download/1.7.0/git-artifact -o ${TMPDIR:-/tmp}/git-artifact"
     "@sha256sum -c"
     "@chmod +x ${TMPDIR:-/tmp}/git-artifact"
     "Copying git repo files meta file to the deploy code repo."
@@ -149,8 +154,60 @@ load ../_helper.bash
   run .vortex/tooling/src/vortex-deploy-artifact
   assert_success
 
+  assert_output_not_contains "--cleanup-stale"
+
   run_steps "assert" "${mocks[@]}"
   assert_equal "2" "$(mock_get_call_num "${mock_realpath}" 1)"
+
+  popd >/dev/null
+}
+
+@test "Artifact deployment passes stale branch cleanup flags when a cleanup pattern is set" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  fixture_ssh_key_prepare
+  fixture_ssh_key
+  fixture_robo
+
+  # Echo git-artifact's arguments so the cleanup flags can be asserted.
+  printf '#!/usr/bin/env bash\necho "ARTIFACT_ARGS: $*"\n' >"${TMPDIR:-/tmp}/git-artifact"
+  chmod +x "${TMPDIR:-/tmp}/git-artifact"
+
+  export VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE="git@github.com:yourorg/your-repo-destination.git"
+  export VORTEX_DEPLOY_ARTIFACT_DST_BRANCH="main"
+  export VORTEX_DEPLOY_ARTIFACT_SRC="dist"
+  export VORTEX_DEPLOY_ARTIFACT_ROOT="."
+  export VORTEX_DEPLOY_ARTIFACT_LOG="deploy-report.txt"
+  export VORTEX_DEPLOY_ARTIFACT_GIT_USER_NAME="test_user"
+  export VORTEX_DEPLOY_ARTIFACT_GIT_USER_EMAIL="test_user@example.com"
+  export VORTEX_DEPLOY_ARTIFACT_CLEANUP_PATTERN="feature/*,bugfix/*"
+  export VORTEX_DEPLOY_ARTIFACT_CLEANUP_AGE="3"
+  local file=${HOME}/.ssh/id_rsa
+
+  mock_realpath=$(mock_command "realpath")
+
+  declare -a STEPS=(
+    "@git config --global user.name #"
+    "@git config --global user.name ${VORTEX_DEPLOY_ARTIFACT_GIT_USER_NAME} # 0 #"
+    "@git config --global user.email #"
+    "@git config --global user.email ${VORTEX_DEPLOY_ARTIFACT_GIT_USER_EMAIL} # 0 #"
+    "@ssh-add -l # ${file}"
+    "@curl -sS -L https://github.com/drevops/git-artifact/releases/download/1.7.0/git-artifact -o ${TMPDIR:-/tmp}/git-artifact"
+    "@sha256sum -c"
+    "@chmod +x ${TMPDIR:-/tmp}/git-artifact"
+    "Running artifact builder."
+    "Finished artifact deployment."
+  )
+  mocks="$(run_steps "setup")"
+
+  run .vortex/tooling/src/vortex-deploy-artifact
+  assert_success
+
+  assert_output_contains "--cleanup-stale"
+  assert_output_contains "--cleanup-pattern=feature/*,bugfix/*"
+  assert_output_contains "--cleanup-age=3"
+
+  run_steps "assert" "${mocks[@]}"
 
   popd >/dev/null
 }


### PR DESCRIPTION
Closes #2696

## Summary

Bumps `git-artifact` from 1.4.0 to 1.7.0 in `vortex-deploy-artifact` and wires its new stale-branch cleanup so remote deployment branches left behind by deleted or merged source branches can be pruned automatically after a successful artifact push. Cleanup is controlled by two new environment variables, `VORTEX_DEPLOY_ARTIFACT_CLEANUP_PATTERN` and `VORTEX_DEPLOY_ARTIFACT_CLEANUP_AGE`, and stays disabled by default until a pattern is set.

## Changes

- `.vortex/tooling/src/vortex-deploy-artifact`: bumped the default `git-artifact` version and SHA256 checksum to 1.7.0, added `VORTEX_DEPLOY_ARTIFACT_CLEANUP_PATTERN` (comma-separated globs or a single regex literal; a non-empty value enables cleanup) and `VORTEX_DEPLOY_ARTIFACT_CLEANUP_AGE` (default `7`), and built the `git-artifact` invocation into an `artifact_args` array so `--cleanup-stale`, `--cleanup-pattern`, and `--cleanup-age` are only appended when a pattern is set.
- `.vortex/tooling/tests/unit/deploy-artifact.bats`: updated the two hardcoded `git-artifact` download version strings to 1.7.0, added an isolated scenario asserting all three cleanup flags stay absent when the cleanup variables are unset, and added a new scenario asserting the flags are passed correctly for a comma-separated multi-pattern value.
- `.vortex/docs/content/tools/git-artifact.mdx`: bumped the documented default version to 1.7.0 and added a "Stale branch cleanup" section documenting both variables, with glob (`feature/*,bugfix/*`) and regex pattern examples.

## Screenshots

N/A - this change affects deploy-time Bash tooling, BATS tests, and docs, with no rendered UI.

## Before / After

```
┌──────────────────────────────────────────────────────┐
│ BEFORE - git-artifact 1.4.0                          │
│                                                      │
│ Every deploy pushes to a same-named branch in the    │
│ destination repo. Branches for deleted or merged     │
│ source branches are never removed - they pile up     │
│ in the destination repo indefinitely.                │
└──────────────────────────────────────────────────────┘

┌──────────────────────────────────────────────────────┐
│ AFTER - git-artifact 1.7.0                           │
│                                                      │
│ VORTEX_DEPLOY_ARTIFACT_CLEANUP_PATTERN opts in to    │
│ pruning: branches matching the pattern and older     │
│ than VORTEX_DEPLOY_ARTIFACT_CLEANUP_AGE days         │
│ (default 7) are deleted after each successful push.  │
│ The just-pushed branch and the remote default        │
│ branch are always protected. Empty pattern (the      │
│ default) keeps 1.4.0 behaviour unchanged.            │
└──────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional stale-branch cleanup after successful artifact deployments.
  * Cleanup can be configured using branch patterns and an age threshold.
  * Recently pushed branches and the destination’s default branch are protected from deletion.
  * Cleanup failures do not invalidate an otherwise successful deployment.

* **Improvements**
  * Updated the default `git-artifact` release to version 1.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->