### PR TITLE
[#2835] Surfaced the Lagoon CLI error on a failed deploy without debug mode.

### DIFF
--- a/.vortex/tooling/src/vortex-deploy-lagoon
+++ b/.vortex/tooling/src/vortex-deploy-lagoon
@@ -95,9 +95,9 @@ is_lagoon_env_limit_exceeded() {
 }
 # @formatter:on
 
-# Run a Lagoon deploy command, surface its output in debug mode, and translate
-# an environment-limit error into a controlled outcome. The captured output is
-# printed only when VORTEX_DEBUG=1 so a debugged deploy shows the CLI reason.
+# Run a Lagoon deploy command, surface its output, and translate an
+# environment-limit error into a controlled outcome. The reason for a failed
+# deploy is carried in ${deploy_error} to be shown with the final status.
 run_lagoon_deploy() {
   local deploy_output
 
@@ -109,22 +109,30 @@ run_lagoon_deploy() {
     exit_code=$?
   fi
 
-  # Surface the raw CLI output only in debug mode.
-  [ "${VORTEX_DEBUG-}" = "1" ] && [ -n "${deploy_output}" ] && printf '%s\n' "${deploy_output}"
-
   if is_lagoon_env_limit_exceeded "${deploy_output}"; then
     note "Lagoon environment limit exceeded."
     [ "${VORTEX_DEPLOY_LAGOON_FAIL_ENV_LIMIT_EXCEEDED}" = "0" ] && exit_code=0
   fi
 
+  # The CLI output is the only record of why a deploy failed, so retain it
+  # rather than making the failure reproducible only with debug enabled.
+  [ "${exit_code}" != "0" ] && deploy_error="${deploy_output}"
+
+  # A deploy that did not fail has nothing to explain, so its output remains
+  # verbose-only.
+  [ "${exit_code}" = "0" ] && [ "${VORTEX_DEBUG-}" = "1" ] && [ -n "${deploy_output}" ] && printf '%s\n' "${deploy_output}"
+
   # Always succeed: the outcome is carried in ${exit_code}. Leaking the status
-  # of the check above would trip 'set -e' at the call site and skip the final
+  # of the checks above would trip 'set -e' at the call site and skip the final
   # deployment status line.
   return 0
 }
 
 # Track exit status to return at the end.
 exit_code=0
+
+# Raw CLI output of a failed deploy, printed with the final status.
+deploy_error=""
 
 info "Started Lagoon deployment."
 
@@ -302,6 +310,10 @@ if [ "${exit_code}" = "0" ]; then
   pass "Finished Lagoon deployment."
 else
   fail "Lagoon deployment completed with errors."
+
+  if [ -n "${deploy_error}" ]; then
+    printf '%s\n' "${deploy_error}"
+  fi
 fi
 
 exit "${exit_code}"

--- a/.vortex/tooling/tests/unit/deploy-lagoon.bats
+++ b/.vortex/tooling/tests/unit/deploy-lagoon.bats
@@ -422,9 +422,9 @@ load ../_helper.bash
     "Completed environment discovery."
     "Deploying environment: project: test_project, branch: test-branch."
     "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 1 # ${limit_error}"
-    "- would exceed the configured limit"
     "Lagoon environment limit exceeded."
     "[FAIL] Lagoon deployment completed with errors."
+    "would exceed the configured limit"
   )
 
   mocks="$(run_steps "setup")"
@@ -536,6 +536,107 @@ load ../_helper.bash
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_failure
+  run_steps "assert" "${mocks[@]}"
+
+  popd >/dev/null
+}
+
+@test "Failure: failed deploy surfaces its error without debug mode" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  fixture_ssh_key_prepare
+  fixture_ssh_key
+
+  export LAGOON_PROJECT="test_project"
+  export VORTEX_DEPLOY_BRANCH="test-branch"
+  export VORTEX_DEPLOY_LAGOON_INSTANCE="amazeeio"
+
+  # Mock a deploy failure unrelated to environment limits.
+  local deploy_error="Error: deployment rejected by policy."
+
+  declare -a STEPS=(
+    "Started Lagoon deployment."
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
+    "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
+    "Deploying environment: project: test_project, branch: test-branch."
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 1 # ${deploy_error}"
+    "[FAIL] Lagoon deployment completed with errors."
+    "Error: deployment rejected by policy."
+  )
+
+  mocks="$(run_steps "setup")"
+
+  run .vortex/tooling/src/vortex-deploy-lagoon
+  assert_failure
+  run_steps "assert" "${mocks[@]}"
+
+  popd >/dev/null
+}
+
+@test "Failure: deploy error survives the tasks that follow a failed redeploy" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  fixture_ssh_key_prepare
+  fixture_ssh_key
+
+  export LAGOON_PROJECT="test_project"
+  export VORTEX_DEPLOY_BRANCH="test-branch"
+  export VORTEX_DEPLOY_ACTION="deploy_override_db"
+  export VORTEX_DEPLOY_LAGOON_INSTANCE="amazeeio"
+
+  local existing_env_json='{"data":[{"name":"test-branch","deploytype":"branch"}]}'
+
+  # Mock a deploy failure unrelated to environment limits.
+  local deploy_error="Error: deployment rejected by policy."
+
+  declare -a STEPS=(
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
+    "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # ${existing_env_json}"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 1 --scope global"
+    "Redeploying environment: project: test_project, branch: test-branch."
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy latest --environment test-branch # 1 # ${deploy_error}"
+    "@sleep 10"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project update variable --environment test-branch --name VORTEX_PROVISION_OVERRIDE_DB --value 0 --scope global"
+    "Removed a database import override flag for the current deployment."
+    "[FAIL] Lagoon deployment completed with errors."
+    "Error: deployment rejected by policy."
+  )
+
+  mocks="$(run_steps "setup")"
+
+  run .vortex/tooling/src/vortex-deploy-lagoon
+  assert_failure
+  run_steps "assert" "${mocks[@]}"
+
+  popd >/dev/null
+}
+
+@test "Successful deploy does not surface its output without debug mode" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  fixture_ssh_key_prepare
+  fixture_ssh_key
+
+  export LAGOON_PROJECT="test_project"
+  export VORTEX_DEPLOY_BRANCH="test-branch"
+  export VORTEX_DEPLOY_LAGOON_INSTANCE="amazeeio"
+
+  declare -a STEPS=(
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
+    "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 0 # Deployment of branch test-branch triggered."
+    "- Deployment of branch test-branch triggered."
+    "Finished Lagoon deployment."
+  )
+
+  mocks="$(run_steps "setup")"
+
+  run .vortex/tooling/src/vortex-deploy-lagoon
+  assert_success
   run_steps "assert" "${mocks[@]}"
 
   popd >/dev/null

--- a/.vortex/tooling/tests/unit/deploy-lagoon.bats
+++ b/.vortex/tooling/tests/unit/deploy-lagoon.bats
@@ -522,7 +522,6 @@ load ../_helper.bash
   # Mock a deploy failure unrelated to environment limits.
   local deploy_error="Error: deployment rejected by policy."
 
-  # shellcheck disable=SC2034
   declare -a STEPS=(
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
@@ -614,6 +613,33 @@ load ../_helper.bash
   popd >/dev/null
 }
 
+@test "Failure: deploy that fails without any output still reports the failure" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  fixture_ssh_key_prepare
+  fixture_ssh_key
+
+  export LAGOON_PROJECT="test_project"
+  export VORTEX_DEPLOY_BRANCH="test-branch"
+  export VORTEX_DEPLOY_LAGOON_INSTANCE="amazeeio"
+
+  declare -a STEPS=(
+    "@ssh-add -l # ${HOME}/.ssh/id_rsa"
+    "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project list environments --output-json --pretty # {\"data\":[]}"
+    "@lagoon --force --skip-update-check --ssh-key ${HOME}/.ssh/id_rsa --lagoon amazeeio --project test_project deploy branch --branch test-branch # 1"
+    "[FAIL] Lagoon deployment completed with errors."
+  )
+
+  mocks="$(run_steps "setup")"
+
+  run .vortex/tooling/src/vortex-deploy-lagoon
+  assert_failure
+  run_steps "assert" "${mocks[@]}"
+
+  popd >/dev/null
+}
+
 @test "Successful deploy does not surface its output without debug mode" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
@@ -624,6 +650,7 @@ load ../_helper.bash
   export VORTEX_DEPLOY_BRANCH="test-branch"
   export VORTEX_DEPLOY_LAGOON_INSTANCE="amazeeio"
 
+  # shellcheck disable=SC2034
   declare -a STEPS=(
     "@ssh-add -l # ${HOME}/.ssh/id_rsa"
     "@lagoon config add --force --lagoon amazeeio --graphql https://api.lagoon.amazeeio.cloud/graphql --hostname ssh.lagoon.amazeeio.cloud --port 32222"


### PR DESCRIPTION
Closes #2835

## Summary
`vortex-deploy-lagoon` routes every deploy through the `run_lagoon_deploy` helper, which captures the Lagoon CLI output so it can be grepped for the environment-limit string, but that captured output was only ever printed when `VORTEX_DEBUG=1`, so a normal CI run that failed showed only the generic `Lagoon deployment completed with errors.` line and discarded the actual reason, meaning diagnosing a failed deploy required re-running the whole pipeline with debug enabled. The helper now retains a failed deploy's output in a new script-level `deploy_error` variable, and the final status block prints it directly beneath the `[FAIL] Lagoon deployment completed with errors.` line, independent of `VORTEX_DEBUG`. A deploy that did not fail keeps its previous debug-only output behaviour.

## Changes
- Added a script-level `deploy_error` variable to `vortex-deploy-lagoon` that retains a failed deploy's captured CLI output.
- The retention happens after the environment-limit handling, so the tolerated case (`VORTEX_DEPLOY_LAGOON_FAIL_ENV_LIMIT_EXCEEDED=0`, which downgrades the deploy to success) stays quiet exactly as before, while a genuine failure (the flag set to `1`) now shows the limit error.
- The final status block prints `${deploy_error}` beneath the `[FAIL] Lagoon deployment completed with errors.` line whenever it is non-empty, independent of `VORTEX_DEBUG`; an empty guard means a silent CLI failure prints no stray blank line.
- Expanded `deploy-lagoon.bats` from 15 to 19 cases: a failed deploy surfacing its error without debug mode, the error surviving the post-deploy tasks that follow a failed `deploy_override_db` redeploy, a failed deploy that produces no output at all, and a successful deploy still not surfacing its output without debug mode.
- Flipped the `FAIL flag set to 1` environment-limit test, which previously asserted the limit reason was absent, to now assert it is shown, since that path is a genuine failure.

## Before / After
```
┌────────────────────────────────────────────────────┐
│ BEFORE (no debug mode)                              │
├────────────────────────────────────────────────────┤
│ [FAIL] Lagoon deployment completed with errors.     │
└────────────────────────────────────────────────────┘

┌────────────────────────────────────────────────────┐
│ AFTER (no debug mode)                               │
├────────────────────────────────────────────────────┤
│ [FAIL] Lagoon deployment completed with errors.     │
│ Error: deployment rejected by policy.               │
└────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment failures now consistently display their error details, including during redeployments and when debug mode is disabled.
  * Environment-limit failures now present completion status and explanatory messages in the correct order.
  * Successful deployments no longer display command output unless debug mode is enabled.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->