### PR TITLE
[#2829] Reduced CI runner disk pressure during provisioning.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -395,17 +395,30 @@ jobs:
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
             #;> TOOL_JEST
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             #;< MIGRATION
             if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
               docker compose exec -T cli mkdir -p .data
               docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
+              rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
             fi
             #;> MIGRATION
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,15 +395,6 @@ jobs:
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
             #;> TOOL_JEST
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.circleci/vortex-test-common.yml
+++ b/.circleci/vortex-test-common.yml
@@ -255,15 +255,6 @@ jobs:
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
             #;> TOOL_JEST
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.circleci/vortex-test-common.yml
+++ b/.circleci/vortex-test-common.yml
@@ -235,7 +235,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -255,17 +255,30 @@ jobs:
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
             #;> TOOL_JEST
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             #;< MIGRATION
             if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
               docker compose exec -T cli mkdir -p .data
               docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
+              rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
             fi
             #;> MIGRATION
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -441,20 +441,6 @@ jobs:
           docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
           #;> TOOL_JEST
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error and its logs become unretrievable,
-      # so the report is written to the job summary, which is stored separately
-      # from the logs and survives.
-      - name: Show disk usage
-        run: |
-          {
-            echo '### Disk usage before provisioning'
-            echo '```'
-            df -h
-            docker system df
-            echo '```'
-          } | tee -a "$GITHUB_STEP_SUMMARY"
-
       - name: Provision site
         run: |
           # Database dumps are removed from the runner once they are inside the

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -422,7 +422,7 @@ jobs:
         run: ./vendor/bin/vortex-login-container-registry
 
       - name: Build stack
-        run: docker compose up --detach && docker builder prune --all --force
+        run: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - name: Export built codebase
         if: ${{ matrix.instance == 0 && !startsWith(github.head_ref || github.ref_name, 'deps/') && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
@@ -441,16 +441,34 @@ jobs:
           docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
           #;> TOOL_JEST
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error and its logs become unretrievable,
+      # so the report is written to the job summary, which is stored separately
+      # from the logs and survives.
+      - name: Show disk usage
+        run: |
+          {
+            echo '### Disk usage before provisioning'
+            echo '```'
+            df -h
+            docker system df
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Provision site
         run: |
+          # Database dumps are removed from the runner once they are inside the
+          # container to avoid holding two copies for the rest of the job.
           if [ -f .data/db.sql ]; then
             docker compose exec cli mkdir -p .data
             docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            rm -f .data/db.sql
           fi
           #;< MIGRATION
           if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
             docker compose exec -T cli mkdir -p .data
             docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
+            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
           fi
           #;> MIGRATION
           docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision

--- a/.vortex/docs/content/continuous-integration/README.mdx
+++ b/.vortex/docs/content/continuous-integration/README.mdx
@@ -187,8 +187,8 @@ by setting the `VORTEX_DEBUG` variable to `1` in your CI provider's settings.
 
 Continuous integration jobs run on hosted runners with a fixed amount of disk
 space - around 14 GB free on the GitHub Actions `ubuntu-latest` runner, and a
-per-resource-class allocation on CircleCI. Pulled container images, database
-dumps, and every file created while provisioning share that space.
+fixed allocation on CircleCI. Pulled container images, database dumps, and every
+file created while provisioning share that space.
 
 When it runs out, the runner is terminated from the outside: the step that was
 running never reports an error and the log archive may be lost entirely, so the

--- a/.vortex/docs/content/continuous-integration/README.mdx
+++ b/.vortex/docs/content/continuous-integration/README.mdx
@@ -204,12 +204,13 @@ failure looks like a hang rather than a disk problem.
   summary, which is stored separately from the logs and stays readable when the
   logs are not.
 
-If a build dies during provisioning, read that report first. If the space is
-genuinely too small for the project, either reduce what has to fit - a sanitized
-dump or a [database container image](#caching-strategy) instead of a full dump -
-or give the job more disk by moving to a larger
-[GitHub Actions runner](/docs/continuous-integration/github-actions#change-runner-size)
-or [CircleCI resource class](/docs/continuous-integration/circleci#change-runner-resource-class).
+If a build dies during provisioning, read that report first. The most reliable
+fix is to reduce what has to fit: a sanitized dump or a
+[database container image](#caching-strategy) instead of a full dump. On GitHub
+Actions, a [larger runner](/docs/continuous-integration/github-actions#change-runner-size)
+also comes with more disk. On CircleCI, disk space is not tied to the
+[resource class](/docs/continuous-integration/circleci#change-runner-resource-class),
+so upgrading it adds CPU and memory but no extra room for the build.
 
 ### Update CI runner image
 

--- a/.vortex/docs/content/continuous-integration/README.mdx
+++ b/.vortex/docs/content/continuous-integration/README.mdx
@@ -194,18 +194,14 @@ When it runs out, the runner is terminated from the outside: the step that was
 running never reports an error and the log archive may be lost entirely, so the
 failure looks like a hang rather than a disk problem.
 
-**Vortex** keeps the build within that budget and makes the limit visible:
+**Vortex** keeps the build within that budget:
 
 - The Docker build cache and dangling images are pruned once the stack is up.
 - The database dump is removed from the runner as soon as it has been copied
   into the container, so only one copy is held during provisioning.
-- The `Show disk usage` step prints `df -h` and `docker system df` immediately
-  before provisioning. On GitHub Actions the report is also written to the job
-  summary, which is stored separately from the logs and stays readable when the
-  logs are not.
 
-If a build dies during provisioning, read that report first. The most reliable
-fix is to reduce what has to fit: a sanitized dump or a
+If a build dies during provisioning without reporting an error, suspect the
+disk. The most reliable fix is to reduce what has to fit: a sanitized dump or a
 [database container image](#caching-strategy) instead of a full dump. On GitHub
 Actions, a [larger runner](/docs/continuous-integration/github-actions#change-runner-size)
 also comes with more disk. On CircleCI, disk space is not tied to the

--- a/.vortex/docs/content/continuous-integration/README.mdx
+++ b/.vortex/docs/content/continuous-integration/README.mdx
@@ -183,6 +183,34 @@ containers:
 To get verbose output when troubleshooting build failures, enable debug mode
 by setting the `VORTEX_DEBUG` variable to `1` in your CI provider's settings.
 
+### Runner disk space
+
+Continuous integration jobs run on hosted runners with a fixed amount of disk
+space - around 14 GB free on the GitHub Actions `ubuntu-latest` runner, and a
+per-resource-class allocation on CircleCI. Pulled container images, database
+dumps, and every file created while provisioning share that space.
+
+When it runs out, the runner is terminated from the outside: the step that was
+running never reports an error and the log archive may be lost entirely, so the
+failure looks like a hang rather than a disk problem.
+
+**Vortex** keeps the build within that budget and makes the limit visible:
+
+- The Docker build cache and dangling images are pruned once the stack is up.
+- The database dump is removed from the runner as soon as it has been copied
+  into the container, so only one copy is held during provisioning.
+- The `Show disk usage` step prints `df -h` and `docker system df` immediately
+  before provisioning. On GitHub Actions the report is also written to the job
+  summary, which is stored separately from the logs and stays readable when the
+  logs are not.
+
+If a build dies during provisioning, read that report first. If the space is
+genuinely too small for the project, either reduce what has to fit - a sanitized
+dump or a [database container image](#caching-strategy) instead of a full dump -
+or give the job more disk by moving to a larger
+[GitHub Actions runner](/docs/continuous-integration/github-actions#change-runner-size)
+or [CircleCI resource class](/docs/continuous-integration/circleci#change-runner-resource-class).
+
 ### Update CI runner image
 
 The CI jobs run inside the [`drevops/ci-runner`](https://github.com/drevops/ci-runner)

--- a/.vortex/docs/content/continuous-integration/circleci.mdx
+++ b/.vortex/docs/content/continuous-integration/circleci.mdx
@@ -67,8 +67,9 @@ the `runner_config` section. Note that this may affect your CircleCI billing:
 resource_class: large  # Options: small, medium, large, xlarge
 ```
 
-Larger resource classes also come with more disk, which matters for projects
-whose provisioning is disk-heavy. See [Runner disk space](/docs/continuous-integration#runner-disk-space).
+Resource classes scale CPU and memory only. Disk space is not tied to the
+resource class, so upgrading it will not help a job that runs out of space -
+see [Runner disk space](/docs/continuous-integration#runner-disk-space).
 
 ### Change test parallelism
 

--- a/.vortex/docs/content/continuous-integration/circleci.mdx
+++ b/.vortex/docs/content/continuous-integration/circleci.mdx
@@ -67,6 +67,9 @@ the `runner_config` section. Note that this may affect your CircleCI billing:
 resource_class: large  # Options: small, medium, large, xlarge
 ```
 
+Larger resource classes also come with more disk, which matters for projects
+whose provisioning is disk-heavy. See [Runner disk space](/docs/continuous-integration#runner-disk-space).
+
 ### Change test parallelism
 
 To speed up test execution, you can increase the number of parallel runners in

--- a/.vortex/docs/content/continuous-integration/github-actions.mdx
+++ b/.vortex/docs/content/continuous-integration/github-actions.mdx
@@ -77,6 +77,9 @@ in the job configuration. Note that this may affect your GitHub billing:
 runs-on: ubuntu-latest-4-cores  # Options: ubuntu-latest, ubuntu-latest-4-cores, etc.
 ```
 
+Larger runners also come with more disk, which matters for projects whose
+provisioning is disk-heavy. See [Runner disk space](/docs/continuous-integration#runner-disk-space).
+
 ### Change test parallelism
 
 To speed up test execution, you can increase the number of parallel runners in

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -390,20 +390,6 @@ jobs:
             COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
           docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error and its logs become unretrievable,
-      # so the report is written to the job summary, which is stored separately
-      # from the logs and survives.
-      - name: Show disk usage
-        run: |
-          {
-            echo '### Disk usage before provisioning'
-            echo '```'
-            df -h
-            docker system df
-            echo '```'
-          } | tee -a "$GITHUB_STEP_SUMMARY"
-
       - name: Provision site
         run: |
           # Database dumps are removed from the runner once they are inside the

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -373,7 +373,7 @@ jobs:
         run: ./vendor/bin/vortex-login-container-registry
 
       - name: Build stack
-        run: docker compose up --detach && docker builder prune --all --force
+        run: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - name: Export built codebase
         if: ${{ matrix.instance == 0 && !startsWith(github.head_ref || github.ref_name, 'deps/') && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
@@ -390,11 +390,28 @@ jobs:
             COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
           docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error and its logs become unretrievable,
+      # so the report is written to the job summary, which is stored separately
+      # from the logs and survives.
+      - name: Show disk usage
+        run: |
+          {
+            echo '### Disk usage before provisioning'
+            echo '```'
+            df -h
+            docker system df
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Provision site
         run: |
+          # Database dumps are removed from the runner once they are inside the
+          # container to avoid holding two copies for the rest of the job.
           if [ -f .data/db.sql ]; then
             docker compose exec cli mkdir -p .data
             docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            rm -f .data/db.sql
           fi
           docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
         timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -335,7 +335,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -353,12 +353,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -353,15 +353,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -471,6 +471,17 @@
+@@ -457,6 +457,17 @@
              </details>
            hide_and_recreate: true
  

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -454,6 +454,17 @@
+@@ -471,6 +471,17 @@
              </details>
            hide_and_recreate: true
  

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
@@ -335,7 +335,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -353,12 +353,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
@@ -353,15 +353,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -335,7 +335,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -353,12 +353,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -353,15 +353,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
@@ -335,7 +335,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -353,12 +353,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
@@ -353,15 +353,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -550,104 +550,3 @@
+@@ -536,104 +536,3 @@
          timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
          with:
            detached: true

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -533,104 +533,3 @@
+@@ -550,104 +550,3 @@
          timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
          with:
            detached: true

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -335,7 +335,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -353,12 +353,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -353,15 +353,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -335,7 +335,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -353,12 +353,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -353,15 +353,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
@@ -8,14 +8,15 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
-           if [ -f .data/db.sql ]; then
+@@ -412,6 +415,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
 +            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -412,6 +415,11 @@
+@@ -398,6 +401,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -340,7 +340,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -358,16 +358,29 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
               docker compose exec -T cli mkdir -p .data
               docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
+              rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -358,15 +358,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
@@ -8,14 +8,15 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
-           if [ -f .data/db.sql ]; then
+@@ -412,6 +415,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
 +            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -412,6 +415,11 @@
+@@ -398,6 +401,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.github/workflows/build-test-deploy.yml
@@ -8,14 +8,15 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
-           if [ -f .data/db.sql ]; then
+@@ -412,6 +415,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
 +            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -412,6 +415,11 @@
+@@ -398,6 +401,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.github/workflows/build-test-deploy.yml
@@ -8,14 +8,15 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
-           if [ -f .data/db.sql ]; then
+@@ -412,6 +415,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
 +            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -412,6 +415,11 @@
+@@ -398,6 +401,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.github/workflows/build-test-deploy.yml
@@ -8,14 +8,15 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
-           if [ -f .data/db.sql ]; then
+@@ -412,6 +415,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
 +            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -412,6 +415,11 @@
+@@ -398,6 +401,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.github/workflows/build-test-deploy.yml
@@ -8,14 +8,15 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
-           if [ -f .data/db.sql ]; then
+@@ -412,6 +415,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
 +            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -412,6 +415,11 @@
+@@ -398,6 +401,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.github/workflows/build-test-deploy.yml
@@ -8,14 +8,15 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
-           if [ -f .data/db.sql ]; then
+@@ -412,6 +415,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
 +            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -412,6 +415,11 @@
+@@ -398,6 +401,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.github/workflows/build-test-deploy.yml
@@ -8,14 +8,15 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -395,6 +398,10 @@
-           if [ -f .data/db.sql ]; then
+@@ -412,6 +415,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
 +            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -412,6 +415,11 @@
+@@ -398,6 +401,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -464,18 +464,6 @@
+@@ -481,18 +481,6 @@
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -481,18 +481,6 @@
+@@ -467,18 +467,6 @@
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_none/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -464,18 +464,6 @@
+@@ -481,18 +481,6 @@
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_none/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -481,18 +481,6 @@
+@@ -467,18 +467,6 @@
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
  

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -179,7 +179,7 @@
        - name: Login to container registry
          run: ./vendor/bin/vortex-login-container-registry
  
-@@ -537,7 +393,6 @@
+@@ -554,7 +410,6 @@
    deploy:
      runs-on: ubuntu-latest
      needs: [build, lint]

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -179,7 +179,7 @@
        - name: Login to container registry
          run: ./vendor/bin/vortex-login-container-registry
  
-@@ -554,7 +410,6 @@
+@@ -540,7 +396,6 @@
    deploy:
      runs-on: ubuntu-latest
      needs: [build, lint]

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -463,18 +458,6 @@
+@@ -480,18 +475,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -480,18 +475,6 @@
+@@ -466,18 +461,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -463,18 +458,6 @@
+@@ -480,18 +475,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -480,18 +475,6 @@
+@@ -466,18 +461,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -463,18 +458,6 @@
+@@ -480,18 +475,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -480,18 +475,6 @@
+@@ -466,18 +461,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -335,7 +335,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -353,12 +353,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -353,15 +353,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -323,7 +323,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -341,12 +341,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -341,15 +341,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -9,7 +9,7 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -421,66 +417,6 @@
+@@ -407,66 +403,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -76,7 +76,7 @@
        - name: Validate Single Directory Components
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: |
-@@ -493,20 +429,6 @@
+@@ -479,20 +415,6 @@
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
@@ -97,7 +97,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -523,16 +445,6 @@
+@@ -509,16 +431,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -9,7 +9,7 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -404,66 +400,6 @@
+@@ -421,66 +417,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -76,7 +76,7 @@
        - name: Validate Single Directory Components
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: |
-@@ -476,20 +412,6 @@
+@@ -493,20 +429,6 @@
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
@@ -97,7 +97,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -506,16 +428,6 @@
+@@ -523,16 +445,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -331,7 +331,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -349,12 +349,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -349,15 +349,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
@@ -23,9 +23,9 @@
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       - name: Provision site
-         run: |
-@@ -398,11 +392,6 @@
+       # Provisioning is the most disk-intensive step: a runner that runs out of
+       # space is killed without a step error and its logs become unretrievable,
+@@ -415,11 +409,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
@@ -23,9 +23,9 @@
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       # Provisioning is the most disk-intensive step: a runner that runs out of
-       # space is killed without a step error and its logs become unretrievable,
-@@ -415,11 +409,6 @@
+       - name: Provision site
+         run: |
+@@ -401,11 +395,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
@@ -347,15 +347,6 @@ jobs:
               if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -347,12 +347,24 @@ jobs:
               if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
@@ -28,9 +28,9 @@
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       # Provisioning is the most disk-intensive step: a runner that runs out of
-       # space is killed without a step error and its logs become unretrievable,
-@@ -416,11 +405,6 @@
+       - name: Provision site
+         run: |
+@@ -402,11 +391,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30
  
@@ -42,7 +42,7 @@
        - name: Test with PHPUnit
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: docker compose exec -T cli vendor/bin/phpunit
-@@ -480,18 +464,6 @@
+@@ -466,18 +450,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
@@ -28,9 +28,9 @@
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       - name: Provision site
-         run: |
-@@ -399,11 +388,6 @@
+       # Provisioning is the most disk-intensive step: a runner that runs out of
+       # space is killed without a step error and its logs become unretrievable,
+@@ -416,11 +405,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30
  
@@ -42,7 +42,7 @@
        - name: Test with PHPUnit
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: docker compose exec -T cli vendor/bin/phpunit
-@@ -463,18 +447,6 @@
+@@ -480,18 +464,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
@@ -324,7 +324,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -341,12 +341,24 @@ jobs:
               if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
@@ -341,15 +341,6 @@ jobs:
               if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -9,7 +9,7 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -475,20 +471,6 @@
+@@ -492,20 +488,6 @@
              exit 1
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -9,7 +9,7 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -492,20 +488,6 @@
+@@ -478,20 +474,6 @@
              exit 1
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -331,7 +331,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -349,12 +349,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -349,15 +349,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -348,12 +348,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
@@ -348,15 +348,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
@@ -22,7 +22,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -463,18 +453,6 @@
+@@ -480,18 +470,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
@@ -22,7 +22,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -480,18 +470,6 @@
+@@ -466,18 +456,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
@@ -4,9 +4,9 @@
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       - name: Provision site
-         run: |
-@@ -398,11 +397,6 @@
+       # Provisioning is the most disk-intensive step: a runner that runs out of
+       # space is killed without a step error and its logs become unretrievable,
+@@ -415,11 +414,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
@@ -4,9 +4,9 @@
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       # Provisioning is the most disk-intensive step: a runner that runs out of
-       # space is killed without a step error and its logs become unretrievable,
-@@ -415,11 +414,6 @@
+       - name: Provision site
+         run: |
+@@ -401,11 +400,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
@@ -352,15 +352,6 @@ jobs:
               if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
@@ -335,7 +335,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -352,12 +352,24 @@ jobs:
               if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -331,7 +331,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -349,12 +349,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -349,15 +349,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -331,7 +331,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -349,12 +349,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -349,15 +349,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -421,66 +421,6 @@
+@@ -407,66 +407,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -65,7 +65,7 @@
        - name: Validate Single Directory Components
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: |
-@@ -523,16 +463,6 @@
+@@ -509,16 +449,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -404,66 +404,6 @@
+@@ -421,66 +421,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -65,7 +65,7 @@
        - name: Validate Single Directory Components
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: |
-@@ -506,16 +446,6 @@
+@@ -523,16 +463,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -335,7 +335,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -353,12 +353,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -353,15 +353,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -331,7 +331,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -349,12 +349,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -349,15 +349,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
@@ -335,7 +335,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -353,12 +353,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
@@ -353,15 +353,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -463,18 +458,6 @@
+@@ -480,18 +475,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,7 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -480,18 +475,6 @@
+@@ -466,18 +461,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
@@ -331,7 +331,7 @@ jobs:
 
       - run:
           name: Build stack
-          command: docker compose up --detach && docker builder prune --all --force
+          command: docker compose up --detach && docker builder prune --all --force && docker image prune --force
 
       - run:
           name: Export built codebase
@@ -349,12 +349,24 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
+      # Provisioning is the most disk-intensive step: a runner that runs out of
+      # space is killed without a step error, so the available space is reported
+      # while there is still a log to write it to.
+      - run:
+          name: Show disk usage
+          command: |
+            df -h
+            docker system df
+
       - run:
           name: Provision site
           command: |
+            # Database dumps are removed from the runner once they are inside the
+            # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
               docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
           no_output_timeout: 30m

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
@@ -349,15 +349,6 @@ jobs:
               COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
 
-      # Provisioning is the most disk-intensive step: a runner that runs out of
-      # space is killed without a step error, so the available space is reported
-      # while there is still a log to write it to.
-      - run:
-          name: Show disk usage
-          command: |
-            df -h
-            docker system df
-
       - run:
           name: Provision site
           command: |

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -43,9 +43,9 @@
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       # Provisioning is the most disk-intensive step: a runner that runs out of
-       # space is killed without a step error and its logs become unretrievable,
-@@ -416,71 +390,6 @@
+       - name: Provision site
+         run: |
+@@ -402,71 +376,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30
  
@@ -117,7 +117,7 @@
        - name: Validate Single Directory Components
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: |
-@@ -493,20 +402,6 @@
+@@ -479,20 +388,6 @@
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
@@ -138,7 +138,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -523,16 +418,6 @@
+@@ -509,16 +404,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -43,9 +43,9 @@
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 -          docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "yarn install --frozen-lockfile"
  
-       - name: Provision site
-         run: |
-@@ -399,71 +373,6 @@
+       # Provisioning is the most disk-intensive step: a runner that runs out of
+       # space is killed without a step error and its logs become unretrievable,
+@@ -416,71 +390,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30
  
@@ -117,7 +117,7 @@
        - name: Validate Single Directory Components
          if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
          run: |
-@@ -476,20 +385,6 @@
+@@ -493,20 +402,6 @@
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
@@ -138,7 +138,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -506,16 +401,6 @@
+@@ -523,16 +418,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error


### PR DESCRIPTION
Closes #2829

## Summary

The `build` CI job can silently exhaust the hosted runner's disk during the `Provision site` step. The runner is killed from the outside rather than the step reporting an error, and the job's log archive becomes unretrievable, so the failure presents as a hang rather than a disk-space problem. This change reduces the disk pressure that causes it: database dumps are removed from the runner as soon as they are copied into the CLI container, and dangling Docker images are pruned alongside the existing build-cache prune. GitHub Actions and CircleCI are updated in lockstep, and the CI documentation gains a section describing the failure mode and the mitigations.

The dump removal is the substantive change - on the projects that hit this, the dump is the dominant disk term, and holding it twice (once on the runner, once inside the container) for the whole provisioning step is what tips a tight build over.

Note that the issue also proposed printing `df -h` before provisioning. That is deliberately not included here.

## Changes

### CI workflows

- `Provision site` now removes each database dump from the runner (`.data/db.sql` and the migration dump) immediately after copying it into the CLI container, so only one copy is held for the rest of the job. This is safe because in the `build` job `.data` is restore-only - the `database` job owns the cache save, and nothing reads the dump after this step.
- `Build stack` now also runs `docker image prune --force`, alongside the existing `docker builder prune --all --force`, to remove dangling images left behind by the build. Dangling-only was chosen over `--all`: the marginal gain is small and `--all` can remove images the stack still needs if step ordering changes later.
- Both changes are applied to `.github/workflows/build-test-deploy.yml` and `.circleci/config.yml`, since the two provider configurations are deliberately kept identical. `.circleci/vortex-test-common.yml` was regenerated from the CircleCI config to keep it in sync.

### Documentation

- Added a "Runner disk space" section to `.vortex/docs/content/continuous-integration/README.mdx` covering the disk budget, what the failure looks like (a step that dies without reporting an error), what **Vortex** now reclaims automatically, and how to reduce what has to fit.
- Cross-linked the new section from `.vortex/docs/content/continuous-integration/github-actions.mdx` (a larger runner does come with more disk) and `.vortex/docs/content/continuous-integration/circleci.mdx` (disk is not tied to the resource class, so upgrading it adds CPU and memory but no extra room).

### Fixtures

- Regenerated installer test snapshots (`ahoy update-snapshots`) across 47 scenarios to match the CI workflow changes.

## Before / After

```
BEFORE: both dumps held on the runner for the whole provisioning step
┌──────────────────────────────────────────────────────────┐
│ build job                                                │
└─────────────────────────┬────────────────────────────────┘
                          ▼
                     Build stack
            docker builder prune --all --force
                          │
                          ▼
                    Provision site
      copy .data/db.sql   ──> cli    (runner copy kept)
      copy .data/db2.sql  ──> cli    (runner copy kept)
                          │
                          ▼
      peak disk = dump x2 + images + build cache
                          │
                          ▼
      ✗ runner killed from the outside - no step error,
        log archive unretrievable, job looks like it hung

AFTER: one copy at a time, plus a wider prune
┌──────────────────────────────────────────────────────────┐
│ build job                                                │
└─────────────────────────┬────────────────────────────────┘
                          ▼
                     Build stack
            docker builder prune --all --force
            docker image prune --force            <- new
                          │
                          ▼
                    Provision site
      copy .data/db.sql   ──> cli, then rm        <- new
      copy .data/db2.sql  ──> cli, then rm        <- new
                          │
                          ▼
      peak disk = dump x1 + images - dangling
                          │
                          ▼
      ✓ headroom restored; the build that used to tip
        over now fits
```
