### PR TITLE
[#2838] Isolated ambient credentials from tooling BATS tests and added missing-token guard coverage.

### DIFF
--- a/.vortex/tooling/tests/_helper.bash
+++ b/.vortex/tooling/tests/_helper.bash
@@ -133,7 +133,12 @@ setup() {
   unset NEWRELIC_USER_KEY
   unset S3_ACCESS_KEY
   unset S3_SECRET_KEY
-  unset DOCKER_CONFIG
+
+  # Point the container registry credential store at the per-test build
+  # directory. Unsetting is not enough here: the consuming default resolves to
+  # "${HOME}/.docker", so an unset value reads the real credential store of the
+  # developer running the suite instead of an empty one.
+  export DOCKER_CONFIG="${BUILD_DIR}/.docker"
 
   # Disable interactive prompts during tests.
   export AHOY_CONFIRM_RESPONSE=y

--- a/.vortex/tooling/tests/_helper.bash
+++ b/.vortex/tooling/tests/_helper.bash
@@ -121,6 +121,20 @@ setup() {
   unset VORTEX_FETCH_DB_FORCE
   unset VORTEX_EXPORT_DB_CONTAINER_REGISTRY_PUSH_PROCEED
 
+  # Isolate ambient credentials from the scripts under test. Scripts fall back
+  # to these unprefixed values whenever their own variable is unset or empty,
+  # and their `.env` loader restores the saved environment last - so a value
+  # exported by the developer's shell wins over `.env` and reaches the script.
+  # Left in place, a script would authenticate against a real service instead
+  # of stopping at the guard a test asserts. Tests that need a credential
+  # export an explicit literal of their own.
+  unset GITHUB_TOKEN
+  unset VORTEX_NOTIFY_GITHUB_TOKEN
+  unset NEWRELIC_USER_KEY
+  unset S3_ACCESS_KEY
+  unset S3_SECRET_KEY
+  unset DOCKER_CONFIG
+
   # Disable interactive prompts during tests.
   export AHOY_CONFIRM_RESPONSE=y
   # Disable waiting when interactive prompts are disabled durin tests.

--- a/.vortex/tooling/tests/unit/notify-diffy.bats
+++ b/.vortex/tooling/tests/unit/notify-diffy.bats
@@ -100,19 +100,26 @@ load ../_helper.bash
 @test "Notify: diffy, missing token" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
+  mock_curl=$(mock_command "curl")
+
   export VORTEX_NOTIFY_CHANNELS="diffy"
   export VORTEX_NOTIFY_EVENT="post_deployment"
   export VORTEX_NOTIFY_BRANCH="feature/my-pr-branch"
   export VORTEX_NOTIFY_SHA="abc123def456"
   export VORTEX_NOTIFY_LABEL="PR-123"
   export VORTEX_NOTIFY_ENVIRONMENT_URL="https://pr-123.example.com"
-  export VORTEX_NOTIFY_DIFFY_TOKEN=""
+  unset VORTEX_NOTIFY_DIFFY_TOKEN
   export VORTEX_NOTIFY_DIFFY_REPOSITORY="myorg/myrepo"
 
   run ./.vortex/tooling/src/vortex-notify
   assert_failure
 
   assert_output_contains "Missing required value for VORTEX_NOTIFY_DIFFY_TOKEN"
+
+  # Assert the guard stops the run before the dispatch. Without this, a token
+  # reaching the script from any source turns the test into a live, authenticated
+  # request to GitHub instead of a failed assertion.
+  assert_equal "0" "$(mock_get_call_num "${mock_curl}")"
 
   popd >/dev/null || exit 1
 }

--- a/.vortex/tooling/tests/unit/notify-github.bats
+++ b/.vortex/tooling/tests/unit/notify-github.bats
@@ -272,6 +272,33 @@ load ../_helper.bash
   popd >/dev/null || exit 1
 }
 
+@test "Notify: github, missing token" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  mock_curl=$(mock_command "curl")
+
+  export VORTEX_NOTIFY_CHANNELS="github"
+  export VORTEX_NOTIFY_EVENT="pre_deployment"
+  unset VORTEX_NOTIFY_GITHUB_TOKEN
+  export VORTEX_NOTIFY_GITHUB_REPOSITORY="myorg/myrepo"
+  export VORTEX_NOTIFY_BRANCH="existingbranch"
+  export VORTEX_NOTIFY_SHA="abc123def456"
+  export VORTEX_NOTIFY_LABEL="existingbranch"
+  export VORTEX_NOTIFY_ENVIRONMENT_URL="https://develop.testproject.com"
+
+  run ./.vortex/tooling/src/vortex-notify
+  assert_failure
+
+  assert_output_contains "Missing required value for VORTEX_NOTIFY_GITHUB_TOKEN"
+
+  # Assert the guard stops the run before the deployment call. Without this, a
+  # token reaching the script from any source turns the test into a live,
+  # authenticated request to GitHub instead of a failed assertion.
+  assert_equal "0" "$(mock_get_call_num "${mock_curl}")"
+
+  popd >/dev/null || exit 1
+}
+
 @test "Notify: github, post_deployment, failure to set status" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 

--- a/.vortex/tooling/tests/unit/notify-newrelic.bats
+++ b/.vortex/tooling/tests/unit/notify-newrelic.bats
@@ -78,6 +78,34 @@ load ../_helper.bash
   popd >/dev/null || exit 1
 }
 
+@test "Notify: newrelic, missing user key" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  mock_curl=$(mock_command "curl")
+
+  export VORTEX_NOTIFY_CHANNELS="newrelic"
+  export VORTEX_NOTIFY_NEWRELIC_ENABLED=true
+  export VORTEX_NOTIFY_EVENT="post_deployment"
+  export VORTEX_NOTIFY_PROJECT="testproject"
+  unset VORTEX_NOTIFY_NEWRELIC_USER_KEY
+  export VORTEX_NOTIFY_BRANCH="main"
+  export VORTEX_NOTIFY_SHA="abc123def456"
+  export VORTEX_NOTIFY_LABEL="main"
+  export VORTEX_NOTIFY_ENVIRONMENT_URL="https://test.example.com"
+
+  run ./.vortex/tooling/src/vortex-notify
+  assert_failure
+
+  assert_output_contains "Missing required value for VORTEX_NOTIFY_NEWRELIC_USER_KEY"
+
+  # Assert the guard stops the run before the application lookup. Without this,
+  # a key reaching the script from any source turns the test into a live,
+  # authenticated request to New Relic instead of a failed assertion.
+  assert_equal "0" "$(mock_get_call_num "${mock_curl}")"
+
+  popd >/dev/null || exit 1
+}
+
 @test "Notify: newrelic, pre_deployment skip" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 


### PR DESCRIPTION
Closes #2838

## Summary

The BATS test `Notify: diffy, missing token` set `VORTEX_NOTIFY_DIFFY_TOKEN=""` to reach `vortex-notify-diffy`'s missing-token guard, but the script resolves its token as `${VORTEX_NOTIFY_DIFFY_TOKEN:-${VORTEX_NOTIFY_GITHUB_TOKEN:-${GITHUB_TOKEN-}}}`, and `${VAR:-default}` substitutes on unset *or* empty, so the explicit empty string fell straight through to an ambient `GITHUB_TOKEN`. The guard was never reached, and the test instead issued a real authenticated `repository_dispatch` request to `api.github.com` using the developer's own token. It passed in CI, where no `GITHUB_TOKEN` is present, so the gap was invisible there and only showed up locally. This change isolates the shared BATS harness from the ambient credentials that shipped scripts fall back to, rewrites the diffy test to `unset` its token and assert zero `curl` calls, and adds equivalent missing-credential tests for `notify-github` and `notify-newrelic`, whose guards share the identical fallback shape but previously had no coverage at all. Nothing under `.vortex/tooling/src/` changes - the ambient fallback is intended product behaviour so consumer CI can rely on its automatically-injected `GITHUB_TOKEN` - so the fix is entirely in the test harness, which is `export-ignore`d from the published `drevops/vortex-tooling` package.

## Changes

### Shared test harness

- `.vortex/tooling/tests/_helper.bash` - the shared `setup()` now unsets `GITHUB_TOKEN`, `VORTEX_NOTIFY_GITHUB_TOKEN`, `NEWRELIC_USER_KEY`, `S3_ACCESS_KEY`, and `S3_SECRET_KEY` before every test, so a script under test can no longer fall back to a credential the developer happens to have exported in their own shell.
- `DOCKER_CONFIG` is exported to `${BUILD_DIR}/.docker` rather than unset, because the value it feeds into resolves to `${HOME}/.docker` when absent - unsetting it would still read the developer's real Docker credential store instead of an empty per-test one.

### Notification tests

- `.vortex/tooling/tests/unit/notify-diffy.bats` - `Notify: diffy, missing token` now `unset`s `VORTEX_NOTIFY_DIFFY_TOKEN` instead of exporting an empty string, mocks `curl`, and asserts `assert_equal "0" "$(mock_get_call_num "${mock_curl}")"`, so a bypassed guard fails the test instead of making a live network call.
- `.vortex/tooling/tests/unit/notify-github.bats` and `.vortex/tooling/tests/unit/notify-newrelic.bats` - added missing-credential tests in the same fail-closed shape, covering `VORTEX_NOTIFY_GITHUB_TOKEN` and `VORTEX_NOTIFY_NEWRELIC_USER_KEY`, which share the identical ambient-fallback pattern but had no test at all before this change.

The full 299-test tooling BATS suite passes with `GITHUB_TOKEN`, `NEWRELIC_USER_KEY`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, and `DOCKER_CONFIG` all exported as canary values, confirming the new isolation does not leak into any other test's expectations.

## Before / After

```
BEFORE: an empty token falls through the fallback chain to an ambient credential
┌──────────────────────────────────────────────────────────────┐
│ Notify: diffy, missing token                                  │
│   export VORTEX_NOTIFY_DIFFY_TOKEN=""                         │
└─────────────────────────┬──────────────────────────────────────┘
                          ▼
   VORTEX_NOTIFY_DIFFY_TOKEN="${VORTEX_NOTIFY_DIFFY_TOKEN:-...}"
        empty string ──> treated as unset ──> falls through
                          │
                          ▼
        ${VORTEX_NOTIFY_GITHUB_TOKEN:-${GITHUB_TOKEN-}}
        developer's ambient GITHUB_TOKEN is still exported
                          │
                          ▼
        [ -z "${VORTEX_NOTIFY_DIFFY_TOKEN}" ]   <- never true
                          │
                          ▼
        ✗ guard skipped - live POST to api.github.com
          repository_dispatch sent with the real token

AFTER: the harness isolates ambient credentials before the test runs
┌──────────────────────────────────────────────────────────────┐
│ setup() in tests/_helper.bash                                  │
│   unset GITHUB_TOKEN                                           │
│   unset VORTEX_NOTIFY_GITHUB_TOKEN                              │
└─────────────────────────┬──────────────────────────────────────┘
                          ▼
        unset VORTEX_NOTIFY_DIFFY_TOKEN
        mock_curl=$(mock_command "curl")
                          │
                          ▼
   VORTEX_NOTIFY_DIFFY_TOKEN="${VORTEX_NOTIFY_DIFFY_TOKEN:-...}"
        unset ──> falls through ──> ${GITHUB_TOKEN-} is unset too
                          │
                          ▼
        [ -z "${VORTEX_NOTIFY_DIFFY_TOKEN}" ]   <- true
                          │
                          ▼
        ✓ guard fires - "Missing required value for
          VORTEX_NOTIFY_DIFFY_TOKEN" - exit 1
                          │
                          ▼
        ✓ assert_equal "0" "$(mock_get_call_num "${mock_curl}")"
          proves no network call was ever made
```
