### PR TITLE
[#2843] Suppressed Composer output of the initial tooling install and adopted the standard progress helpers.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
@@ -21,10 +21,36 @@
 set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
+# Run Composer without exposing its progress output, which is an internal detail
+# of this bootstrap rather than something that was asked for. The captured
+# output is replayed on stderr when the command fails, so failures remain
+# diagnosable. Debug mode streams the output as it happens.
+composer_run() {
+  if [ "${VORTEX_DEBUG-}" = "1" ]; then
+    composer "$@"
+    return
+  fi
+
+  local output status=0
+  output=$(composer "$@" 2>&1) || status=$?
+
+  if [ "${status}" -ne 0 ]; then
+    if [ -n "${output}" ]; then
+      printf "%s\n" "${output}" >&2
+    fi
+
+    return "${status}"
+  fi
+}
+
 # Already installed and its binaries linked - nothing to do.
 if [ -d ./vendor/drevops/vortex-tooling ] && ls ./vendor/bin/vortex-* >/dev/null 2>&1; then
   exit 0
 fi
+
+# The install runs before any other output and takes a noticeable amount of
+# time, so announce it rather than leaving the terminal blank.
+printf "[INFO] Installing Vortex tooling.\n"
 
 mkdir -p vendor-temp vendor/drevops
 
@@ -50,21 +76,21 @@ echo "{\"require\":{\"drevops/vortex-tooling\":\"${version}\"}}" >vendor-temp/co
 # Carry over inline patches declared for our package, if any.
 patches=$(composer config extra.patches.drevops/vortex-tooling --json 2>/dev/null) || patches=
 if [ -n "${patches}" ] && [ "${patches}" != "[]" ] && [ "${patches}" != "{}" ]; then
-  composer --working-dir=vendor-temp config extra.patches.drevops/vortex-tooling --json "${patches}"
+  composer_run --working-dir=vendor-temp config extra.patches.drevops/vortex-tooling --json "${patches}"
 fi
 
 # Carry over the patches-file pointer, if defined. Prefix with '..' so the
 # path resolves from inside 'vendor-temp/' back to the project root.
 patches_file=$(composer config extra.patches-file 2>/dev/null) || patches_file=
 if [ -n "${patches_file}" ]; then
-  composer --working-dir=vendor-temp config extra.patches-file "../${patches_file}"
+  composer_run --working-dir=vendor-temp config extra.patches-file "../${patches_file}"
 fi
 
 # When any patches were registered, pull in the composer-patches plugin and
 # allow it to run during install.
 if [ -n "${patches}" ] || [ -n "${patches_file}" ]; then
-  composer --working-dir=vendor-temp require --no-update cweagans/composer-patches:^2
-  composer --working-dir=vendor-temp config allow-plugins.cweagans/composer-patches true
+  composer_run --working-dir=vendor-temp require --no-update cweagans/composer-patches:^2
+  composer_run --working-dir=vendor-temp config allow-plugins.cweagans/composer-patches true
   # Inline 'extra.patches' paths (and paths inside a 'patches-file') are
   # relative to the project root. Copy the project 'patches/' directory into
   # the throwaway project so those paths resolve from inside 'vendor-temp/'.
@@ -73,7 +99,7 @@ if [ -n "${patches}" ] || [ -n "${patches_file}" ]; then
   fi
 fi
 
-composer --working-dir=vendor-temp install --no-dev --no-interaction
+composer_run --working-dir=vendor-temp install --no-dev --no-interaction
 
 # The target directory may already be occupied by a package copy without the
 # 'vendor/bin/vortex-*' proxies (e.g. an older tooling version mid-way through

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
@@ -21,6 +21,16 @@
 set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
+# ------------------------------------------------------------------------------
+
+# @formatter:off
+info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[36m[INFO] %s\033[0m\n" "${1}" || printf "[INFO] %s\n" "${1}"; }
+note() { printf "       %s\n" "${1}"; }
+task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
+pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+# @formatter:on
+
 # Run Composer without exposing its progress output, which is an internal detail
 # of this bootstrap rather than something that was asked for. The captured
 # output is replayed on stderr when the command fails, so failures remain
@@ -35,6 +45,8 @@ composer_run() {
   output=$(composer "$@" 2>&1) || status=$?
 
   if [ "${status}" -ne 0 ]; then
+    fail "Composer command failed."
+
     if [ -n "${output}" ]; then
       printf "%s\n" "${output}" >&2
     fi
@@ -48,9 +60,7 @@ if [ -d ./vendor/drevops/vortex-tooling ] && ls ./vendor/bin/vortex-* >/dev/null
   exit 0
 fi
 
-# The install runs before any other output and takes a noticeable amount of
-# time, so announce it rather than leaving the terminal blank.
-printf "[INFO] Installing Vortex tooling.\n"
+info "Started Vortex tooling installation."
 
 mkdir -p vendor-temp vendor/drevops
 
@@ -120,3 +130,5 @@ if [ -d vendor-temp/vendor/bin ]; then
     [ -e "${bin}" ] && mv "${bin}" vendor/bin/
   done
 fi
+
+pass "Finished Vortex tooling installation."

--- a/.vortex/tests/phpunit/Functional/ToolingBootstrapTest.php
+++ b/.vortex/tests/phpunit/Functional/ToolingBootstrapTest.php
@@ -71,12 +71,14 @@ class ToolingBootstrapTest extends FunctionalTestCase {
     // process output, so the default verbosity is restored here - otherwise
     // the assertions below would hold regardless of the script's behaviour.
     $short_circuits = $package_present && $binaries_present;
-    $expected_output = [
-      $short_circuits ? '! Installing Vortex tooling' : '* Installing Vortex tooling',
-      '! No composer.lock file present',
-      '! Loading composer repositories',
-      '! Generating autoload files',
-    ];
+    $expected_output = $short_circuits
+      ? ['! Installing Vortex tooling']
+      : [
+        '* Installing Vortex tooling',
+        '! No composer.lock file present',
+        '! Loading composer repositories',
+        '! Generating autoload files',
+      ];
 
     $this->cmd('bash scripts/vortex-tooling.sh', $expected_output, txt: 'Bootstrap must succeed regardless of the pre-existing vendor state', env: ['SHELL_VERBOSITY' => 0]);
 

--- a/.vortex/tests/phpunit/Functional/ToolingBootstrapTest.php
+++ b/.vortex/tests/phpunit/Functional/ToolingBootstrapTest.php
@@ -20,6 +20,16 @@ use PHPUnit\Framework\Attributes\Group;
 class ToolingBootstrapTest extends FunctionalTestCase {
 
   /**
+   * Environment that makes the bootstrap output reproducible.
+   *
+   * The harness silences Composer through 'SHELL_VERBOSITY' when it does not
+   * stream process output, which would make the output assertions hold
+   * regardless of the script's behaviour, and the progress helpers emit ANSI
+   * colour whenever the terminal reports support for it.
+   */
+  protected const OUTPUT_ENV = ['SHELL_VERBOSITY' => 0, 'TERM' => 'dumb'];
+
+  /**
    * The working directory before the test chdir'd into the fixture project.
    */
   protected string $originalCwd = '';
@@ -66,17 +76,14 @@ class ToolingBootstrapTest extends FunctionalTestCase {
       File::dump($stale_bin, "pre-existing binary\n");
     }
 
-    // The harness silences Composer through 'SHELL_VERBOSITY' when it does not
-    // stream process output, so the default verbosity is restored here -
-    // otherwise the output assertions below would hold regardless of the
-    // script's behaviour.
     $short_circuits = $package_present && $binaries_present;
-    $process = $this->cmd('bash scripts/vortex-tooling.sh', txt: 'Bootstrap must succeed regardless of the pre-existing vendor state', env: ['SHELL_VERBOSITY' => 0]);
+    $process = $this->cmd('bash scripts/vortex-tooling.sh', txt: 'Bootstrap must succeed regardless of the pre-existing vendor state', env: static::OUTPUT_ENV);
 
     // Both streams are matched in full rather than probed for known Composer
     // strings: only an exact match proves the bootstrap stays silent, since
     // unanticipated output would slip past a list of negative substrings.
-    $this->assertSame($short_circuits ? '' : '[INFO] Installing Vortex tooling.', trim($process->getOutput()), 'Only the announcement is written to stdout.');
+    $expected_output = $short_circuits ? '' : "[INFO] Started Vortex tooling installation.\n[ OK ] Finished Vortex tooling installation.";
+    $this->assertSame($expected_output, trim($process->getOutput()), 'Only the progress messages are written to stdout.');
     $this->assertSame('', trim($process->getErrorOutput()), 'Nothing is written to stderr.');
 
     $this->assertDirectoryDoesNotExist($project_dir . '/vendor-temp', 'The throwaway Composer project is removed.');
@@ -103,7 +110,7 @@ class ToolingBootstrapTest extends FunctionalTestCase {
     $this->logSubstep('Assert a repeated run short-circuits without reinstalling');
     $canary = $project_dir . '/vendor/drevops/vortex-tooling/canary.txt';
     File::dump($canary, "canary\n");
-    $process = $this->cmd('bash scripts/vortex-tooling.sh', txt: 'Repeated bootstrap run must exit early and print nothing', env: ['SHELL_VERBOSITY' => 0]);
+    $process = $this->cmd('bash scripts/vortex-tooling.sh', txt: 'Repeated bootstrap run must exit early and print nothing', env: static::OUTPUT_ENV);
     $this->assertSame('', trim($process->getOutput()), 'The repeated run writes nothing to stdout.');
     $this->assertSame('', trim($process->getErrorOutput()), 'The repeated run writes nothing to stderr.');
     $this->assertFileExists($canary, 'The repeated run does not reinstall the package.');
@@ -122,7 +129,7 @@ class ToolingBootstrapTest extends FunctionalTestCase {
     $project_dir = $this->prepareProject(minimal_composer_json: TRUE, tooling_constraint: '999.999.999');
     chdir($project_dir);
 
-    $this->cmdFail('bash scripts/vortex-tooling.sh', ['* Your requirements could not be resolved'], txt: 'A failing bootstrap replays the suppressed Composer output', env: ['SHELL_VERBOSITY' => 0]);
+    $this->cmdFail('bash scripts/vortex-tooling.sh', ['* [FAIL] Composer command failed.', '* Your requirements could not be resolved'], txt: 'A failing bootstrap reports the failure and replays the suppressed Composer output', env: static::OUTPUT_ENV);
 
     $this->assertDirectoryDoesNotExist($project_dir . '/vendor-temp', 'The throwaway Composer project is removed after a failure.');
 

--- a/.vortex/tests/phpunit/Functional/ToolingBootstrapTest.php
+++ b/.vortex/tests/phpunit/Functional/ToolingBootstrapTest.php
@@ -66,11 +66,23 @@ class ToolingBootstrapTest extends FunctionalTestCase {
       File::dump($stale_bin, "pre-existing binary\n");
     }
 
-    $this->cmd('bash scripts/vortex-tooling.sh', txt: 'Bootstrap must succeed regardless of the pre-existing vendor state');
+    // The bootstrap must not leak Composer's progress output. The harness
+    // silences Composer through 'SHELL_VERBOSITY' when it does not stream
+    // process output, so the default verbosity is restored here - otherwise
+    // the assertions below would hold regardless of the script's behaviour.
+    $short_circuits = $package_present && $binaries_present;
+    $expected_output = [
+      $short_circuits ? '! Installing Vortex tooling' : '* Installing Vortex tooling',
+      '! No composer.lock file present',
+      '! Loading composer repositories',
+      '! Generating autoload files',
+    ];
+
+    $this->cmd('bash scripts/vortex-tooling.sh', $expected_output, txt: 'Bootstrap must succeed regardless of the pre-existing vendor state', env: ['SHELL_VERBOSITY' => 0]);
 
     $this->assertDirectoryDoesNotExist($project_dir . '/vendor-temp', 'The throwaway Composer project is removed.');
 
-    if ($package_present && $binaries_present) {
+    if ($short_circuits) {
       $this->logSubstep('Assert the bootstrap short-circuited and did not touch the existing state');
       $this->assertFileExists($package_marker, 'The existing package copy is left untouched.');
       $this->assertFileContainsString($stale_bin, 'pre-existing binary', 'The existing binary is left untouched.');
@@ -92,8 +104,26 @@ class ToolingBootstrapTest extends FunctionalTestCase {
     $this->logSubstep('Assert a repeated run short-circuits without reinstalling');
     $canary = $project_dir . '/vendor/drevops/vortex-tooling/canary.txt';
     File::dump($canary, "canary\n");
-    $this->cmd('bash scripts/vortex-tooling.sh', txt: 'Repeated bootstrap run must exit early');
+    $this->cmd('bash scripts/vortex-tooling.sh', ['! Installing Vortex tooling'], txt: 'Repeated bootstrap run must exit early and print nothing', env: ['SHELL_VERBOSITY' => 0]);
     $this->assertFileExists($canary, 'The repeated run does not reinstall the package.');
+
+    $this->logStepFinish();
+  }
+
+  #[Group('p1')]
+  public function testBootstrapReplaysComposerOutputOnFailure(): void {
+    $this->logStepStart();
+
+    // A constraint that no repository can satisfy makes Composer fail during
+    // dependency resolution, which is the failure mode the suppression must
+    // not hide: the bootstrap runs from the ahoy entrypoint, so a silent
+    // failure there would block every command with no explanation.
+    $project_dir = $this->prepareProject(minimal_composer_json: TRUE, tooling_constraint: '999.999.999');
+    chdir($project_dir);
+
+    $this->cmdFail('bash scripts/vortex-tooling.sh', ['* Your requirements could not be resolved'], txt: 'A failing bootstrap replays the suppressed Composer output', env: ['SHELL_VERBOSITY' => 0]);
+
+    $this->assertDirectoryDoesNotExist($project_dir . '/vendor-temp', 'The throwaway Composer project is removed after a failure.');
 
     $this->logStepFinish();
   }
@@ -130,7 +160,7 @@ class ToolingBootstrapTest extends FunctionalTestCase {
     $this->logStepFinish();
   }
 
-  protected function prepareProject(bool $minimal_composer_json = FALSE): string {
+  protected function prepareProject(bool $minimal_composer_json = FALSE, ?string $tooling_constraint = NULL): string {
     $root = static::locationsRoot();
     $project_dir = static::$tmp . '/project';
 
@@ -166,6 +196,8 @@ class ToolingBootstrapTest extends FunctionalTestCase {
     if (!is_string($constraint)) {
       throw new \RuntimeException('The template composer.json does not require the tooling package.');
     }
+
+    $constraint = $tooling_constraint ?? $constraint;
 
     $path_repository = NULL;
     $repositories = $template['repositories'] ?? [];

--- a/.vortex/tests/phpunit/Functional/ToolingBootstrapTest.php
+++ b/.vortex/tests/phpunit/Functional/ToolingBootstrapTest.php
@@ -66,21 +66,18 @@ class ToolingBootstrapTest extends FunctionalTestCase {
       File::dump($stale_bin, "pre-existing binary\n");
     }
 
-    // The bootstrap must not leak Composer's progress output. The harness
-    // silences Composer through 'SHELL_VERBOSITY' when it does not stream
-    // process output, so the default verbosity is restored here - otherwise
-    // the assertions below would hold regardless of the script's behaviour.
+    // The harness silences Composer through 'SHELL_VERBOSITY' when it does not
+    // stream process output, so the default verbosity is restored here -
+    // otherwise the output assertions below would hold regardless of the
+    // script's behaviour.
     $short_circuits = $package_present && $binaries_present;
-    $expected_output = $short_circuits
-      ? ['! Installing Vortex tooling']
-      : [
-        '* Installing Vortex tooling',
-        '! No composer.lock file present',
-        '! Loading composer repositories',
-        '! Generating autoload files',
-      ];
+    $process = $this->cmd('bash scripts/vortex-tooling.sh', txt: 'Bootstrap must succeed regardless of the pre-existing vendor state', env: ['SHELL_VERBOSITY' => 0]);
 
-    $this->cmd('bash scripts/vortex-tooling.sh', $expected_output, txt: 'Bootstrap must succeed regardless of the pre-existing vendor state', env: ['SHELL_VERBOSITY' => 0]);
+    // Both streams are matched in full rather than probed for known Composer
+    // strings: only an exact match proves the bootstrap stays silent, since
+    // unanticipated output would slip past a list of negative substrings.
+    $this->assertSame($short_circuits ? '' : '[INFO] Installing Vortex tooling.', trim($process->getOutput()), 'Only the announcement is written to stdout.');
+    $this->assertSame('', trim($process->getErrorOutput()), 'Nothing is written to stderr.');
 
     $this->assertDirectoryDoesNotExist($project_dir . '/vendor-temp', 'The throwaway Composer project is removed.');
 
@@ -106,7 +103,9 @@ class ToolingBootstrapTest extends FunctionalTestCase {
     $this->logSubstep('Assert a repeated run short-circuits without reinstalling');
     $canary = $project_dir . '/vendor/drevops/vortex-tooling/canary.txt';
     File::dump($canary, "canary\n");
-    $this->cmd('bash scripts/vortex-tooling.sh', ['! Installing Vortex tooling'], txt: 'Repeated bootstrap run must exit early and print nothing', env: ['SHELL_VERBOSITY' => 0]);
+    $process = $this->cmd('bash scripts/vortex-tooling.sh', txt: 'Repeated bootstrap run must exit early and print nothing', env: ['SHELL_VERBOSITY' => 0]);
+    $this->assertSame('', trim($process->getOutput()), 'The repeated run writes nothing to stdout.');
+    $this->assertSame('', trim($process->getErrorOutput()), 'The repeated run writes nothing to stderr.');
     $this->assertFileExists($canary, 'The repeated run does not reinstall the package.');
 
     $this->logStepFinish();

--- a/scripts/vortex-tooling.sh
+++ b/scripts/vortex-tooling.sh
@@ -21,6 +21,16 @@
 set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
+# ------------------------------------------------------------------------------
+
+# @formatter:off
+info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[36m[INFO] %s\033[0m\n" "${1}" || printf "[INFO] %s\n" "${1}"; }
+note() { printf "       %s\n" "${1}"; }
+task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
+pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+# @formatter:on
+
 # Run Composer without exposing its progress output, which is an internal detail
 # of this bootstrap rather than something that was asked for. The captured
 # output is replayed on stderr when the command fails, so failures remain
@@ -35,6 +45,8 @@ composer_run() {
   output=$(composer "$@" 2>&1) || status=$?
 
   if [ "${status}" -ne 0 ]; then
+    fail "Composer command failed."
+
     if [ -n "${output}" ]; then
       printf "%s\n" "${output}" >&2
     fi
@@ -48,9 +60,7 @@ if [ -d ./vendor/drevops/vortex-tooling ] && ls ./vendor/bin/vortex-* >/dev/null
   exit 0
 fi
 
-# The install runs before any other output and takes a noticeable amount of
-# time, so announce it rather than leaving the terminal blank.
-printf "[INFO] Installing Vortex tooling.\n"
+info "Started Vortex tooling installation."
 
 mkdir -p vendor-temp vendor/drevops
 
@@ -127,3 +137,5 @@ if [ -d vendor-temp/vendor/bin ]; then
     [ -e "${bin}" ] && mv "${bin}" vendor/bin/
   done
 fi
+
+pass "Finished Vortex tooling installation."

--- a/scripts/vortex-tooling.sh
+++ b/scripts/vortex-tooling.sh
@@ -21,10 +21,36 @@
 set -eu
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
+# Run Composer without exposing its progress output, which is an internal detail
+# of this bootstrap rather than something that was asked for. The captured
+# output is replayed on stderr when the command fails, so failures remain
+# diagnosable. Debug mode streams the output as it happens.
+composer_run() {
+  if [ "${VORTEX_DEBUG-}" = "1" ]; then
+    composer "$@"
+    return
+  fi
+
+  local output status=0
+  output=$(composer "$@" 2>&1) || status=$?
+
+  if [ "${status}" -ne 0 ]; then
+    if [ -n "${output}" ]; then
+      printf "%s\n" "${output}" >&2
+    fi
+
+    return "${status}"
+  fi
+}
+
 # Already installed and its binaries linked - nothing to do.
 if [ -d ./vendor/drevops/vortex-tooling ] && ls ./vendor/bin/vortex-* >/dev/null 2>&1; then
   exit 0
 fi
+
+# The install runs before any other output and takes a noticeable amount of
+# time, so announce it rather than leaving the terminal blank.
+printf "[INFO] Installing Vortex tooling.\n"
 
 mkdir -p vendor-temp vendor/drevops
 
@@ -51,27 +77,27 @@ echo "{\"require\":{\"drevops/vortex-tooling\":\"${version}\"}}" >vendor-temp/co
 # In dev mode the package is not yet on Packagist, so add a path repository
 # pointing at the in-tree copy. The installer strips this VORTEX_DEV-fenced
 # block from consumer sites.
-composer --working-dir=vendor-temp config repositories.vortex-tooling --json '{"type":"path","url":"../.vortex/tooling","options":{"symlink":false,"versions":{"drevops/vortex-tooling":"1.3.0"}}}'
+composer_run --working-dir=vendor-temp config repositories.vortex-tooling --json '{"type":"path","url":"../.vortex/tooling","options":{"symlink":false,"versions":{"drevops/vortex-tooling":"1.3.0"}}}'
 #;> VORTEX_DEV
 
 # Carry over inline patches declared for our package, if any.
 patches=$(composer config extra.patches.drevops/vortex-tooling --json 2>/dev/null) || patches=
 if [ -n "${patches}" ] && [ "${patches}" != "[]" ] && [ "${patches}" != "{}" ]; then
-  composer --working-dir=vendor-temp config extra.patches.drevops/vortex-tooling --json "${patches}"
+  composer_run --working-dir=vendor-temp config extra.patches.drevops/vortex-tooling --json "${patches}"
 fi
 
 # Carry over the patches-file pointer, if defined. Prefix with '..' so the
 # path resolves from inside 'vendor-temp/' back to the project root.
 patches_file=$(composer config extra.patches-file 2>/dev/null) || patches_file=
 if [ -n "${patches_file}" ]; then
-  composer --working-dir=vendor-temp config extra.patches-file "../${patches_file}"
+  composer_run --working-dir=vendor-temp config extra.patches-file "../${patches_file}"
 fi
 
 # When any patches were registered, pull in the composer-patches plugin and
 # allow it to run during install.
 if [ -n "${patches}" ] || [ -n "${patches_file}" ]; then
-  composer --working-dir=vendor-temp require --no-update cweagans/composer-patches:^2
-  composer --working-dir=vendor-temp config allow-plugins.cweagans/composer-patches true
+  composer_run --working-dir=vendor-temp require --no-update cweagans/composer-patches:^2
+  composer_run --working-dir=vendor-temp config allow-plugins.cweagans/composer-patches true
   # Inline 'extra.patches' paths (and paths inside a 'patches-file') are
   # relative to the project root. Copy the project 'patches/' directory into
   # the throwaway project so those paths resolve from inside 'vendor-temp/'.
@@ -80,7 +106,7 @@ if [ -n "${patches}" ] || [ -n "${patches_file}" ]; then
   fi
 fi
 
-composer --working-dir=vendor-temp install --no-dev --no-interaction
+composer_run --working-dir=vendor-temp install --no-dev --no-interaction
 
 # The target directory may already be occupied by a package copy without the
 # 'vendor/bin/vortex-*' proxies (e.g. an older tooling version mid-way through


### PR DESCRIPTION
Closes #2843

## Summary

The `ahoy` entrypoint bootstraps `drevops/vortex-tooling` into `vendor/` before every command, so on a fresh clone the first `ahoy <anything>` was preceded by ten lines of raw Composer progress output before the requested command produced a single line of its own. The highlighted `No composer.lock file present` warning was the most misleading part: it refers to the throwaway `vendor-temp/` project the bootstrap creates, not to the user's site, so it read as a problem with their clone.

Every mutating Composer call in `scripts/vortex-tooling.sh` now runs through a helper that captures its output and replays it on stderr only when the command fails, preserving Composer's own exit code rather than flattening it. `VORTEX_DEBUG=1` still streams the output as it happens, matching the `set -x` behaviour already in the script.

`composer --quiet` was deliberately not used. It also suppresses failure messages, and because this bootstrap runs from the `ahoy` entrypoint, a silent failure would abort every command including the ones needed to recover.

## Changes

### `scripts/vortex-tooling.sh`

- Adopted the standard progress helpers (`info`, `note`, `task`, `pass`, `fail`) used by the shipped tooling scripts, replacing the absence of any progress reporting in this script.
- Added a `composer_run()` helper that streams Composer directly under `VORTEX_DEBUG=1` and otherwise captures stdout and stderr, writing them to stderr and returning Composer's exit code only when the command fails.
- Routed the mutating Composer calls through it: the `config` writes, `require --no-update`, and `install`. The read-only `composer show` and `composer config` lookups keep their existing capture, since their output is consumed rather than displayed.
- Bracketed the install with `info "Started Vortex tooling installation."` and a closing `pass` line, both emitted only on runs that actually install. The early-exit guard means every subsequent command prints nothing at all.
- Labelled the replayed Composer output with `fail` so a failure report is not an unexplained blob.

### `.vortex/tests/phpunit/Functional/ToolingBootstrapTest.php`

- `testBootstrap` now matches both output streams in full rather than probing for individual Composer strings, since unanticipated output would slip past a list of negative substring checks. The installing path asserts stdout is exactly the two progress messages and stderr is empty; the short-circuit path asserts both streams are empty, as does the repeated short-circuited run.
- Added `testBootstrapReplaysComposerOutputOnFailure`, which forces an unresolvable tooling constraint and asserts the failure is reported, the suppressed Composer output still reaches the terminal, and `vendor-temp/` is cleaned up. This is the assertion that pins the design choice against a future simplification to `composer --quiet`.
- Added an `OUTPUT_ENV` constant used by every output assertion. It restores Composer's default verbosity, which the harness otherwise suppresses through `SHELL_VERBOSITY` (without it the assertions would hold regardless of the script's behaviour), and pins `TERM` so the progress helpers' colour branch is deterministic across environments.
- Extended `prepareProject()` with an optional tooling-constraint override used by the new failure test.

### Generated

- `.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh` is the regenerated installer snapshot of the same script, with the `VORTEX_DEV` fenced block stripped as the installer does for consumer sites. Produced by `ahoy update-snapshots`, not hand-edited.

## Before / After

```
BEFORE                                          AFTER
──────                                          ─────

$ a build                                       $ a build
                                                │
┌──────────────────────────────────────┐        ├─ [INFO] Started Vortex tooling installation.
│ No composer.lock file present.       │        ├─ [ OK ] Finished Vortex tooling installation.
│ Updating dependencies to latest ...  │        │
│ Loading composer repositories ...    │        └─ [INFO] Started reset.
│ Updating dependencies                │
│ Lock file operations: 1 install ...  │
│   - Locking drevops/vortex-tooling   │        Composer output appears only on failure:
│ Writing lock file                    │
│ Installing dependencies from lock    │        ├─ [FAIL] Composer command failed.
│ Package operations: 1 install ...    │        └─ <full Composer output on stderr,
│   - Installing drevops/vortex-...    │            with Composer's exit code preserved>
│ Generating autoload files            │
└──────────────────────────────────────┘        Subsequent commands print nothing at all -
  ten lines of throwaway-project detail          the early-exit guard short-circuits before
  before the command's own first line            any output.
                                                
[INFO] Started reset.                           VORTEX_DEBUG=1 streams Composer verbatim.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer progress and success messages during tooling installation.
  * Composer output is now shown only in debug mode, while failures display relevant error details.
  * Development tooling installations now support configured patches and local development sources.

* **Bug Fixes**
  * Repeated bootstrap runs now exit cleanly without duplicate output.
  * Improved cleanup of temporary installation files after successful or failed runs.

* **Tests**
  * Added coverage for deterministic bootstrap output and Composer failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->