### PR TITLE
Fixed docs workflows building the v2 binary from the removed '.vortex/installer' path.

### DIFF
--- a/.github/workflows/vortex-release.yml
+++ b/.github/workflows/vortex-release.yml
@@ -99,10 +99,11 @@ jobs:
           path: .vortex/installer/build/installer.phar
           if-no-files-found: error
 
-      # Build the other major's installer from its '{N}.x' branch so it is
-      # published alongside the current one. Checked out into a separate path so
-      # the current installer build above is untouched. Mirrors how the docs job
-      # pulls the other major's branch content.
+      # Build the other major from its '{N}.x' branch so it is published
+      # alongside the current one. Checked out into a separate path so the
+      # build above is untouched. Mirrors how the docs job pulls the other
+      # major's branch content. Each major builds whatever it ships - the
+      # installer above, the CLI here - so this leg keeps its own paths.
       - name: Checkout v${{ env.OTHER_MAJOR }} branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -110,19 +111,19 @@ jobs:
           path: vortex-v${{ env.OTHER_MAJOR }}
           persist-credentials: false
 
-      - name: Build v${{ env.OTHER_MAJOR }} installer
+      - name: Build v${{ env.OTHER_MAJOR }} binary
         run: |
           composer install
-          sed -i "s/\"vortex-installer-version\": \"development\"/\"vortex-installer-version\": \"${OTHER_MAJOR}.x-dev\"/g" box.json
+          sed -i "s/\"vortex-cli-version\": \"development\"/\"vortex-cli-version\": \"${OTHER_MAJOR}.x-dev\"/g" box.json
           composer build
-          ./build/installer.phar --version
-        working-directory: vortex-v${{ env.OTHER_MAJOR }}/.vortex/installer
+          ./.build/vortex.phar --version
+        working-directory: vortex-v${{ env.OTHER_MAJOR }}/.vortex/cli
 
-      - name: Upload v${{ env.OTHER_MAJOR }} installer artifact
+      - name: Upload v${{ env.OTHER_MAJOR }} artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: vortex-installer-v${{ env.OTHER_MAJOR }}
-          path: vortex-v${{ env.OTHER_MAJOR }}/.vortex/installer/build/installer.phar
+          path: vortex-v${{ env.OTHER_MAJOR }}/.vortex/cli/.build/vortex.phar
           if-no-files-found: error
 
   vortex-release-docs:
@@ -183,20 +184,22 @@ jobs:
           name: vortex-installer-v2
           path: installer-v2
 
-      # Publish both installers. '/v1/install' and '/v2/install' are the stable
+      # Publish both majors. '/v1/install' and '/v2/install' are the stable
       # per-major pins, always built from each major's own source. The bare
       # '/install' is a copy of the current major's pin, selected by the
       # 'VORTEX_CURRENT_MAJOR' repository variable (default 1) - bumping that one
       # variable is the only action needed to promote a new major.
-      - name: Copy installers to docs
+      - name: Copy binaries to docs
         run: |
           case "${CURRENT_MAJOR}" in
             1|2) ;;
             *) echo "Invalid VORTEX_CURRENT_MAJOR='${CURRENT_MAJOR}'. Expected 1 or 2."; exit 1 ;;
           esac
           mkdir -p ../.vortex/docs/static/v1 ../.vortex/docs/static/v2
-          cp ../installer-v1/installer.phar ../.vortex/docs/static/v1/install
-          cp ../installer-v2/installer.phar ../.vortex/docs/static/v2/install
+          # Each artifact holds exactly one PHAR, but its filename depends on
+          # what that major ships, so it is matched rather than named.
+          cp ../installer-v1/*.phar ../.vortex/docs/static/v1/install
+          cp ../installer-v2/*.phar ../.vortex/docs/static/v2/install
           cp "../.vortex/docs/static/v${CURRENT_MAJOR}/install" ../.vortex/docs/static/install
           php ../.vortex/docs/static/install --version
 

--- a/.github/workflows/vortex-test-docs.yml
+++ b/.github/workflows/vortex-test-docs.yml
@@ -107,11 +107,11 @@ jobs:
           git -C "${{ github.workspace }}" checkout "origin/${OTHER_MAJOR}.x" -- .vortex/docs/content || { echo "Failed to check out content from ${OTHER_MAJOR}.x."; exit 1; }
         working-directory: '${{ github.workspace }}/.vortex/docs'
 
-      # On the main deploy, publish both installers to match the multi-version
+      # On the main deploy, publish both majors to match the multi-version
       # docs: '/v1/install' and '/v2/install' are the stable per-major pins and
       # the bare '/install' is a copy of the current major's pin (the
       # 'VORTEX_CURRENT_MAJOR' repository variable, default 1). The downloaded
-      # installer above is the current major (built from 'main'); the other
+      # binary above is the current major (built from 'main'); the other
       # major is built from its '{N}.x' branch. Mirrors 'vortex-release.yml'.
       - name: Checkout v${{ env.OTHER_MAJOR }} branch
         if: github.event.workflow_run.head_branch == 'main'
@@ -121,19 +121,21 @@ jobs:
           path: vortex-v${{ env.OTHER_MAJOR }}
           persist-credentials: false
 
-      - name: Build and publish v${{ env.OTHER_MAJOR }} installer
+      # Each major builds whatever it ships - the installer here, the CLI on
+      # '2.x' - so this leg keeps its own paths, box token and PHAR name.
+      - name: Build and publish v${{ env.OTHER_MAJOR }} binary
         if: github.event.workflow_run.head_branch == 'main'
         run: |
           case "${CURRENT_MAJOR}" in
             1|2) ;;
             *) echo "Invalid VORTEX_CURRENT_MAJOR='${CURRENT_MAJOR}'. Expected 1 or 2."; exit 1 ;;
           esac
-          composer --working-dir="vortex-v${OTHER_MAJOR}/.vortex/installer" install
-          sed -i "s/\"vortex-installer-version\": \"development\"/\"vortex-installer-version\": \"${OTHER_MAJOR}.x-dev\"/g" "vortex-v${OTHER_MAJOR}/.vortex/installer/box.json"
-          composer --working-dir="vortex-v${OTHER_MAJOR}/.vortex/installer" build
+          composer --working-dir="vortex-v${OTHER_MAJOR}/.vortex/cli" install
+          sed -i "s/\"vortex-cli-version\": \"development\"/\"vortex-cli-version\": \"${OTHER_MAJOR}.x-dev\"/g" "vortex-v${OTHER_MAJOR}/.vortex/cli/box.json"
+          composer --working-dir="vortex-v${OTHER_MAJOR}/.vortex/cli" build
           mkdir -p .vortex/docs/static/v1 .vortex/docs/static/v2
           cp .vortex/docs/static/install ".vortex/docs/static/v${CURRENT_MAJOR}/install"
-          cp "vortex-v${OTHER_MAJOR}/.vortex/installer/build/installer.phar" ".vortex/docs/static/v${OTHER_MAJOR}/install"
+          cp "vortex-v${OTHER_MAJOR}/.vortex/cli/.build/vortex.phar" ".vortex/docs/static/v${OTHER_MAJOR}/install"
           cp ".vortex/docs/static/v${CURRENT_MAJOR}/install" .vortex/docs/static/install
 
       - name: Build documentation site


### PR DESCRIPTION
## Summary

The `Vortex - Test docs` workflow on `main` failed at the "Build and publish v2 installer" step with `Invalid working directory specified, vortex-v2/.vortex/installer does not exist.` The `2.x` branch renamed `.vortex/installer` to `.vortex/cli`, replaced the `box.json` replacement token `vortex-installer-version` with `vortex-cli-version`, and now builds `.build/vortex.phar` instead of `build/installer.phar`. Both `vortex-test-docs.yml` (the failing workflow) and `vortex-release.yml` build the other major's binary by checking out the `2.x` branch, and both still referenced the old `.vortex/installer` layout, so `vortex-release.yml` carried the same defect and would have broken the next release. This updates the other-major build leg in both workflows to the current `2.x` layout, renames the affected step labels from "installer" to "binary"/"artifact" wording since v2 ships a CLI rather than an installer, and switches the docs job's copy step to a `*.phar` glob since the v2 artifact now contains `vortex.phar` instead of `installer.phar`.

## Changes

- `.github/workflows/vortex-test-docs.yml`: build the other major's binary in `.vortex/cli` instead of `.vortex/installer`, sed the `vortex-cli-version` box.json token instead of `vortex-installer-version`, copy `.build/vortex.phar` instead of `build/installer.phar`, and renamed the step to "Build and publish v${{ env.OTHER_MAJOR }} binary".
- `.github/workflows/vortex-release.yml`: the same working-directory, box.json token, and PHAR path fixes for the "Build v${{ env.OTHER_MAJOR }} binary" step, plus a `*.phar` glob in the docs job's "Copy binaries to docs" step so it matches whichever PHAR name each major's artifact actually contains, since the artifact is now `vortex.phar` for v2 rather than `installer.phar`.
- Renamed step names on the other-major legs from "installer" to "binary"/"artifact" wording in both files to reflect that v2 ships a CLI, not an installer. Artifact *names* (`vortex-installer-vN`) are left unchanged - they are internal identifiers consumed within the same workflow run, and `2.x` uses the same names.
- Updated the surrounding comments in both files to describe that each major builds and ships its own thing (installer vs CLI) with its own paths.

## Verification

`actionlint` passes on both changed files. The fixed step is gated on `head_branch == 'main'`, so this PR's own CI cannot exercise it - the failure only reproduces on a `main` docs run. To compensate, the exact CI sequence (`composer install`, then `sed` of the `vortex-cli-version` token in `box.json`, then `composer build`) was run locally against the real `2.x` `.vortex/cli` tree. It produced `.build/vortex.phar`, and `./.build/vortex.phar --version` printed `Vortex CLI 2.x-dev`, confirming the new path, token, and PHAR name all line up with what `2.x` actually ships.

## Before / After

```
BEFORE - other-major build leg (checked out from '2.x')
┌────────────────────────────────────────────────────────────────┐
│ working-directory:  vortex-v2/.vortex/installer                 │
│ box.json token:      "vortex-installer-version"                 │
│ built PHAR:          build/installer.phar                       │
│ artifact copy:        installer-v2/installer.phar                │
├────────────────────────────────────────────────────────────────┤
│ result:  Invalid working directory specified,                   │
│          vortex-v2/.vortex/installer does not exist.            │
└────────────────────────────────────────────────────────────────┘

AFTER - other-major build leg (checked out from '2.x')
┌────────────────────────────────────────────────────────────────┐
│ working-directory:  vortex-v2/.vortex/cli                       │
│ box.json token:      "vortex-cli-version"                       │
│ built PHAR:          .build/vortex.phar                         │
│ artifact copy:        installer-v2/*.phar                        │
├────────────────────────────────────────────────────────────────┤
│ result:  ./.build/vortex.phar --version                         │
│          -> Vortex CLI 2.x-dev                                  │
└────────────────────────────────────────────────────────────────┘
```
