### PR TITLE
[#2863] Added opt-in for visual regression on non-PR deployments.

### DIFF
--- a/.github/workflows/test-vr.yml
+++ b/.github/workflows/test-vr.yml
@@ -130,12 +130,23 @@ jobs:
             return 1
           }
 
+          # Records the gate decision and ends the step.
+          proceed() {
+            echo "${1}"
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          skip() {
+            echo "::notice::${1}"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
           # Manual workflow_dispatch always proceeds - the operator
           # explicitly asked for a comparison.
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            echo "Manual dispatch, proceeding."
-            echo "skipped=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            proceed "Manual dispatch."
           fi
 
           # No PR resolved - the deployment targets a permanent environment
@@ -143,23 +154,17 @@ jobs:
           # only when the deployed branch is explicitly opted in.
           if [ -z "${PR_NUMBER}" ]; then
             if ref_matches "${BRANCH}" "${DIFFY_NON_PR_BRANCHES}"; then
-              echo "Deployed branch '${BRANCH}' matches VR_DIFFY_NON_PR_BRANCHES, proceeding."
-              echo "skipped=false" >> "$GITHUB_OUTPUT"
-              exit 0
+              proceed "Deployed branch '${BRANCH}' matches VR_DIFFY_NON_PR_BRANCHES."
             fi
 
-            echo "::notice::No PR associated with this deployment and branch '${BRANCH}' does not match VR_DIFFY_NON_PR_BRANCHES, skipping visual regression."
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            skip "No PR associated with this deployment and branch '${BRANCH}' does not match VR_DIFFY_NON_PR_BRANCHES, skipping visual regression."
           fi
 
           # PR resolved - fetch labels and head branch in one call. A failed
           # lookup means the 'pr-<number>' segment in the URL did not come
           # from a pull request in this repository.
           if ! pr_data="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels,headRefName)"; then
-            echo "::notice::PR #${PR_NUMBER} could not be read, skipping visual regression."
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            skip "PR #${PR_NUMBER} could not be read, skipping visual regression."
           fi
 
           head_ref="$(printf '%s' "${pr_data}" | jq -r '.headRefName')"
@@ -168,20 +173,17 @@ jobs:
           # Auto-run bypass: PRs from configured branches (e.g. Renovate's
           # `deps/*`) skip the label check.
           if ref_matches "${head_ref}" "${DIFFY_AUTO_BRANCHES}"; then
-            echo "PR #${PR_NUMBER} head branch '${head_ref}' matches VR_DIFFY_AUTO_BRANCHES, proceeding."
-            echo "skipped=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            proceed "PR #${PR_NUMBER} head branch '${head_ref}' matches VR_DIFFY_AUTO_BRANCHES."
           fi
 
           # Label check (case-insensitive).
           needle="$(printf '%s' "${DIFFY_PR_LABEL}" | tr '[:upper:]' '[:lower:]')"
+
           if echo "${labels_lower}" | grep -qx "${needle}"; then
-            echo "PR #${PR_NUMBER} has the '${DIFFY_PR_LABEL}' label, proceeding."
-            echo "skipped=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::PR #${PR_NUMBER} does not have the '${DIFFY_PR_LABEL}' label and head branch '${head_ref}' does not match VR_DIFFY_AUTO_BRANCHES, skipping visual regression."
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            proceed "PR #${PR_NUMBER} has the '${DIFFY_PR_LABEL}' label."
           fi
+
+          skip "PR #${PR_NUMBER} does not have the '${DIFFY_PR_LABEL}' label and head branch '${head_ref}' does not match VR_DIFFY_AUTO_BRANCHES, skipping visual regression."
 
       - name: Validate target URL
         if: steps.gate.outputs.skipped != 'true'

--- a/.github/workflows/test-vr.yml
+++ b/.github/workflows/test-vr.yml
@@ -43,8 +43,8 @@ env:
   DIFFY_CLI_VERSION: ${{ vars.VR_DIFFY_CLI_VERSION || '0.1.53' }}
   DIFFY_MAX_WAIT: ${{ vars.VR_DIFFY_MAX_WAIT || '2700' }}
   DIFFY_PR_LABEL: ${{ vars.VR_DIFFY_PR_LABEL || 'VR' }}
-  DIFFY_AUTO_BRANCHES: ${{ vars.VR_DIFFY_AUTO_BRANCHES || 'deps/*' }}
-  DIFFY_NON_PR_BRANCHES: ${{ vars.VR_DIFFY_NON_PR_BRANCHES }}
+  DIFFY_PR_SKIP_BRANCHES: ${{ vars.VR_DIFFY_PR_SKIP_BRANCHES || 'deps/*' }}
+  DIFFY_BRANCHES: ${{ vars.VR_DIFFY_BRANCHES }}
   DIFFY_POLL_INTERVAL: ${{ vars.VR_DIFFY_POLL_INTERVAL || '30' }}
   SOURCE_ENV: ${{ github.event.client_payload.source_env || inputs.source_env || 'production' }}
   TARGET_URL: ${{ github.event.client_payload.target_url || inputs.target_url }}
@@ -97,93 +97,50 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Matches a git ref against a comma-separated list of glob
-          # patterns. Returns 0 on the first match; 1 when the ref or the
-          # list is empty, or when nothing matches.
+          # Matches a git ref against a comma-separated glob list. Splitting
+          # on whitespace as well as commas absorbs padding around each
+          # pattern.
           ref_matches() {
-            local ref="${1}"
-            local list="${2}"
-            local pattern
-            local patterns
-
-            if [ -z "${ref}" ] || [ -z "${list}" ]; then
-              return 1
-            fi
-
-            IFS=',' read -ra patterns <<<"${list}"
-
+            local ref="${1}" pattern patterns
+            [ -n "${ref}" ] || return 1
+            [ -n "${2}" ] || return 1
+            IFS=$', \t' read -ra patterns <<<"${2}"
             for pattern in "${patterns[@]}"; do
-              # Trim surrounding whitespace.
-              pattern="${pattern#"${pattern%%[![:space:]]*}"}"
-              pattern="${pattern%"${pattern##*[![:space:]]}"}"
-
-              if [ -z "${pattern}" ]; then
-                continue
-              fi
-
               # shellcheck disable=SC2254
-              case "${ref}" in
-                ${pattern}) return 0 ;;
-              esac
+              case "${ref}" in ${pattern}) return 0 ;; esac
             done
-
             return 1
           }
 
-          # Records the gate decision and ends the step.
-          proceed() {
-            echo "${1}"
-            echo "skipped=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          }
+          # Record the gate decision and end the step.
+          proceed() { echo "${1}"; echo "skipped=false" >> "$GITHUB_OUTPUT"; exit 0; }
+          skip() { echo "::notice::${1}"; echo "skipped=true" >> "$GITHUB_OUTPUT"; exit 0; }
 
-          skip() {
-            echo "::notice::${1}"
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          }
-
-          # Manual workflow_dispatch always proceeds - the operator
-          # explicitly asked for a comparison.
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            proceed "Manual dispatch."
-          fi
+          # The operator explicitly asked for a comparison.
+          [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && proceed "Manual dispatch."
 
           # No PR resolved - the deployment targets a permanent environment
           # such as a release branch, 'develop', 'dev' or 'stage'. Those run
           # only when the deployed branch is explicitly opted in.
           if [ -z "${PR_NUMBER}" ]; then
-            if ref_matches "${BRANCH}" "${DIFFY_NON_PR_BRANCHES}"; then
-              proceed "Deployed branch '${BRANCH}' matches VR_DIFFY_NON_PR_BRANCHES."
-            fi
-
-            skip "No PR associated with this deployment and branch '${BRANCH}' does not match VR_DIFFY_NON_PR_BRANCHES, skipping visual regression."
+            ref_matches "${BRANCH}" "${DIFFY_BRANCHES}" && proceed "Deployed branch '${BRANCH}' matches VR_DIFFY_BRANCHES."
+            skip "No PR associated with this deployment and branch '${BRANCH}' does not match VR_DIFFY_BRANCHES, skipping visual regression."
           fi
 
-          # PR resolved - fetch labels and head branch in one call. A failed
-          # lookup means the 'pr-<number>' segment in the URL did not come
-          # from a pull request in this repository.
-          if ! pr_data="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels,headRefName)"; then
-            skip "PR #${PR_NUMBER} could not be read, skipping visual regression."
-          fi
+          # A failed lookup means the 'pr-<number>' segment in the URL did
+          # not come from a pull request in this repository.
+          pr_data="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels,headRefName)" || skip "PR #${PR_NUMBER} could not be read, skipping visual regression."
 
           head_ref="$(printf '%s' "${pr_data}" | jq -r '.headRefName')"
-          labels_lower="$(printf '%s' "${pr_data}" | jq -r '.labels[].name' | tr '[:upper:]' '[:lower:]')"
+          labels="$(printf '%s' "${pr_data}" | jq -r '.labels[].name')"
 
-          # Auto-run bypass: PRs from configured branches (e.g. Renovate's
-          # `deps/*`) skip the label check.
-          if ref_matches "${head_ref}" "${DIFFY_AUTO_BRANCHES}"; then
-            proceed "PR #${PR_NUMBER} head branch '${head_ref}' matches VR_DIFFY_AUTO_BRANCHES."
-          fi
+          # PRs from configured branches (e.g. Renovate's `deps/*`) skip the
+          # label check.
+          ref_matches "${head_ref}" "${DIFFY_PR_SKIP_BRANCHES}" && proceed "PR #${PR_NUMBER} head branch '${head_ref}' matches VR_DIFFY_PR_SKIP_BRANCHES."
 
-          # Label check (case-insensitive).
-          needle="$(printf '%s' "${DIFFY_PR_LABEL}" | tr '[:upper:]' '[:lower:]')"
+          echo "${labels}" | grep -qixF "${DIFFY_PR_LABEL}" && proceed "PR #${PR_NUMBER} has the '${DIFFY_PR_LABEL}' label."
 
-          if echo "${labels_lower}" | grep -qx "${needle}"; then
-            proceed "PR #${PR_NUMBER} has the '${DIFFY_PR_LABEL}' label."
-          fi
-
-          skip "PR #${PR_NUMBER} does not have the '${DIFFY_PR_LABEL}' label and head branch '${head_ref}' does not match VR_DIFFY_AUTO_BRANCHES, skipping visual regression."
+          skip "PR #${PR_NUMBER} does not have the '${DIFFY_PR_LABEL}' label and head branch '${head_ref}' does not match VR_DIFFY_PR_SKIP_BRANCHES, skipping visual regression."
 
       - name: Validate target URL
         if: steps.gate.outputs.skipped != 'true'

--- a/.github/workflows/test-vr.yml
+++ b/.github/workflows/test-vr.yml
@@ -114,8 +114,8 @@ jobs:
 
             for pattern in "${patterns[@]}"; do
               # Trim surrounding whitespace.
-              pattern="${pattern# }"
-              pattern="${pattern% }"
+              pattern="${pattern#"${pattern%%[![:space:]]*}"}"
+              pattern="${pattern%"${pattern##*[![:space:]]}"}"
 
               if [ -z "${pattern}" ]; then
                 continue

--- a/.github/workflows/test-vr.yml
+++ b/.github/workflows/test-vr.yml
@@ -1,9 +1,9 @@
 # GitHub Actions visual regression testing workflow.
 #
 # Runs a Diffy visual regression comparison after a deployment lands.
-# Triggered automatically by 'notify-diffy' (via repository_dispatch)
-# when the deployed PR has the configured label, or manually via
-# 'workflow_dispatch' against any URL.
+# Triggered automatically by 'notify-diffy' (via repository_dispatch) when
+# the deployed PR has the configured label or the deployed branch is opted
+# in, or manually via 'workflow_dispatch' against any URL.
 name: Test - Visual regression
 
 on:
@@ -44,9 +44,11 @@ env:
   DIFFY_MAX_WAIT: ${{ vars.VR_DIFFY_MAX_WAIT || '2700' }}
   DIFFY_PR_LABEL: ${{ vars.VR_DIFFY_PR_LABEL || 'VR' }}
   DIFFY_AUTO_BRANCHES: ${{ vars.VR_DIFFY_AUTO_BRANCHES || 'deps/*' }}
+  DIFFY_NON_PR_BRANCHES: ${{ vars.VR_DIFFY_NON_PR_BRANCHES }}
   DIFFY_POLL_INTERVAL: ${{ vars.VR_DIFFY_POLL_INTERVAL || '30' }}
   SOURCE_ENV: ${{ github.event.client_payload.source_env || inputs.source_env || 'production' }}
   TARGET_URL: ${{ github.event.client_payload.target_url || inputs.target_url }}
+  BRANCH: ${{ github.event.client_payload.branch }}
   LABEL: ${{ github.event.client_payload.label || inputs.label || 'manual' }}
 
 jobs:
@@ -74,18 +76,18 @@ jobs:
 
           # Hosting providers expose PR environments via URLs that contain
           # a 'pr-<number>' segment (e.g. 'app.pr-123.example.lagoon.cloud').
-          # Extract the number from the URL; if no match, this is not a PR
-          # deployment and visual regression should not run.
+          # Extract the number from the URL; a URL without one is not a PR
+          # deployment and is gated on the deployed branch instead.
           pr_number="$(printf '%s' "${TARGET_URL}" | sed -n 's|.*pr-\([0-9]\{1,\}\).*|\1|p')"
 
           if [ -n "${pr_number}" ]; then
             echo "PR #${pr_number} resolved from target URL ${TARGET_URL}."
           else
-            echo "::notice::No PR pattern found in target URL ${TARGET_URL}. Visual regression will not run."
+            echo "No PR pattern found in target URL ${TARGET_URL}."
           fi
           echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
 
-      - name: Gate run on PR label (or skip for non-PR contexts on dispatch)
+      - name: Gate run on PR label or opted-in branch
         id: gate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -95,6 +97,39 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Matches a git ref against a comma-separated list of glob
+          # patterns. Returns 0 on the first match; 1 when the ref or the
+          # list is empty, or when nothing matches.
+          ref_matches() {
+            local ref="${1}"
+            local list="${2}"
+            local pattern
+            local patterns
+
+            if [ -z "${ref}" ] || [ -z "${list}" ]; then
+              return 1
+            fi
+
+            IFS=',' read -ra patterns <<<"${list}"
+
+            for pattern in "${patterns[@]}"; do
+              # Trim surrounding whitespace.
+              pattern="${pattern# }"
+              pattern="${pattern% }"
+
+              if [ -z "${pattern}" ]; then
+                continue
+              fi
+
+              # shellcheck disable=SC2254
+              case "${ref}" in
+                ${pattern}) return 0 ;;
+              esac
+            done
+
+            return 1
+          }
+
           # Manual workflow_dispatch always proceeds - the operator
           # explicitly asked for a comparison.
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
@@ -103,36 +138,39 @@ jobs:
             exit 0
           fi
 
-          # repository_dispatch with no PR resolved - nothing to gate on.
+          # No PR resolved - the deployment targets a permanent environment
+          # such as a release branch, 'develop', 'dev' or 'stage'. Those run
+          # only when the deployed branch is explicitly opted in.
           if [ -z "${PR_NUMBER}" ]; then
-            echo "::notice::No PR associated with this deployment, skipping visual regression."
+            if ref_matches "${BRANCH}" "${DIFFY_NON_PR_BRANCHES}"; then
+              echo "Deployed branch '${BRANCH}' matches VR_DIFFY_NON_PR_BRANCHES, proceeding."
+              echo "skipped=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            echo "::notice::No PR associated with this deployment and branch '${BRANCH}' does not match VR_DIFFY_NON_PR_BRANCHES, skipping visual regression."
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # PR resolved - fetch labels and head branch in one call.
-          pr_data="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels,headRefName)"
+          # PR resolved - fetch labels and head branch in one call. A failed
+          # lookup means the 'pr-<number>' segment in the URL did not come
+          # from a pull request in this repository.
+          if ! pr_data="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels,headRefName)"; then
+            echo "::notice::PR #${PR_NUMBER} could not be read, skipping visual regression."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           head_ref="$(printf '%s' "${pr_data}" | jq -r '.headRefName')"
           labels_lower="$(printf '%s' "${pr_data}" | jq -r '.labels[].name' | tr '[:upper:]' '[:lower:]')"
 
           # Auto-run bypass: PRs from configured branches (e.g. Renovate's
           # `deps/*`) skip the label check.
-          if [ -n "${DIFFY_AUTO_BRANCHES}" ]; then
-            IFS=',' read -ra patterns <<<"${DIFFY_AUTO_BRANCHES}"
-            for pattern in "${patterns[@]}"; do
-              # Trim surrounding whitespace.
-              pattern="${pattern# }"
-              pattern="${pattern% }"
-              [ -z "${pattern}" ] && continue
-              # shellcheck disable=SC2254
-              case "${head_ref}" in
-                ${pattern})
-                  echo "PR #${PR_NUMBER} head branch '${head_ref}' matches auto-run pattern '${pattern}', proceeding."
-                  echo "skipped=false" >> "$GITHUB_OUTPUT"
-                  exit 0
-                  ;;
-              esac
-            done
+          if ref_matches "${head_ref}" "${DIFFY_AUTO_BRANCHES}"; then
+            echo "PR #${PR_NUMBER} head branch '${head_ref}' matches VR_DIFFY_AUTO_BRANCHES, proceeding."
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           # Label check (case-insensitive).

--- a/.vortex/docs/content/development/visual-regression.mdx
+++ b/.vortex/docs/content/development/visual-regression.mdx
@@ -108,7 +108,7 @@ GitHub branch protection rules.
 ```text
 ┌─ GitHub ────────────────────────────────────┐
 │                                             │
-│      PR opened with `VR` label              │
+│   PR with `VR` label, or opted-in branch    │
 │                  │                          │
 │                  ▼                          │
 │           build-test-deploy.yml             │
@@ -142,11 +142,20 @@ GitHub branch protection rules.
 │                  ▼                          │
 │      vr-compare: parse PR from URL, gate    │
 │                  │                          │
+│         ┌────────┴────────┐                 │
+│         ▼                 ▼                 │
+│   PR deployment      no PR resolved         │
+│         │                 │                 │
+│         ▼                 ▼                 │
+│    VR label or        branch in             │
+│    auto-branch       non-PR list            │
+│         │                 │                 │
+│         └────────┬────────┘                 │
 │                  ▼                          │
 │        Report in workflow run summary       │
 │                  │                          │
 │                  ▼                          │
-│                vr-report                    │
+│             vr-report (PR only)             │
 │                  │                          │
 │                  ▼                          │
 │        PR comment + Diffy report link       │
@@ -347,7 +356,8 @@ entry point.
 
 1. Posts the same report as a sticky comment on the PR, with a link to
    the Diffy report. Re-deploys edit the same comment rather than
-   stacking.
+   stacking. The job runs only when a PR was resolved - manual runs and
+   opted-in branch deployments report through the run summary alone.
 
 ## Making it blocking
 

--- a/.vortex/docs/content/development/visual-regression.mdx
+++ b/.vortex/docs/content/development/visual-regression.mdx
@@ -108,7 +108,7 @@ GitHub branch protection rules.
 ```text
 ┌─ GitHub ────────────────────────────────────┐
 │                                             │
-│   PR with `VR` label, or opted-in branch    │
+│         PR opened or branch pushed          │
 │                  │                          │
 │                  ▼                          │
 │           build-test-deploy.yml             │

--- a/.vortex/docs/content/development/visual-regression.mdx
+++ b/.vortex/docs/content/development/visual-regression.mdx
@@ -7,7 +7,8 @@ sidebar_label: Visual regression
 **Vortex** ships an optional visual regression workflow powered by
 [Diffy](../tools/diffy.mdx). It compares the just-deployed environment
 against a baseline (typically `production`) and posts the result back to
-the related pull request.
+the related pull request, or to the workflow run summary when the
+deployment has no pull request.
 
 ## Account setup
 
@@ -75,6 +76,7 @@ the site. In Cloudflare, add an IP Access Rule for that address with the
 | `VR_DIFFY_POLL_INTERVAL` | `30` | Polling interval in seconds |
 | `VR_DIFFY_PR_LABEL` | `VR` | PR label that opts a deployment into visual regression. Case-insensitive |
 | `VR_DIFFY_AUTO_BRANCHES` | `deps/*` | Comma-separated glob list of PR head branches that bypass the label gate (matches Renovate's `branchPrefix`). Set to empty to require the label on every PR. |
+| `VR_DIFFY_NON_PR_BRANCHES` | (empty) | Comma-separated glob list of deployed branches that run visual regression when the deployment is *not* a PR environment (for example `release/*`). Empty means non-PR deployments never run. |
 | `VR_DIFFY_SOURCE_ENV` | `production` | Default Diffy source environment for comparisons |
 
 Add these under *Settings > Secrets and variables > Actions > Repository
@@ -158,8 +160,9 @@ commit SHA**. The workflow itself extracts the PR number from the
 deployed environment URL by matching the `pr-<number>` segment (e.g.
 `https://pr-123.example.com/` resolves to PR #123) and verifies the
 `VR` label is present (case-insensitive). If the target URL has no
-`pr-<number>` segment, the deployment is not a PR environment and the
-run is skipped.
+`pr-<number>` segment, the deployment is not a PR environment and the run
+is skipped unless the deployed branch is opted in - see [Release and other
+non-PR deployments](#release-and-other-non-pr-deployments).
 
 This means the PR lookup works uniformly across hosting providers - the
 host only needs to expose the deployed environment URL, which all of
@@ -251,6 +254,45 @@ Consumers using Dependabot just append:
 `VR_DIFFY_AUTO_BRANCHES=deps/*,dependabot/*`. Consumers who want the
 label as the only gate (no auto-bypass) set the variable to empty.
 
+## Release and other non-PR deployments
+
+A deployment that is not a pull request environment - a release branch, an
+integration branch such as `develop`, or a permanent `dev`/`stage`
+environment - has no pull request to carry the `VR` label, so it is skipped
+by default.
+
+Set `VR_DIFFY_NON_PR_BRANCHES` to a comma-separated glob list of deployed
+branch names to compare them automatically:
+
+```ini
+VR_DIFFY_NON_PR_BRANCHES=release/*
+```
+
+| Deployment | `VR_DIFFY_NON_PR_BRANCHES` | Runs? |
+|---|---|---|
+| PR environment (`pr-123` in the URL) | any value | gated by the `VR` label and `VR_DIFFY_AUTO_BRANCHES` as usual |
+| Branch `release/1.2.3` | (empty) | no |
+| Branch `release/1.2.3` | `release/*` | **yes** |
+| Branch `develop` | `release/*` | no |
+| Branch `develop` | `release/*,develop` | **yes** |
+| Any branch | `*` | **yes** (every non-PR deployment) |
+
+The deployed branch travels in the dispatch payload, so no GitHub API call
+is needed to resolve it.
+
+:::note
+
+Patterns match the **git branch name**, not the hostname. Hosting providers
+sanitize branch names for URLs - Lagoon deploys `release/26.7.5` to a host
+containing `release-26-7-5` - but the gate compares against the original
+`release/26.7.5`.
+
+:::
+
+There is no pull request to comment on for these runs, so the result
+appears in the workflow run summary and in the Diffy UI instead of as a PR
+comment.
+
 ## How the PR is resolved
 
 The workflow extracts the PR number from the deployed environment URL by
@@ -272,7 +314,8 @@ This means:
 
 If the target URL has no `pr-<number>` segment (for example, a deploy to
 a named environment like `dev`/`test`/`prod`), the workflow treats it as
-"not a PR deployment" and exits without running.
+"not a PR deployment" and runs only when the deployed branch matches
+`VR_DIFFY_NON_PR_BRANCHES`.
 
 ## Missed-window behavior
 
@@ -288,8 +331,9 @@ entry point.
 
 `vr-compare`:
 
-1. Resolves the PR number from the target URL and gates on the label
-   (or auto-branch pattern for dependency PRs).
+1. Resolves the PR number from the target URL and gates on the label (or
+   the auto-branch pattern for dependency PRs, or the deployed-branch
+   opt-in for non-PR deployments).
 2. Installs the pinned Diffy CLI.
 3. Calls `diffy project:compare` with the target URL and a label.
 4. Polls the comparison status, printing progress to the job log every
@@ -323,9 +367,14 @@ be posted, which is not a merge-blocker.
 ## Costs and quotas
 
 Diffy bills per screenshot set. **Vortex**'s default gating (`VR` label on
-PRs only, plus the `deps/*` auto-branch list) keeps the run rate low.
-Adjust `VR_DIFFY_PR_LABEL`, `VR_DIFFY_AUTO_BRANCHES`, and
+PRs only, plus the `deps/*` auto-branch list, with non-PR deployments off
+entirely) keeps the run rate low. Adjust `VR_DIFFY_PR_LABEL`,
+`VR_DIFFY_AUTO_BRANCHES`, `VR_DIFFY_NON_PR_BRANCHES`, and
 `VORTEX_NOTIFY_DIFFY_BRANCHES` to suit the team's review rhythm.
+
+Scope `VR_DIFFY_NON_PR_BRANCHES` as narrowly as the workflow allows: `*`
+compares on every deployment to every permanent environment, which on a
+busy integration branch consumes quota quickly.
 
 ## Disabling
 

--- a/.vortex/docs/content/development/visual-regression.mdx
+++ b/.vortex/docs/content/development/visual-regression.mdx
@@ -75,8 +75,8 @@ the site. In Cloudflare, add an IP Access Rule for that address with the
 | `VR_DIFFY_MAX_WAIT` | `2700` | Maximum seconds to wait for a comparison to complete (45 minutes) |
 | `VR_DIFFY_POLL_INTERVAL` | `30` | Polling interval in seconds |
 | `VR_DIFFY_PR_LABEL` | `VR` | PR label that opts a deployment into visual regression. Case-insensitive |
-| `VR_DIFFY_AUTO_BRANCHES` | `deps/*` | Comma-separated glob list of PR head branches that bypass the label gate (matches Renovate's `branchPrefix`). Set to empty to require the label on every PR. |
-| `VR_DIFFY_NON_PR_BRANCHES` | (empty) | Comma-separated glob list of deployed branches that run visual regression when the deployment is *not* a PR environment (for example `release/*`). Empty means non-PR deployments never run. |
+| `VR_DIFFY_PR_SKIP_BRANCHES` | `deps/*` | Comma-separated glob list of PR head branches that skip the label gate (matches Renovate's `branchPrefix`). Set to empty to require the label on every PR. |
+| `VR_DIFFY_BRANCHES` | (empty) | Comma-separated glob list of deployed branches that run visual regression when the deployment has no pull request (for example `release/*`). Empty means such deployments never run. |
 | `VR_DIFFY_SOURCE_ENV` | `production` | Default Diffy source environment for comparisons |
 
 Add these under *Settings > Secrets and variables > Actions > Repository
@@ -148,7 +148,7 @@ GitHub branch protection rules.
 │         │                 │                 │
 │         ▼                 ▼                 │
 │    VR label or        branch in             │
-│    auto-branch       non-PR list            │
+│   PR skip list       branch list            │
 │         │                 │                 │
 │         └────────┬────────┘                 │
 │                  ▼                          │
@@ -230,8 +230,8 @@ be the sole gate.
 PRs raised by Renovate (or any other automated dependency-update bot)
 typically do not carry the `VR` label - they carry their own bot label
 (e.g. `Dependencies`). To still run visual regression on them, the
-workflow consults `VR_DIFFY_AUTO_BRANCHES`: a comma-separated glob list
-of PR head branches that bypass the `VR` label gate.
+workflow consults `VR_DIFFY_PR_SKIP_BRANCHES`: a comma-separated glob
+list of PR head branches that skip the `VR` label gate.
 
 The default value is `deps/*`, matching **Vortex**'s Renovate `branchPrefix`
 configuration. Other common values:
@@ -243,13 +243,12 @@ configuration. Other common values:
 | Dependabot | `dependabot/` | `dependabot/*` |
 
 Multiple patterns can be combined with commas:
-`VR_DIFFY_AUTO_BRANCHES=deps/*,dependabot/*`. Set the variable to empty
-to disable the bypass entirely (every PR, including bot PRs, then needs
-the label).
+`VR_DIFFY_PR_SKIP_BRANCHES=deps/*,dependabot/*`. Set the variable to
+empty to require the label on every PR, including bot PRs.
 
 ### Default behavior out of the box
 
-With `VR_DIFFY_AUTO_BRANCHES=deps/*` (default) and
+With `VR_DIFFY_PR_SKIP_BRANCHES=deps/*` (default) and
 `VR_DIFFY_PR_LABEL=VR` (default):
 
 | PR head branch | Has `VR` label? | Runs? |
@@ -260,8 +259,8 @@ With `VR_DIFFY_AUTO_BRANCHES=deps/*` (default) and
 | `deps/drupal-core-11.2` | yes | yes (matches `deps/*`, label irrelevant) |
 
 Consumers using Dependabot just append:
-`VR_DIFFY_AUTO_BRANCHES=deps/*,dependabot/*`. Consumers who want the
-label as the only gate (no auto-bypass) set the variable to empty.
+`VR_DIFFY_PR_SKIP_BRANCHES=deps/*,dependabot/*`. Consumers who want the
+label as the only gate set the variable to empty.
 
 ## Release and other non-PR deployments
 
@@ -270,16 +269,16 @@ integration branch such as `develop`, or a permanent `dev`/`stage`
 environment - has no pull request to carry the `VR` label, so it is skipped
 by default.
 
-Set `VR_DIFFY_NON_PR_BRANCHES` to a comma-separated glob list of deployed
-branch names to compare them automatically:
+Set `VR_DIFFY_BRANCHES` to a comma-separated glob list of deployed branch
+names to compare them automatically:
 
 ```ini
-VR_DIFFY_NON_PR_BRANCHES=release/*
+VR_DIFFY_BRANCHES=release/*
 ```
 
-| Deployment | `VR_DIFFY_NON_PR_BRANCHES` | Runs? |
+| Deployment | `VR_DIFFY_BRANCHES` | Runs? |
 |---|---|---|
-| PR environment (`pr-123` in the URL) | any value | gated by the `VR` label and `VR_DIFFY_AUTO_BRANCHES` as usual |
+| PR environment (`pr-123` in the URL) | any value | gated by the `VR` label and `VR_DIFFY_PR_SKIP_BRANCHES` as usual |
 | Branch `release/1.2.3` | (empty) | no |
 | Branch `release/1.2.3` | `release/*` | **yes** |
 | Branch `develop` | `release/*` | no |
@@ -324,7 +323,7 @@ This means:
 If the target URL has no `pr-<number>` segment (for example, a deploy to
 a named environment like `dev`/`test`/`prod`), the workflow treats it as
 "not a PR deployment" and runs only when the deployed branch matches
-`VR_DIFFY_NON_PR_BRANCHES`.
+`VR_DIFFY_BRANCHES`.
 
 ## Missed-window behavior
 
@@ -379,10 +378,10 @@ be posted, which is not a merge-blocker.
 Diffy bills per screenshot set. **Vortex**'s default gating (`VR` label on
 PRs only, plus the `deps/*` auto-branch list, with non-PR deployments off
 entirely) keeps the run rate low. Adjust `VR_DIFFY_PR_LABEL`,
-`VR_DIFFY_AUTO_BRANCHES`, `VR_DIFFY_NON_PR_BRANCHES`, and
+`VR_DIFFY_PR_SKIP_BRANCHES`, `VR_DIFFY_BRANCHES`, and
 `VORTEX_NOTIFY_DIFFY_BRANCHES` to suit the team's review rhythm.
 
-Scope `VR_DIFFY_NON_PR_BRANCHES` as narrowly as the workflow allows: `*`
+Scope `VR_DIFFY_BRANCHES` as narrowly as the workflow allows: `*`
 compares on every deployment to every permanent environment, which on a
 busy integration branch consumes quota quickly.
 

--- a/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
@@ -114,8 +114,8 @@ jobs:
 
             for pattern in "${patterns[@]}"; do
               # Trim surrounding whitespace.
-              pattern="${pattern# }"
-              pattern="${pattern% }"
+              pattern="${pattern#"${pattern%%[![:space:]]*}"}"
+              pattern="${pattern%"${pattern##*[![:space:]]}"}"
 
               if [ -z "${pattern}" ]; then
                 continue

--- a/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
@@ -130,12 +130,23 @@ jobs:
             return 1
           }
 
+          # Records the gate decision and ends the step.
+          proceed() {
+            echo "${1}"
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          skip() {
+            echo "::notice::${1}"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
           # Manual workflow_dispatch always proceeds - the operator
           # explicitly asked for a comparison.
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            echo "Manual dispatch, proceeding."
-            echo "skipped=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            proceed "Manual dispatch."
           fi
 
           # No PR resolved - the deployment targets a permanent environment
@@ -143,23 +154,17 @@ jobs:
           # only when the deployed branch is explicitly opted in.
           if [ -z "${PR_NUMBER}" ]; then
             if ref_matches "${BRANCH}" "${DIFFY_NON_PR_BRANCHES}"; then
-              echo "Deployed branch '${BRANCH}' matches VR_DIFFY_NON_PR_BRANCHES, proceeding."
-              echo "skipped=false" >> "$GITHUB_OUTPUT"
-              exit 0
+              proceed "Deployed branch '${BRANCH}' matches VR_DIFFY_NON_PR_BRANCHES."
             fi
 
-            echo "::notice::No PR associated with this deployment and branch '${BRANCH}' does not match VR_DIFFY_NON_PR_BRANCHES, skipping visual regression."
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            skip "No PR associated with this deployment and branch '${BRANCH}' does not match VR_DIFFY_NON_PR_BRANCHES, skipping visual regression."
           fi
 
           # PR resolved - fetch labels and head branch in one call. A failed
           # lookup means the 'pr-<number>' segment in the URL did not come
           # from a pull request in this repository.
           if ! pr_data="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels,headRefName)"; then
-            echo "::notice::PR #${PR_NUMBER} could not be read, skipping visual regression."
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            skip "PR #${PR_NUMBER} could not be read, skipping visual regression."
           fi
 
           head_ref="$(printf '%s' "${pr_data}" | jq -r '.headRefName')"
@@ -168,20 +173,17 @@ jobs:
           # Auto-run bypass: PRs from configured branches (e.g. Renovate's
           # `deps/*`) skip the label check.
           if ref_matches "${head_ref}" "${DIFFY_AUTO_BRANCHES}"; then
-            echo "PR #${PR_NUMBER} head branch '${head_ref}' matches VR_DIFFY_AUTO_BRANCHES, proceeding."
-            echo "skipped=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            proceed "PR #${PR_NUMBER} head branch '${head_ref}' matches VR_DIFFY_AUTO_BRANCHES."
           fi
 
           # Label check (case-insensitive).
           needle="$(printf '%s' "${DIFFY_PR_LABEL}" | tr '[:upper:]' '[:lower:]')"
+
           if echo "${labels_lower}" | grep -qx "${needle}"; then
-            echo "PR #${PR_NUMBER} has the '${DIFFY_PR_LABEL}' label, proceeding."
-            echo "skipped=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::PR #${PR_NUMBER} does not have the '${DIFFY_PR_LABEL}' label and head branch '${head_ref}' does not match VR_DIFFY_AUTO_BRANCHES, skipping visual regression."
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            proceed "PR #${PR_NUMBER} has the '${DIFFY_PR_LABEL}' label."
           fi
+
+          skip "PR #${PR_NUMBER} does not have the '${DIFFY_PR_LABEL}' label and head branch '${head_ref}' does not match VR_DIFFY_AUTO_BRANCHES, skipping visual regression."
 
       - name: Validate target URL
         if: steps.gate.outputs.skipped != 'true'
@@ -304,20 +306,6 @@ jobs:
 
           echo "Diff summary: ${pages_changed} of ${pages_total} pages changed (${changes_percent}% total)."
           echo "Report URL: ${shared_url}"
-
-          # Runs without a PR - opted-in branches and manual dispatches -
-          # have nowhere to post a comment, so the run summary is the only
-          # place the result surfaces inside GitHub.
-          {
-            echo "### Visual regression report"
-            echo
-            echo "- **Pages changed**: ${pages_changed} of ${pages_total}"
-            echo "- **Overall difference**: ${changes_percent}%"
-            echo "- **Target environment**: ${TARGET_URL}"
-            echo "- **Source environment**: ${SOURCE_ENV}"
-            echo
-            echo "[View full Diffy report](${shared_url})"
-          } >> "$GITHUB_STEP_SUMMARY"
         env:
           STEPS_COMPARE_OUTPUTS_DIFF_ID: ${{ steps.compare.outputs.diff_id }}
 

--- a/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
@@ -43,8 +43,8 @@ env:
   DIFFY_CLI_VERSION: ${{ vars.VR_DIFFY_CLI_VERSION || '__VERSION__' }}
   DIFFY_MAX_WAIT: ${{ vars.VR_DIFFY_MAX_WAIT || '2700' }}
   DIFFY_PR_LABEL: ${{ vars.VR_DIFFY_PR_LABEL || 'VR' }}
-  DIFFY_AUTO_BRANCHES: ${{ vars.VR_DIFFY_AUTO_BRANCHES || 'deps/*' }}
-  DIFFY_NON_PR_BRANCHES: ${{ vars.VR_DIFFY_NON_PR_BRANCHES }}
+  DIFFY_PR_SKIP_BRANCHES: ${{ vars.VR_DIFFY_PR_SKIP_BRANCHES || 'deps/*' }}
+  DIFFY_BRANCHES: ${{ vars.VR_DIFFY_BRANCHES }}
   DIFFY_POLL_INTERVAL: ${{ vars.VR_DIFFY_POLL_INTERVAL || '30' }}
   SOURCE_ENV: ${{ github.event.client_payload.source_env || inputs.source_env || 'production' }}
   TARGET_URL: ${{ github.event.client_payload.target_url || inputs.target_url }}
@@ -97,93 +97,50 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Matches a git ref against a comma-separated list of glob
-          # patterns. Returns 0 on the first match; 1 when the ref or the
-          # list is empty, or when nothing matches.
+          # Matches a git ref against a comma-separated glob list. Splitting
+          # on whitespace as well as commas absorbs padding around each
+          # pattern.
           ref_matches() {
-            local ref="${1}"
-            local list="${2}"
-            local pattern
-            local patterns
-
-            if [ -z "${ref}" ] || [ -z "${list}" ]; then
-              return 1
-            fi
-
-            IFS=',' read -ra patterns <<<"${list}"
-
+            local ref="${1}" pattern patterns
+            [ -n "${ref}" ] || return 1
+            [ -n "${2}" ] || return 1
+            IFS=$', \t' read -ra patterns <<<"${2}"
             for pattern in "${patterns[@]}"; do
-              # Trim surrounding whitespace.
-              pattern="${pattern#"${pattern%%[![:space:]]*}"}"
-              pattern="${pattern%"${pattern##*[![:space:]]}"}"
-
-              if [ -z "${pattern}" ]; then
-                continue
-              fi
-
               # shellcheck disable=SC2254
-              case "${ref}" in
-                ${pattern}) return 0 ;;
-              esac
+              case "${ref}" in ${pattern}) return 0 ;; esac
             done
-
             return 1
           }
 
-          # Records the gate decision and ends the step.
-          proceed() {
-            echo "${1}"
-            echo "skipped=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          }
+          # Record the gate decision and end the step.
+          proceed() { echo "${1}"; echo "skipped=false" >> "$GITHUB_OUTPUT"; exit 0; }
+          skip() { echo "::notice::${1}"; echo "skipped=true" >> "$GITHUB_OUTPUT"; exit 0; }
 
-          skip() {
-            echo "::notice::${1}"
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          }
-
-          # Manual workflow_dispatch always proceeds - the operator
-          # explicitly asked for a comparison.
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            proceed "Manual dispatch."
-          fi
+          # The operator explicitly asked for a comparison.
+          [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && proceed "Manual dispatch."
 
           # No PR resolved - the deployment targets a permanent environment
           # such as a release branch, 'develop', 'dev' or 'stage'. Those run
           # only when the deployed branch is explicitly opted in.
           if [ -z "${PR_NUMBER}" ]; then
-            if ref_matches "${BRANCH}" "${DIFFY_NON_PR_BRANCHES}"; then
-              proceed "Deployed branch '${BRANCH}' matches VR_DIFFY_NON_PR_BRANCHES."
-            fi
-
-            skip "No PR associated with this deployment and branch '${BRANCH}' does not match VR_DIFFY_NON_PR_BRANCHES, skipping visual regression."
+            ref_matches "${BRANCH}" "${DIFFY_BRANCHES}" && proceed "Deployed branch '${BRANCH}' matches VR_DIFFY_BRANCHES."
+            skip "No PR associated with this deployment and branch '${BRANCH}' does not match VR_DIFFY_BRANCHES, skipping visual regression."
           fi
 
-          # PR resolved - fetch labels and head branch in one call. A failed
-          # lookup means the 'pr-<number>' segment in the URL did not come
-          # from a pull request in this repository.
-          if ! pr_data="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels,headRefName)"; then
-            skip "PR #${PR_NUMBER} could not be read, skipping visual regression."
-          fi
+          # A failed lookup means the 'pr-<number>' segment in the URL did
+          # not come from a pull request in this repository.
+          pr_data="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels,headRefName)" || skip "PR #${PR_NUMBER} could not be read, skipping visual regression."
 
           head_ref="$(printf '%s' "${pr_data}" | jq -r '.headRefName')"
-          labels_lower="$(printf '%s' "${pr_data}" | jq -r '.labels[].name' | tr '[:upper:]' '[:lower:]')"
+          labels="$(printf '%s' "${pr_data}" | jq -r '.labels[].name')"
 
-          # Auto-run bypass: PRs from configured branches (e.g. Renovate's
-          # `deps/*`) skip the label check.
-          if ref_matches "${head_ref}" "${DIFFY_AUTO_BRANCHES}"; then
-            proceed "PR #${PR_NUMBER} head branch '${head_ref}' matches VR_DIFFY_AUTO_BRANCHES."
-          fi
+          # PRs from configured branches (e.g. Renovate's `deps/*`) skip the
+          # label check.
+          ref_matches "${head_ref}" "${DIFFY_PR_SKIP_BRANCHES}" && proceed "PR #${PR_NUMBER} head branch '${head_ref}' matches VR_DIFFY_PR_SKIP_BRANCHES."
 
-          # Label check (case-insensitive).
-          needle="$(printf '%s' "${DIFFY_PR_LABEL}" | tr '[:upper:]' '[:lower:]')"
+          echo "${labels}" | grep -qixF "${DIFFY_PR_LABEL}" && proceed "PR #${PR_NUMBER} has the '${DIFFY_PR_LABEL}' label."
 
-          if echo "${labels_lower}" | grep -qx "${needle}"; then
-            proceed "PR #${PR_NUMBER} has the '${DIFFY_PR_LABEL}' label."
-          fi
-
-          skip "PR #${PR_NUMBER} does not have the '${DIFFY_PR_LABEL}' label and head branch '${head_ref}' does not match VR_DIFFY_AUTO_BRANCHES, skipping visual regression."
+          skip "PR #${PR_NUMBER} does not have the '${DIFFY_PR_LABEL}' label and head branch '${head_ref}' does not match VR_DIFFY_PR_SKIP_BRANCHES, skipping visual regression."
 
       - name: Validate target URL
         if: steps.gate.outputs.skipped != 'true'

--- a/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
@@ -1,9 +1,9 @@
 # GitHub Actions visual regression testing workflow.
 #
 # Runs a Diffy visual regression comparison after a deployment lands.
-# Triggered automatically by 'notify-diffy' (via repository_dispatch)
-# when the deployed PR has the configured label, or manually via
-# 'workflow_dispatch' against any URL.
+# Triggered automatically by 'notify-diffy' (via repository_dispatch) when
+# the deployed PR has the configured label or the deployed branch is opted
+# in, or manually via 'workflow_dispatch' against any URL.
 name: Test - Visual regression
 
 on:
@@ -44,9 +44,11 @@ env:
   DIFFY_MAX_WAIT: ${{ vars.VR_DIFFY_MAX_WAIT || '2700' }}
   DIFFY_PR_LABEL: ${{ vars.VR_DIFFY_PR_LABEL || 'VR' }}
   DIFFY_AUTO_BRANCHES: ${{ vars.VR_DIFFY_AUTO_BRANCHES || 'deps/*' }}
+  DIFFY_NON_PR_BRANCHES: ${{ vars.VR_DIFFY_NON_PR_BRANCHES }}
   DIFFY_POLL_INTERVAL: ${{ vars.VR_DIFFY_POLL_INTERVAL || '30' }}
   SOURCE_ENV: ${{ github.event.client_payload.source_env || inputs.source_env || 'production' }}
   TARGET_URL: ${{ github.event.client_payload.target_url || inputs.target_url }}
+  BRANCH: ${{ github.event.client_payload.branch }}
   LABEL: ${{ github.event.client_payload.label || inputs.label || 'manual' }}
 
 jobs:
@@ -74,18 +76,18 @@ jobs:
 
           # Hosting providers expose PR environments via URLs that contain
           # a 'pr-<number>' segment (e.g. 'app.pr-123.example.lagoon.cloud').
-          # Extract the number from the URL; if no match, this is not a PR
-          # deployment and visual regression should not run.
+          # Extract the number from the URL; a URL without one is not a PR
+          # deployment and is gated on the deployed branch instead.
           pr_number="$(printf '%s' "${TARGET_URL}" | sed -n 's|.*pr-\([0-9]\{1,\}\).*|\1|p')"
 
           if [ -n "${pr_number}" ]; then
             echo "PR #${pr_number} resolved from target URL ${TARGET_URL}."
           else
-            echo "::notice::No PR pattern found in target URL ${TARGET_URL}. Visual regression will not run."
+            echo "No PR pattern found in target URL ${TARGET_URL}."
           fi
           echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
 
-      - name: Gate run on PR label (or skip for non-PR contexts on dispatch)
+      - name: Gate run on PR label or opted-in branch
         id: gate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -95,6 +97,39 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Matches a git ref against a comma-separated list of glob
+          # patterns. Returns 0 on the first match; 1 when the ref or the
+          # list is empty, or when nothing matches.
+          ref_matches() {
+            local ref="${1}"
+            local list="${2}"
+            local pattern
+            local patterns
+
+            if [ -z "${ref}" ] || [ -z "${list}" ]; then
+              return 1
+            fi
+
+            IFS=',' read -ra patterns <<<"${list}"
+
+            for pattern in "${patterns[@]}"; do
+              # Trim surrounding whitespace.
+              pattern="${pattern# }"
+              pattern="${pattern% }"
+
+              if [ -z "${pattern}" ]; then
+                continue
+              fi
+
+              # shellcheck disable=SC2254
+              case "${ref}" in
+                ${pattern}) return 0 ;;
+              esac
+            done
+
+            return 1
+          }
+
           # Manual workflow_dispatch always proceeds - the operator
           # explicitly asked for a comparison.
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
@@ -103,36 +138,39 @@ jobs:
             exit 0
           fi
 
-          # repository_dispatch with no PR resolved - nothing to gate on.
+          # No PR resolved - the deployment targets a permanent environment
+          # such as a release branch, 'develop', 'dev' or 'stage'. Those run
+          # only when the deployed branch is explicitly opted in.
           if [ -z "${PR_NUMBER}" ]; then
-            echo "::notice::No PR associated with this deployment, skipping visual regression."
+            if ref_matches "${BRANCH}" "${DIFFY_NON_PR_BRANCHES}"; then
+              echo "Deployed branch '${BRANCH}' matches VR_DIFFY_NON_PR_BRANCHES, proceeding."
+              echo "skipped=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            echo "::notice::No PR associated with this deployment and branch '${BRANCH}' does not match VR_DIFFY_NON_PR_BRANCHES, skipping visual regression."
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # PR resolved - fetch labels and head branch in one call.
-          pr_data="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels,headRefName)"
+          # PR resolved - fetch labels and head branch in one call. A failed
+          # lookup means the 'pr-<number>' segment in the URL did not come
+          # from a pull request in this repository.
+          if ! pr_data="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json labels,headRefName)"; then
+            echo "::notice::PR #${PR_NUMBER} could not be read, skipping visual regression."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           head_ref="$(printf '%s' "${pr_data}" | jq -r '.headRefName')"
           labels_lower="$(printf '%s' "${pr_data}" | jq -r '.labels[].name' | tr '[:upper:]' '[:lower:]')"
 
           # Auto-run bypass: PRs from configured branches (e.g. Renovate's
           # `deps/*`) skip the label check.
-          if [ -n "${DIFFY_AUTO_BRANCHES}" ]; then
-            IFS=',' read -ra patterns <<<"${DIFFY_AUTO_BRANCHES}"
-            for pattern in "${patterns[@]}"; do
-              # Trim surrounding whitespace.
-              pattern="${pattern# }"
-              pattern="${pattern% }"
-              [ -z "${pattern}" ] && continue
-              # shellcheck disable=SC2254
-              case "${head_ref}" in
-                ${pattern})
-                  echo "PR #${PR_NUMBER} head branch '${head_ref}' matches auto-run pattern '${pattern}', proceeding."
-                  echo "skipped=false" >> "$GITHUB_OUTPUT"
-                  exit 0
-                  ;;
-              esac
-            done
+          if ref_matches "${head_ref}" "${DIFFY_AUTO_BRANCHES}"; then
+            echo "PR #${PR_NUMBER} head branch '${head_ref}' matches VR_DIFFY_AUTO_BRANCHES, proceeding."
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           # Label check (case-insensitive).
@@ -266,6 +304,20 @@ jobs:
 
           echo "Diff summary: ${pages_changed} of ${pages_total} pages changed (${changes_percent}% total)."
           echo "Report URL: ${shared_url}"
+
+          # Runs without a PR - opted-in branches and manual dispatches -
+          # have nowhere to post a comment, so the run summary is the only
+          # place the result surfaces inside GitHub.
+          {
+            echo "### Visual regression report"
+            echo
+            echo "- **Pages changed**: ${pages_changed} of ${pages_total}"
+            echo "- **Overall difference**: ${changes_percent}%"
+            echo "- **Target environment**: ${TARGET_URL}"
+            echo "- **Source environment**: ${SOURCE_ENV}"
+            echo
+            echo "[View full Diffy report](${shared_url})"
+          } >> "$GITHUB_STEP_SUMMARY"
         env:
           STEPS_COMPARE_OUTPUTS_DIFF_ID: ${{ steps.compare.outputs.diff_id }}
 


### PR DESCRIPTION
Closes #2863

## Summary

The gate step in `.github/workflows/test-vr.yml` exited as soon as the dispatched `target_url` had no `pr-<number>` segment, so a release branch or any other permanent-environment deployment could never trigger a Diffy comparison automatically - only a manual `workflow_dispatch` with a hand-pasted URL could. This adds an opt-in repository variable, `VR_DIFFY_BRANCHES`, holding a comma-separated glob list of deployed branch names. When a dispatch resolves no PR, the gate matches the deployed branch against that list before deciding to skip. The branch is already carried in the `client_payload.branch` field that `vortex-notify-diffy` sends, so the check costs no extra API call. The variable is empty by default, which preserves today's behaviour exactly.

## Breaking change

`VR_DIFFY_AUTO_BRANCHES` is renamed to `VR_DIFFY_PR_SKIP_BRANCHES`, so each variable now states which gate it controls: `VR_DIFFY_PR_SKIP_BRANCHES` lists PR head branches that skip the label check, and `VR_DIFFY_BRANCHES` lists deployed branches that run without a PR. A consumer that has set the old repository variable falls back to the `deps/*` default until it is renamed - same value in the common case, but it needs calling out in the release notes.

## Changes

### Gate

- Added `DIFFY_BRANCHES` (from `vars.VR_DIFFY_BRANCHES`, empty by default) and `BRANCH` (from `client_payload.branch`) to the workflow-level `env` block, so neither value is interpolated into a `run:` script.
- Reworked the no-PR-resolved path to consult the opt-in list: it proceeds when the deployed branch matches a pattern, and otherwise skips with the same `::notice::` as before.
- Extracted the comma-separated glob matching into a `ref_matches` helper, reused by both the new opt-in check and the `VR_DIFFY_PR_SKIP_BRANCHES` PR head-branch check, which previously carried the only copy of that loop inline. The list is split on whitespace as well as commas, so padding around a pattern is absorbed rather than trimmed by hand.
- Extracted `proceed` and `skip` helpers for the "record the decision and end the step" pair that was written out at all seven exit points, and collapsed the guards into AND lists. The step is roughly half its previous height, and each decision is now a single line.
- Replaced the lowercase-both-sides label comparison with a case-insensitive fixed-string `grep`, which also removes the risk of a label containing regex metacharacters being treated as a pattern.
- Guarded the `gh pr view` lookup with an exit-status check. A `pr-<number>` segment that does not resolve to a real pull request now skips the run with a `::notice::` instead of failing the `vr-compare` check under `set -euo pipefail` - a comparison that should not run must not present as a red check.
- Renamed the step to `Gate run on PR label or opted-in branch`, and downgraded the "no PR pattern found" line from `::notice::` to a plain `echo` since it is no longer a terminal outcome.

### Documentation

- Documented `VR_DIFFY_BRANCHES` in the variables table, renamed `VR_DIFFY_AUTO_BRANCHES` throughout, and added a `Release and other non-PR deployments` section with a run/no-run decision table.
- Called out that patterns match the git branch name, not the hostname: Lagoon deploys `release/26.7.5` to a host containing `release-26-7-5`, and the gate compares against the original branch name.
- Redrew the automatic-deployment diagram so both gate paths are visible and rejoin at the run-summary node, and noted in the Jobs section that `vr-report` runs only when a PR was resolved.
- Updated `How the PR is resolved` and `Costs and quotas`, the latter warning that `*` compares on every deployment to every permanent environment.

### Fixtures

- Regenerated the `visual_regression_enabled` installer fixture via `ahoy update-snapshots`.

## Verification

The gate is inline shell inside YAML with no test harness in this repository, so the decision table was exercised locally by running the step verbatim against a mocked `gh`: 19 cases covering manual dispatch, the four PR paths (label, lowercase label, no label, `deps/*` skip), a failed PR lookup, a mixed-case configured label, and nine no-PR cases including the empty default, the `*` wildcard, multi-pattern lists, space- and tab-padded lists, an all-empty list, and the sanitized-hostname trap. `actionlint` (the pinned CI image and ignore list) and `zizmor` both pass.

## Before / After

```
BEFORE                                  AFTER
──────                                  ─────
repository_dispatch                     repository_dispatch
        │                                       │
        ▼                                       ▼
  pr-<n> in URL?                          pr-<n> in URL?
        │                                       │
   ┌────┴────┐                             ┌────┴────┐
  yes        no                           yes        no
   │          │                            │          │
   ▼          ▼                            ▼          ▼
label /   skipped=true                  label /   branch matches
PR skip    (always - no                 PR skip   VR_DIFFY_BRANCHES?
branch      way to opt in)              branch          │
gate                                    gate       ┌────┴────┐
   │                                       │      yes        no
   ▼                                       ▼       │          │
diffy compare                        diffy compare ◄┘         ▼
                                                        skipped=true
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running visual regression checks on opted-in non-PR deployments via branch configuration.
  * Enhanced gating so PR runs depend on labels, while non-PR runs follow an explicit branch opt-in.
  * Improved reporting: when PR context isn’t available, results appear in workflow summaries and the Diffy UI instead of PR comments.

* **Bug Fixes**
  * Visual regression now safely skips when PR metadata can’t be read, with clearer messaging.

* **Documentation**
  * Updated visual regression docs with the non-PR opt-in mechanism, run/no-run matrix examples, and quota guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
