### PR TITLE
Added the visual regression report to the GitHub Actions run summary.

### DIFF
--- a/.github/workflows/test-vr.yml
+++ b/.github/workflows/test-vr.yml
@@ -64,6 +64,7 @@ jobs:
       shared_url: ${{ steps.result.outputs.shared_url }}
       pages_changed: ${{ steps.result.outputs.pages_changed }}
       pages_total: ${{ steps.result.outputs.pages_total }}
+      summary: ${{ steps.summary.outputs.summary }}
 
     steps:
       - name: Resolve PR number from target URL
@@ -253,7 +254,7 @@ jobs:
           result_json="$(/tmp/diffy.phar diff:get-result "${diff_id}" --format=json)"
 
           shared_url="$(printf '%s' "${result_json}" | jq -r '.diffSharedUrl // empty')"
-          pages_changed="$(printf '%s' "${result_json}" | jq -r '[.diffs | to_entries[] | select(.value | to_entries | map(.value.percentageChanges // 0) | add > 0)] | length')"
+          pages_changed="$(printf '%s' "${result_json}" | jq -r '[.diffs[] | select([.[].percentageChanges | tonumber? // 0] | add > 0)] | length')"
           pages_total="$(printf '%s' "${result_json}" | jq -r '.diffs | length')"
 
           {
@@ -267,6 +268,39 @@ jobs:
           echo "Report URL: ${shared_url}"
         env:
           STEPS_COMPARE_OUTPUTS_DIFF_ID: ${{ steps.compare.outputs.diff_id }}
+
+      - name: Write run summary
+        id: summary
+        if: steps.gate.outputs.skipped != 'true'
+        run: |
+          set -euo pipefail
+
+          summary="$(printf '%s\n' \
+            "### Visual regression report" \
+            "" \
+            "**${PAGES_CHANGED} of ${PAGES_TOTAL}** pages changed, **${CHANGES_PERCENT}%** overall difference." \
+            "" \
+            "| Setting | Value |" \
+            "| --- | --- |" \
+            "| Source environment | \`${SOURCE_ENV}\` |" \
+            "| Target environment | \`${TARGET_URL}\` |" \
+            "| Diff ID | \`${DIFF_ID}\` |" \
+            "" \
+            "[View full Diffy report](${SHARED_URL})")"
+
+          printf '%s\n' "${summary}" >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo "summary<<VR_SUMMARY_EOF"
+            printf '%s\n' "${summary}"
+            echo "VR_SUMMARY_EOF"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          CHANGES_PERCENT: ${{ steps.result.outputs.changes_percent }}
+          SHARED_URL: ${{ steps.result.outputs.shared_url }}
+          PAGES_CHANGED: ${{ steps.result.outputs.pages_changed }}
+          PAGES_TOTAL: ${{ steps.result.outputs.pages_total }}
+          DIFF_ID: ${{ steps.compare.outputs.diff_id }}
 
   vr-report:
     runs-on: ubuntu-latest
@@ -282,13 +316,5 @@ jobs:
         with:
           number: ${{ needs.vr-compare.outputs.pr_number }}
           header: vr-diffy
-          message: |
-            ### Visual regression report
-
-            - **Pages changed**: ${{ needs.vr-compare.outputs.pages_changed }} of ${{ needs.vr-compare.outputs.pages_total }}
-            - **Overall difference**: ${{ needs.vr-compare.outputs.changes_percent }}%
-            - **Target environment**: ${{ env.TARGET_URL }}
-            - **Source environment**: ${{ env.SOURCE_ENV }}
-
-            [View full Diffy report](${{ needs.vr-compare.outputs.shared_url }})
+          message: ${{ needs.vr-compare.outputs.summary }}
           hide_and_recreate: true

--- a/.vortex/docs/content/development/visual-regression.mdx
+++ b/.vortex/docs/content/development/visual-regression.mdx
@@ -141,6 +141,9 @@ GitHub branch protection rules.
 │      vr-compare: parse PR from URL, gate    │
 │                  │                          │
 │                  ▼                          │
+│        Report in workflow run summary       │
+│                  │                          │
+│                  ▼                          │
 │                vr-report                    │
 │                  │                          │
 │                  ▼                          │
@@ -179,7 +182,7 @@ them do.
 │              vr-compare job                 │
 │                  │                          │
 │                  ▼                          │
-│              vr-report job                  │
+│        Report in workflow run summary       │
 │                                             │
 └────────────────────┬────────────────────────┘
                      │
@@ -192,8 +195,8 @@ them do.
 ```
 
 Use this entry point for ad-hoc comparisons against a known environment
-URL. No PR is involved, so the result is visible only in the Diffy UI
-(and in the workflow run log).
+URL. No PR is involved, so there is no comment to post - the result is
+shown in the workflow run summary and in the Diffy UI.
 
 ## Limiting which branches dispatch
 
@@ -293,11 +296,14 @@ entry point.
    `VR_DIFFY_POLL_INTERVAL` seconds.
 5. Fetches the diff result and exposes the diff ID, PR number, change
    percentage, page counts, and shared report URL as job outputs.
+6. Renders the report into the workflow run summary, so the result is
+   readable in the GitHub Actions UI without opening the job log.
 
 `vr-report`:
 
-1. Posts a sticky comment on the PR with the summary and a link to the
-   Diffy report. Re-deploys edit the same comment rather than stacking.
+1. Posts the same report as a sticky comment on the PR, with a link to
+   the Diffy report. Re-deploys edit the same comment rather than
+   stacking.
 
 ## Making it blocking
 

--- a/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml
@@ -64,6 +64,7 @@ jobs:
       shared_url: ${{ steps.result.outputs.shared_url }}
       pages_changed: ${{ steps.result.outputs.pages_changed }}
       pages_total: ${{ steps.result.outputs.pages_total }}
+      summary: ${{ steps.summary.outputs.summary }}
 
     steps:
       - name: Resolve PR number from target URL
@@ -253,7 +254,7 @@ jobs:
           result_json="$(/tmp/diffy.phar diff:get-result "${diff_id}" --format=json)"
 
           shared_url="$(printf '%s' "${result_json}" | jq -r '.diffSharedUrl // empty')"
-          pages_changed="$(printf '%s' "${result_json}" | jq -r '[.diffs | to_entries[] | select(.value | to_entries | map(.value.percentageChanges // 0) | add > 0)] | length')"
+          pages_changed="$(printf '%s' "${result_json}" | jq -r '[.diffs[] | select([.[].percentageChanges | tonumber? // 0] | add > 0)] | length')"
           pages_total="$(printf '%s' "${result_json}" | jq -r '.diffs | length')"
 
           {
@@ -267,6 +268,39 @@ jobs:
           echo "Report URL: ${shared_url}"
         env:
           STEPS_COMPARE_OUTPUTS_DIFF_ID: ${{ steps.compare.outputs.diff_id }}
+
+      - name: Write run summary
+        id: summary
+        if: steps.gate.outputs.skipped != 'true'
+        run: |
+          set -euo pipefail
+
+          summary="$(printf '%s\n' \
+            "### Visual regression report" \
+            "" \
+            "**${PAGES_CHANGED} of ${PAGES_TOTAL}** pages changed, **${CHANGES_PERCENT}%** overall difference." \
+            "" \
+            "| Setting | Value |" \
+            "| --- | --- |" \
+            "| Source environment | \`${SOURCE_ENV}\` |" \
+            "| Target environment | \`${TARGET_URL}\` |" \
+            "| Diff ID | \`${DIFF_ID}\` |" \
+            "" \
+            "[View full Diffy report](${SHARED_URL})")"
+
+          printf '%s\n' "${summary}" >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo "summary<<VR_SUMMARY_EOF"
+            printf '%s\n' "${summary}"
+            echo "VR_SUMMARY_EOF"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          CHANGES_PERCENT: ${{ steps.result.outputs.changes_percent }}
+          SHARED_URL: ${{ steps.result.outputs.shared_url }}
+          PAGES_CHANGED: ${{ steps.result.outputs.pages_changed }}
+          PAGES_TOTAL: ${{ steps.result.outputs.pages_total }}
+          DIFF_ID: ${{ steps.compare.outputs.diff_id }}
 
   vr-report:
     runs-on: ubuntu-latest
@@ -282,13 +316,5 @@ jobs:
         with:
           number: ${{ needs.vr-compare.outputs.pr_number }}
           header: vr-diffy
-          message: |
-            ### Visual regression report
-
-            - **Pages changed**: ${{ needs.vr-compare.outputs.pages_changed }} of ${{ needs.vr-compare.outputs.pages_total }}
-            - **Overall difference**: ${{ needs.vr-compare.outputs.changes_percent }}%
-            - **Target environment**: ${{ env.TARGET_URL }}
-            - **Source environment**: ${{ env.SOURCE_ENV }}
-
-            [View full Diffy report](${{ needs.vr-compare.outputs.shared_url }})
+          message: ${{ needs.vr-compare.outputs.summary }}
           hide_and_recreate: true


### PR DESCRIPTION
## Summary

The visual regression result was readable only in the `vr-compare` job log and, for PR runs, in a sticky PR comment that `vr-report` assembled itself from four separate job outputs. This adds a `Write run summary` step to `vr-compare` that renders the report once into `$GITHUB_STEP_SUMMARY`, so the result is visible directly in the GitHub Actions run UI - including on manual dispatches, where no PR comment is posted at all. The same rendered markdown is exposed as a new `summary` job output and reused verbatim by `vr-report`, so the run summary and the PR comment can no longer drift apart. The change also fixes a `jq` bug that made the report claim every page had changed regardless of its actual diff percentage.

## Changes

- Added a `Write run summary` step to the `vr-compare` job. It renders a heading, a one-line `X of Y pages changed, Z% overall difference` statement, a settings table (source environment, target environment, diff ID), and a link to the Diffy report into `$GITHUB_STEP_SUMMARY`, and writes the same markdown to a `summary` step output. Every interpolated value is passed through the step's `env` block rather than inlined into the script.
- Exposed `summary: ${{ steps.summary.outputs.summary }}` as a `vr-compare` job output.
- Reduced the `vr-report` sticky comment to `message: ${{ needs.vr-compare.outputs.summary }}`, replacing the hand-assembled bullet list that read `pages_changed`, `pages_total`, `changes_percent`, and `shared_url` individually and additionally depended on workflow-level `env` resolving in the second job.
- Fixed the `pages_changed` expression in the `Fetch comparison result` step. Diffy returns `percentageChanges` as a JSON string, so the previous `map(.value.percentageChanges // 0) | add > 0` concatenated the string values (`"0" + "0"` becomes `"00"`) and, because `jq` sorts every string above every number, the comparison was true for every page - the report always claimed all pages had changed. The new `[.[].percentageChanges | tonumber? // 0] | add > 0` coerces each value to a number before summing. Checked against a sample Diffy payload: the old expression reported 3 of 3 pages changed where the new one correctly reports 1 of 3, and the new form tolerates numeric values, absent `percentageChanges` keys, and empty page objects without erroring.
- Updated `.vortex/docs/content/development/visual-regression.mdx` to match: the `vr-compare` step list gained the run-summary step, the `vr-report` entry now states it posts the same report, both ASCII flow diagrams show where the run summary is produced, and the manual-dispatch note no longer claims the result is visible "only in the Diffy UI (and in the workflow run log)".
- Regenerated `.vortex/installer/tests/Fixtures/handler_process/visual_regression_enabled/.github/workflows/test-vr.yml` with `ahoy update-snapshots`.

## Screenshots

N/A - the change covers a CI workflow and a documentation page.

## Before / After

```text
BEFORE

┌──────────────────────────────────────────────────────────────┐
│ vr-compare job                                               │
│   parse result: buggy jq marks every page as changed         │
│   outputs: pages_changed, pages_total, changes_percent,      │
│            shared_url                                        │
└────────────────────────────┬─────────────────────────────────┘
                             │  job log only, run summary empty
                             ▼
┌──────────────────────────────────────────────────────────────┐
│ vr-report job                                                │
│   rebuilds its own bullet list from the four outputs         │
│   above, plus workflow-level env for the environments        │
│   posts the sticky PR comment                                │
└──────────────────────────────────────────────────────────────┘

Manual dispatch: no PR, so no comment - the result never leaves
the job log and the Diffy UI.


AFTER

┌──────────────────────────────────────────────────────────────┐
│ vr-compare job                                               │
│   parse result: jq coerces to number before comparing        │
│   Write run summary renders the report once into             │
│   the run summary                                            │
│   output: summary (one rendered markdown blob)               │
└────────────────────────────┬─────────────────────────────────┘
                             │
               ┌─────────────┴─────────────┐
               ▼                           ▼
          run summary                 PR comment

Both are produced from the same rendered markdown, so they cannot
disagree, and the run summary is written whether or not the run
resolved a PR.
```
