### PR TITLE
Triggered 'Vortex - Test docs' from both per-major test workflows.

### DIFF
--- a/.github/workflows/vortex-test-docs.yml
+++ b/.github/workflows/vortex-test-docs.yml
@@ -1,27 +1,32 @@
 # This action is used for Vortex maintenance. It will not be used in the scaffolded project.
 name: Vortex - Test docs
 
+# Each major ships its own binary from its own workflow, so listen to both:
+# 'workflow_run' is registered from the default branch only, making this the
+# single definition that has to serve branches of either major.
 on:
   workflow_run:
-    workflows: ['Vortex - Test installer']
+    workflows: ['Vortex - Test installer', 'Vortex - Test CLI']
     types:
       - completed
 
 jobs:
   vortex-test-docs:
     runs-on: ubuntu-latest
-    # Only run if installer workflow succeeded
+    # Only run if the triggering workflow succeeded
     if: github.event.workflow_run.conclusion == 'success'
 
     permissions:
       contents: read # Checkout the repository at the triggering commit.
-      actions: read # Download the installer artifact from the test-installer workflow run.
+      actions: read # Download the binary artifact from the triggering workflow run.
       statuses: write # Post pending/final commit statuses via 'gh api repos/.../statuses/...'.
       pull-requests: write # Post the Netlify preview link comment on the originating PR.
 
     env:
       CURRENT_MAJOR: ${{ vars.VORTEX_CURRENT_MAJOR || '1' }}
       OTHER_MAJOR: ${{ (vars.VORTEX_CURRENT_MAJOR || '1') == '1' && '2' || '1' }}
+      BINARY_ARTIFACT: ${{ github.event.workflow_run.name == 'Vortex - Test CLI' && 'vortex-cli' || 'vortex-installer' }}
+      BINARY_FILE: ${{ github.event.workflow_run.name == 'Vortex - Test CLI' && 'vortex.phar' || 'installer.phar' }}
 
     steps:
       # Post pending status to the PR commit.
@@ -55,18 +60,21 @@ jobs:
         with:
           php-version: 8.3
 
-      - name: Download installer artifact
+      # Pin the download to the triggering run rather than a workflow name:
+      # searching by name returns the most recent successful run across all
+      # branches, which would pull a binary built from a different commit.
+      - name: Download the binary artifact
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
-          workflow: vortex-test-installer.yml
-          name: vortex-installer
+          run_id: ${{ github.event.workflow_run.id }}
+          name: ${{ env.BINARY_ARTIFACT }}
           path: .vortex/docs/static
           if_no_artifact_found: fail
           allow_forks: true
 
-      - name: Copy installer to docs
+      - name: Copy the binary to docs
         run: |
-          mv .vortex/docs/static/installer.phar .vortex/docs/static/install
+          mv ".vortex/docs/static/${BINARY_FILE}" .vortex/docs/static/install
           php .vortex/docs/static/install --version
 
       - name: Check docs up-to-date

--- a/.vortex/tests/zizmor.yml
+++ b/.vortex/tests/zizmor.yml
@@ -17,9 +17,9 @@ rules:
     #   needs a write token on fork PRs and never checks out PR code.
     # - label-merge-conflict: labels PRs with merge-conflict status via
     #   'eps1lon/actions-label-merge-conflict'; never checks out PR code.
-    # - vortex-test-docs: chained run after 'Vortex - Test installer'; the
-    #   'head_sha' interpolation has been moved into 'env:' to remove the
-    #   injection surface.
+    # - vortex-test-docs: chained run after a per-major test workflow; the
+    #   'head_sha' interpolation lives in 'env:' to remove the injection
+    #   surface.
     ignore:
       - assign-author.yml
       - label-merge-conflict.yml


### PR DESCRIPTION
## Summary

`vortex-test-docs.yml` is defined once, on the default branch (`main`), because GitHub only registers `workflow_run` triggers from a repository's default-branch copy of a workflow file, so that single definition has to serve pull requests on every major version's branches. It previously listened only for `Vortex - Test installer`, a workflow that does not exist on the `2.x` lineage, where the installer was relocated into the `drevops/vortex-cli` package and its test workflow renamed to `Vortex - Test CLI`. As a result the trigger never fired on `2.x` branches, the required `Vortex - Test docs` status was never posted, and every `2.x` pull request was blocked indefinitely (the failure mode behind PR #2877, for example). This change makes the workflow trigger on both `Vortex - Test installer` and `Vortex - Test CLI`, derives the artifact name and phar filename from whichever workflow triggered the run, and downloads the artifact by `run_id` instead of by workflow name so it always matches the triggering commit rather than the most recent successful run across all branches.

## Changes

### `.github/workflows/vortex-test-docs.yml`
- Added `Vortex - Test CLI` alongside `Vortex - Test installer` to the `workflow_run` trigger list, so the workflow fires regardless of which major produced the triggering run.
- Added job-level `env` vars `BINARY_ARTIFACT` and `BINARY_FILE`, derived from `github.event.workflow_run.name`, so the artifact name (`vortex-installer` vs `vortex-cli`) and the downloaded phar filename (`installer.phar` vs `vortex.phar`) match whichever workflow triggered the run.
- Changed the artifact download step to resolve by `run_id: ${{ github.event.workflow_run.id }}` instead of by `workflow: vortex-test-installer.yml`, because resolving by workflow name returns the most recent successful run across all branches and can download a binary built from an unrelated commit.
- Renamed the download and copy steps and updated their comments to describe a binary artifact from either source workflow instead of assuming the installer.

### `.vortex/tests/zizmor.yml`
- Updated the stale `vortex-test-docs` ignore-rule comment to describe the trigger generically (a per-major test workflow) instead of naming only `Vortex - Test installer`, keeping it accurate now that two workflows can trigger the chained run.

## Before / After

Before - the trigger list names one workflow, so only `main`-lineage runs match, and the artifact is fetched by workflow name (latest successful run on any branch):

```
┌─────────────────────────┐    ┌─────────────────────────┐
│ main: 'Test installer'  │    │ 2.x: 'Test CLI'          │
│ workflow completes      │    │ workflow completes       │
└────────────┬─────────────┘    └────────────┬─────────────┘
             │ name matches                   │ name NOT in
             │ workflow_run list               workflow_run list
             ▼                                 ✕
┌──────────────────────────┐        (workflow_run never fires)
│ vortex-test-docs          │
│ download ARTIFACT BY NAME │
│ 'vortex-installer' from   │
│ vortex-test-installer.yml │
│ (latest run, any branch)  │
└────────────┬───────────────┘
             ▼
  'Test docs' posted             'Test docs' NEVER posted
  on main PRs                    -> 2.x PRs blocked forever
```

After - both workflows are listed, the artifact/file names are derived from the triggering run's own name, and the download is pinned to that exact run:

```
┌─────────────────────────┐    ┌─────────────────────────┐
│ main: 'Test installer'  │    │ 2.x: 'Test CLI'          │
│ workflow completes      │    │ workflow completes       │
└────────────┬─────────────┘    └────────────┬─────────────┘
             │                                │
             └───────────────┬────────────────┘
                              │ both names in workflow_run list
                              ▼
              ┌───────────────────────────────────┐
              │ vortex-test-docs                  │
              │ BINARY_ARTIFACT/BINARY_FILE set    │
              │ from event.workflow_run.name       │
              │ download pinned to                 │
              │ run_id: event.workflow_run.id      │
              └────────────────┬────────────────────┘
                                ▼
              'Test docs' posted on BOTH lineages
              -> 2.x PRs unblocked
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation tests now run reliably after successful installer or CLI test workflows.
  * The correct build artifact and executable are selected automatically for each triggering workflow.
  * Artifacts are downloaded from the exact workflow run that initiated the documentation tests.

* **Documentation**
  * Updated workflow security documentation to reflect the revised chained test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->