### PR TITLE
Converged naming, visibility, and idiom conventions across the installer and '.vortex/tests' harness.

### DIFF
--- a/.vortex/installer/src/Command/BuildCommand.php
+++ b/.vortex/installer/src/Command/BuildCommand.php
@@ -30,8 +30,6 @@ class BuildCommand extends Command implements ProcessRunnerAwareInterface, Comma
 
   const OPTION_SKIP_REQUIREMENTS_CHECK = 'skip-requirements-check';
 
-  const TROUBLESHOOTING_URL = 'https://vortex.drevops.com/troubleshooting';
-
   /**
    * Defines default command name.
    *
@@ -117,22 +115,6 @@ class BuildCommand extends Command implements ProcessRunnerAwareInterface, Comma
 
     $this->showFailureSummary();
     return Command::FAILURE;
-  }
-
-  /**
-   * Get the project machine name from .env.
-   */
-  protected function getProjectMachineName(): string {
-    $env_file = $this->destination . '/.env';
-
-    if (file_exists($env_file)) {
-      $content = file_get_contents($env_file);
-      if ($content !== FALSE && preg_match('/^VORTEX_PROJECT=(.+)$/m', $content, $matches)) {
-        return trim($matches[1]);
-      }
-    }
-
-    return basename($this->destination);
   }
 
   /**

--- a/.vortex/installer/src/Command/BuildCommand.php
+++ b/.vortex/installer/src/Command/BuildCommand.php
@@ -47,7 +47,7 @@ class BuildCommand extends Command implements ProcessRunnerAwareInterface, Comma
   /**
    * The working directory for the build.
    */
-  protected string $cwd;
+  protected string $destination;
 
   /**
    * {@inheritdoc}
@@ -68,7 +68,7 @@ class BuildCommand extends Command implements ProcessRunnerAwareInterface, Comma
     Tui::init($output);
 
     $this->isProfile = (bool) $input->getOption(static::OPTION_PROFILE);
-    $this->cwd = $this->getDestination($input);
+    $this->destination = $this->getDestination($input);
 
     if (!$input->getOption(static::OPTION_SKIP_REQUIREMENTS_CHECK)) {
       $requirements_ok = Task::action(
@@ -100,7 +100,7 @@ class BuildCommand extends Command implements ProcessRunnerAwareInterface, Comma
           $env['VORTEX_PROVISION_TYPE'] = 'profile';
         }
 
-        $this->processRunner = $this->getProcessRunner()->setCwd($this->cwd);
+        $this->processRunner = $this->getProcessRunner()->setCwd($this->destination);
         $this->processRunner->run('ahoy build', env: $env);
 
         return $this->processRunner->getExitCode() === RunnerInterface::EXIT_SUCCESS;
@@ -123,7 +123,7 @@ class BuildCommand extends Command implements ProcessRunnerAwareInterface, Comma
    * Get the project machine name from .env.
    */
   protected function getProjectMachineName(): string {
-    $env_file = $this->cwd . '/.env';
+    $env_file = $this->destination . '/.env';
 
     if (file_exists($env_file)) {
       $content = file_get_contents($env_file);
@@ -132,7 +132,7 @@ class BuildCommand extends Command implements ProcessRunnerAwareInterface, Comma
       }
     }
 
-    return basename($this->cwd);
+    return basename($this->destination);
   }
 
   /**
@@ -145,7 +145,7 @@ class BuildCommand extends Command implements ProcessRunnerAwareInterface, Comma
    *   The local development URL, or NULL if it cannot be determined.
    */
   protected function getLocalDevUrl(): ?string {
-    $runner = $this->getProcessRunner()->setCwd($this->cwd);
+    $runner = $this->getProcessRunner()->setCwd($this->destination);
     $runner->run('docker', ['compose', 'config', '--format', 'json'], output: new NullOutput());
 
     if ($runner->getExitCode() === RunnerInterface::EXIT_SUCCESS) {

--- a/.vortex/installer/src/Command/BuildCommand.php
+++ b/.vortex/installer/src/Command/BuildCommand.php
@@ -57,8 +57,8 @@ class BuildCommand extends Command implements ProcessRunnerAwareInterface, Comma
     $this->setDescription('Build the site using ahoy build.');
     $this->setHelp('Checks requirements and runs ahoy build to set up the local site.');
     $this->addDestinationOption();
-    $this->addOption(static::OPTION_PROFILE, 'p', InputOption::VALUE_NONE, 'Build from install profile instead of loading database.');
-    $this->addOption(static::OPTION_SKIP_REQUIREMENTS_CHECK, NULL, InputOption::VALUE_NONE, 'Skip checking for required tools.');
+    $this->addOption(self::OPTION_PROFILE, 'p', InputOption::VALUE_NONE, 'Build from install profile instead of loading database.');
+    $this->addOption(self::OPTION_SKIP_REQUIREMENTS_CHECK, NULL, InputOption::VALUE_NONE, 'Skip checking for required tools.');
   }
 
   /**
@@ -67,10 +67,10 @@ class BuildCommand extends Command implements ProcessRunnerAwareInterface, Comma
   protected function execute(InputInterface $input, OutputInterface $output): int {
     Tui::init($output);
 
-    $this->isProfile = (bool) $input->getOption(static::OPTION_PROFILE);
+    $this->isProfile = (bool) $input->getOption(self::OPTION_PROFILE);
     $this->destination = $this->getDestination($input);
 
-    if (!$input->getOption(static::OPTION_SKIP_REQUIREMENTS_CHECK)) {
+    if (!$input->getOption(self::OPTION_SKIP_REQUIREMENTS_CHECK)) {
       $requirements_ok = Task::action(
         label: 'Checking requirements',
         action: function (): bool {

--- a/.vortex/installer/src/Command/CheckRequirementsCommand.php
+++ b/.vortex/installer/src/Command/CheckRequirementsCommand.php
@@ -79,8 +79,8 @@ class CheckRequirementsCommand extends Command implements ProcessRunnerAwareInte
     $this->setDescription('Check if required tools are installed and running.');
     $this->setHelp('Checks for Docker, Docker Compose, Ahoy, and Pygmy.');
     $this->addDestinationOption();
-    $this->addOption(static::OPTION_ONLY, 'o', InputOption::VALUE_REQUIRED, sprintf('Comma-separated list of requirements to check. Available: %s.', implode(', ', static::REQUIREMENTS)));
-    $this->addOption(static::OPTION_NO_SUMMARY, NULL, InputOption::VALUE_NONE, 'Hide summary with tool versions.');
+    $this->addOption(self::OPTION_ONLY, 'o', InputOption::VALUE_REQUIRED, sprintf('Comma-separated list of requirements to check. Available: %s.', implode(', ', self::REQUIREMENTS)));
+    $this->addOption(self::OPTION_NO_SUMMARY, NULL, InputOption::VALUE_NONE, 'Hide summary with tool versions.');
   }
 
   /**
@@ -91,14 +91,14 @@ class CheckRequirementsCommand extends Command implements ProcessRunnerAwareInte
 
     $this->destination = $this->getDestination($input);
 
-    $only = $input->getOption(static::OPTION_ONLY);
+    $only = $input->getOption(self::OPTION_ONLY);
     $requirements = $this->validateRequirements($only ? array_map(trim(...), explode(',', (string) $only)) : NULL);
 
     $this->processRunner ??= $this->getProcessRunner()->setCwd($this->destination);
     $this->present = [];
     $this->missing = [];
 
-    if (in_array(static::REQ_DOCKER, $requirements, TRUE)) {
+    if (in_array(self::REQ_DOCKER, $requirements, TRUE)) {
       Task::action(
         label: 'Checking Docker',
         action: fn(): bool => $this->checkDocker(),
@@ -106,7 +106,7 @@ class CheckRequirementsCommand extends Command implements ProcessRunnerAwareInte
       );
     }
 
-    if (in_array(static::REQ_DOCKER_COMPOSE, $requirements, TRUE)) {
+    if (in_array(self::REQ_DOCKER_COMPOSE, $requirements, TRUE)) {
       Task::action(
         label: 'Checking Docker Compose',
         action: fn(): bool => $this->checkDockerCompose(),
@@ -114,7 +114,7 @@ class CheckRequirementsCommand extends Command implements ProcessRunnerAwareInte
       );
     }
 
-    if (in_array(static::REQ_AHOY, $requirements, TRUE)) {
+    if (in_array(self::REQ_AHOY, $requirements, TRUE)) {
       Task::action(
         label: 'Checking Ahoy',
         action: fn(): bool => $this->checkAhoy(),
@@ -122,7 +122,7 @@ class CheckRequirementsCommand extends Command implements ProcessRunnerAwareInte
       );
     }
 
-    if (in_array(static::REQ_PYGMY, $requirements, TRUE)) {
+    if (in_array(self::REQ_PYGMY, $requirements, TRUE)) {
       Task::action(
         label: 'Checking Pygmy',
         action: fn(): bool => $this->checkPygmy(),
@@ -130,7 +130,7 @@ class CheckRequirementsCommand extends Command implements ProcessRunnerAwareInte
       );
     }
 
-    if (!$input->getOption(static::OPTION_NO_SUMMARY)) {
+    if (!$input->getOption(self::OPTION_NO_SUMMARY)) {
       $summary = $this->getResultsSummary();
       Tui::box($summary['content'], $summary['title']);
     }
@@ -155,13 +155,13 @@ class CheckRequirementsCommand extends Command implements ProcessRunnerAwareInte
    */
   protected function validateRequirements(?array $only): array {
     if ($only !== NULL) {
-      $unknown = array_diff($only, static::REQUIREMENTS);
+      $unknown = array_diff($only, self::REQUIREMENTS);
       if (!empty($unknown)) {
-        throw new \InvalidArgumentException(sprintf("Unknown requirements: %s.\nAvailable: %s.", implode(', ', $unknown), implode(', ', static::REQUIREMENTS)));
+        throw new \InvalidArgumentException(sprintf("Unknown requirements: %s.\nAvailable: %s.", implode(', ', $unknown), implode(', ', self::REQUIREMENTS)));
       }
     }
 
-    return $only ?? static::REQUIREMENTS;
+    return $only ?? self::REQUIREMENTS;
   }
 
   /**

--- a/.vortex/installer/src/Command/CheckRequirementsCommand.php
+++ b/.vortex/installer/src/Command/CheckRequirementsCommand.php
@@ -69,7 +69,7 @@ class CheckRequirementsCommand extends Command implements ProcessRunnerAwareInte
   /**
    * The working directory for checks.
    */
-  protected string $cwd;
+  protected string $destination;
 
   /**
    * {@inheritdoc}
@@ -89,12 +89,12 @@ class CheckRequirementsCommand extends Command implements ProcessRunnerAwareInte
   protected function execute(InputInterface $input, OutputInterface $output): int {
     Tui::init($output);
 
-    $this->cwd = $this->getDestination($input);
+    $this->destination = $this->getDestination($input);
 
     $only = $input->getOption(static::OPTION_ONLY);
     $requirements = $this->validateRequirements($only ? array_map(trim(...), explode(',', (string) $only)) : NULL);
 
-    $this->processRunner ??= $this->getProcessRunner()->setCwd($this->cwd);
+    $this->processRunner ??= $this->getProcessRunner()->setCwd($this->destination);
     $this->present = [];
     $this->missing = [];
 

--- a/.vortex/installer/src/Command/InstallCommand.php
+++ b/.vortex/installer/src/Command/InstallCommand.php
@@ -456,11 +456,11 @@ EOF
   /**
    * Set the repository downloader.
    *
-   * @param \DrevOps\VortexInstaller\Downloader\RepositoryDownloader $repositoryDownloader
+   * @param \DrevOps\VortexInstaller\Downloader\RepositoryDownloader $repository_downloader
    *   The repository downloader.
    */
-  public function setRepositoryDownloader(RepositoryDownloader $repositoryDownloader): void {
-    $this->repositoryDownloader = $repositoryDownloader;
+  public function setRepositoryDownloader(RepositoryDownloader $repository_downloader): void {
+    $this->repositoryDownloader = $repository_downloader;
   }
 
   /**
@@ -479,11 +479,11 @@ EOF
   /**
    * Set the file downloader.
    *
-   * @param \DrevOps\VortexInstaller\Downloader\Downloader $fileDownloader
+   * @param \DrevOps\VortexInstaller\Downloader\Downloader $file_downloader
    *   The file downloader.
    */
-  public function setFileDownloader(Downloader $fileDownloader): void {
-    $this->fileDownloader = $fileDownloader;
+  public function setFileDownloader(Downloader $file_downloader): void {
+    $this->fileDownloader = $file_downloader;
   }
 
 }

--- a/.vortex/installer/src/Command/InstallCommand.php
+++ b/.vortex/installer/src/Command/InstallCommand.php
@@ -136,17 +136,17 @@ class InstallCommand extends Command implements CommandRunnerAwareInterface, Exe
   php installer.php --uri=https://github.com/drevops/vortex/commit/abcd123
 EOF
     );
-    $this->addOption(static::OPTION_DESTINATION, NULL, InputOption::VALUE_REQUIRED, 'Destination directory. Defaults to the current directory.');
-    $this->addOption(static::OPTION_ROOT, NULL, InputOption::VALUE_REQUIRED, 'Path to the root for file path resolution. If not specified, current directory is used.');
-    $this->addOption(static::OPTION_NO_INTERACTION, 'n', InputOption::VALUE_NONE, 'Do not ask any interactive question.');
-    $this->addOption(static::OPTION_CONFIG, 'c', InputOption::VALUE_REQUIRED, 'A JSON string with options or a path to a JSON file.');
-    $this->addOption(static::OPTION_URI, 'l', InputOption::VALUE_REQUIRED, 'Remote or local repository URI with an optional git ref set after @.');
-    $this->addOption(static::OPTION_NO_CLEANUP, NULL, InputOption::VALUE_NONE, 'Do not remove installer after successful installation.');
-    $this->addOption(static::OPTION_BUILD, 'b', InputOption::VALUE_NONE, 'Run auto-build after installation without prompting.');
-    $this->addOption(static::OPTION_PROMPTS, 'p', InputOption::VALUE_REQUIRED, 'A JSON string with prompt answers or a path to a JSON file. Keys are prompt IDs from --schema.');
-    $this->addOption(static::OPTION_SCHEMA, NULL, InputOption::VALUE_NONE, 'Output prompt schema as JSON.');
-    $this->addOption(static::OPTION_VALIDATE, NULL, InputOption::VALUE_NONE, 'Validate config without installing.');
-    $this->addOption(static::OPTION_AGENT_HELP, NULL, InputOption::VALUE_NONE, 'Output instructions for AI agents on how to use the installer.');
+    $this->addOption(self::OPTION_DESTINATION, NULL, InputOption::VALUE_REQUIRED, 'Destination directory. Defaults to the current directory.');
+    $this->addOption(self::OPTION_ROOT, NULL, InputOption::VALUE_REQUIRED, 'Path to the root for file path resolution. If not specified, current directory is used.');
+    $this->addOption(self::OPTION_NO_INTERACTION, 'n', InputOption::VALUE_NONE, 'Do not ask any interactive question.');
+    $this->addOption(self::OPTION_CONFIG, 'c', InputOption::VALUE_REQUIRED, 'A JSON string with options or a path to a JSON file.');
+    $this->addOption(self::OPTION_URI, 'l', InputOption::VALUE_REQUIRED, 'Remote or local repository URI with an optional git ref set after @.');
+    $this->addOption(self::OPTION_NO_CLEANUP, NULL, InputOption::VALUE_NONE, 'Do not remove installer after successful installation.');
+    $this->addOption(self::OPTION_BUILD, 'b', InputOption::VALUE_NONE, 'Run auto-build after installation without prompting.');
+    $this->addOption(self::OPTION_PROMPTS, 'p', InputOption::VALUE_REQUIRED, 'A JSON string with prompt answers or a path to a JSON file. Keys are prompt IDs from --schema.');
+    $this->addOption(self::OPTION_SCHEMA, NULL, InputOption::VALUE_NONE, 'Output prompt schema as JSON.');
+    $this->addOption(self::OPTION_VALIDATE, NULL, InputOption::VALUE_NONE, 'Validate config without installing.');
+    $this->addOption(self::OPTION_AGENT_HELP, NULL, InputOption::VALUE_NONE, 'Output instructions for AI agents on how to use the installer.');
   }
 
   /**
@@ -159,15 +159,15 @@ EOF
       return Command::SUCCESS;
     }
 
-    if ($input->getOption(static::OPTION_AGENT_HELP)) {
+    if ($input->getOption(self::OPTION_AGENT_HELP)) {
       return $this->handleAgentHelp($output);
     }
 
-    if ($input->getOption(static::OPTION_SCHEMA)) {
+    if ($input->getOption(self::OPTION_SCHEMA)) {
       return $this->handleSchema($input, $output);
     }
 
-    if ($input->getOption(static::OPTION_VALIDATE)) {
+    if ($input->getOption(self::OPTION_VALIDATE)) {
       return $this->handleValidate($input, $output);
     }
 
@@ -323,7 +323,7 @@ EOF
    * Handle --validate option.
    */
   protected function handleValidate(InputInterface $input, OutputInterface $output): int {
-    $prompts_option = $input->getOption(static::OPTION_PROMPTS);
+    $prompts_option = $input->getOption(self::OPTION_PROMPTS);
 
     if (empty($prompts_option) || !is_string($prompts_option)) {
       $output->writeln('The --validate option requires --prompts.');

--- a/.vortex/installer/src/Command/InstallCommand.php
+++ b/.vortex/installer/src/Command/InstallCommand.php
@@ -35,8 +35,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Run command.
  *
  * Install command.
- *
- * @package DrevOps\VortexInstaller\Command
  */
 class InstallCommand extends Command implements CommandRunnerAwareInterface, ExecutableFinderAwareInterface {
 

--- a/.vortex/installer/src/Command/InstallCommand.php
+++ b/.vortex/installer/src/Command/InstallCommand.php
@@ -379,7 +379,7 @@ EOF
     $starter = $responses[Starter::id()] ?? Starter::LOAD_DATABASE_DEMO;
     $is_profile = in_array($starter, [Starter::INSTALL_PROFILE_CORE, Starter::INSTALL_PROFILE_DRUPALCMS], TRUE);
 
-    $args = ['--destination' => $this->config->getDst()];
+    $args = ['--destination' => $this->config->getDestination()];
     if ($is_profile) {
       $args['--profile'] = '1';
     }
@@ -411,7 +411,7 @@ EOF
       return;
     }
 
-    $project_major = Version::detectProjectMajor((string) $this->config->getDst());
+    $project_major = Version::detectProjectMajor((string) $this->config->getDestination());
     if ($project_major === NULL || $project_major === $installer_major) {
       return;
     }

--- a/.vortex/installer/src/Command/InstallCommand.php
+++ b/.vortex/installer/src/Command/InstallCommand.php
@@ -49,8 +49,6 @@ class InstallCommand extends Command implements CommandRunnerAwareInterface, Exe
 
   const OPTION_CONFIG = 'config';
 
-  const OPTION_QUIET = 'quiet';
-
   const OPTION_URI = 'uri';
 
   const OPTION_NO_CLEANUP = 'no-cleanup';

--- a/.vortex/installer/src/Downloader/Archiver.php
+++ b/.vortex/installer/src/Downloader/Archiver.php
@@ -193,7 +193,7 @@ class Archiver implements ArchiverInterface {
     }
 
     $top_dir = reset($entries);
-    $source_path = $source . DIRECTORY_SEPARATOR . $top_dir;
+    $source_path = $source . '/' . $top_dir;
 
     File::copy($source_path, $destination);
   }

--- a/.vortex/installer/src/Downloader/Archiver.php
+++ b/.vortex/installer/src/Downloader/Archiver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DrevOps\VortexInstaller\Downloader;
 
-use AlexSkrypnyk\File\File;
+use DrevOps\VortexInstaller\Utils\File;
 use PhpZip\ZipFile;
 
 /**
@@ -102,11 +102,7 @@ class Archiver implements ArchiverInterface {
   protected function extractTar(string $archive_path, string $destination, bool $strip_first_level): void {
     $temp_dir = NULL;
     try {
-      $temp_dir = $strip_first_level ? sys_get_temp_dir() . '/vortex_extract_' . uniqid() : $destination;
-
-      if ($strip_first_level) {
-        mkdir($temp_dir);
-      }
+      $temp_dir = $strip_first_level ? File::tmpdir() : $destination;
 
       // Use tar command to preserve symlinks (PharData doesn't preserve them).
       $command = sprintf(
@@ -155,8 +151,7 @@ class Archiver implements ArchiverInterface {
       $zip->openFile($archive_path);
 
       if ($strip_first_level) {
-        $temp_dir = sys_get_temp_dir() . '/vortex_extract_' . uniqid();
-        mkdir($temp_dir);
+        $temp_dir = File::tmpdir();
 
         $zip->extractTo($temp_dir);
 

--- a/.vortex/installer/src/Downloader/Archiver.php
+++ b/.vortex/installer/src/Downloader/Archiver.php
@@ -34,7 +34,7 @@ class Archiver implements ArchiverInterface {
 
     if (strlen($header) >= 512) {
       $tar_magic = substr($header, 257, 5);
-      if ($tar_magic === "ustar" || $tar_magic === "00000") {
+      if ($tar_magic === 'ustar' || $tar_magic === '00000') {
         return 'tar';
       }
     }

--- a/.vortex/installer/src/Downloader/Artifact.php
+++ b/.vortex/installer/src/Downloader/Artifact.php
@@ -66,7 +66,7 @@ final readonly class Artifact {
    */
   public static function create(string $repo, string $ref): self {
     // Validate ref syntax.
-    if (!Validator::gitRef($ref)) {
+    if (!Validator::isGitRef($ref)) {
       throw new \RuntimeException(sprintf('Invalid git reference: "%s". Reference must be a valid git tag, branch, or commit hash.', $ref));
     }
     return new self($repo, $ref);
@@ -176,7 +176,7 @@ final readonly class Artifact {
       [$repo, $ref] = $github_pattern;
 
       // Validate the extracted ref.
-      if (!Validator::gitRef($ref)) {
+      if (!Validator::isGitRef($ref)) {
         throw new \RuntimeException(sprintf('Invalid git reference: "%s". Reference must be a valid git tag, branch, or commit hash.', $ref));
       }
 
@@ -220,7 +220,7 @@ final readonly class Artifact {
       $ref = $matches[2] ?? RepositoryDownloader::REF_HEAD;
     }
 
-    if (!Validator::gitRef($ref)) {
+    if (!Validator::isGitRef($ref)) {
       throw new \RuntimeException(sprintf('Invalid git reference: "%s". Reference must be a valid git tag, branch, or commit hash.', $ref));
     }
 

--- a/.vortex/installer/src/Downloader/Artifact.php
+++ b/.vortex/installer/src/Downloader/Artifact.php
@@ -15,16 +15,16 @@ use DrevOps\VortexInstaller\Utils\Validator;
 final readonly class Artifact {
 
   /**
-   * Private constructor - use factory method instead.
+   * Constructor - use a factory method instead.
    *
    * @param string $repo
    *   The repository URL or local path.
    * @param string $ref
    *   The git reference (tag, branch, commit, or special refs).
    */
-  private function __construct(
-    private string $repo,
-    private string $ref,
+  protected function __construct(
+    protected string $repo,
+    protected string $ref,
   ) {}
 
   /**

--- a/.vortex/installer/src/Downloader/RepositoryDownloader.php
+++ b/.vortex/installer/src/Downloader/RepositoryDownloader.php
@@ -54,7 +54,7 @@ class RepositoryDownloader implements RepositoryDownloaderInterface {
       $version = $this->downloadFromLocal($artifact, $destination);
     }
 
-    if (!is_readable($destination . DIRECTORY_SEPARATOR . 'composer.json')) {
+    if (!is_readable($destination . '/composer.json')) {
       throw new \RuntimeException('The downloaded repository does not contain a composer.json file.');
     }
 

--- a/.vortex/installer/src/Downloader/RepositoryDownloader.php
+++ b/.vortex/installer/src/Downloader/RepositoryDownloader.php
@@ -46,15 +46,15 @@ class RepositoryDownloader implements RepositoryDownloaderInterface {
   ) {
   }
 
-  public function download(Artifact $artifact, ?string $dst = NULL, ?string $release_prefix = NULL): string {
+  public function download(Artifact $artifact, ?string $destination = NULL, ?string $release_prefix = NULL): string {
     if ($artifact->isRemote()) {
-      $version = $this->downloadFromRemote($artifact, $dst, $release_prefix);
+      $version = $this->downloadFromRemote($artifact, $destination, $release_prefix);
     }
     else {
-      $version = $this->downloadFromLocal($artifact, $dst);
+      $version = $this->downloadFromLocal($artifact, $destination);
     }
 
-    if (!is_readable($dst . DIRECTORY_SEPARATOR . 'composer.json')) {
+    if (!is_readable($destination . DIRECTORY_SEPARATOR . 'composer.json')) {
       throw new \RuntimeException('The downloaded repository does not contain a composer.json file.');
     }
 

--- a/.vortex/installer/src/Downloader/RepositoryDownloaderInterface.php
+++ b/.vortex/installer/src/Downloader/RepositoryDownloaderInterface.php
@@ -14,7 +14,7 @@ interface RepositoryDownloaderInterface {
    *
    * @param \DrevOps\VortexInstaller\Downloader\Artifact $artifact
    *   The artifact to download (contains repository and reference).
-   * @param string|null $dst
+   * @param string|null $destination
    *   The destination directory. If NULL, a temporary directory will be used
    *   for local repositories.
    * @param string|null $release_prefix
@@ -30,6 +30,6 @@ interface RepositoryDownloaderInterface {
    * @throws \InvalidArgumentException
    *   If the destination is null for remote downloads.
    */
-  public function download(Artifact $artifact, ?string $dst = NULL, ?string $release_prefix = NULL): string;
+  public function download(Artifact $artifact, ?string $destination = NULL, ?string $release_prefix = NULL): string;
 
 }

--- a/.vortex/installer/src/Logger/FileLogger.php
+++ b/.vortex/installer/src/Logger/FileLogger.php
@@ -47,7 +47,7 @@ class FileLogger implements FileLoggerInterface {
     }
 
     $name = $this->buildFilename($command, $args);
-    $this->path = $this->getDir() . '/' . static::LOG_DIR . '/' . $name . '-' . date('Y-m-d-His') . '.log';
+    $this->path = $this->getDir() . '/' . self::LOG_DIR . '/' . $name . '-' . date('Y-m-d-His') . '.log';
 
     $log_dir = dirname($this->path);
     if (!is_dir($log_dir)) {

--- a/.vortex/installer/src/Prompts/Handlers/AbstractHandler.php
+++ b/.vortex/installer/src/Prompts/Handlers/AbstractHandler.php
@@ -13,7 +13,7 @@ abstract class AbstractHandler implements HandlerInterface {
   /**
    * The destination directory.
    */
-  protected string $dstDir;
+  protected string $destinationDir;
 
   /**
    * The temporary directory.
@@ -43,7 +43,7 @@ abstract class AbstractHandler implements HandlerInterface {
   public function __construct(
     protected Config $config,
   ) {
-    $this->dstDir = $this->config->getDst();
+    $this->destinationDir = $this->config->getDestination();
     $this->tmpDir = $this->config->get(Config::TMP);
   }
 

--- a/.vortex/installer/src/Prompts/Handlers/AiCodeInstructions.php
+++ b/.vortex/installer/src/Prompts/Handlers/AiCodeInstructions.php
@@ -37,7 +37,7 @@ class AiCodeInstructions extends AbstractHandler {
       return NULL;
     }
 
-    return File::exists($this->dstDir . '/AGENTS.md') || File::exists($this->dstDir . '/CLAUDE.md') || File::exists($this->dstDir . '/.claude/settings.json');
+    return File::exists($this->destinationDir . '/AGENTS.md') || File::exists($this->destinationDir . '/CLAUDE.md') || File::exists($this->destinationDir . '/.claude/settings.json');
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/AssignAuthorPr.php
+++ b/.vortex/installer/src/Prompts/Handlers/AssignAuthorPr.php
@@ -33,7 +33,7 @@ class AssignAuthorPr extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    return $this->isInstalled() ? file_exists($this->dstDir . '/.github/workflows/assign-author.yml') : NULL;
+    return $this->isInstalled() ? file_exists($this->destinationDir . '/.github/workflows/assign-author.yml') : NULL;
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/CiProvider.php
+++ b/.vortex/installer/src/Prompts/Handlers/CiProvider.php
@@ -123,13 +123,6 @@ class CiProvider extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function postInstall(): ?string {
-    return NULL;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function postBuild(string $result): ?string {
     if ($this->isInstalled()) {
       return NULL;

--- a/.vortex/installer/src/Prompts/Handlers/CiProvider.php
+++ b/.vortex/installer/src/Prompts/Handlers/CiProvider.php
@@ -60,11 +60,11 @@ class CiProvider extends AbstractHandler {
       return NULL;
     }
 
-    if (is_readable($this->dstDir . '/.github/workflows/build-test-deploy.yml')) {
+    if (is_readable($this->destinationDir . '/.github/workflows/build-test-deploy.yml')) {
       return self::GITHUB_ACTIONS;
     }
 
-    if (is_readable($this->dstDir . '/.circleci/config.yml')) {
+    if (is_readable($this->destinationDir . '/.circleci/config.yml')) {
       return self::CIRCLECI;
     }
 

--- a/.vortex/installer/src/Prompts/Handlers/CodeCoverageProvider.php
+++ b/.vortex/installer/src/Prompts/Handlers/CodeCoverageProvider.php
@@ -51,14 +51,14 @@ class CodeCoverageProvider extends AbstractHandler {
       return NULL;
     }
 
-    $gha_files = glob($this->dstDir . '/.github/workflows/*.{yml,yaml}', GLOB_BRACE) ?: [];
+    $gha_files = glob($this->destinationDir . '/.github/workflows/*.{yml,yaml}', GLOB_BRACE) ?: [];
     foreach ($gha_files as $gha_file) {
       if (is_readable($gha_file) && File::contains($gha_file, 'codecov/codecov-action')) {
         return self::CODECOV;
       }
     }
 
-    $circle = $this->dstDir . '/.circleci/config.yml';
+    $circle = $this->destinationDir . '/.circleci/config.yml';
     if (is_readable($circle) && File::contains($circle, 'codecov -Z -s')) {
       return self::CODECOV;
     }

--- a/.vortex/installer/src/Prompts/Handlers/CodeProvider.php
+++ b/.vortex/installer/src/Prompts/Handlers/CodeProvider.php
@@ -54,11 +54,11 @@ class CodeProvider extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    if (file_exists($this->dstDir . '/.github')) {
+    if (file_exists($this->destinationDir . '/.github')) {
       return self::GITHUB;
     }
 
-    return $this->isInstalled() && file_exists($this->dstDir . '/.git') ? self::OTHER : NULL;
+    return $this->isInstalled() && file_exists($this->destinationDir . '/.git') ? self::OTHER : NULL;
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/CodeProvider.php
+++ b/.vortex/installer/src/Prompts/Handlers/CodeProvider.php
@@ -69,9 +69,7 @@ class CodeProvider extends AbstractHandler {
     $t = $this->tmpDir;
 
     if ($v === self::GITHUB) {
-      if (file_exists($t . '/.github/PULL_REQUEST_TEMPLATE.md')) {
-        File::remove($t . '/.github/PULL_REQUEST_TEMPLATE.md');
-      }
+      File::remove($t . '/.github/PULL_REQUEST_TEMPLATE.md');
 
       if (file_exists($t . '/.github/PULL_REQUEST_TEMPLATE.dist.md')) {
         rename($t . '/.github/PULL_REQUEST_TEMPLATE.dist.md', $t . '/.github/PULL_REQUEST_TEMPLATE.md');

--- a/.vortex/installer/src/Prompts/Handlers/CodeProvider.php
+++ b/.vortex/installer/src/Prompts/Handlers/CodeProvider.php
@@ -22,7 +22,7 @@ class CodeProvider extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public static function description(array $responses): string {
+  public static function description(array $responses): ?string {
     return 'Vortex offers full automation with GitHub, while support for other providers is limited.';
   }
 

--- a/.vortex/installer/src/Prompts/Handlers/CustomModules.php
+++ b/.vortex/installer/src/Prompts/Handlers/CustomModules.php
@@ -162,7 +162,7 @@ DOC;
         File::remove($path);
       }
 
-      static::removeDemoBehatFeatures($t);
+      self::removeDemoBehatFeatures($t);
     }
 
     if (!in_array(self::SEARCH, $selected)) {

--- a/.vortex/installer/src/Prompts/Handlers/CustomModules.php
+++ b/.vortex/installer/src/Prompts/Handlers/CustomModules.php
@@ -91,7 +91,7 @@ DOC;
 
     $modules = [];
 
-    $module_dir = $this->dstDir . '/' . $this->webroot . '/modules/custom';
+    $module_dir = $this->destinationDir . '/' . $this->webroot . '/modules/custom';
 
     if (is_dir($module_dir . '/' . $prefix . '_base')) {
       $modules[] = self::BASE;
@@ -200,10 +200,10 @@ DOC;
    */
   protected function discoverModulePrefix(): ?string {
     $locations = [
-      $this->dstDir . sprintf('/%s/modules/custom/*_base', $this->webroot),
-      $this->dstDir . sprintf('/%s/modules/custom/*_core', $this->webroot),
-      $this->dstDir . sprintf('/%s/sites/all/modules/custom/*_base', $this->webroot),
-      $this->dstDir . sprintf('/%s/sites/all/modules/custom/*_core', $this->webroot),
+      $this->destinationDir . sprintf('/%s/modules/custom/*_base', $this->webroot),
+      $this->destinationDir . sprintf('/%s/modules/custom/*_core', $this->webroot),
+      $this->destinationDir . sprintf('/%s/sites/all/modules/custom/*_base', $this->webroot),
+      $this->destinationDir . sprintf('/%s/sites/all/modules/custom/*_core', $this->webroot),
     ];
 
     $path = File::findMatchingPath($locations);

--- a/.vortex/installer/src/Prompts/Handlers/DatabaseFetchSource.php
+++ b/.vortex/installer/src/Prompts/Handlers/DatabaseFetchSource.php
@@ -97,7 +97,7 @@ class DatabaseFetchSource extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    return Env::getFromDotenv('VORTEX_FETCH_DB_SOURCE', $this->dstDir);
+    return Env::getFromDotenv('VORTEX_FETCH_DB_SOURCE', $this->destinationDir);
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/DatabaseImage.php
+++ b/.vortex/installer/src/Prompts/Handlers/DatabaseImage.php
@@ -78,7 +78,7 @@ class DatabaseImage extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    return Env::getFromDotenv('VORTEX_DB_IMAGE', $this->dstDir);
+    return Env::getFromDotenv('VORTEX_DB_IMAGE', $this->destinationDir);
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/DatabaseImage.php
+++ b/.vortex/installer/src/Prompts/Handlers/DatabaseImage.php
@@ -85,7 +85,7 @@ class DatabaseImage extends AbstractHandler {
    * {@inheritdoc}
    */
   public function validate(): ?callable {
-    return fn($v): ?string => Validator::containerImage($v) ? NULL : 'Please enter a valid container image name with an optional tag.';
+    return fn($v): ?string => Validator::isContainerImage($v) ? NULL : 'Please enter a valid container image name with an optional tag.';
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/DependencyUpdatesProvider.php
+++ b/.vortex/installer/src/Prompts/Handlers/DependencyUpdatesProvider.php
@@ -54,15 +54,15 @@ class DependencyUpdatesProvider extends AbstractHandler {
       return NULL;
     }
 
-    if (!is_readable($this->dstDir . '/renovate.json')) {
+    if (!is_readable($this->destinationDir . '/renovate.json')) {
       return self::NONE;
     }
 
-    if (file_exists($this->dstDir . '/.github/workflows/update-dependencies.yml')) {
+    if (file_exists($this->destinationDir . '/.github/workflows/update-dependencies.yml')) {
       return self::RENOVATEBOT_CI;
     }
 
-    if (File::contains($this->dstDir . '/.circleci/config.yml', 'update-dependencies')) {
+    if (File::contains($this->destinationDir . '/.circleci/config.yml', 'update-dependencies')) {
       return self::RENOVATEBOT_CI;
     }
 

--- a/.vortex/installer/src/Prompts/Handlers/DeployTypes.php
+++ b/.vortex/installer/src/Prompts/Handlers/DeployTypes.php
@@ -75,7 +75,7 @@ class DeployTypes extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    $types = Env::getFromDotenv('VORTEX_DEPLOY_TYPES', $this->dstDir);
+    $types = Env::getFromDotenv('VORTEX_DEPLOY_TYPES', $this->destinationDir);
 
     if (!empty($types)) {
       $types = Converter::fromList($types);

--- a/.vortex/installer/src/Prompts/Handlers/Domain.php
+++ b/.vortex/installer/src/Prompts/Handlers/Domain.php
@@ -54,7 +54,7 @@ class Domain extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    $origin = Env::getFromDotenv('DRUPAL_STAGE_FILE_PROXY_ORIGIN', $this->dstDir);
+    $origin = Env::getFromDotenv('DRUPAL_STAGE_FILE_PROXY_ORIGIN', $this->destinationDir);
 
     if ($origin) {
       return Converter::domain($origin);

--- a/.vortex/installer/src/Prompts/Handlers/Domain.php
+++ b/.vortex/installer/src/Prompts/Handlers/Domain.php
@@ -67,7 +67,7 @@ class Domain extends AbstractHandler {
    * {@inheritdoc}
    */
   public function validate(): ?callable {
-    return fn($v): ?string => Validator::domain($v) ? NULL : 'Please enter a valid domain name.';
+    return fn($v): ?string => Validator::isDomain($v) ? NULL : 'Please enter a valid domain name.';
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/Dotenv.php
+++ b/.vortex/installer/src/Prompts/Handlers/Dotenv.php
@@ -23,8 +23,8 @@ class Dotenv extends AbstractHandler {
   public function process(): void {
     $t = $this->tmpDir;
 
-    if (is_readable($this->dstDir . '/.env')) {
-      $variables = Env::parseDotenv($this->dstDir . '/.env');
+    if (is_readable($this->destinationDir . '/.env')) {
+      $variables = Env::parseDotenv($this->destinationDir . '/.env');
       foreach ($variables as $name => $value) {
         Env::writeValueDotenv($name, $value, $t . '/.env');
       }

--- a/.vortex/installer/src/Prompts/Handlers/FrontendBuild.php
+++ b/.vortex/installer/src/Prompts/Handlers/FrontendBuild.php
@@ -59,7 +59,7 @@ class FrontendBuild extends AbstractHandler {
     }
 
     // Build in the container unless the project explicitly opted out.
-    return Env::getFromDotenv('VORTEX_FRONTEND_BUILD_SKIP', $this->dstDir) !== '1';
+    return Env::getFromDotenv('VORTEX_FRONTEND_BUILD_SKIP', $this->destinationDir) !== '1';
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/FrontendBuild.php
+++ b/.vortex/installer/src/Prompts/Handlers/FrontendBuild.php
@@ -69,7 +69,7 @@ class FrontendBuild extends AbstractHandler {
     // Only persist an explicit boolean answer; a non-boolean response means
     // the prompt was not shown.
     if (is_bool($this->response)) {
-      Env::writeValueDotenv('VORTEX_FRONTEND_BUILD_SKIP', $this->response ? '0' : '1', $this->tmpDir . '/.env');
+      Env::writeValueDotenv('VORTEX_FRONTEND_BUILD_SKIP', $this->getResponseAsBool() ? '0' : '1', $this->tmpDir . '/.env');
     }
   }
 

--- a/.vortex/installer/src/Prompts/Handlers/Gitleaks.php
+++ b/.vortex/installer/src/Prompts/Handlers/Gitleaks.php
@@ -40,7 +40,7 @@ class Gitleaks extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    return $this->isInstalled() ? file_exists($this->dstDir . '/.gitleaks.toml') : NULL;
+    return $this->isInstalled() ? file_exists($this->destinationDir . '/.gitleaks.toml') : NULL;
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/HandlerInterface.php
+++ b/.vortex/installer/src/Prompts/Handlers/HandlerInterface.php
@@ -10,8 +10,6 @@ use DrevOps\VortexInstaller\Prompts\PromptType;
  * Interface HandlerInterface.
  *
  * The interface for the prompt handlers.
- *
- * @package DrevOps\VortexInstaller\Prompts\Handlers
  */
 interface HandlerInterface {
 

--- a/.vortex/installer/src/Prompts/Handlers/HostingProjectName.php
+++ b/.vortex/installer/src/Prompts/Handlers/HostingProjectName.php
@@ -72,7 +72,7 @@ class HostingProjectName extends AbstractHandler {
    */
   public function discover(): null|string|bool|array {
     // Try Acquia.
-    $v = Env::getFromDotenv('VORTEX_ACQUIA_APP_NAME', $this->dstDir);
+    $v = Env::getFromDotenv('VORTEX_ACQUIA_APP_NAME', $this->destinationDir);
     if (!empty($v)) {
       return $v;
     }
@@ -81,7 +81,7 @@ class HostingProjectName extends AbstractHandler {
     // new settings.acquia.php uses AH_SITE_GROUP environment variable instead
     // of a hardcoded project name. Kept for backward compatibility with older
     // installations.
-    $acquia_settings_file = $this->dstDir . sprintf('/%s/sites/default/includes/providers/settings.acquia.php', $this->webroot);
+    $acquia_settings_file = $this->destinationDir . sprintf('/%s/sites/default/includes/providers/settings.acquia.php', $this->webroot);
     if (file_exists($acquia_settings_file)) {
       $content = file_get_contents($acquia_settings_file);
       // Require '/var/www/site-php/your_site/your_site-settings.inc';.
@@ -91,13 +91,13 @@ class HostingProjectName extends AbstractHandler {
     }
 
     // Try Lagoon.
-    $v = Env::getFromDotenv('LAGOON_PROJECT', $this->dstDir);
+    $v = Env::getFromDotenv('LAGOON_PROJECT', $this->destinationDir);
     if (!empty($v)) {
       return $v;
     }
 
     // Try to discover from drush/sites/lagoon.site.yml.
-    $lagoon_site_file = $this->dstDir . '/drush/sites/lagoon.site.yml';
+    $lagoon_site_file = $this->destinationDir . '/drush/sites/lagoon.site.yml';
     if (file_exists($lagoon_site_file)) {
       $content = file_get_contents($lagoon_site_file);
       if ($content !== FALSE && preg_match('/user:\s*([a-z0-9_]+)-/', $content, $matches) && (!empty($matches[1]) && $matches[1] !== 'your_site')) {

--- a/.vortex/installer/src/Prompts/Handlers/HostingProvider.php
+++ b/.vortex/installer/src/Prompts/Handlers/HostingProvider.php
@@ -81,13 +81,13 @@ class HostingProvider extends AbstractHandler {
     $t = $this->tmpDir;
     $w = $this->webroot;
 
-    if ($v === static::ACQUIA) {
+    if ($v === self::ACQUIA) {
       File::removeTokenAsync('!HOSTING_ACQUIA');
       File::removeTokenAsync('!SETTINGS_PROVIDER_ACQUIA');
 
       $this->removeLagoon();
     }
-    elseif ($v === static::LAGOON) {
+    elseif ($v === self::LAGOON) {
       File::removeTokenAsync('!HOSTING_LAGOON');
       File::removeTokenAsync('!SETTINGS_PROVIDER_LAGOON');
 

--- a/.vortex/installer/src/Prompts/Handlers/HostingProvider.php
+++ b/.vortex/installer/src/Prompts/Handlers/HostingProvider.php
@@ -62,11 +62,11 @@ class HostingProvider extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    if (is_readable($this->dstDir . '/hooks') || Env::getFromDotenv('VORTEX_FETCH_DB_SOURCE', $this->dstDir) === DatabaseFetchSource::ACQUIA) {
+    if (is_readable($this->destinationDir . '/hooks') || Env::getFromDotenv('VORTEX_FETCH_DB_SOURCE', $this->destinationDir) === DatabaseFetchSource::ACQUIA) {
       return self::ACQUIA;
     }
 
-    if (is_readable($this->dstDir . '/.lagoon.yml')) {
+    if (is_readable($this->destinationDir . '/.lagoon.yml')) {
       return self::LAGOON;
     }
 

--- a/.vortex/installer/src/Prompts/Handlers/HostingProvider.php
+++ b/.vortex/installer/src/Prompts/Handlers/HostingProvider.php
@@ -130,13 +130,6 @@ class HostingProvider extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function postInstall(): ?string {
-    return NULL;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function postBuild(string $result): ?string {
     if ($this->isInstalled()) {
       return NULL;

--- a/.vortex/installer/src/Prompts/Handlers/Internal.php
+++ b/.vortex/installer/src/Prompts/Handlers/Internal.php
@@ -138,7 +138,7 @@ class Internal extends AbstractHandler {
   protected function processDemoMode(array $responses, string $dir): void {
     $is_demo = $this->config->get(Config::IS_DEMO);
 
-    if (is_null($is_demo)) {
+    if ($is_demo === NULL) {
       if ($responses[Starter::id()] !== Starter::LOAD_DATABASE_DEMO) {
         $is_demo = FALSE;
       }

--- a/.vortex/installer/src/Prompts/Handlers/Internal.php
+++ b/.vortex/installer/src/Prompts/Handlers/Internal.php
@@ -98,7 +98,7 @@ class Internal extends AbstractHandler {
     $files = glob($t . '/.circleci/vortex-*.yml');
     if ($files) {
       foreach ($files as $file) {
-        @unlink($file);
+        File::remove($file);
       }
     }
 

--- a/.vortex/installer/src/Prompts/Handlers/Internal.php
+++ b/.vortex/installer/src/Prompts/Handlers/Internal.php
@@ -80,19 +80,19 @@ class Internal extends AbstractHandler {
       return $content;
     });
 
-    if (file_exists($t . DIRECTORY_SEPARATOR . 'README.dist.md')) {
-      rename($t . DIRECTORY_SEPARATOR . 'README.dist.md', $t . DIRECTORY_SEPARATOR . 'README.md');
+    if (file_exists($t . '/README.dist.md')) {
+      rename($t . '/README.dist.md', $t . '/README.md');
     }
 
     // Remove Vortex internal files.
-    File::remove($t . DIRECTORY_SEPARATOR . '.vortex');
-    File::remove($t . DIRECTORY_SEPARATOR . '.claude' . DIRECTORY_SEPARATOR . 'skills');
+    File::remove($t . '/.vortex');
+    File::remove($t . '/.claude/skills');
 
     File::remove($t . '/.github/FUNDING.yml');
-    File::remove($t . 'CODE_OF_CONDUCT.md');
-    File::remove($t . 'CONTRIBUTING.md');
-    File::remove($t . 'LICENSE');
-    File::remove($t . 'SECURITY.md');
+    File::remove($t . '/CODE_OF_CONDUCT.md');
+    File::remove($t . '/CONTRIBUTING.md');
+    File::remove($t . '/LICENSE');
+    File::remove($t . '/SECURITY.md');
 
     // Remove Vortex internal CircleCI configs.
     $files = glob($t . '/.circleci/vortex-*.yml');
@@ -114,7 +114,7 @@ class Internal extends AbstractHandler {
     // Also remove the path repository that points at the in-tree
     // .vortex/tooling package - consumer sites get drevops/vortex-tooling
     // from packagist instead.
-    $composer_json_path = $t . DIRECTORY_SEPARATOR . 'composer.json';
+    $composer_json_path = $t . '/composer.json';
     if (file_exists($composer_json_path)) {
       $content = file_get_contents($composer_json_path);
       $composer_json = json_decode((string) $content, FALSE);
@@ -145,7 +145,7 @@ class Internal extends AbstractHandler {
       // Check if it should be enabled based on the provision type and database
       // download source.
       elseif ($responses[ProvisionType::id()] === ProvisionType::DATABASE) {
-        $db_file_exists = file_exists(Env::get('VORTEX_DB_DIR', './.data') . DIRECTORY_SEPARATOR . Env::get('VORTEX_DB_FILE', 'db.sql'));
+        $db_file_exists = file_exists(Env::get('VORTEX_DB_DIR', './.data') . '/' . Env::get('VORTEX_DB_FILE', 'db.sql'));
         $has_comment = File::contains($this->destinationDir . '/.env', 'Override project-specific values for demonstration purposes');
 
         // Demo mode can only be used if the user selected a URL or a container

--- a/.vortex/installer/src/Prompts/Handlers/Internal.php
+++ b/.vortex/installer/src/Prompts/Handlers/Internal.php
@@ -146,7 +146,7 @@ class Internal extends AbstractHandler {
       // download source.
       elseif ($responses[ProvisionType::id()] === ProvisionType::DATABASE) {
         $db_file_exists = file_exists(Env::get('VORTEX_DB_DIR', './.data') . DIRECTORY_SEPARATOR . Env::get('VORTEX_DB_FILE', 'db.sql'));
-        $has_comment = File::contains($this->dstDir . '/.env', 'Override project-specific values for demonstration purposes');
+        $has_comment = File::contains($this->destinationDir . '/.env', 'Override project-specific values for demonstration purposes');
 
         // Demo mode can only be used if the user selected a URL or a container
         // registry download source. This is because the demo mode would not
@@ -192,7 +192,7 @@ class Internal extends AbstractHandler {
     if (!$this->isInstalled()) {
       $output .= PHP_EOL;
       $output .= 'Add and commit all files:' . PHP_EOL;
-      $output .= '  cd ' . $this->config->getDst() . PHP_EOL;
+      $output .= '  cd ' . $this->config->getDestination() . PHP_EOL;
       $output .= '  git add -A' . PHP_EOL;
       $output .= '  git commit -m "Initial commit."' . PHP_EOL;
       $output .= PHP_EOL;

--- a/.vortex/installer/src/Prompts/Handlers/LabelMergeConflictsPr.php
+++ b/.vortex/installer/src/Prompts/Handlers/LabelMergeConflictsPr.php
@@ -33,7 +33,7 @@ class LabelMergeConflictsPr extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    return $this->isInstalled() ? file_exists($this->dstDir . '/.github/workflows/label-merge-conflict.yml') : NULL;
+    return $this->isInstalled() ? file_exists($this->destinationDir . '/.github/workflows/label-merge-conflict.yml') : NULL;
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/MachineName.php
+++ b/.vortex/installer/src/Prompts/Handlers/MachineName.php
@@ -54,13 +54,13 @@ class MachineName extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    $v = Env::getFromDotenv('VORTEX_PROJECT', $this->dstDir);
+    $v = Env::getFromDotenv('VORTEX_PROJECT', $this->destinationDir);
 
     if (!empty($v)) {
       return $v;
     }
 
-    $v = JsonManipulator::fromFile($this->dstDir . '/composer.json')?->getProperty('name');
+    $v = JsonManipulator::fromFile($this->destinationDir . '/composer.json')?->getProperty('name');
     if ($v && preg_match('/([^\/]+)\/(.+)/', (string) $v, $matches) && !empty($matches[2])) {
       return trim($matches[2]);
     }

--- a/.vortex/installer/src/Prompts/Handlers/Migration.php
+++ b/.vortex/installer/src/Prompts/Handlers/Migration.php
@@ -40,7 +40,7 @@ class Migration extends AbstractHandler {
     }
 
     try {
-      $dc = Yaml::parseFile($this->dstDir . '/docker-compose.yml');
+      $dc = Yaml::parseFile($this->destinationDir . '/docker-compose.yml');
     }
     catch (\Exception) {
       return NULL;

--- a/.vortex/installer/src/Prompts/Handlers/MigrationFetchSource.php
+++ b/.vortex/installer/src/Prompts/Handlers/MigrationFetchSource.php
@@ -94,7 +94,7 @@ class MigrationFetchSource extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    return Env::getFromDotenv('VORTEX_FETCH_DB2_SOURCE', $this->dstDir);
+    return Env::getFromDotenv('VORTEX_FETCH_DB2_SOURCE', $this->destinationDir);
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/MigrationImage.php
+++ b/.vortex/installer/src/Prompts/Handlers/MigrationImage.php
@@ -84,7 +84,7 @@ class MigrationImage extends AbstractHandler {
    * {@inheritdoc}
    */
   public function validate(): ?callable {
-    return fn($v): ?string => Validator::containerImage($v) ? NULL : 'Please enter a valid container image name with an optional tag.';
+    return fn($v): ?string => Validator::isContainerImage($v) ? NULL : 'Please enter a valid container image name with an optional tag.';
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/MigrationImage.php
+++ b/.vortex/installer/src/Prompts/Handlers/MigrationImage.php
@@ -77,7 +77,7 @@ class MigrationImage extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    return Env::getFromDotenv('VORTEX_DB2_IMAGE', $this->dstDir);
+    return Env::getFromDotenv('VORTEX_DB2_IMAGE', $this->destinationDir);
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/ModulePrefix.php
+++ b/.vortex/installer/src/Prompts/Handlers/ModulePrefix.php
@@ -53,18 +53,18 @@ class ModulePrefix extends AbstractHandler {
    */
   public function discover(): null|string|bool|array {
     $locations = [
-      $this->dstDir . sprintf('/%s/modules/custom/*_base', $this->webroot),
-      $this->dstDir . sprintf('/%s/modules/custom/*_core', $this->webroot),
-      $this->dstDir . sprintf('/%s/sites/all/modules/custom/*_base', $this->webroot),
-      $this->dstDir . sprintf('/%s/sites/all/modules/custom/*_core', $this->webroot),
-      $this->dstDir . sprintf('/%s/profiles/*/modules/*_base', $this->webroot),
-      $this->dstDir . sprintf('/%s/profiles/*/modules/*_core', $this->webroot),
-      $this->dstDir . sprintf('/%s/profiles/*/modules/custom/*_base', $this->webroot),
-      $this->dstDir . sprintf('/%s/profiles/*/modules/custom/*_core', $this->webroot),
-      $this->dstDir . sprintf('/%s/profiles/custom/*/modules/*_base', $this->webroot),
-      $this->dstDir . sprintf('/%s/profiles/custom/*/modules/*_core', $this->webroot),
-      $this->dstDir . sprintf('/%s/profiles/custom/*/modules/custom/*_base', $this->webroot),
-      $this->dstDir . sprintf('/%s/profiles/custom/*/modules/custom/*_core', $this->webroot),
+      $this->destinationDir . sprintf('/%s/modules/custom/*_base', $this->webroot),
+      $this->destinationDir . sprintf('/%s/modules/custom/*_core', $this->webroot),
+      $this->destinationDir . sprintf('/%s/sites/all/modules/custom/*_base', $this->webroot),
+      $this->destinationDir . sprintf('/%s/sites/all/modules/custom/*_core', $this->webroot),
+      $this->destinationDir . sprintf('/%s/profiles/*/modules/*_base', $this->webroot),
+      $this->destinationDir . sprintf('/%s/profiles/*/modules/*_core', $this->webroot),
+      $this->destinationDir . sprintf('/%s/profiles/*/modules/custom/*_base', $this->webroot),
+      $this->destinationDir . sprintf('/%s/profiles/*/modules/custom/*_core', $this->webroot),
+      $this->destinationDir . sprintf('/%s/profiles/custom/*/modules/*_base', $this->webroot),
+      $this->destinationDir . sprintf('/%s/profiles/custom/*/modules/*_core', $this->webroot),
+      $this->destinationDir . sprintf('/%s/profiles/custom/*/modules/custom/*_base', $this->webroot),
+      $this->destinationDir . sprintf('/%s/profiles/custom/*/modules/custom/*_core', $this->webroot),
     ];
 
     $path = File::findMatchingPath($locations);

--- a/.vortex/installer/src/Prompts/Handlers/Modules.php
+++ b/.vortex/installer/src/Prompts/Handlers/Modules.php
@@ -35,7 +35,7 @@ class Modules extends AbstractHandler {
    * {@inheritdoc}
    */
   public function options(array $responses): ?array {
-    return static::getAvailableModules();
+    return self::getAvailableModules();
   }
 
   /**
@@ -43,7 +43,7 @@ class Modules extends AbstractHandler {
    */
   public function default(array $responses): null|string|bool|array {
     // Default to all modules selected (meaning none will be removed).
-    return array_keys(static::getAvailableModules());
+    return array_keys(self::getAvailableModules());
   }
 
   /**
@@ -62,7 +62,7 @@ class Modules extends AbstractHandler {
     }
 
     // Filter discovered modules to only include those in our available list.
-    $available_modules = array_keys(static::getAvailableModules());
+    $available_modules = array_keys(self::getAvailableModules());
     $modules = array_intersect($discovered_modules, $available_modules);
 
     sort($modules);
@@ -75,7 +75,7 @@ class Modules extends AbstractHandler {
    */
   public function process(): void {
     $selected_modules = $this->getResponseAsArray();
-    $all_modules = static::getAvailableModules();
+    $all_modules = self::getAvailableModules();
 
     $t = $this->tmpDir;
     $w = $this->webroot;
@@ -117,7 +117,7 @@ class Modules extends AbstractHandler {
 
     // Without any development modules left to install, the script has no
     // operations to perform, so remove it rather than shipping an empty shell.
-    if (count(array_intersect(static::DEV_MODULES, $selected_modules)) === 0) {
+    if (count(array_intersect(self::DEV_MODULES, $selected_modules)) === 0) {
       File::remove($t . '/scripts/provision-10-enable-dev-modules.sh');
     }
 

--- a/.vortex/installer/src/Prompts/Handlers/Modules.php
+++ b/.vortex/installer/src/Prompts/Handlers/Modules.php
@@ -54,7 +54,7 @@ class Modules extends AbstractHandler {
       return NULL;
     }
 
-    $composer_file = $this->dstDir . '/composer.json';
+    $composer_file = $this->destinationDir . '/composer.json';
     $discovered_modules = $this->getModulesFromComposerFile($composer_file);
 
     if ($discovered_modules === NULL) {

--- a/.vortex/installer/src/Prompts/Handlers/Name.php
+++ b/.vortex/installer/src/Prompts/Handlers/Name.php
@@ -43,14 +43,14 @@ class Name extends AbstractHandler {
    */
   public function default(array $responses): null|string|bool|array {
     // Discover the name from the project directory.
-    return Converter::label(basename((string) $this->config->getDst()));
+    return Converter::label(basename((string) $this->config->getDestination()));
   }
 
   /**
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    $v = JsonManipulator::fromFile($this->dstDir . '/composer.json')?->getProperty('description');
+    $v = JsonManipulator::fromFile($this->destinationDir . '/composer.json')?->getProperty('description');
 
     if ($v && preg_match('/Drupal \d+ .* of ([0-9a-zA-Z\- ]+)(\s?\.|for)/', (string) $v, $matches) && !empty($matches[1])) {
       return trim($matches[1]);

--- a/.vortex/installer/src/Prompts/Handlers/NotificationChannels.php
+++ b/.vortex/installer/src/Prompts/Handlers/NotificationChannels.php
@@ -82,7 +82,7 @@ class NotificationChannels extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    $channels = Env::getFromDotenv('VORTEX_NOTIFY_CHANNELS', $this->dstDir);
+    $channels = Env::getFromDotenv('VORTEX_NOTIFY_CHANNELS', $this->destinationDir);
 
     if (!empty($channels)) {
       $channels = Converter::fromList($channels);

--- a/.vortex/installer/src/Prompts/Handlers/Org.php
+++ b/.vortex/installer/src/Prompts/Handlers/Org.php
@@ -53,7 +53,7 @@ class Org extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    $v = JsonManipulator::fromFile($this->dstDir . '/composer.json')?->getProperty('description');
+    $v = JsonManipulator::fromFile($this->destinationDir . '/composer.json')?->getProperty('description');
 
     if ($v && preg_match('/Drupal \d+ .* of ([0-9a-zA-Z\- ]+) for ([0-9a-zA-Z\- ]+)/', (string) $v, $matches) && !empty($matches[2])) {
       return $matches[2];

--- a/.vortex/installer/src/Prompts/Handlers/OrgMachineName.php
+++ b/.vortex/installer/src/Prompts/Handlers/OrgMachineName.php
@@ -53,7 +53,7 @@ class OrgMachineName extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    $v = JsonManipulator::fromFile($this->dstDir . '/composer.json')?->getProperty('name');
+    $v = JsonManipulator::fromFile($this->destinationDir . '/composer.json')?->getProperty('name');
 
     if ($v && preg_match('/([^\/]+)\/(.+)/', (string) $v, $matches) && !empty($matches[1])) {
       return $matches[1];

--- a/.vortex/installer/src/Prompts/Handlers/PreserveDocsProject.php
+++ b/.vortex/installer/src/Prompts/Handlers/PreserveDocsProject.php
@@ -33,7 +33,7 @@ class PreserveDocsProject extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    return $this->isInstalled() ? file_exists($this->dstDir . '/docs/README.md') : NULL;
+    return $this->isInstalled() ? file_exists($this->destinationDir . '/docs/README.md') : NULL;
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/Profile.php
+++ b/.vortex/installer/src/Prompts/Handlers/Profile.php
@@ -106,17 +106,17 @@ class Profile extends AbstractHandler {
    */
   public function discoverName(): null|string|bool|array {
     if ($this->isInstalled()) {
-      $value = Env::getFromDotenv('DRUPAL_PROFILE', $this->dstDir);
+      $value = Env::getFromDotenv('DRUPAL_PROFILE', $this->destinationDir);
       if (!empty($value)) {
         return $value;
       }
     }
 
     $locations = [
-      $this->dstDir . sprintf('/%s/profiles/*/*.info', $this->webroot),
-      $this->dstDir . sprintf('/%s/profiles/*/*.info.yml', $this->webroot),
-      $this->dstDir . sprintf('/%s/profiles/custom/*/*.info', $this->webroot),
-      $this->dstDir . sprintf('/%s/profiles/custom/*/*.info.yml', $this->webroot),
+      $this->destinationDir . sprintf('/%s/profiles/*/*.info', $this->webroot),
+      $this->destinationDir . sprintf('/%s/profiles/*/*.info.yml', $this->webroot),
+      $this->destinationDir . sprintf('/%s/profiles/custom/*/*.info', $this->webroot),
+      $this->destinationDir . sprintf('/%s/profiles/custom/*/*.info.yml', $this->webroot),
     ];
 
     $path = File::findMatchingPath($locations);

--- a/.vortex/installer/src/Prompts/Handlers/Profile.php
+++ b/.vortex/installer/src/Prompts/Handlers/Profile.php
@@ -63,7 +63,7 @@ class Profile extends AbstractHandler {
   public function discover(): null|string|bool|array {
     $value = $this->discoverName();
 
-    if (!is_null($value)) {
+    if ($value !== NULL) {
       return in_array($value, [self::STANDARD, self::MINIMAL, self::DEMO_UMAMI], TRUE) ? $value : self::CUSTOM;
     }
 
@@ -76,7 +76,7 @@ class Profile extends AbstractHandler {
   public function resolvedValue(array $responses): null|string|bool|array {
     $discovered = $this->discover();
 
-    if (!is_null($discovered)) {
+    if ($discovered !== NULL) {
       return $discovered;
     }
 

--- a/.vortex/installer/src/Prompts/Handlers/ProfileCustom.php
+++ b/.vortex/installer/src/Prompts/Handlers/ProfileCustom.php
@@ -18,13 +18,6 @@ class ProfileCustom extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public function hint(array $responses): ?string {
-    return NULL;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function placeholder(array $responses): ?string {
     return 'E.g. my_profile';
   }

--- a/.vortex/installer/src/Prompts/Handlers/ProvisionType.php
+++ b/.vortex/installer/src/Prompts/Handlers/ProvisionType.php
@@ -71,7 +71,7 @@ DOC;
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    $type = Env::getFromDotenv('VORTEX_PROVISION_TYPE', $this->dstDir);
+    $type = Env::getFromDotenv('VORTEX_PROVISION_TYPE', $this->destinationDir);
 
     return $type && in_array($type, [self::DATABASE, self::PROFILE], TRUE) ? $type : NULL;
   }

--- a/.vortex/installer/src/Prompts/Handlers/ProvisionType.php
+++ b/.vortex/installer/src/Prompts/Handlers/ProvisionType.php
@@ -85,7 +85,7 @@ DOC;
 
     Env::writeValueDotenv('VORTEX_PROVISION_TYPE', $v, $t . '/.env');
 
-    if ($v === static::PROFILE) {
+    if ($v === self::PROFILE) {
       File::removeTokenAsync('!PROVISION_TYPE_PROFILE');
     }
     else {

--- a/.vortex/installer/src/Prompts/Handlers/ProvisionType.php
+++ b/.vortex/installer/src/Prompts/Handlers/ProvisionType.php
@@ -24,7 +24,7 @@ class ProvisionType extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public static function description(array $responses): string {
+  public static function description(array $responses): ?string {
     $label1 = Tui::bold('Import from database dump');
     $label2 = Tui::bold('Install from profile');
 

--- a/.vortex/installer/src/Prompts/Handlers/Services.php
+++ b/.vortex/installer/src/Prompts/Handlers/Services.php
@@ -80,7 +80,7 @@ class Services extends AbstractHandler {
     }
 
     try {
-      $dc = Yaml::parseFile($this->dstDir . '/docker-compose.yml');
+      $dc = Yaml::parseFile($this->destinationDir . '/docker-compose.yml');
     }
     catch (\Exception) {
       return NULL;

--- a/.vortex/installer/src/Prompts/Handlers/Services.php
+++ b/.vortex/installer/src/Prompts/Handlers/Services.php
@@ -135,31 +135,31 @@ class Services extends AbstractHandler {
     }
 
     if (!in_array(self::CLAMAV, $v)) {
-      File::remove($t . DIRECTORY_SEPARATOR . '.docker/config/clamav');
-      File::remove($t . DIRECTORY_SEPARATOR . '.docker/clamav.dockerfile');
-      File::remove($t . DIRECTORY_SEPARATOR . $w . DIRECTORY_SEPARATOR . 'sites/default/includes/modules/settings.clamav.php');
-      File::remove($t . DIRECTORY_SEPARATOR . 'tests/behat/features/clamav.feature');
-      File::replaceContentInFile($t . DIRECTORY_SEPARATOR . 'docker-compose.yml', 'clamav:3310', '');
-      File::replaceContentInFile($t . DIRECTORY_SEPARATOR . 'composer.json', '/\s*"drupal\/clamav":\s*"[^\"]+",?\n/', "\n");
+      File::remove($t . '/.docker/config/clamav');
+      File::remove($t . '/.docker/clamav.dockerfile');
+      File::remove($t . '/' . $w . '/sites/default/includes/modules/settings.clamav.php');
+      File::remove($t . '/tests/behat/features/clamav.feature');
+      File::replaceContentInFile($t . '/docker-compose.yml', 'clamav:3310', '');
+      File::replaceContentInFile($t . '/composer.json', '/\s*"drupal\/clamav":\s*"[^\"]+",?\n/', "\n");
     }
 
     if (!in_array(self::SOLR, $v)) {
-      File::remove($t . DIRECTORY_SEPARATOR . '.docker/config/solr');
-      File::remove($t . DIRECTORY_SEPARATOR . '.docker/solr.dockerfile');
-      File::remove($t . DIRECTORY_SEPARATOR . $w . DIRECTORY_SEPARATOR . 'sites/default/includes/modules/settings.solr.php');
-      File::remove($t . DIRECTORY_SEPARATOR . 'tests/behat/features/search.feature');
-      File::remove($t . DIRECTORY_SEPARATOR . 'scripts/provision-30-search-index.sh');
-      File::replaceContentInFile($t . DIRECTORY_SEPARATOR . 'composer.json', '/\s*"drupal\/solr":\s*"[^\"]+",?\n/', "\n");
-      File::replaceContentInFile($t . DIRECTORY_SEPARATOR . 'composer.json', '/\s*"drupal\/search_api_solr":\s*"[^\"]+",?\n/', "\n");
+      File::remove($t . '/.docker/config/solr');
+      File::remove($t . '/.docker/solr.dockerfile');
+      File::remove($t . '/' . $w . '/sites/default/includes/modules/settings.solr.php');
+      File::remove($t . '/tests/behat/features/search.feature');
+      File::remove($t . '/scripts/provision-30-search-index.sh');
+      File::replaceContentInFile($t . '/composer.json', '/\s*"drupal\/solr":\s*"[^\"]+",?\n/', "\n");
+      File::replaceContentInFile($t . '/composer.json', '/\s*"drupal\/search_api_solr":\s*"[^\"]+",?\n/', "\n");
     }
 
     if (!in_array(self::REDIS, $v)) {
-      File::remove($t . DIRECTORY_SEPARATOR . '.docker/config/redis');
-      File::remove($t . DIRECTORY_SEPARATOR . '.docker/redis.dockerfile');
-      File::remove($t . DIRECTORY_SEPARATOR . $w . DIRECTORY_SEPARATOR . 'sites/default/includes/modules/settings.redis.php');
-      File::replaceContentInFile($t . DIRECTORY_SEPARATOR . 'docker-compose.yml', 'redis:6379', '');
-      File::replaceContentInFile($t . DIRECTORY_SEPARATOR . 'composer.json', '/\s*"drupal\/redis":\s*"[^\"]+",?\n/', "\n");
-      File::remove($t . DIRECTORY_SEPARATOR . 'tests/behat/features/redis.feature');
+      File::remove($t . '/.docker/config/redis');
+      File::remove($t . '/.docker/redis.dockerfile');
+      File::remove($t . '/' . $w . '/sites/default/includes/modules/settings.redis.php');
+      File::replaceContentInFile($t . '/docker-compose.yml', 'redis:6379', '');
+      File::replaceContentInFile($t . '/composer.json', '/\s*"drupal\/redis":\s*"[^\"]+",?\n/', "\n");
+      File::remove($t . '/tests/behat/features/redis.feature');
     }
   }
 

--- a/.vortex/installer/src/Prompts/Handlers/Theme.php
+++ b/.vortex/installer/src/Prompts/Handlers/Theme.php
@@ -64,7 +64,7 @@ class Theme extends AbstractHandler {
   public function discover(): null|string|bool|array {
     $value = $this->discoverName();
 
-    if (!is_null($value)) {
+    if ($value !== NULL) {
       return in_array($value, [self::OLIVERO, self::CLARO, self::STARK], TRUE) ? $value : self::CUSTOM;
     }
 
@@ -75,13 +75,7 @@ class Theme extends AbstractHandler {
    * {@inheritdoc}
    */
   public function resolvedValue(array $responses): null|string|bool|array {
-    $discovered = $this->discover();
-
-    if (!is_null($discovered)) {
-      return $discovered;
-    }
-
-    return NULL;
+    return $this->discover();
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/Theme.php
+++ b/.vortex/installer/src/Prompts/Handlers/Theme.php
@@ -103,13 +103,13 @@ class Theme extends AbstractHandler {
    */
   public function discoverName(): null|string|bool|array {
     if ($this->isInstalled()) {
-      $value = Env::getFromDotenv('DRUPAL_THEME', $this->dstDir);
+      $value = Env::getFromDotenv('DRUPAL_THEME', $this->destinationDir);
       if (!empty($value)) {
         return $value;
       }
     }
 
-    $path = static::findThemeFile($this->dstDir, $this->webroot);
+    $path = static::findThemeFile($this->destinationDir, $this->webroot);
 
     if (empty($path)) {
       return NULL;
@@ -156,7 +156,7 @@ class Theme extends AbstractHandler {
     Env::writeValueDotenv('DRUPAL_MAINTENANCE_THEME', $v, $t . '/.env');
 
     // Find the theme file in the destination directory.
-    $file_dst = static::findThemeFile($this->dstDir, $w, $v);
+    $file_dst = static::findThemeFile($this->destinationDir, $w, $v);
 
     // Remove the theme-related files from the template if not found OR
     // if found, but the theme is not from Vortex.

--- a/.vortex/installer/src/Prompts/Handlers/Theme.php
+++ b/.vortex/installer/src/Prompts/Handlers/Theme.php
@@ -187,34 +187,34 @@ class Theme extends AbstractHandler {
   /**
    * Remove theme-related configuration lines from various files.
    */
-  protected function removeThemeConfigLines(string $tmpDir): void {
-    File::removeLineInFile($tmpDir . '/phpcs.xml', '<file>web/themes/custom</file>');
-    File::removeLineInFile($tmpDir . '/phpcs.xml', '<exclude-pattern>web\/themes\/custom\/.*\/build\/.*</exclude-pattern>');
-    File::removeLineInFile($tmpDir . '/phpcs.xml', '<exclude-pattern>web\/themes\/custom\/.*\/fonts\/.*</exclude-pattern>');
-    File::removeLineInFile($tmpDir . '/phpcs.xml', '<exclude-pattern>web\/themes\/custom\/.*\/images\/.*</exclude-pattern>');
-    File::removeLineInFile($tmpDir . '/phpcs.xml', '<exclude-pattern>web\/themes\/custom\/.*\/node_modules\/.*</exclude-pattern>');
+  protected function removeThemeConfigLines(string $tmp_dir): void {
+    File::removeLineInFile($tmp_dir . '/phpcs.xml', '<file>web/themes/custom</file>');
+    File::removeLineInFile($tmp_dir . '/phpcs.xml', '<exclude-pattern>web\/themes\/custom\/.*\/build\/.*</exclude-pattern>');
+    File::removeLineInFile($tmp_dir . '/phpcs.xml', '<exclude-pattern>web\/themes\/custom\/.*\/fonts\/.*</exclude-pattern>');
+    File::removeLineInFile($tmp_dir . '/phpcs.xml', '<exclude-pattern>web\/themes\/custom\/.*\/images\/.*</exclude-pattern>');
+    File::removeLineInFile($tmp_dir . '/phpcs.xml', '<exclude-pattern>web\/themes\/custom\/.*\/node_modules\/.*</exclude-pattern>');
 
-    File::removeLineInFile($tmpDir . '/phpstan.neon', '- web/themes/custom');
+    File::removeLineInFile($tmp_dir . '/phpstan.neon', '- web/themes/custom');
 
-    File::removeLineInFile($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/*/tests/src/Unit</directory>');
-    File::removeLineInFile($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/**/tests/src/Unit</directory>');
-    File::removeLineInFile($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/*/tests/src/Kernel</directory>');
-    File::removeLineInFile($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/**/tests/src/Kernel</directory>');
-    File::removeLineInFile($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/*/tests/src/Functional</directory>');
-    File::removeLineInFile($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/**/tests/src/Functional</directory>');
-    File::removeLineInFile($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/*/tests/src/FunctionalJavascript</directory>');
-    File::removeLineInFile($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/**/tests/src/FunctionalJavascript</directory>');
-    File::removeLineInFile($tmpDir . '/phpunit.xml', '<directory>web/themes/custom</directory>');
-    File::removeLineInFile($tmpDir . '/phpunit.xml', '<directory suffix="Test.php">web/themes/custom</directory>');
-    File::removeLineInFile($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/*/node_modules</directory>');
-    File::removeLineInFile($tmpDir . '/phpunit.xml', '<directory>web/themes/custom/**/node_modules</directory>');
+    File::removeLineInFile($tmp_dir . '/phpunit.xml', '<directory>web/themes/custom/*/tests/src/Unit</directory>');
+    File::removeLineInFile($tmp_dir . '/phpunit.xml', '<directory>web/themes/custom/**/tests/src/Unit</directory>');
+    File::removeLineInFile($tmp_dir . '/phpunit.xml', '<directory>web/themes/custom/*/tests/src/Kernel</directory>');
+    File::removeLineInFile($tmp_dir . '/phpunit.xml', '<directory>web/themes/custom/**/tests/src/Kernel</directory>');
+    File::removeLineInFile($tmp_dir . '/phpunit.xml', '<directory>web/themes/custom/*/tests/src/Functional</directory>');
+    File::removeLineInFile($tmp_dir . '/phpunit.xml', '<directory>web/themes/custom/**/tests/src/Functional</directory>');
+    File::removeLineInFile($tmp_dir . '/phpunit.xml', '<directory>web/themes/custom/*/tests/src/FunctionalJavascript</directory>');
+    File::removeLineInFile($tmp_dir . '/phpunit.xml', '<directory>web/themes/custom/**/tests/src/FunctionalJavascript</directory>');
+    File::removeLineInFile($tmp_dir . '/phpunit.xml', '<directory>web/themes/custom</directory>');
+    File::removeLineInFile($tmp_dir . '/phpunit.xml', '<directory suffix="Test.php">web/themes/custom</directory>');
+    File::removeLineInFile($tmp_dir . '/phpunit.xml', '<directory>web/themes/custom/*/node_modules</directory>');
+    File::removeLineInFile($tmp_dir . '/phpunit.xml', '<directory>web/themes/custom/**/node_modules</directory>');
 
-    File::removeLineInFile($tmpDir . '/rector.php', "__DIR__ . '/web/themes/custom',");
+    File::removeLineInFile($tmp_dir . '/rector.php', "__DIR__ . '/web/themes/custom',");
 
-    File::removeLineInFile($tmpDir . '/.twig-cs-fixer.php', "\$finder->in(__DIR__ . '/web/themes/custom');");
+    File::removeLineInFile($tmp_dir . '/.twig-cs-fixer.php', "\$finder->in(__DIR__ . '/web/themes/custom');");
 
-    File::replaceContentInFile($tmpDir . '/.ahoy.yml', 'cmd: ahoy lint-be && ahoy lint-fe && ahoy lint-tests', 'cmd: ahoy lint-be && ahoy lint-tests');
-    File::replaceContentInFile($tmpDir . '/.ahoy.yml', 'cmd: ahoy lint-be-fix && ahoy lint-fe-fix', 'cmd: ahoy lint-be-fix');
+    File::replaceContentInFile($tmp_dir . '/.ahoy.yml', 'cmd: ahoy lint-be && ahoy lint-fe && ahoy lint-tests', 'cmd: ahoy lint-be && ahoy lint-tests');
+    File::replaceContentInFile($tmp_dir . '/.ahoy.yml', 'cmd: ahoy lint-be-fix && ahoy lint-fe-fix', 'cmd: ahoy lint-be-fix');
   }
 
   protected static function findThemeFile(string $dir, string $webroot, ?string $text = NULL): ?string {

--- a/.vortex/installer/src/Prompts/Handlers/Theme.php
+++ b/.vortex/installer/src/Prompts/Handlers/Theme.php
@@ -109,7 +109,7 @@ class Theme extends AbstractHandler {
       }
     }
 
-    $path = static::findThemeFile($this->destinationDir, $this->webroot);
+    $path = self::findThemeFile($this->destinationDir, $this->webroot);
 
     if (empty($path)) {
       return NULL;
@@ -135,7 +135,7 @@ class Theme extends AbstractHandler {
     // Handle core themes (no custom theme files needed)
     if (in_array($v, [self::OLIVERO, self::CLARO, self::STARK])) {
       // Remove custom theme files if they exist.
-      $file_tmpl = static::findThemeFile($t, $w);
+      $file_tmpl = self::findThemeFile($t, $w);
       if (!empty($file_tmpl) && is_readable($file_tmpl)) {
         File::remove(dirname($file_tmpl));
         File::rmdirIfEmpty(dirname($file_tmpl));
@@ -156,7 +156,7 @@ class Theme extends AbstractHandler {
     Env::writeValueDotenv('DRUPAL_MAINTENANCE_THEME', $v, $t . '/.env');
 
     // Find the theme file in the destination directory.
-    $file_dst = static::findThemeFile($this->destinationDir, $w, $v);
+    $file_dst = self::findThemeFile($this->destinationDir, $w, $v);
 
     // Remove the theme-related files from the template if not found OR
     // if found, but the theme is not from Vortex.
@@ -166,10 +166,10 @@ class Theme extends AbstractHandler {
       (
         empty($file_dst)
         ||
-        !static::isVortexTheme(dirname($file_dst))
+        !self::isVortexTheme(dirname($file_dst))
       )
     ) {
-      $file_tmpl = static::findThemeFile($t, $w);
+      $file_tmpl = self::findThemeFile($t, $w);
       if (!empty($file_tmpl) && is_readable($file_tmpl)) {
         File::remove(dirname($file_tmpl));
       }

--- a/.vortex/installer/src/Prompts/Handlers/Timezone.php
+++ b/.vortex/installer/src/Prompts/Handlers/Timezone.php
@@ -644,7 +644,7 @@ class Timezone extends AbstractHandler {
   public function discover(): null|string|bool|array {
     $value = NULL;
 
-    $from_env = Env::getFromDotenv('TZ', $this->dstDir);
+    $from_env = Env::getFromDotenv('TZ', $this->destinationDir);
     if ($from_env) {
       $value = $from_env;
     }

--- a/.vortex/installer/src/Prompts/Handlers/Tools.php
+++ b/.vortex/installer/src/Prompts/Handlers/Tools.php
@@ -55,7 +55,7 @@ class Tools extends AbstractHandler {
    */
   public function options(array $responses): ?array {
     $options = [];
-    foreach (static::getToolDefinitions('tools') as $tool => $config) {
+    foreach (self::getToolDefinitions('tools') as $tool => $config) {
       $options[$tool] = $config['title'];
     }
     return $options;
@@ -90,7 +90,7 @@ class Tools extends AbstractHandler {
 
     $tools = [];
 
-    foreach (static::getToolDefinitions('tools') as $tool => $config) {
+    foreach (self::getToolDefinitions('tools') as $tool => $config) {
       if (isset($config['present']) && $config['present'] instanceof \Closure && $config['present']->bindTo($this)()) {
         $tools[] = $tool;
       }
@@ -107,8 +107,8 @@ class Tools extends AbstractHandler {
   public function process(): void {
     $selected_tools = $this->getResponseAsArray();
 
-    $tools = static::getToolDefinitions('tools');
-    $groups = static::getToolDefinitions('groups');
+    $tools = self::getToolDefinitions('tools');
+    $groups = self::getToolDefinitions('groups');
 
     $missing_tools = array_diff_key($tools, array_flip($selected_tools));
 
@@ -136,7 +136,7 @@ class Tools extends AbstractHandler {
   }
 
   protected function processTool(string $name): void {
-    $tool = static::getToolDefinitions('tools')[$name];
+    $tool = self::getToolDefinitions('tools')[$name];
 
     // Remove associated files.
     if (isset($tool['files'])) {
@@ -217,7 +217,7 @@ class Tools extends AbstractHandler {
   }
 
   protected function processGroup(string $name): void {
-    $config = static::getToolDefinitions('groups')[$name];
+    $config = self::getToolDefinitions('groups')[$name];
     $selected_tools = $this->getResponseAsArray();
 
     if (!isset($config['tools']) || array_intersect($config['tools'], $selected_tools)) {

--- a/.vortex/installer/src/Prompts/Handlers/Tools.php
+++ b/.vortex/installer/src/Prompts/Handlers/Tools.php
@@ -249,12 +249,12 @@ class Tools extends AbstractHandler {
     $map = [
       self::PHPCS => [
         'title' => 'PHP CodeSniffer',
-        'present' => fn(): mixed => File::contains($this->dstDir . '/composer.json', 'dealerdirect/phpcodesniffer-composer-installer') ||
-          File::contains($this->dstDir . '/composer.json', 'drupal/coder') ||
-          File::contains($this->dstDir . '/composer.json', 'squizlabs/php_codesniffer') ||
-          File::contains($this->dstDir . '/composer.json', 'phpcompatibility/php-compatibility') ||
-          File::contains($this->dstDir . '/composer.json', 'drevops/phpcs-standard') ||
-          File::exists($this->dstDir . '/phpcs.xml'),
+        'present' => fn(): mixed => File::contains($this->destinationDir . '/composer.json', 'dealerdirect/phpcodesniffer-composer-installer') ||
+          File::contains($this->destinationDir . '/composer.json', 'drupal/coder') ||
+          File::contains($this->destinationDir . '/composer.json', 'squizlabs/php_codesniffer') ||
+          File::contains($this->destinationDir . '/composer.json', 'phpcompatibility/php-compatibility') ||
+          File::contains($this->destinationDir . '/composer.json', 'drevops/phpcs-standard') ||
+          File::exists($this->destinationDir . '/phpcs.xml'),
         'composer.json' => function (JsonManipulator $cj): void {
           $cj->removeSubNode('require-dev', 'dealerdirect/phpcodesniffer-composer-installer');
           $cj->removeConfigSetting('allow-plugins.dealerdirect/phpcodesniffer-composer-installer');
@@ -273,10 +273,10 @@ class Tools extends AbstractHandler {
 
       self::PHPSTAN => [
         'title' => 'PHPStan',
-        'present' => fn(): mixed => File::contains($this->dstDir . '/composer.json', 'phpstan/phpstan') ||
-          File::contains($this->dstDir . '/composer.json', 'mglaman/phpstan-drupal') ||
-          File::contains($this->dstDir . '/composer.json', 'phpstan/extension-installer') ||
-          File::exists($this->dstDir . '/phpstan.neon'),
+        'present' => fn(): mixed => File::contains($this->destinationDir . '/composer.json', 'phpstan/phpstan') ||
+          File::contains($this->destinationDir . '/composer.json', 'mglaman/phpstan-drupal') ||
+          File::contains($this->destinationDir . '/composer.json', 'phpstan/extension-installer') ||
+          File::exists($this->destinationDir . '/phpstan.neon'),
         'composer.json' => function (JsonManipulator $cj): void {
           $cj->removeSubNode('require-dev', 'phpstan/phpstan');
           $cj->removeSubNode('require-dev', 'mglaman/phpstan-drupal');
@@ -293,9 +293,9 @@ class Tools extends AbstractHandler {
 
       self::RECTOR => [
         'title' => 'Rector',
-        'present' => fn(): mixed => File::contains($this->dstDir . '/composer.json', 'rector/rector') ||
-          File::contains($this->dstDir . '/composer.json', 'palantirnet/drupal-rector') ||
-          File::exists($this->dstDir . '/rector.php'),
+        'present' => fn(): mixed => File::contains($this->destinationDir . '/composer.json', 'rector/rector') ||
+          File::contains($this->destinationDir . '/composer.json', 'palantirnet/drupal-rector') ||
+          File::exists($this->destinationDir . '/rector.php'),
         'composer.json' => function (JsonManipulator $cj): void {
           $cj->removeSubNode('require-dev', 'rector/rector');
           $cj->removeSubNode('require-dev', 'palantirnet/drupal-rector');
@@ -311,8 +311,8 @@ class Tools extends AbstractHandler {
 
       self::ESLINT => [
         'title' => 'ESLint',
-        'present' => fn(): mixed => File::contains($this->dstDir . '/package.json', '"eslint":') ||
-          File::exists($this->dstDir . '/.eslintrc.json'),
+        'present' => fn(): mixed => File::contains($this->destinationDir . '/package.json', '"eslint":') ||
+          File::exists($this->destinationDir . '/.eslintrc.json'),
         'package.json' => function (JsonManipulator $pj): void {
           $pj->removeSubNode('devDependencies', 'eslint');
           $pj->removeSubNode('devDependencies', 'eslint-config-airbnb-base');
@@ -334,8 +334,8 @@ class Tools extends AbstractHandler {
 
       self::STYLELINT => [
         'title' => 'Stylelint',
-        'present' => fn(): mixed => File::contains($this->dstDir . '/package.json', '"stylelint":') ||
-          File::exists($this->dstDir . '/.stylelintrc.js'),
+        'present' => fn(): mixed => File::contains($this->destinationDir . '/package.json', '"stylelint":') ||
+          File::exists($this->destinationDir . '/.stylelintrc.js'),
         'package.json' => function (JsonManipulator $pj): void {
           $pj->removeSubNode('devDependencies', 'stylelint');
           $pj->removeSubNode('devDependencies', 'stylelint-config-standard');
@@ -350,8 +350,8 @@ class Tools extends AbstractHandler {
 
       self::JEST => [
         'title' => 'Jest',
-        'present' => fn(): mixed => File::contains($this->dstDir . '/package.json', '"jest":') ||
-          File::exists($this->dstDir . '/jest.config.js'),
+        'present' => fn(): mixed => File::contains($this->destinationDir . '/package.json', '"jest":') ||
+          File::exists($this->destinationDir . '/jest.config.js'),
         'package.json' => function (JsonManipulator $pj): void {
           $pj->removeSubNode('devDependencies', 'jest');
           $pj->removeSubNode('devDependencies', 'jest-environment-jsdom');
@@ -371,9 +371,9 @@ class Tools extends AbstractHandler {
 
       self::PHPUNIT => [
         'title' => 'PHPUnit',
-        'present' => fn(): mixed => File::contains($this->dstDir . '/composer.json', 'phpunit/phpunit') ||
-          File::contains($this->dstDir . '/composer.json', 'phpspec/prophecy-phpunit') ||
-          File::exists($this->dstDir . '/phpunit.xml'),
+        'present' => fn(): mixed => File::contains($this->destinationDir . '/composer.json', 'phpunit/phpunit') ||
+          File::contains($this->destinationDir . '/composer.json', 'phpspec/prophecy-phpunit') ||
+          File::exists($this->destinationDir . '/phpunit.xml'),
         'composer.json' => function (JsonManipulator $cj): void {
           $cj->removeSubNode('require-dev', 'phpunit/phpunit');
           $cj->removeSubNode('require-dev', 'phpspec/prophecy-phpunit');
@@ -416,12 +416,12 @@ class Tools extends AbstractHandler {
 
       self::BEHAT => [
         'title' => 'Behat',
-        'present' => fn(): mixed => File::contains($this->dstDir . '/composer.json', 'behat/behat') ||
-          File::contains($this->dstDir . '/composer.json', 'drupal/drupal-extension') ||
-          File::contains($this->dstDir . '/composer.json', 'drevops/behat-format-progress-fail') ||
-          File::contains($this->dstDir . '/composer.json', 'drevops/behat-screenshot') ||
-          File::contains($this->dstDir . '/composer.json', 'drevops/behat-steps') ||
-          File::exists($this->dstDir . '/behat.yml'),
+        'present' => fn(): mixed => File::contains($this->destinationDir . '/composer.json', 'behat/behat') ||
+          File::contains($this->destinationDir . '/composer.json', 'drupal/drupal-extension') ||
+          File::contains($this->destinationDir . '/composer.json', 'drevops/behat-format-progress-fail') ||
+          File::contains($this->destinationDir . '/composer.json', 'drevops/behat-screenshot') ||
+          File::contains($this->destinationDir . '/composer.json', 'drevops/behat-steps') ||
+          File::exists($this->destinationDir . '/behat.yml'),
         'composer.json' => function (JsonManipulator $cj): void {
           $cj->removeSubNode('require-dev', 'behat/behat');
           $cj->removeSubNode('require-dev', 'drupal/drupal-extension');
@@ -456,8 +456,8 @@ class Tools extends AbstractHandler {
 
       self::TWIG_CS_FIXER => [
         'title' => 'Twig CS Fixer',
-        'present' => fn(): mixed => File::contains($this->dstDir . '/composer.json', 'vincentlanglet/twig-cs-fixer') ||
-          File::exists($this->dstDir . '/.twig-cs-fixer.php'),
+        'present' => fn(): mixed => File::contains($this->destinationDir . '/composer.json', 'vincentlanglet/twig-cs-fixer') ||
+          File::exists($this->destinationDir . '/.twig-cs-fixer.php'),
         'composer.json' => function (JsonManipulator $cj): void {
           $cj->removeSubNode('require-dev', 'vincentlanglet/twig-cs-fixer');
         },
@@ -471,9 +471,9 @@ class Tools extends AbstractHandler {
 
       self::DCLINT => [
         'title' => 'DCLint',
-        'present' => fn(): mixed => File::exists($this->dstDir . '/.dclintrc') ||
-          File::contains($this->dstDir . '/.github/workflows/build-test-deploy.yml', 'dclint') ||
-          File::contains($this->dstDir . '/.circleci/config.yml', 'dclint'),
+        'present' => fn(): mixed => File::exists($this->destinationDir . '/.dclintrc') ||
+          File::contains($this->destinationDir . '/.github/workflows/build-test-deploy.yml', 'dclint') ||
+          File::contains($this->destinationDir . '/.circleci/config.yml', 'dclint'),
         'files' => ['.dclintrc'],
         'strings' => ['/^.*dclint.*\n?/m'],
       ],
@@ -483,10 +483,10 @@ class Tools extends AbstractHandler {
       // would make the choice impossible to reverse.
       self::HADOLINT => [
         'title' => 'Hadolint',
-        'present' => fn(): mixed => File::exists($this->dstDir . '/.hadolint.yaml') ||
-          File::exists($this->dstDir . '/.hadolint.yml') ||
-          File::contains($this->dstDir . '/.github/workflows/build-test-deploy.yml', 'hadolint') ||
-          File::contains($this->dstDir . '/.circleci/config.yml', 'hadolint'),
+        'present' => fn(): mixed => File::exists($this->destinationDir . '/.hadolint.yaml') ||
+          File::exists($this->destinationDir . '/.hadolint.yml') ||
+          File::contains($this->destinationDir . '/.github/workflows/build-test-deploy.yml', 'hadolint') ||
+          File::contains($this->destinationDir . '/.circleci/config.yml', 'hadolint'),
       ],
 
       // Tool groups with shared resources.

--- a/.vortex/installer/src/Prompts/Handlers/VersionScheme.php
+++ b/.vortex/installer/src/Prompts/Handlers/VersionScheme.php
@@ -26,7 +26,7 @@ class VersionScheme extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public static function description(array $responses): string {
+  public static function description(array $responses): ?string {
     $label1 = Tui::bold('Calendar Versioning (CalVer)');
     $label11 = Tui::underscore('year.month.patch');
     $label12 = Tui::underscore('24.1.0');

--- a/.vortex/installer/src/Prompts/Handlers/VersionScheme.php
+++ b/.vortex/installer/src/Prompts/Handlers/VersionScheme.php
@@ -82,7 +82,7 @@ DOC;
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    $scheme = Env::getFromDotenv('VORTEX_RELEASE_VERSION_SCHEME', $this->dstDir);
+    $scheme = Env::getFromDotenv('VORTEX_RELEASE_VERSION_SCHEME', $this->destinationDir);
 
     if (in_array($scheme, [self::CALVER, self::SEMVER, self::OTHER], TRUE)) {
       return $scheme;

--- a/.vortex/installer/src/Prompts/Handlers/VisualRegression.php
+++ b/.vortex/installer/src/Prompts/Handlers/VisualRegression.php
@@ -26,7 +26,7 @@ class VisualRegression extends AbstractHandler {
   /**
    * {@inheritdoc}
    */
-  public static function description(array $responses): string {
+  public static function description(array $responses): ?string {
     return <<<DOC
 Diffy-powered visual regression workflow to compare deployed environments.
 

--- a/.vortex/installer/src/Prompts/Handlers/VisualRegression.php
+++ b/.vortex/installer/src/Prompts/Handlers/VisualRegression.php
@@ -56,7 +56,7 @@ DOC;
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    return $this->isInstalled() ? file_exists($this->dstDir . '/.github/workflows/test-vr.yml') : NULL;
+    return $this->isInstalled() ? file_exists($this->destinationDir . '/.github/workflows/test-vr.yml') : NULL;
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/Webroot.php
+++ b/.vortex/installer/src/Prompts/Handlers/Webroot.php
@@ -63,16 +63,16 @@ class Webroot extends AbstractHandler {
    * {@inheritdoc}
    */
   public function discover(): null|string|bool|array {
-    $v = Env::getFromDotenv('WEBROOT', $this->dstDir);
+    $v = Env::getFromDotenv('WEBROOT', $this->destinationDir);
 
     if (!empty($v)) {
       return $v;
     }
 
-    $v = JsonManipulator::fromFile($this->dstDir . '/composer.json')?->getProperty('extra.drupal-scaffold.locations.web-root');
+    $v = JsonManipulator::fromFile($this->destinationDir . '/composer.json')?->getProperty('extra.drupal-scaffold.locations.web-root');
     if (!empty($v)) {
       try {
-        $v = File::toRelative($v, $this->dstDir);
+        $v = File::toRelative($v, $this->destinationDir);
       }
       catch (\Exception) {
         $v = NULL;

--- a/.vortex/installer/src/Prompts/Handlers/Webroot.php
+++ b/.vortex/installer/src/Prompts/Handlers/Webroot.php
@@ -151,7 +151,7 @@ class Webroot extends AbstractHandler {
 
     File::replaceContentAsync(fn(string $content): string => preg_replace('/=' . preg_quote($webroot, '/') . '\b/', '=' . $v, $content) ?? $content);
 
-    rename($t . DIRECTORY_SEPARATOR . $webroot, $t . DIRECTORY_SEPARATOR . $v);
+    rename($t . '/' . $webroot, $t . '/' . $v);
   }
 
 }

--- a/.vortex/installer/src/Prompts/Handlers/Webroot.php
+++ b/.vortex/installer/src/Prompts/Handlers/Webroot.php
@@ -90,7 +90,7 @@ class Webroot extends AbstractHandler {
    * {@inheritdoc}
    */
   public function validate(): ?callable {
-    return fn($v): ?string => Validator::dirname($v) ? NULL : 'Please enter a valid webroot name: only lowercase letters, numbers, and underscores are allowed.';
+    return fn($v): ?string => Validator::isDirname($v) ? NULL : 'Please enter a valid webroot name: only lowercase letters, numbers, and underscores are allowed.';
   }
 
   /**

--- a/.vortex/installer/src/Prompts/Handlers/Webroot.php
+++ b/.vortex/installer/src/Prompts/Handlers/Webroot.php
@@ -106,7 +106,7 @@ class Webroot extends AbstractHandler {
   public function resolvedValue(array $responses): null|string|bool|array {
     $discovered = $this->discover();
 
-    if (!is_null($discovered)) {
+    if ($discovered !== NULL) {
       return $discovered;
     }
 

--- a/.vortex/installer/src/Prompts/InstallerPresenter.php
+++ b/.vortex/installer/src/Prompts/InstallerPresenter.php
@@ -12,8 +12,6 @@ use DrevOps\VortexInstaller\Utils\Tui;
 
 /**
  * Presents installer headers, footers, and post-build messages.
- *
- * @package DrevOps\VortexInstaller\Prompts
  */
 class InstallerPresenter {
 

--- a/.vortex/installer/src/Prompts/PromptManager.php
+++ b/.vortex/installer/src/Prompts/PromptManager.php
@@ -358,34 +358,6 @@ class PromptManager {
   }
 
   /**
-   * Run all post-install processors.
-   */
-  public function runPostInstall(): string {
-    $output = '';
-
-    $ids = [
-      Starter::id(),
-      HostingProvider::id(),
-      CiProvider::id(),
-      Internal::id(),
-    ];
-
-    foreach ($ids as $id) {
-      if (!array_key_exists($id, $this->handlers)) {
-        throw new \RuntimeException(sprintf('Handler for "%s" not found.', $id));
-      }
-
-      $handler_output = $this->handlers[$id]->postInstall();
-
-      if (is_string($handler_output) && !empty($handler_output)) {
-        $output .= $handler_output;
-      }
-    }
-
-    return $output;
-  }
-
-  /**
    * Run all post-build processors.
    *
    * @param string $result

--- a/.vortex/installer/src/Prompts/PromptManager.php
+++ b/.vortex/installer/src/Prompts/PromptManager.php
@@ -60,8 +60,6 @@ use function Laravel\Prompts\info;
  * PromptManager.
  *
  * Centralised place for providing prompts and their processing.
- *
- * @package DrevOps\VortexInstaller
  */
 class PromptManager {
 

--- a/.vortex/installer/src/Prompts/PromptManager.php
+++ b/.vortex/installer/src/Prompts/PromptManager.php
@@ -692,7 +692,7 @@ class PromptManager {
       'validate' => $handler->validate(),
     ];
 
-    $description = $handler->description($responses);
+    $description = $handler::description($responses);
     if ($description !== NULL) {
       $args['description'] = PHP_EOL . $description . PHP_EOL;
     }

--- a/.vortex/installer/src/Prompts/PromptManager.php
+++ b/.vortex/installer/src/Prompts/PromptManager.php
@@ -565,7 +565,7 @@ class PromptManager {
 
     $suffix = $suffix !== NULL ? $this->currentResponseIndex . '.' . $suffix : $this->currentResponseIndex;
 
-    return $text . ' ' . Tui::dim('(' . $suffix . '/' . static::TOTAL_RESPONSES . ')');
+    return $text . ' ' . Tui::dim('(' . $suffix . '/' . self::TOTAL_RESPONSES . ')');
   }
 
   /**

--- a/.vortex/installer/src/Prompts/PromptManager.php
+++ b/.vortex/installer/src/Prompts/PromptManager.php
@@ -619,7 +619,7 @@ class PromptManager {
    * @throws \RuntimeException
    *   If any prompt value is invalid.
    */
-  private function resolvePromptOverrides(): void {
+  protected function resolvePromptOverrides(): void {
     $raw = $this->config->get(Config::PROMPTS);
 
     if (!is_array($raw) || empty($raw)) {
@@ -653,7 +653,7 @@ class PromptManager {
    * @return mixed
    *   The prompt result.
    */
-  private function prompt(string $handler_class, array $responses = []): mixed {
+  protected function prompt(string $handler_class, array $responses = []): mixed {
     $handler = $this->handlers[$handler_class::id()];
     $fn = '\\Laravel\\Prompts\\' . $handler->type()->promptFunction();
 
@@ -677,7 +677,7 @@ class PromptManager {
    * @return array
    *   Array of prompt arguments suitable for Laravel prompts.
    */
-  private function args(string $handler_class, mixed $default_override = NULL, array $responses = []): array {
+  protected function args(string $handler_class, mixed $default_override = NULL, array $responses = []): array {
     $id = $handler_class::id();
 
     if (!array_key_exists($id, $this->handlers)) {

--- a/.vortex/installer/src/Prompts/PromptManager.php
+++ b/.vortex/installer/src/Prompts/PromptManager.php
@@ -431,7 +431,7 @@ class PromptManager {
     $proceed = TRUE;
 
     if (!$this->config->getNoInteraction()) {
-      Tui::line(sprintf('Vortex will be installed into your project\'s directory "%s"', $this->config->getDst()));
+      Tui::line(sprintf('Vortex will be installed into your project\'s directory "%s"', $this->config->getDestination()));
       $proceed = confirm(
         label: 'Proceed with installing Vortex?',
       );
@@ -530,7 +530,7 @@ class PromptManager {
 
     $values['Locations'] = Tui::LIST_SECTION_TITLE;
     $values['Current directory'] = $this->config->getRoot();
-    $values['Destination directory'] = $this->config->getDst();
+    $values['Destination directory'] = $this->config->getDestination();
     $values['Vortex repository'] = $this->config->get(Config::REPO);
     $values['Vortex reference'] = $this->config->get(Config::REF);
 

--- a/.vortex/installer/src/Prompts/PromptManager.php
+++ b/.vortex/installer/src/Prompts/PromptManager.php
@@ -489,10 +489,10 @@ class PromptManager {
     $values['Workflow'] = Tui::LIST_SECTION_TITLE;
     $values['Provision type'] = $responses[ProvisionType::id()];
 
-    if ($responses[ProvisionType::id()] == ProvisionType::DATABASE) {
+    if ($responses[ProvisionType::id()] === ProvisionType::DATABASE) {
       $values['Database source'] = $responses[DatabaseFetchSource::id()];
 
-      if ($responses[DatabaseFetchSource::id()] == DatabaseFetchSource::CONTAINER_REGISTRY) {
+      if ($responses[DatabaseFetchSource::id()] === DatabaseFetchSource::CONTAINER_REGISTRY) {
         $values['Database container image'] = $responses[DatabaseImage::id()];
       }
     }
@@ -502,7 +502,7 @@ class PromptManager {
       if ($responses[Migration::id()] === TRUE && isset($responses[MigrationFetchSource::id()])) {
         $values['Migration database source'] = $responses[MigrationFetchSource::id()];
 
-        if ($responses[MigrationFetchSource::id()] == MigrationFetchSource::CONTAINER_REGISTRY && isset($responses[MigrationImage::id()])) {
+        if ($responses[MigrationFetchSource::id()] === MigrationFetchSource::CONTAINER_REGISTRY && isset($responses[MigrationImage::id()])) {
           $values['Migration database container image'] = $responses[MigrationImage::id()];
         }
       }
@@ -559,7 +559,7 @@ class PromptManager {
    *   The formatted label text.
    */
   protected function label(string $text, ?string $suffix = NULL): string {
-    if (is_null($suffix)) {
+    if ($suffix === NULL) {
       $this->currentResponseIndex++;
     }
 
@@ -693,7 +693,7 @@ class PromptManager {
     ];
 
     $description = $handler->description($responses);
-    if (!is_null($description)) {
+    if ($description !== NULL) {
       $args['description'] = PHP_EOL . $description . PHP_EOL;
     }
 
@@ -714,20 +714,20 @@ class PromptManager {
     // Get from discovery.
     $default_from_discovery = $this->handlers[$id]->discover();
 
-    if (!is_null($default_from_prompts)) {
+    if ($default_from_prompts !== NULL) {
       $default = $default_from_prompts;
     }
-    elseif (!is_null($default_from_discovery)) {
+    elseif ($default_from_discovery !== NULL) {
       $default = $default_from_discovery;
     }
-    elseif (!is_null($default_override)) {
+    elseif ($default_override !== NULL) {
       $default = $default_override;
     }
     else {
       $default = $default_from_handler;
     }
 
-    if (!is_null($default) && $default !== '') {
+    if ($default !== NULL && $default !== '') {
       $args['default'] = $default;
     }
 

--- a/.vortex/installer/src/Prompts/PromptType.php
+++ b/.vortex/installer/src/Prompts/PromptType.php
@@ -6,8 +6,6 @@ namespace DrevOps\VortexInstaller\Prompts;
 
 /**
  * Prompt input types covering all Laravel Prompts input types.
- *
- * @package DrevOps\VortexInstaller\Prompts
  */
 enum PromptType: string {
 

--- a/.vortex/installer/src/Runner/AbstractRunner.php
+++ b/.vortex/installer/src/Runner/AbstractRunner.php
@@ -50,9 +50,7 @@ abstract class AbstractRunner implements RunnerInterface {
    * {@inheritdoc}
    */
   public function getLogger(): FileLoggerInterface {
-    if (!isset($this->logger)) {
-      $this->logger = new FileLogger();
-    }
+    $this->logger ??= new FileLogger();
 
     return $this->logger;
   }

--- a/.vortex/installer/src/Runner/CommandRunner.php
+++ b/.vortex/installer/src/Runner/CommandRunner.php
@@ -80,10 +80,10 @@ class CommandRunner extends AbstractRunner {
     $composite_output = new class($buffered_output, $output, $logger, $this->shouldStream) extends BufferedOutput {
 
       public function __construct(
-        private readonly BufferedOutput $bufferedOutput,
-        private readonly OutputInterface $output,
-        private readonly LoggerInterface $logger,
-        private readonly bool $shouldStream,
+        protected readonly BufferedOutput $bufferedOutput,
+        protected readonly OutputInterface $output,
+        protected readonly LoggerInterface $logger,
+        protected readonly bool $shouldStream,
       ) {
         parent::__construct();
       }

--- a/.vortex/installer/src/Runner/ExecutableFinderAwareTrait.php
+++ b/.vortex/installer/src/Runner/ExecutableFinderAwareTrait.php
@@ -25,9 +25,7 @@ trait ExecutableFinderAwareTrait {
    *   The executable finder instance.
    */
   public function getExecutableFinder(): ExecutableFinder {
-    if ($this->executableFinder === NULL) {
-      $this->executableFinder = new ExecutableFinder();
-    }
+    $this->executableFinder ??= new ExecutableFinder();
     return $this->executableFinder;
   }
 

--- a/.vortex/installer/src/Schema/AgentHelp.php
+++ b/.vortex/installer/src/Schema/AgentHelp.php
@@ -6,8 +6,6 @@ namespace DrevOps\VortexInstaller\Schema;
 
 /**
  * Renders AI agent instructions for the installer.
- *
- * @package DrevOps\VortexInstaller\Schema
  */
 class AgentHelp {
 

--- a/.vortex/installer/src/Schema/SchemaGenerator.php
+++ b/.vortex/installer/src/Schema/SchemaGenerator.php
@@ -10,8 +10,6 @@ use DrevOps\VortexInstaller\Utils\Normalizer;
 
 /**
  * Generates a JSON schema of all installer prompts.
- *
- * @package DrevOps\VortexInstaller\Schema
  */
 class SchemaGenerator {
 

--- a/.vortex/installer/src/Schema/SchemaGenerator.php
+++ b/.vortex/installer/src/Schema/SchemaGenerator.php
@@ -34,7 +34,7 @@ class SchemaGenerator {
     $prompts = [];
 
     foreach ($this->handlers as $id => $handler) {
-      if (in_array($id, static::getExcludedHandlers(), TRUE)) {
+      if (in_array($id, self::getExcludedHandlers(), TRUE)) {
         continue;
       }
 

--- a/.vortex/installer/src/Schema/SchemaValidator.php
+++ b/.vortex/installer/src/Schema/SchemaValidator.php
@@ -9,8 +9,6 @@ use DrevOps\VortexInstaller\Prompts\PromptType;
 
 /**
  * Validates prompt values against handler definitions.
- *
- * @package DrevOps\VortexInstaller\Schema
  */
 class SchemaValidator {
 

--- a/.vortex/installer/src/Task/Task.php
+++ b/.vortex/installer/src/Task/Task.php
@@ -35,7 +35,7 @@ class Task {
 
       $task_output = new TaskOutput($original_output);
 
-      static::start($label);
+      self::start($label);
 
       Tui::setOutput($task_output);
 
@@ -61,7 +61,7 @@ class Task {
     }
     else {
       $success = $success && is_callable($success) ? $success($return) : $success;
-      static::ok($success ? Tui::normalizeText($success) : 'OK');
+      self::ok($success ? Tui::normalizeText($success) : 'OK');
     }
 
     return $return;
@@ -74,14 +74,14 @@ class Task {
     $message = '✦ ' . $message;
     $message = Tui::normalizeText($message);
 
-    static::$message = Tui::blue(wordwrap($message, $width - $right_offset, PHP_EOL));
-    static::$hint = $hint ? wordwrap(Tui::normalizeText($hint), $width - $right_offset, PHP_EOL) : NULL;
+    self::$message = Tui::blue(wordwrap($message, $width - $right_offset, PHP_EOL));
+    self::$hint = $hint ? wordwrap(Tui::normalizeText($hint), $width - $right_offset, PHP_EOL) : NULL;
 
-    Tui::note(static::$message);
+    Tui::note(self::$message);
     Tui::note(str_repeat(Tui::caretUp(), 5));
 
-    if (static::$hint) {
-      Tui::note(str_repeat(' ', $sublist_indent) . Tui::dim(static::$hint));
+    if (self::$hint) {
+      Tui::note(str_repeat(' ', $sublist_indent) . Tui::dim(self::$hint));
       Tui::note(str_repeat(Tui::caretUp(), 5));
     }
 

--- a/.vortex/installer/src/Utils/Config.php
+++ b/.vortex/installer/src/Utils/Config.php
@@ -109,16 +109,20 @@ final class Config {
     return (bool) $this->get(self::QUIET, FALSE);
   }
 
-  public function setQuiet(bool $value = TRUE): void {
+  public function setQuiet(bool $value = TRUE): static {
     $this->set(self::QUIET, $value);
+
+    return $this;
   }
 
   public function getNoInteraction(): bool {
     return (bool) $this->get(self::NO_INTERACTION, FALSE);
   }
 
-  public function setNoInteraction(bool $value = TRUE): void {
+  public function setNoInteraction(bool $value = TRUE): static {
     $this->set(self::NO_INTERACTION, $value);
+
+    return $this;
   }
 
   public function isVortexProject(): bool {

--- a/.vortex/installer/src/Utils/Config.php
+++ b/.vortex/installer/src/Utils/Config.php
@@ -87,7 +87,7 @@ final class Config {
       $value = Env::get($name, $value);
     }
 
-    if (!is_null($value)) {
+    if ($value !== NULL) {
       $this->store[$name] = $value;
     }
 

--- a/.vortex/installer/src/Utils/Config.php
+++ b/.vortex/installer/src/Utils/Config.php
@@ -13,7 +13,7 @@ final class Config {
 
   const ROOT = 'VORTEX_INSTALLER_ROOT_DIR';
 
-  const DST = 'VORTEX_INSTALLER_DST_DIR';
+  const DESTINATION = 'VORTEX_INSTALLER_DST_DIR';
 
   const TMP = 'VORTEX_INSTALLER_TMP_DIR';
 
@@ -48,9 +48,9 @@ final class Config {
    */
   protected array $store = [];
 
-  public function __construct(?string $root = NULL, ?string $dst = NULL, ?string $tmp = NULL) {
+  public function __construct(?string $root = NULL, ?string $destination = NULL, ?string $tmp = NULL) {
     $this->set(self::ROOT, $root ?: File::cwd());
-    $this->set(self::DST, $dst ?: $this->get(self::ROOT), TRUE);
+    $this->set(self::DESTINATION, $destination ?: $this->get(self::ROOT), TRUE);
     $this->set(self::TMP, $tmp ?: File::tmpdir());
   }
 
@@ -98,8 +98,8 @@ final class Config {
     return $this->get(self::ROOT);
   }
 
-  public function getDst(): ?string {
-    return $this->get(self::DST);
+  public function getDestination(): ?string {
+    return $this->get(self::DESTINATION);
   }
 
   /**

--- a/.vortex/installer/src/Utils/Config.php
+++ b/.vortex/installer/src/Utils/Config.php
@@ -8,8 +8,6 @@ namespace DrevOps\VortexInstaller\Utils;
  * Installer configuration.
  *
  * Installer config is a config of this installer script.
- *
- * @package DrevOps\VortexInstaller
  */
 final class Config {
 

--- a/.vortex/installer/src/Utils/Converter.php
+++ b/.vortex/installer/src/Utils/Converter.php
@@ -9,7 +9,7 @@ use AlexSkrypnyk\Str2Name\Str2Name;
 class Converter extends Str2Name {
 
   public static function machineExtended(string $value): string {
-    $string = static::strict($value);
+    $string = self::strict($value);
 
     return mb_strtolower(str_replace([' '], '_', $string));
   }

--- a/.vortex/installer/src/Utils/Env.php
+++ b/.vortex/installer/src/Utils/Env.php
@@ -32,7 +32,7 @@ class Env {
       return $env_value;
     }
 
-    $file = $dir . DIRECTORY_SEPARATOR . '.env';
+    $file = $dir . '/.env';
     if (!is_readable($file)) {
       return NULL;
     }

--- a/.vortex/installer/src/Utils/Env.php
+++ b/.vortex/installer/src/Utils/Env.php
@@ -28,7 +28,7 @@ class Env {
   public static function getFromDotenv(string $name, string $dir): ?string {
     // Environment variables always take precedence.
     $env_value = self::get($name);
-    if (!is_null($env_value)) {
+    if ($env_value !== NULL) {
       return $env_value;
     }
 

--- a/.vortex/installer/src/Utils/Env.php
+++ b/.vortex/installer/src/Utils/Env.php
@@ -27,7 +27,7 @@ class Env {
 
   public static function getFromDotenv(string $name, string $dir): ?string {
     // Environment variables always take precedence.
-    $env_value = static::get($name);
+    $env_value = self::get($name);
     if (!is_null($env_value)) {
       return $env_value;
     }
@@ -37,7 +37,7 @@ class Env {
       return NULL;
     }
 
-    $parsed = static::parseDotenv($file);
+    $parsed = self::parseDotenv($file);
 
     return $parsed !== [] ? ($parsed[$name] ?? NULL) : NULL;
   }
@@ -51,10 +51,10 @@ class Env {
    *   Override existing values.
    */
   public static function putFromDotenv(string $filename = '.env', bool $override_existing = FALSE): void {
-    $values = static::parseDotenv($filename);
+    $values = self::parseDotenv($filename);
 
     foreach ($values as $var => $value) {
-      if (!static::get($var) || $override_existing) {
+      if (!self::get($var) || $override_existing) {
         putenv($var . '=' . $value);
       }
     }
@@ -174,7 +174,7 @@ class Env {
     }
     else {
       // Format the new value with proper quoting.
-      $new_value = static::formatValueForDotenv($value);
+      $new_value = self::formatValueForDotenv($value);
       $prefix = $enabled ? '' : '# ';
       $replacement = $prefix . '$1=' . $new_value;
 
@@ -198,7 +198,7 @@ class Env {
     }
 
     // Return parsed values after modification.
-    return static::parseDotenv($filename);
+    return self::parseDotenv($filename);
   }
 
   /**
@@ -229,15 +229,15 @@ class Env {
       return (int) $value;
     }
 
-    if ($value === static::TRUE) {
+    if ($value === self::TRUE) {
       return TRUE;
     }
 
-    if ($value === static::FALSE) {
+    if ($value === self::FALSE) {
       return FALSE;
     }
 
-    if ($value === static::NULL) {
+    if ($value === self::NULL) {
       return NULL;
     }
 

--- a/.vortex/installer/src/Utils/File.php
+++ b/.vortex/installer/src/Utils/File.php
@@ -16,7 +16,7 @@ class File extends UpstreamFile {
    *   Array of paths to ignore.
    */
   public static function ignoredPaths(array $paths = []): array {
-    return array_merge(parent::ignoredPaths($paths), static::internalPaths());
+    return array_merge(parent::ignoredPaths($paths), self::internalPaths());
   }
 
   /**
@@ -27,7 +27,7 @@ class File extends UpstreamFile {
       $path = DIRECTORY_SEPARATOR . substr($path, 2);
     }
 
-    return in_array($path, static::internalPaths());
+    return in_array($path, self::internalPaths());
   }
 
   /**
@@ -57,7 +57,7 @@ class File extends UpstreamFile {
    *   value for the search string.
    */
   public static function replaceContentAsync(callable|array|string $replacements, ?string $replace = NULL): void {
-    static::addDirectoryTask(function (ContentFile $file) use ($replacements, $replace): ContentFile {
+    self::addDirectoryTask(function (ContentFile $file) use ($replacements, $replace): ContentFile {
       $content = $file->getContent();
 
       if (is_callable($replacements)) {
@@ -73,7 +73,7 @@ class File extends UpstreamFile {
         }
 
         foreach ($replacements as $search => $replace_value) {
-          $content = static::replaceContent($content, $search, $replace_value);
+          $content = self::replaceContent($content, $search, $replace_value);
         }
       }
 
@@ -91,9 +91,9 @@ class File extends UpstreamFile {
    *   If TRUE, remove content between the start and end tokens.
    */
   public static function removeTokenAsync(string $token, bool $with_content = TRUE): void {
-    static::addDirectoryTask(function (ContentFile $file) use ($token, $with_content): ContentFile {
+    self::addDirectoryTask(function (ContentFile $file) use ($token, $with_content): ContentFile {
       $content = $file->getContent();
-      $content = static::removeToken($content, '#;< ' . $token, '#;> ' . $token, $with_content);
+      $content = self::removeToken($content, '#;< ' . $token, '#;> ' . $token, $with_content);
       $file->setContent($content);
       return $file;
     });
@@ -113,7 +113,7 @@ class File extends UpstreamFile {
    */
   public static function toRelative(string $path, ?string $base = NULL): string {
     $base ??= (string) getcwd();
-    $absolute = static::absolute($path, $base);
+    $absolute = self::absolute($path, $base);
 
     return str_replace($base . DIRECTORY_SEPARATOR, '', $absolute);
   }

--- a/.vortex/installer/src/Utils/FileManager.php
+++ b/.vortex/installer/src/Utils/FileManager.php
@@ -24,18 +24,18 @@ class FileManager {
   public function prepareDestination(): array {
     $messages = [];
 
-    $dst = $this->config->getDst();
-    if (!is_dir($dst)) {
-      $dst = File::mkdir($dst);
-      $messages[] = sprintf('Created directory "%s".', $dst);
+    $destination = $this->config->getDestination();
+    if (!is_dir($destination)) {
+      $destination = File::mkdir($destination);
+      $messages[] = sprintf('Created directory "%s".', $destination);
     }
 
-    if (!is_readable($dst . '/.git')) {
-      $messages[] = sprintf('Initialising a new Git repository in directory "%s".', $dst);
-      passthru(sprintf('git --work-tree="%s" --git-dir="%s/.git" init > /dev/null', $dst, $dst));
+    if (!is_readable($destination . '/.git')) {
+      $messages[] = sprintf('Initialising a new Git repository in directory "%s".', $destination);
+      passthru(sprintf('git --work-tree="%s" --git-dir="%s/.git" init > /dev/null', $destination, $destination));
 
-      if (!File::exists($dst . '/.git')) {
-        throw new \RuntimeException(sprintf('Unable to initialise Git repository in directory "%s".', $dst));
+      if (!File::exists($destination . '/.git')) {
+        throw new \RuntimeException(sprintf('Unable to initialise Git repository in directory "%s".', $destination));
       }
     }
 
@@ -44,7 +44,7 @@ class FileManager {
 
   public function copyFiles(): void {
     $src = $this->config->get(Config::TMP);
-    $dst = $this->config->getDst();
+    $destination = $this->config->getDestination();
 
     // Due to the way symlinks can be ordered, we cannot copy files one-by-one
     // into destination directory. Instead, we are removing all ignored files
@@ -76,14 +76,14 @@ class FileManager {
       File::rmdirIfEmpty($dir);
     }
 
-    // Src directory is now "clean" - copy it to dst directory.
+    // Src directory is now "clean" - copy it to destination directory.
     if (is_dir($src) && !File::dirIsEmpty($src)) {
-      File::copy($src, $dst);
+      File::copy($src, $destination);
     }
 
     // Special case for .env.local as it may exist.
-    if (!file_exists($dst . '/.env.local') && file_exists($dst . '/.env.local.example')) {
-      File::copy($dst . '/.env.local.example', $dst . '/.env.local');
+    if (!file_exists($destination . '/.env.local') && file_exists($destination . '/.env.local.example')) {
+      File::copy($destination . '/.env.local.example', $destination . '/.env.local');
     }
 
     $this->removeObsoletePaths();
@@ -97,7 +97,7 @@ class FileManager {
    * artifacts do not linger across upgrades.
    */
   public function removeObsoletePaths(): void {
-    $dst = $this->config->getDst();
+    $destination = $this->config->getDestination();
 
     // 'scripts/vortex/' was the location of shipped Vortex scripts before
     // they were extracted into the 'drevops/vortex-tooling' Composer package.
@@ -107,7 +107,7 @@ class FileManager {
     ];
 
     foreach ($obsolete as $relative) {
-      $path = $dst . DIRECTORY_SEPARATOR . $relative;
+      $path = $destination . DIRECTORY_SEPARATOR . $relative;
       if (file_exists($path)) {
         File::remove($path);
       }
@@ -133,14 +133,14 @@ class FileManager {
     }
 
     // Reload variables from destination's .env.
-    Env::putFromDotenv($this->config->getDst() . '/.env');
+    Env::putFromDotenv($this->config->getDestination() . '/.env');
 
     $url = Env::get('VORTEX_FETCH_DB_URL');
     if (empty($url)) {
       return 'No database fetch URL provided. Skipping demo database fetch.';
     }
 
-    $data_dir = $this->config->getDst() . DIRECTORY_SEPARATOR . Env::get('VORTEX_DB_DIR', './.data');
+    $data_dir = $this->config->getDestination() . DIRECTORY_SEPARATOR . Env::get('VORTEX_DB_DIR', './.data');
     $db_file = Env::get('VORTEX_DB_FILE', 'db.sql');
 
     if (file_exists($data_dir . DIRECTORY_SEPARATOR . $db_file)) {

--- a/.vortex/installer/src/Utils/FileManager.php
+++ b/.vortex/installer/src/Utils/FileManager.php
@@ -8,8 +8,6 @@ use DrevOps\VortexInstaller\Downloader\Downloader;
 
 /**
  * File operations for the installation process.
- *
- * @package DrevOps\VortexInstaller\Utils
  */
 class FileManager {
 

--- a/.vortex/installer/src/Utils/FileManager.php
+++ b/.vortex/installer/src/Utils/FileManager.php
@@ -107,7 +107,7 @@ class FileManager {
     ];
 
     foreach ($obsolete as $relative) {
-      $path = $destination . DIRECTORY_SEPARATOR . $relative;
+      $path = $destination . '/' . $relative;
       if (file_exists($path)) {
         File::remove($path);
       }
@@ -140,10 +140,10 @@ class FileManager {
       return 'No database fetch URL provided. Skipping demo database fetch.';
     }
 
-    $data_dir = $this->config->getDestination() . DIRECTORY_SEPARATOR . Env::get('VORTEX_DB_DIR', './.data');
+    $data_dir = $this->config->getDestination() . '/' . Env::get('VORTEX_DB_DIR', './.data');
     $db_file = Env::get('VORTEX_DB_FILE', 'db.sql');
 
-    if (file_exists($data_dir . DIRECTORY_SEPARATOR . $db_file)) {
+    if (file_exists($data_dir . '/' . $db_file)) {
       return 'Database dump file already exists. Skipping demo database fetch.';
     }
 
@@ -153,7 +153,7 @@ class FileManager {
       $messages[] = sprintf('Created data directory "%s".', $data_dir);
     }
 
-    $destination = $data_dir . DIRECTORY_SEPARATOR . $db_file;
+    $destination = $data_dir . '/' . $db_file;
     $downloader->download($url, $destination);
 
     $messages[] = sprintf('No database dump file was found in "%s" directory.', $data_dir);

--- a/.vortex/installer/src/Utils/Git.php
+++ b/.vortex/installer/src/Utils/Git.php
@@ -103,7 +103,7 @@ class Git extends GitRepository {
     }
 
     foreach ($output as $file) {
-      $tracked_files[] = $dir . DIRECTORY_SEPARATOR . $file;
+      $tracked_files[] = $dir . '/' . $file;
     }
 
     return $tracked_files;

--- a/.vortex/installer/src/Utils/Git.php
+++ b/.vortex/installer/src/Utils/Git.php
@@ -88,17 +88,17 @@ class Git extends GitRepository {
    */
   public static function getTrackedFiles(string $dir): array {
     if (!is_dir($dir . '/.git')) {
-      throw new \RuntimeException("The directory is not a Git repository.");
+      throw new \RuntimeException('The directory is not a Git repository.');
     }
 
     $tracked_files = [];
     $output = [];
     $code = 0;
-    $command = sprintf("cd %s && git ls-files", escapeshellarg($dir));
+    $command = sprintf('cd %s && git ls-files', escapeshellarg($dir));
     exec($command, $output, $code);
     if ($code !== 0) {
       // @codeCoverageIgnoreStart
-      throw new \RuntimeException("Failed to retrieve tracked files using git ls-files.");
+      throw new \RuntimeException('Failed to retrieve tracked files using git ls-files.');
       // @codeCoverageIgnoreEnd
     }
 

--- a/.vortex/installer/src/Utils/Normalizer.php
+++ b/.vortex/installer/src/Utils/Normalizer.php
@@ -8,8 +8,6 @@ namespace DrevOps\VortexInstaller\Utils;
  * Installer configuration.
  *
  * Installer config is a config of this installer script.
- *
- * @package DrevOps\VortexInstaller
  */
 final class Normalizer {
 

--- a/.vortex/installer/src/Utils/OptionsResolver.php
+++ b/.vortex/installer/src/Utils/OptionsResolver.php
@@ -107,7 +107,7 @@ class OptionsResolver {
     }
 
     // Check if the project is a Vortex project.
-    $config->set(Config::IS_VORTEX_PROJECT, File::contains($config->getDestination() . DIRECTORY_SEPARATOR . 'README.md', '/badge\/Vortex-/'));
+    $config->set(Config::IS_VORTEX_PROJECT, File::contains($config->getDestination() . '/README.md', '/badge\/Vortex-/'));
 
     // Flag to proceed with installation. If FALSE - the installation will only
     // print resolved values and will not proceed.

--- a/.vortex/installer/src/Utils/OptionsResolver.php
+++ b/.vortex/installer/src/Utils/OptionsResolver.php
@@ -70,17 +70,17 @@ class OptionsResolver {
     }
 
     // Set destination directory.
-    $dst_from_option = !empty($options['destination']) && is_scalar($options['destination']) ? strval($options['destination']) : NULL;
-    $dst_from_env = Env::get(Config::DST);
-    $dst_from_config = $config->get(Config::DST);
-    $dst_from_root = $config->get(Config::ROOT);
+    $destination_from_option = !empty($options['destination']) && is_scalar($options['destination']) ? strval($options['destination']) : NULL;
+    $destination_from_env = Env::get(Config::DESTINATION);
+    $destination_from_config = $config->get(Config::DESTINATION);
+    $destination_from_root = $config->get(Config::ROOT);
 
-    $dst = $dst_from_option ?: ($dst_from_env ?: ($dst_from_config ?: $dst_from_root));
-    $dst = File::realpath($dst);
-    $config->set(Config::DST, $dst, TRUE);
+    $destination = $destination_from_option ?: ($destination_from_env ?: ($destination_from_config ?: $destination_from_root));
+    $destination = File::realpath($destination);
+    $config->set(Config::DESTINATION, $destination, TRUE);
 
     // Load values from the destination .env file, if it exists.
-    $dest_env_file = $config->getDst() . '/.env';
+    $dest_env_file = $config->getDestination() . '/.env';
 
     if (File::exists($dest_env_file)) {
       Env::putFromDotenv($dest_env_file);
@@ -107,7 +107,7 @@ class OptionsResolver {
     }
 
     // Check if the project is a Vortex project.
-    $config->set(Config::IS_VORTEX_PROJECT, File::contains($config->getDst() . DIRECTORY_SEPARATOR . 'README.md', '/badge\/Vortex-/'));
+    $config->set(Config::IS_VORTEX_PROJECT, File::contains($config->getDestination() . DIRECTORY_SEPARATOR . 'README.md', '/badge\/Vortex-/'));
 
     // Flag to proceed with installation. If FALSE - the installation will only
     // print resolved values and will not proceed.

--- a/.vortex/installer/src/Utils/OptionsResolver.php
+++ b/.vortex/installer/src/Utils/OptionsResolver.php
@@ -115,7 +115,7 @@ class OptionsResolver {
 
     // Internal flag to enforce DEMO mode. If not set, the demo mode will be
     // discovered automatically.
-    if (!is_null(Env::get(Config::IS_DEMO))) {
+    if (Env::get(Config::IS_DEMO) !== NULL) {
       $config->set(Config::IS_DEMO, (bool) Env::get(Config::IS_DEMO));
     }
 

--- a/.vortex/installer/src/Utils/OptionsResolver.php
+++ b/.vortex/installer/src/Utils/OptionsResolver.php
@@ -9,8 +9,6 @@ use Symfony\Component\Process\ExecutableFinder;
 
 /**
  * Resolves CLI options and environment variables into Config and Artifact.
- *
- * @package DrevOps\VortexInstaller\Utils
  */
 class OptionsResolver {
 

--- a/.vortex/installer/src/Utils/Strings.php
+++ b/.vortex/installer/src/Utils/Strings.php
@@ -90,7 +90,7 @@ class Strings {
     );
   }
 
-  private static function processDocblock(array $matches): string {
+  protected static function processDocblock(array $matches): string {
     $full_match = $matches[0];
     $leading_whitespace = $matches[1];
     $comment_content = $matches[2];

--- a/.vortex/installer/src/Utils/Tui.php
+++ b/.vortex/installer/src/Utils/Tui.php
@@ -23,8 +23,8 @@ class Tui {
   protected static bool $isInteractive = TRUE;
 
   public static function init(OutputInterface $output, bool $is_interactive = TRUE): void {
-    static::$output = $output;
-    static::$isInteractive = $is_interactive;
+    self::$output = $output;
+    self::$isInteractive = $is_interactive;
 
     // We cannot use any Symfony console styles here, because Laravel Prompts
     // does not correctly calculate the length of strings with style tags, which
@@ -38,14 +38,14 @@ class Tui {
   }
 
   public static function output(): OutputInterface {
-    if (!isset(static::$output)) {
+    if (!isset(self::$output)) {
       throw new \RuntimeException('Output not set. Call Tui::init() first.');
     }
-    return static::$output;
+    return self::$output;
   }
 
   public static function setOutput(OutputInterface $output): void {
-    static::$output = $output;
+    self::$output = $output;
     Prompt::setOutput($output);
   }
 
@@ -66,7 +66,7 @@ class Tui {
   }
 
   public static function confirm(string $label, bool $default = TRUE, ?string $hint = NULL): bool {
-    if (!static::$isInteractive) {
+    if (!self::$isInteractive) {
       return $default;
     }
 
@@ -78,49 +78,49 @@ class Tui {
   }
 
   public static function line(string $message, int $padding = 1): void {
-    static::$output->writeln(str_repeat(' ', max(0, $padding)) . $message);
+    self::$output->writeln(str_repeat(' ', max(0, $padding)) . $message);
   }
 
   public static function green(string $text): string {
-    return static::escapeMultiline($text, 32);
+    return self::escapeMultiline($text, 32);
   }
 
   public static function blue(string $text): string {
-    return static::escapeMultiline($text, 34);
+    return self::escapeMultiline($text, 34);
   }
 
   public static function purple(string $text): string {
-    return static::escapeMultiline($text, 35);
+    return self::escapeMultiline($text, 35);
   }
 
   public static function yellow(string $text): string {
-    return static::escapeMultiline($text, 33);
+    return self::escapeMultiline($text, 33);
   }
 
   public static function cyan(string $text): string {
-    return static::escapeMultiline($text, 36);
+    return self::escapeMultiline($text, 36);
   }
 
   public static function bold(string $text): string {
-    return static::escapeMultiline($text, 1, 22);
+    return self::escapeMultiline($text, 1, 22);
   }
 
   public static function underscore(string $text): string {
-    return static::escapeMultiline($text, 4, 0);
+    return self::escapeMultiline($text, 4, 0);
   }
 
   public static function dim(string $text): string {
     // Replace reset codes with reset+dim to maintain dim through color resets.
     $text = str_replace("\033[0m", "\033[0m\033[2m", $text);
-    return static::escapeMultiline($text, 2, 22);
+    return self::escapeMultiline($text, 2, 22);
   }
 
   public static function undim(string $text): string {
-    return static::escapeMultiline($text, 22, 22);
+    return self::escapeMultiline($text, 22, 22);
   }
 
   public static function getChar(): string {
-    if (!static::$isInteractive) {
+    if (!self::$isInteractive) {
       return '';
     }
 
@@ -168,7 +168,7 @@ class Tui {
       }
     }
 
-    $terminal_width = static::terminalWidth();
+    $terminal_width = self::terminalWidth();
 
     // (margin + 2 x border + 2 x padding) x 2 - 1 collapse divider width.
     $column_width = max(1, (int) floor(($terminal_width - (1 + (1 + 1) * 2) * 2 - 1) / 2));
@@ -177,27 +177,27 @@ class Tui {
     $rows = [];
     foreach ($values as $key => $value) {
       if ($value === self::LIST_SECTION_TITLE) {
-        $rows[] = [Tui::cyan(Tui::bold(static::normalizeText($key)))];
+        $rows[] = [Tui::cyan(Tui::bold(self::normalizeText($key)))];
         continue;
       }
 
-      $key = static::normalizeText($key);
-      $value = static::normalizeText($value);
+      $key = self::normalizeText($key);
+      $value = self::normalizeText($value);
 
-      $key = '  ' . wordwrap(static::normalizeText($key), $column_width + 2, PHP_EOL . '  ', TRUE);
-      $value = wordwrap(static::normalizeText($value), $column_width, PHP_EOL, TRUE);
+      $key = '  ' . wordwrap(self::normalizeText($key), $column_width + 2, PHP_EOL . '  ', TRUE);
+      $value = wordwrap(self::normalizeText($value), $column_width, PHP_EOL, TRUE);
 
       $rows[] = [$key, $value];
     }
 
-    intro(PHP_EOL . static::normalizeText($title) . PHP_EOL);
+    intro(PHP_EOL . self::normalizeText($title) . PHP_EOL);
     table($header, $rows);
   }
 
   public static function box(string $content, ?string $title = NULL, ?int $width = NULL): void {
     $rows = [];
 
-    $width ??= static::terminalWidth();
+    $width ??= self::terminalWidth();
 
     // 1 margin + 1 border + 1 padding + 1 padding + 1 border + 1 margin.
     $offset = 6;
@@ -206,8 +206,8 @@ class Tui {
 
     if ($title) {
       $title = wordwrap($title, $width - $offset, PHP_EOL, FALSE);
-      $rows[] = [static::green($title)];
-      $rows[] = [static::green(str_repeat('─', Strings::strlenPlain(explode(PHP_EOL, static::normalizeText($title))[0]))) . PHP_EOL];
+      $rows[] = [self::green($title)];
+      $rows[] = [self::green(str_repeat('─', Strings::strlenPlain(explode(PHP_EOL, self::normalizeText($title))[0]))) . PHP_EOL];
     }
 
     $rows[] = [$content];
@@ -258,7 +258,7 @@ class Tui {
     preg_match_all('/\X/u', (string) $text, $matches);
 
     $utf8_chars = $matches[0];
-    $utf8_chars = array_map(fn(string $char): string => Strings::isAsciiStart($char) ? $char : $char . static::utfPadding($char), $utf8_chars);
+    $utf8_chars = array_map(fn(string $char): string => Strings::isAsciiStart($char) ? $char : $char . self::utfPadding($char), $utf8_chars);
 
     return implode('', $utf8_chars);
   }

--- a/.vortex/installer/src/Utils/Validator.php
+++ b/.vortex/installer/src/Utils/Validator.php
@@ -8,8 +8,6 @@ namespace DrevOps\VortexInstaller\Utils;
  * Converter.
  *
  * Convert strings to different formats.
- *
- * @package DrevOps\VortexInstaller
  */
 class Validator {
 

--- a/.vortex/installer/src/Utils/Validator.php
+++ b/.vortex/installer/src/Utils/Validator.php
@@ -11,31 +11,31 @@ namespace DrevOps\VortexInstaller\Utils;
  */
 class Validator {
 
-  public static function containerImage(string $value): bool {
+  public static function isContainerImage(string $value): bool {
     $regex = '/^(?:[a-z0-9.\-]+(?::\d+)?\/)?[a-z0-9]+(?:[._\-][a-z0-9]+)*(?:\/[a-z0-9]+(?:[._\-][a-z0-9]+)*)*(?::[a-zA-Z0-9][a-zA-Z0-9._\-]{0,127})?$/x';
 
     return (bool) preg_match($regex, $value);
   }
 
-  public static function domain(string $value): bool {
+  public static function isDomain(string $value): bool {
     return !filter_var($value, FILTER_VALIDATE_IP)
       && filter_var($value, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)
       && str_contains($value, '.');
   }
 
-  public static function githubProject(string $value): bool {
+  public static function isGithubProject(string $value): bool {
     return (bool) preg_match('/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/', $value);
   }
 
-  public static function dirname(string $value): bool {
+  public static function isDirname(string $value): bool {
     return (bool) preg_match('/^(?!^(?:\.{1,2}|CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$)[\w\-.]+$/i', $value);
   }
 
-  public static function gitCommitSha(string $value): bool {
+  public static function isGitCommitSha(string $value): bool {
     return (bool) preg_match('/^[0-9a-f]{40}$/i', $value);
   }
 
-  public static function gitCommitShaShort(string $value): bool {
+  public static function isGitCommitShaShort(string $value): bool {
     return (bool) preg_match('/^[0-9a-f]{7}$/i', $value);
   }
 
@@ -64,14 +64,14 @@ class Validator {
    *
    * @see https://git-scm.com/docs/git-check-ref-format
    */
-  public static function gitRef(string $value): bool {
+  public static function isGitRef(string $value): bool {
     // Reserved keywords have special meaning.
     if (in_array($value, ['stable', 'HEAD'], TRUE)) {
       return TRUE;
     }
 
     // Already supported: commit hashes.
-    if (self::gitCommitSha($value) || self::gitCommitShaShort($value)) {
+    if (self::isGitCommitSha($value) || self::isGitCommitShaShort($value)) {
       return TRUE;
     }
 

--- a/.vortex/installer/src/Utils/Version.php
+++ b/.vortex/installer/src/Utils/Version.php
@@ -83,7 +83,7 @@ class Version {
    *   The project's major, or NULL when it cannot be determined.
    */
   public static function detectProjectMajor(string $dir): ?int {
-    $composer_json = $dir . DIRECTORY_SEPARATOR . 'composer.json';
+    $composer_json = $dir . '/composer.json';
 
     if (!is_file($composer_json)) {
       return NULL;

--- a/.vortex/installer/src/Utils/Yaml.php
+++ b/.vortex/installer/src/Utils/Yaml.php
@@ -12,7 +12,7 @@ class Yaml extends SymfonyYaml {
   public static function validateFile(string $path): void {
     // Check if the file exists and is readable.
     if (!file_exists($path) || !is_readable($path)) {
-      throw new \InvalidArgumentException('File does not exist or is not readable: ' . $path);
+      throw new \RuntimeException('File does not exist or is not readable: ' . $path);
     }
 
     self::parseFile($path);

--- a/.vortex/installer/src/Utils/Yaml.php
+++ b/.vortex/installer/src/Utils/Yaml.php
@@ -15,11 +15,11 @@ class Yaml extends SymfonyYaml {
       throw new \InvalidArgumentException('File does not exist or is not readable: ' . $path);
     }
 
-    static::parseFile($path);
+    self::parseFile($path);
   }
 
   public static function validate(string $content): void {
-    static::parse($content);
+    self::parse($content);
   }
 
   public static function collapseEmptyLinesInLiteralBlock(string $content): string {

--- a/.vortex/installer/tests/Functional/FunctionalTestCase.php
+++ b/.vortex/installer/tests/Functional/FunctionalTestCase.php
@@ -55,13 +55,13 @@ abstract class FunctionalTestCase extends UnitTestCase {
     $this->replaceVersions($actual);
   }
 
-  protected function runNonInteractiveInstall(?string $dst = NULL, array $options = [], bool $expect_fail = FALSE): void {
-    $dst ??= static::$sut;
+  protected function runNonInteractiveInstall(?string $destination = NULL, array $options = [], bool $expect_fail = FALSE): void {
+    $destination ??= static::$sut;
 
     $defaults = [
       InstallCommand::OPTION_NO_INTERACTION => TRUE,
       InstallCommand::OPTION_URI => File::dir(static::$root),
-      InstallCommand::OPTION_DESTINATION => $dst,
+      InstallCommand::OPTION_DESTINATION => $destination,
     ];
 
     $options += $defaults;
@@ -77,8 +77,8 @@ abstract class FunctionalTestCase extends UnitTestCase {
     $this->applicationRun($args, [], $expect_fail);
   }
 
-  protected function runInteractiveInstall(array $answers = [], ?string $dst = NULL, array $options = [], bool $expect_fail = FALSE): void {
-    $this->runNonInteractiveInstall($dst, $options + [InstallCommand::OPTION_NO_INTERACTION => FALSE], $expect_fail);
+  protected function runInteractiveInstall(array $answers = [], ?string $destination = NULL, array $options = [], bool $expect_fail = FALSE): void {
+    $this->runNonInteractiveInstall($destination, $options + [InstallCommand::OPTION_NO_INTERACTION => FALSE], $expect_fail);
   }
 
   protected function assertSutContains(string|array $needles): void {

--- a/.vortex/installer/tests/Functional/FunctionalTestCase.php
+++ b/.vortex/installer/tests/Functional/FunctionalTestCase.php
@@ -77,10 +77,6 @@ abstract class FunctionalTestCase extends UnitTestCase {
     $this->applicationRun($args, [], $expect_fail);
   }
 
-  protected function runInteractiveInstall(array $answers = [], ?string $destination = NULL, array $options = [], bool $expect_fail = FALSE): void {
-    $this->runNonInteractiveInstall($destination, $options + [InstallCommand::OPTION_NO_INTERACTION => FALSE], $expect_fail);
-  }
-
   protected function assertSutContains(string|array $needles): void {
     $needles = is_array($needles) ? $needles : [$needles];
 

--- a/.vortex/installer/tests/Functional/PharTest.php
+++ b/.vortex/installer/tests/Functional/PharTest.php
@@ -82,7 +82,7 @@ class PharTest extends FunctionalTestCase {
     $this->assertFileExists($this->pharFile, 'PHAR file should NOT be removed when --help option is used');
   }
 
-  protected static function buildPhar(string $dst): void {
+  protected static function buildPhar(string $destination): void {
     fwrite(STDERR, 'Building installer PHAR file...');
     if (!file_exists('vendor')) {
       $exit_code = 0;

--- a/.vortex/installer/tests/Traits/TuiTrait.php
+++ b/.vortex/installer/tests/Traits/TuiTrait.php
@@ -10,8 +10,6 @@ use Laravel\Prompts\Prompt;
 
 trait TuiTrait {
 
-  const TUI_MAX_QUESTIONS = 25;
-
   protected static function tuiSetUp(): void {
     Tui::init((new BufferedConsoleOutput()), FALSE);
 

--- a/.vortex/installer/tests/Unit/ConfigTest.php
+++ b/.vortex/installer/tests/Unit/ConfigTest.php
@@ -26,19 +26,19 @@ class ConfigTest extends UnitTestCase {
     $config = new Config();
 
     $this->assertEquals(File::cwd(), $config->getRoot());
-    $this->assertEquals(File::cwd(), $config->getDst());
+    $this->assertEquals(File::cwd(), $config->getDestination());
     $this->assertNotNull($config->get(Config::TMP));
   }
 
   public function testConstructorWithParameters(): void {
     $root = '/custom/root';
-    $dst = '/custom/dst';
+    $destination = '/custom/dst';
     $tmp = '/custom/tmp';
 
-    $config = new Config($root, $dst, $tmp);
+    $config = new Config($root, $destination, $tmp);
 
     $this->assertEquals($root, $config->getRoot());
-    $this->assertEquals($dst, $config->getDst());
+    $this->assertEquals($destination, $config->getDestination());
     $this->assertEquals($tmp, $config->get(Config::TMP));
   }
 
@@ -46,7 +46,7 @@ class ConfigTest extends UnitTestCase {
     $config = new Config();
 
     $this->assertEquals(File::cwd(), $config->getRoot());
-    $this->assertEquals(File::cwd(), $config->getDst());
+    $this->assertEquals(File::cwd(), $config->getDestination());
     $this->assertNotNull($config->get(Config::TMP));
   }
 
@@ -191,12 +191,12 @@ class ConfigTest extends UnitTestCase {
     $this->assertEquals($root, $config->get(Config::ROOT));
   }
 
-  public function testGetDst(): void {
-    $dst = '/test/dst';
-    $config = new Config(NULL, $dst);
+  public function testGetDestination(): void {
+    $destination = '/test/dst';
+    $config = new Config(NULL, $destination);
 
-    $this->assertEquals($dst, $config->getDst());
-    $this->assertEquals($dst, $config->get(Config::DST));
+    $this->assertEquals($destination, $config->getDestination());
+    $this->assertEquals($destination, $config->get(Config::DESTINATION));
   }
 
   #[DataProvider('dataProviderIsQuiet')]
@@ -294,7 +294,7 @@ class ConfigTest extends UnitTestCase {
   public function testConstants(): void {
     // Test that all constants are defined and have expected values.
     $this->assertEquals('VORTEX_INSTALLER_ROOT_DIR', Config::ROOT);
-    $this->assertEquals('VORTEX_INSTALLER_DST_DIR', Config::DST);
+    $this->assertEquals('VORTEX_INSTALLER_DST_DIR', Config::DESTINATION);
     $this->assertEquals('VORTEX_INSTALLER_TMP_DIR', Config::TMP);
     $this->assertEquals('VORTEX_INSTALLER_TEMPLATE_REPO', Config::REPO);
     $this->assertEquals('VORTEX_INSTALLER_TEMPLATE_REF', Config::REF);
@@ -313,7 +313,7 @@ class ConfigTest extends UnitTestCase {
     // Set environment variables.
     static::envSetMultiple([
       Config::ROOT => '/env/root',
-      Config::DST => '/env/dst',
+      Config::DESTINATION => '/env/dst',
       Config::TMP => '/env/tmp',
     ]);
 
@@ -321,8 +321,8 @@ class ConfigTest extends UnitTestCase {
 
     // Environment variables should take precedence for ROOT and TMP.
     $this->assertEquals('/env/root', $config->getRoot());
-    // DST is set with skip_env=TRUE in constructor, so param value is used.
-    $this->assertEquals('/param/dst', $config->getDst());
+    // DESTINATION is set with skip_env=TRUE, so the param value wins.
+    $this->assertEquals('/param/dst', $config->getDestination());
     $this->assertEquals('/env/tmp', $config->get(Config::TMP));
   }
 

--- a/.vortex/installer/tests/Unit/ConfigTest.php
+++ b/.vortex/installer/tests/Unit/ConfigTest.php
@@ -51,15 +51,15 @@ class ConfigTest extends UnitTestCase {
   }
 
   #[DataProvider('dataProviderFromStringValid')]
-  public function testFromStringValid(string $json, array $expectedValues): void {
+  public function testFromStringValid(string $json, array $expected_values): void {
     $config = Config::fromString($json);
 
-    if (empty($expectedValues)) {
+    if (empty($expected_values)) {
       // For empty JSON, just assert that config was created successfully.
       $this->assertInstanceOf(Config::class, $config);
     }
     else {
-      foreach ($expectedValues as $key => $value) {
+      foreach ($expected_values as $key => $value) {
         $this->assertEquals($value, $config->get($key));
       }
     }
@@ -93,9 +93,9 @@ class ConfigTest extends UnitTestCase {
   }
 
   #[DataProvider('dataProviderFromStringInvalid')]
-  public function testFromStringInvalid(string $json, string $expectedError): void {
+  public function testFromStringInvalid(string $json, string $expected_error): void {
     $this->expectException(\RuntimeException::class);
-    $this->expectExceptionMessage($expectedError);
+    $this->expectExceptionMessage($expected_error);
 
     Config::fromString($json);
   }

--- a/.vortex/installer/tests/Unit/Downloader/ArchiverTest.php
+++ b/.vortex/installer/tests/Unit/Downloader/ArchiverTest.php
@@ -48,7 +48,7 @@ class ArchiverTest extends UnitTestCase {
   }
 
   #[DataProvider('dataProviderValidateInvalid')]
-  public function testValidateInvalid(?string $path, ?string $content, string $expectedMessage): void {
+  public function testValidateInvalid(?string $path, ?string $content, string $expected_message): void {
     if ($path === NULL) {
       $path = self::$tmp . '/test_invalid_' . uniqid() . '.txt';
       if ($content !== NULL) {
@@ -57,20 +57,20 @@ class ArchiverTest extends UnitTestCase {
     }
 
     $this->expectException(\RuntimeException::class);
-    $this->expectExceptionMessage($expectedMessage);
+    $this->expectExceptionMessage($expected_message);
     $this->archiver->validate($path);
   }
 
   #[DataProvider('dataProviderExtract')]
-  public function testExtract(string $creator, bool $strip, string $expectedPath): void {
+  public function testExtract(string $creator, bool $strip, string $expected_path): void {
     $archive_path = $this->$creator();
     $destination = self::$tmp . '/test_extract_' . uniqid();
     File::mkdir($destination);
 
     $this->archiver->extract($archive_path, $destination, $strip);
 
-    $this->assertFileExists($destination . $expectedPath);
-    $this->assertEquals('Test content', file_get_contents($destination . $expectedPath));
+    $this->assertFileExists($destination . $expected_path);
+    $this->assertEquals('Test content', file_get_contents($destination . $expected_path));
 
     if ($strip) {
       $this->assertFileDoesNotExist($destination . '/test_archive');
@@ -78,7 +78,7 @@ class ArchiverTest extends UnitTestCase {
   }
 
   #[DataProvider('dataProviderExtractErrors')]
-  public function testExtractErrors(?string $extension, ?string $content, bool $strip, ?string $creator, string $expectedMessage): void {
+  public function testExtractErrors(?string $extension, ?string $content, bool $strip, ?string $creator, string $expected_message): void {
     if ($creator !== NULL) {
       $archive_path = $this->$creator();
     }
@@ -91,7 +91,7 @@ class ArchiverTest extends UnitTestCase {
     File::mkdir($destination);
 
     $this->expectException(\RuntimeException::class);
-    $this->expectExceptionMessage($expectedMessage);
+    $this->expectExceptionMessage($expected_message);
     $this->archiver->extract($archive_path, $destination, $strip);
   }
 
@@ -141,17 +141,17 @@ class ArchiverTest extends UnitTestCase {
     yield 'non-existent file' => [
       'path' => '/non/existent/file.tar.gz',
       'content' => NULL,
-      'expectedMessage' => 'Archive file does not exist',
+      'expected_message' => 'Archive file does not exist',
     ];
     yield 'empty file' => [
       'path' => NULL,
       'content' => '',
-      'expectedMessage' => 'Archive is empty',
+      'expected_message' => 'Archive is empty',
     ];
     yield 'invalid archive' => [
       'path' => NULL,
       'content' => 'This is not an archive',
-      'expectedMessage' => 'File does not appear to be a valid archive',
+      'expected_message' => 'File does not appear to be a valid archive',
     ];
   }
 
@@ -165,22 +165,22 @@ class ArchiverTest extends UnitTestCase {
     yield 'tar.gz without strip' => [
       'creator' => 'createTestTarGz',
       'strip' => FALSE,
-      'expectedPath' => '/test_archive/test_file.txt',
+      'expected_path' => '/test_archive/test_file.txt',
     ];
     yield 'tar.gz with strip' => [
       'creator' => 'createTestTarGz',
       'strip' => TRUE,
-      'expectedPath' => '/test_file.txt',
+      'expected_path' => '/test_file.txt',
     ];
     yield 'zip without strip' => [
       'creator' => 'createTestZip',
       'strip' => FALSE,
-      'expectedPath' => '/test_archive/test_file.txt',
+      'expected_path' => '/test_archive/test_file.txt',
     ];
     yield 'zip with strip' => [
       'creator' => 'createTestZip',
       'strip' => TRUE,
-      'expectedPath' => '/test_file.txt',
+      'expected_path' => '/test_file.txt',
     ];
   }
 
@@ -196,28 +196,28 @@ class ArchiverTest extends UnitTestCase {
       'content' => 'Rar! fake content',
       'strip' => FALSE,
       'creator' => NULL,
-      'expectedMessage' => 'Unsupported archive format',
+      'expected_message' => 'Unsupported archive format',
     ];
     yield 'invalid tar.gz archive' => [
       'extension' => '.tar.gz',
       'content' => "\x1f\x8b" . 'invalid tar content',
       'strip' => FALSE,
       'creator' => NULL,
-      'expectedMessage' => 'Failed to extract tar archive',
+      'expected_message' => 'Failed to extract tar archive',
     ];
     yield 'invalid zip archive' => [
       'extension' => '.zip',
       'content' => "\x50\x4b\x03\x04invalid zip content",
       'strip' => FALSE,
       'creator' => NULL,
-      'expectedMessage' => 'Failed to extract ZIP archive',
+      'expected_message' => 'Failed to extract ZIP archive',
     ];
     yield 'multiple top-level directories with strip' => [
       'extension' => NULL,
       'content' => NULL,
       'strip' => TRUE,
       'creator' => 'createTestMultipleTopLevel',
-      'expectedMessage' => 'Expected single top-level directory in archive',
+      'expected_message' => 'Expected single top-level directory in archive',
     ];
   }
 

--- a/.vortex/installer/tests/Unit/Downloader/ArtifactTest.php
+++ b/.vortex/installer/tests/Unit/Downloader/ArtifactTest.php
@@ -17,18 +17,18 @@ use PHPUnit\Framework\TestCase;
 class ArtifactTest extends TestCase {
 
   #[DataProvider('dataProviderFromUri')]
-  public function testFromUri(?string $uri, string $expectedRepo, string $expectedRef, ?string $expectedException = NULL, ?string $expectedMessage = NULL): void {
-    if ($expectedException !== NULL) {
-      /** @var class-string<\Throwable> $expectedException */
-      $this->expectException($expectedException);
-      $this->expectExceptionMessage($expectedMessage);
+  public function testFromUri(?string $uri, string $expected_repo, string $expected_ref, ?string $expected_exception = NULL, ?string $expected_message = NULL): void {
+    if ($expected_exception !== NULL) {
+      /** @var class-string<\Throwable> $expected_exception */
+      $this->expectException($expected_exception);
+      $this->expectExceptionMessage($expected_message);
     }
 
     $artifact = Artifact::fromUri($uri);
 
-    if ($expectedException === NULL) {
-      $this->assertEquals($expectedRepo, $artifact->getRepo());
-      $this->assertEquals($expectedRef, $artifact->getRef());
+    if ($expected_exception === NULL) {
+      $this->assertEquals($expected_repo, $artifact->getRepo());
+      $this->assertEquals($expected_ref, $artifact->getRef());
     }
   }
 
@@ -221,16 +221,16 @@ class ArtifactTest extends TestCase {
   }
 
   #[DataProvider('dataProviderCreate')]
-  public function testCreate(string $repo, string $ref, ?string $expectedException = NULL, ?string $expectedMessage = NULL): void {
-    if ($expectedException !== NULL) {
-      /** @var class-string<\Throwable> $expectedException */
-      $this->expectException($expectedException);
-      $this->expectExceptionMessage($expectedMessage);
+  public function testCreate(string $repo, string $ref, ?string $expected_exception = NULL, ?string $expected_message = NULL): void {
+    if ($expected_exception !== NULL) {
+      /** @var class-string<\Throwable> $expected_exception */
+      $this->expectException($expected_exception);
+      $this->expectExceptionMessage($expected_message);
     }
 
     $artifact = Artifact::create($repo, $ref);
 
-    if ($expectedException === NULL) {
+    if ($expected_exception === NULL) {
       $this->assertEquals($repo, $artifact->getRepo());
       $this->assertEquals($ref, $artifact->getRef());
     }
@@ -345,9 +345,9 @@ class ArtifactTest extends TestCase {
   }
 
   #[DataProvider('dataProviderGetRepoUrl')]
-  public function testGetRepoUrl(string $repo, string $expectedUrl): void {
+  public function testGetRepoUrl(string $repo, string $expected_url): void {
     $artifact = Artifact::create($repo, 'HEAD');
-    $this->assertEquals($expectedUrl, $artifact->getRepoUrl());
+    $this->assertEquals($expected_url, $artifact->getRepoUrl());
   }
 
   /**

--- a/.vortex/installer/tests/Unit/Downloader/RepositoryDownloaderTest.php
+++ b/.vortex/installer/tests/Unit/Downloader/RepositoryDownloaderTest.php
@@ -108,11 +108,11 @@ class RepositoryDownloaderTest extends UnitTestCase {
   }
 
   #[DataProvider('dataProviderDiscoverLatestReleaseRemote')]
-  public function testDiscoverLatestReleaseRemote(string $repo, mixed $releaseData, bool $throwException, bool $skipMockSetup, ?string $expectedVersion, ?string $expectedException, ?string $expectedMessage): void {
+  public function testDiscoverLatestReleaseRemote(string $repo, mixed $release_data, bool $throw_exception, bool $skip_mock_setup, ?string $expected_version, ?string $expected_exception, ?string $expected_message): void {
     $mock_http_client = $this->createMock(ClientInterface::class);
 
-    if (!$skipMockSetup) {
-      if ($throwException) {
+    if (!$skip_mock_setup) {
+      if ($throw_exception) {
         $mock_http_client->method('request')->willThrowException(new RequestException('API error', $this->createMock(RequestInterface::class)));
       }
       else {
@@ -120,7 +120,7 @@ class RepositoryDownloaderTest extends UnitTestCase {
         $mock_body = $this->createMock(StreamInterface::class);
         $mock_response->method('getBody')->willReturn($mock_body);
 
-        $release_json = is_array($releaseData) ? json_encode($releaseData) : $releaseData;
+        $release_json = is_array($release_data) ? json_encode($release_data) : $release_data;
 
         $mock_body->method('getContents')->willReturn($release_json);
         $mock_response->method('getStatusCode')->willReturn(200);
@@ -135,22 +135,22 @@ class RepositoryDownloaderTest extends UnitTestCase {
     $destination = self::$tmp . '/destination_' . uniqid();
     File::mkdir($destination);
 
-    if ($expectedVersion !== NULL) {
+    if ($expected_version !== NULL) {
       File::dump($destination . '/composer.json', '{}');
     }
 
     $downloader = new RepositoryDownloader($mock_http_client, $mock_archiver, NULL, $mock_file_downloader);
 
-    if ($expectedException !== NULL) {
-      /** @var class-string<\Throwable> $expectedException */
-      $this->expectException($expectedException);
-      $this->expectExceptionMessage($expectedMessage);
+    if ($expected_exception !== NULL) {
+      /** @var class-string<\Throwable> $expected_exception */
+      $this->expectException($expected_exception);
+      $this->expectExceptionMessage($expected_message);
     }
 
     $version = $downloader->download(Artifact::create($repo, 'stable'), $destination);
 
-    if ($expectedVersion !== NULL) {
-      $this->assertEquals($expectedVersion, $version);
+    if ($expected_version !== NULL) {
+      $this->assertEquals($expected_version, $version);
     }
   }
 
@@ -224,15 +224,15 @@ class RepositoryDownloaderTest extends UnitTestCase {
   }
 
   #[DataProvider('dataProviderDownloadWithNullDestination')]
-  public function testDownloadWithNullDestination(string $repo, string $expectedMessage): void {
+  public function testDownloadWithNullDestination(string $repo, string $expected_message): void {
     $downloader = new RepositoryDownloader();
     $this->expectException(\InvalidArgumentException::class);
-    $this->expectExceptionMessage($expectedMessage);
+    $this->expectExceptionMessage($expected_message);
     $downloader->download(Artifact::create($repo, 'HEAD'));
   }
 
   #[DataProvider('dataProviderDownloadFromLocal')]
-  public function testDownloadFromLocal(string $ref, string $expectedVersion): void {
+  public function testDownloadFromLocal(string $ref, string $expected_version): void {
     $temp_repo_dir = $this->createGitRepo();
     $destination = self::$tmp . '/dest_' . uniqid();
     File::mkdir($destination);
@@ -244,14 +244,14 @@ class RepositoryDownloaderTest extends UnitTestCase {
       $commit_hash = trim($output);
       $this->assertNotEmpty($commit_hash, 'Git rev-parse returned empty output');
       $ref = substr($commit_hash, 0, 7);
-      $expectedVersion = $ref;
+      $expected_version = $ref;
     }
 
     /** @var \PHPUnit\Framework\MockObject\MockObject&\DrevOps\VortexInstaller\Downloader\ArchiverInterface $mock_archiver */
     $mock_archiver = $this->createMockArchiverWithExtract();
     $downloader = new RepositoryDownloader(NULL, $mock_archiver);
     $version = $downloader->download(Artifact::create($temp_repo_dir, $ref), $destination);
-    $this->assertEquals($expectedVersion, $version);
+    $this->assertEquals($expected_version, $version);
     $this->removeGitRepo($temp_repo_dir);
   }
 
@@ -339,112 +339,112 @@ class RepositoryDownloaderTest extends UnitTestCase {
   public static function dataProviderDiscoverLatestReleaseRemote(): \Iterator {
     yield 'valid releases' => [
       'repo' => 'https://github.com/user/repo',
-      'releaseData' => [
+      'release_data' => [
         ['tag_name' => 'v2.0.0', 'draft' => FALSE],
         ['tag_name' => 'v1.0.0', 'draft' => FALSE],
       ],
-      'throwException' => FALSE,
-      'skipMockSetup' => FALSE,
-      'expectedVersion' => 'v2.0.0',
-      'expectedException' => NULL,
-      'expectedMessage' => NULL,
+      'throw_exception' => FALSE,
+      'skip_mock_setup' => FALSE,
+      'expected_version' => 'v2.0.0',
+      'expected_exception' => NULL,
+      'expected_message' => NULL,
     ];
     yield 'skips drafts' => [
       'repo' => 'https://github.com/user/repo',
-      'releaseData' => [
+      'release_data' => [
         ['tag_name' => 'v3.0.0', 'draft' => TRUE],
         ['tag_name' => 'v2.0.0', 'draft' => FALSE],
       ],
-      'throwException' => FALSE,
-      'skipMockSetup' => FALSE,
-      'expectedVersion' => 'v2.0.0',
-      'expectedException' => NULL,
-      'expectedMessage' => NULL,
+      'throw_exception' => FALSE,
+      'skip_mock_setup' => FALSE,
+      'expected_version' => 'v2.0.0',
+      'expected_exception' => NULL,
+      'expected_message' => NULL,
     ];
     yield 'no releases' => [
       'repo' => 'https://github.com/user/repo',
-      'releaseData' => [],
-      'throwException' => FALSE,
-      'skipMockSetup' => FALSE,
-      'expectedVersion' => NULL,
-      'expectedException' => \RuntimeException::class,
-      'expectedMessage' => 'Unable to discover the latest release',
+      'release_data' => [],
+      'throw_exception' => FALSE,
+      'skip_mock_setup' => FALSE,
+      'expected_version' => NULL,
+      'expected_exception' => \RuntimeException::class,
+      'expected_message' => 'Unable to discover the latest release',
     ];
     yield 'request exception' => [
       'repo' => 'https://github.com/user/repo',
-      'releaseData' => NULL,
-      'throwException' => TRUE,
-      'skipMockSetup' => FALSE,
-      'expectedVersion' => NULL,
-      'expectedException' => \RuntimeException::class,
-      'expectedMessage' => 'Unable to access repository',
+      'release_data' => NULL,
+      'throw_exception' => TRUE,
+      'skip_mock_setup' => FALSE,
+      'expected_version' => NULL,
+      'expected_exception' => \RuntimeException::class,
+      'expected_message' => 'Unable to access repository',
     ];
     yield 'empty response' => [
       'repo' => 'https://github.com/user/repo',
-      'releaseData' => '',
-      'throwException' => FALSE,
-      'skipMockSetup' => FALSE,
-      'expectedVersion' => NULL,
-      'expectedException' => \RuntimeException::class,
-      'expectedMessage' => 'Unable to download release information from',
+      'release_data' => '',
+      'throw_exception' => FALSE,
+      'skip_mock_setup' => FALSE,
+      'expected_version' => NULL,
+      'expected_exception' => \RuntimeException::class,
+      'expected_message' => 'Unable to download release information from',
     ];
     yield 'invalid url' => [
       'repo' => 'https://',
-      'releaseData' => NULL,
-      'throwException' => FALSE,
-      'skipMockSetup' => TRUE,
-      'expectedVersion' => NULL,
-      'expectedException' => \RuntimeException::class,
-      'expectedMessage' => 'Local repository path does not exist',
+      'release_data' => NULL,
+      'throw_exception' => FALSE,
+      'skip_mock_setup' => TRUE,
+      'expected_version' => NULL,
+      'expected_exception' => \RuntimeException::class,
+      'expected_message' => 'Local repository path does not exist',
     ];
     yield 'SemVer+CalVer format - single release' => [
       'repo' => str_replace('.git', '', RepositoryDownloader::DEFAULT_REPO),
-      'releaseData' => [
+      'release_data' => [
         ['tag_name' => '1.0.0+2025.11.0', 'draft' => FALSE],
       ],
-      'throwException' => FALSE,
-      'skipMockSetup' => FALSE,
-      'expectedVersion' => '1.0.0+2025.11.0',
-      'expectedException' => NULL,
-      'expectedMessage' => NULL,
+      'throw_exception' => FALSE,
+      'skip_mock_setup' => FALSE,
+      'expected_version' => '1.0.0+2025.11.0',
+      'expected_exception' => NULL,
+      'expected_message' => NULL,
     ];
     yield 'SemVer+CalVer format - multiple releases' => [
       'repo' => str_replace('.git', '', RepositoryDownloader::DEFAULT_REPO),
-      'releaseData' => [
+      'release_data' => [
         ['tag_name' => '1.2.0+2025.12.0', 'draft' => FALSE],
         ['tag_name' => '1.1.0+2025.11.0', 'draft' => FALSE],
         ['tag_name' => '1.0.0+2025.10.0', 'draft' => FALSE],
       ],
-      'throwException' => FALSE,
-      'skipMockSetup' => FALSE,
-      'expectedVersion' => '1.2.0+2025.12.0',
-      'expectedException' => NULL,
-      'expectedMessage' => NULL,
+      'throw_exception' => FALSE,
+      'skip_mock_setup' => FALSE,
+      'expected_version' => '1.2.0+2025.12.0',
+      'expected_exception' => NULL,
+      'expected_message' => NULL,
     ];
     yield 'SemVer+CalVer format - skip draft' => [
       'repo' => str_replace('.git', '', RepositoryDownloader::DEFAULT_REPO),
-      'releaseData' => [
+      'release_data' => [
         ['tag_name' => '2.0.0+2026.01.0', 'draft' => TRUE],
         ['tag_name' => '1.0.0+2025.11.0', 'draft' => FALSE],
       ],
-      'throwException' => FALSE,
-      'skipMockSetup' => FALSE,
-      'expectedVersion' => '1.0.0+2025.11.0',
-      'expectedException' => NULL,
-      'expectedMessage' => NULL,
+      'throw_exception' => FALSE,
+      'skip_mock_setup' => FALSE,
+      'expected_version' => '1.0.0+2025.11.0',
+      'expected_exception' => NULL,
+      'expected_message' => NULL,
     ];
     yield 'Mixed format - SemVer+CalVer and CalVer' => [
       'repo' => str_replace('.git', '', RepositoryDownloader::DEFAULT_REPO),
-      'releaseData' => [
+      'release_data' => [
         ['tag_name' => '1.0.0+2025.11.0', 'draft' => FALSE],
         ['tag_name' => '25.10.0', 'draft' => FALSE],
         ['tag_name' => '25.9.0', 'draft' => FALSE],
       ],
-      'throwException' => FALSE,
-      'skipMockSetup' => FALSE,
-      'expectedVersion' => '1.0.0+2025.11.0',
-      'expectedException' => NULL,
-      'expectedMessage' => NULL,
+      'throw_exception' => FALSE,
+      'skip_mock_setup' => FALSE,
+      'expected_version' => '1.0.0+2025.11.0',
+      'expected_exception' => NULL,
+      'expected_message' => NULL,
     ];
   }
 
@@ -457,11 +457,11 @@ class RepositoryDownloaderTest extends UnitTestCase {
   public static function dataProviderDownloadWithNullDestination(): \Iterator {
     yield 'remote repository' => [
       'repo' => 'https://github.com/user/repo',
-      'expectedMessage' => 'Destination cannot be null for remote downloads',
+      'expected_message' => 'Destination cannot be null for remote downloads',
     ];
     yield 'local repository' => [
       'repo' => '/path/to/repo',
-      'expectedMessage' => 'Destination cannot be null for local downloads',
+      'expected_message' => 'Destination cannot be null for local downloads',
     ];
   }
 
@@ -474,25 +474,25 @@ class RepositoryDownloaderTest extends UnitTestCase {
   public static function dataProviderDownloadFromLocal(): \Iterator {
     yield 'HEAD ref' => [
       'ref' => 'HEAD',
-      'expectedVersion' => 'develop',
+      'expected_version' => 'develop',
     ];
     yield 'stable ref' => [
       'ref' => 'stable',
-      'expectedVersion' => 'develop',
+      'expected_version' => 'develop',
     ];
     yield 'commit hash' => [
       'ref' => 'COMMIT_HASH',
-      'expectedVersion' => 'COMMIT_HASH',
+      'expected_version' => 'COMMIT_HASH',
     ];
   }
 
-  protected function createMockHttpClient(int $statusCode = 200, string $bodyContent = 'mock content'): ClientInterface {
+  protected function createMockHttpClient(int $status_code = 200, string $body_content = 'mock content'): ClientInterface {
     $mock_client = $this->createMock(ClientInterface::class);
     $mock_response = $this->createMock(ResponseInterface::class);
     $mock_body = $this->createMock(StreamInterface::class);
     $mock_response->method('getBody')->willReturn($mock_body);
-    $mock_body->method('getContents')->willReturn($bodyContent);
-    $mock_response->method('getStatusCode')->willReturn($statusCode);
+    $mock_body->method('getContents')->willReturn($body_content);
+    $mock_response->method('getStatusCode')->willReturn($status_code);
     $mock_client->method('request')->willReturn($mock_response);
     return $mock_client;
   }

--- a/.vortex/installer/tests/Unit/JsonManipulatorTest.php
+++ b/.vortex/installer/tests/Unit/JsonManipulatorTest.php
@@ -16,7 +16,7 @@ class JsonManipulatorTest extends UnitTestCase {
   /**
    * Sample JSON content for testing.
    */
-  private const SAMPLE_JSON = '{
+  protected const SAMPLE_JSON = '{
     "name": "test/package",
     "description": "A test package",
     "version": "1.0.0",
@@ -40,7 +40,7 @@ class JsonManipulatorTest extends UnitTestCase {
   /**
    * Invalid JSON content for testing error cases.
    */
-  private const INVALID_JSON = '{
+  protected const INVALID_JSON = '{
     "name": "test/package",
     "description": "A test package"
     "invalid": missing comma
@@ -49,7 +49,7 @@ class JsonManipulatorTest extends UnitTestCase {
   /**
    * Create a temporary JSON file for testing.
    */
-  private function createTempJsonFile(string $content): string {
+  protected function createTempJsonFile(string $content): string {
     $temp_file = tempnam(sys_get_temp_dir(), 'json_test_');
     file_put_contents($temp_file, $content);
     return $temp_file;

--- a/.vortex/installer/tests/Unit/Runner/AbstractRunnerTest.php
+++ b/.vortex/installer/tests/Unit/Runner/AbstractRunnerTest.php
@@ -701,12 +701,12 @@ class ConcreteRunner extends AbstractRunner {
   /**
    * Public setter for exitCode (for testing).
    */
-  public function setExitCode(int $exitCode): void {
-    if ($exitCode < 0 || $exitCode > 255) {
+  public function setExitCode(int $exit_code): void {
+    if ($exit_code < 0 || $exit_code > 255) {
       throw new \RuntimeException('Exit code is out of valid range (0-255).');
     }
 
-    $this->exitCode = $exitCode;
+    $this->exitCode = $exit_code;
   }
 
   /**

--- a/.vortex/installer/tests/Unit/TaskTest.php
+++ b/.vortex/installer/tests/Unit/TaskTest.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace DrevOps\VortexInstaller\Tests\Unit;
 
-use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use DrevOps\VortexInstaller\Task\Task;
 use DrevOps\VortexInstaller\Utils\Tui;
-
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 /**

--- a/.vortex/installer/tests/Unit/TuiTest.php
+++ b/.vortex/installer/tests/Unit/TuiTest.php
@@ -69,9 +69,9 @@ class TuiTest extends UnitTestCase {
   }
 
   #[DataProvider('dataProviderColorMethods')]
-  public function testColorMethods(string $method, string $input, string $expectedAnsi): void {
+  public function testColorMethods(string $method, string $input, string $expected_ansi): void {
     $result = Tui::$method($input);
-    $this->assertStringContainsString($expectedAnsi, $result);
+    $this->assertStringContainsString($expected_ansi, $result);
     $this->assertStringContainsString($input, $result);
   }
 

--- a/.vortex/installer/tests/Unit/TuiTest.php
+++ b/.vortex/installer/tests/Unit/TuiTest.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 namespace DrevOps\VortexInstaller\Tests\Unit;
 
 use DrevOps\VortexInstaller\Utils\Strings;
+use DrevOps\VortexInstaller\Utils\Tui;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use DrevOps\VortexInstaller\Utils\Tui;
-
 use Symfony\Component\Console\Output\BufferedOutput;
 
 /**

--- a/.vortex/installer/tests/Unit/Utils/FileManagerTest.php
+++ b/.vortex/installer/tests/Unit/Utils/FileManagerTest.php
@@ -35,10 +35,10 @@ class FileManagerTest extends UnitTestCase {
    * Tests for prepareDestination().
    */
   public function testPrepareDestinationExistingDirWithGit(): void {
-    $dst = self::$sut;
-    mkdir($dst . '/.git', 0777, TRUE);
+    $destination = self::$sut;
+    mkdir($destination . '/.git', 0777, TRUE);
 
-    $config = new Config('/tmp/root', $dst, '/tmp/tmp');
+    $config = new Config('/tmp/root', $destination, '/tmp/tmp');
     $fm = new FileManager($config);
 
     $messages = $fm->prepareDestination();
@@ -47,28 +47,28 @@ class FileManagerTest extends UnitTestCase {
   }
 
   public function testPrepareDestinationExistingDirWithoutGit(): void {
-    $dst = self::$sut;
+    $destination = self::$sut;
 
-    $config = new Config('/tmp/root', $dst, '/tmp/tmp');
+    $config = new Config('/tmp/root', $destination, '/tmp/tmp');
     $fm = new FileManager($config);
 
     $messages = $fm->prepareDestination();
 
     $this->assertNotEmpty($messages);
-    $this->assertDirectoryExists($dst . '/.git');
+    $this->assertDirectoryExists($destination . '/.git');
     $this->assertStringContainsString('Initialising a new Git repository', $messages[0]);
   }
 
   public function testPrepareDestinationCreatesNewDir(): void {
-    $dst = self::$sut . '/new_subdir';
+    $destination = self::$sut . '/new_subdir';
 
-    $config = new Config('/tmp/root', $dst, '/tmp/tmp');
+    $config = new Config('/tmp/root', $destination, '/tmp/tmp');
     $fm = new FileManager($config);
 
     $messages = $fm->prepareDestination();
 
-    $this->assertDirectoryExists($dst);
-    $this->assertDirectoryExists($dst . '/.git');
+    $this->assertDirectoryExists($destination);
+    $this->assertDirectoryExists($destination . '/.git');
 
     $has_created_msg = FALSE;
     $has_git_msg = FALSE;
@@ -89,34 +89,34 @@ class FileManagerTest extends UnitTestCase {
    */
   public function testCopyFilesCopiesToDestination(): void {
     $src = self::$sut . '/src_copy';
-    $dst = self::$sut . '/dst_copy';
+    $destination = self::$sut . '/dst_copy';
     mkdir($src, 0777, TRUE);
-    mkdir($dst, 0777, TRUE);
+    mkdir($destination, 0777, TRUE);
     file_put_contents($src . '/test.txt', 'content');
 
-    $config = new Config('/tmp/root', $dst, $src);
+    $config = new Config('/tmp/root', $destination, $src);
     $fm = new FileManager($config);
 
     $fm->copyFiles();
 
-    $this->assertFileExists($dst . '/test.txt');
-    $this->assertEquals('content', file_get_contents($dst . '/test.txt'));
+    $this->assertFileExists($destination . '/test.txt');
+    $this->assertEquals('content', file_get_contents($destination . '/test.txt'));
   }
 
   public function testCopyFilesCreatesEnvLocal(): void {
     $src = self::$sut . '/src_envlocal';
-    $dst = self::$sut . '/dst_envlocal';
+    $destination = self::$sut . '/dst_envlocal';
     mkdir($src, 0777, TRUE);
-    mkdir($dst, 0777, TRUE);
+    mkdir($destination, 0777, TRUE);
     file_put_contents($src . '/test.txt', 'content');
 
-    $config = new Config('/tmp/root', $dst, $src);
+    $config = new Config('/tmp/root', $destination, $src);
     $fm = new FileManager($config);
 
     $fm->copyFiles();
 
     // Create the .env.local.example after copy.
-    file_put_contents($dst . '/.env.local.example', 'EXAMPLE=1');
+    file_put_contents($destination . '/.env.local.example', 'EXAMPLE=1');
 
     // Re-run to trigger the .env.local creation.
     // Recreate src for the second run.
@@ -124,34 +124,34 @@ class FileManagerTest extends UnitTestCase {
     file_put_contents($src . '/dummy.txt', 'dummy');
     $fm->copyFiles();
 
-    $this->assertFileExists($dst . '/.env.local');
-    $this->assertEquals('EXAMPLE=1', file_get_contents($dst . '/.env.local'));
+    $this->assertFileExists($destination . '/.env.local');
+    $this->assertEquals('EXAMPLE=1', file_get_contents($destination . '/.env.local'));
   }
 
   public function testCopyFilesSkipsEnvLocalIfExists(): void {
     $src = self::$sut . '/src_envexist';
-    $dst = self::$sut . '/dst_envexist';
+    $destination = self::$sut . '/dst_envexist';
     mkdir($src, 0777, TRUE);
-    mkdir($dst, 0777, TRUE);
+    mkdir($destination, 0777, TRUE);
     file_put_contents($src . '/test.txt', 'content');
-    file_put_contents($dst . '/.env.local', 'EXISTING=1');
-    file_put_contents($dst . '/.env.local.example', 'EXAMPLE=1');
+    file_put_contents($destination . '/.env.local', 'EXISTING=1');
+    file_put_contents($destination . '/.env.local.example', 'EXAMPLE=1');
 
-    $config = new Config('/tmp/root', $dst, $src);
+    $config = new Config('/tmp/root', $destination, $src);
     $fm = new FileManager($config);
 
     $fm->copyFiles();
 
-    $this->assertEquals('EXISTING=1', file_get_contents($dst . '/.env.local'));
+    $this->assertEquals('EXISTING=1', file_get_contents($destination . '/.env.local'));
   }
 
   public function testCopyFilesHandlesEmptySrc(): void {
     $src = self::$sut . '/src_empty';
-    $dst = self::$sut . '/dst_empty';
+    $destination = self::$sut . '/dst_empty';
     mkdir($src, 0777, TRUE);
-    mkdir($dst, 0777, TRUE);
+    mkdir($destination, 0777, TRUE);
 
-    $config = new Config('/tmp/root', $dst, $src);
+    $config = new Config('/tmp/root', $destination, $src);
     $fm = new FileManager($config);
 
     // Should not throw.
@@ -166,28 +166,28 @@ class FileManagerTest extends UnitTestCase {
     // 'drevops/vortex-tooling' Composer package. The legacy directory must
     // be removed from the destination after the copy.
     $src = self::$sut . '/src_obsolete';
-    $dst = self::$sut . '/dst_obsolete';
+    $destination = self::$sut . '/dst_obsolete';
     mkdir($src, 0777, TRUE);
-    mkdir($dst . '/scripts/vortex', 0777, TRUE);
+    mkdir($destination . '/scripts/vortex', 0777, TRUE);
     file_put_contents($src . '/test.txt', 'new');
-    file_put_contents($dst . '/scripts/vortex/legacy.sh', 'legacy');
-    file_put_contents($dst . '/scripts/keep.sh', 'custom');
+    file_put_contents($destination . '/scripts/vortex/legacy.sh', 'legacy');
+    file_put_contents($destination . '/scripts/keep.sh', 'custom');
 
-    $config = new Config('/tmp/root', $dst, $src);
+    $config = new Config('/tmp/root', $destination, $src);
     $fm = new FileManager($config);
 
     $fm->copyFiles();
 
-    $this->assertDirectoryDoesNotExist($dst . '/scripts/vortex', 'Legacy scripts/vortex/ directory removed after copy.');
-    $this->assertFileExists($dst . '/scripts/keep.sh', 'Sibling custom scripts/ entries preserved.');
-    $this->assertFileExists($dst . '/test.txt', 'New files copied from source.');
+    $this->assertDirectoryDoesNotExist($destination . '/scripts/vortex', 'Legacy scripts/vortex/ directory removed after copy.');
+    $this->assertFileExists($destination . '/scripts/keep.sh', 'Sibling custom scripts/ entries preserved.');
+    $this->assertFileExists($destination . '/test.txt', 'New files copied from source.');
   }
 
   public function testRemoveObsoletePathsSilentOnMissing(): void {
-    $dst = self::$sut . '/dst_no_obsolete';
-    mkdir($dst, 0777, TRUE);
+    $destination = self::$sut . '/dst_no_obsolete';
+    mkdir($destination, 0777, TRUE);
 
-    $config = new Config('/tmp/root', $dst, '/tmp/tmp');
+    $config = new Config('/tmp/root', $destination, '/tmp/tmp');
     $fm = new FileManager($config);
 
     // Should not throw when there is nothing to remove.
@@ -223,10 +223,10 @@ class FileManagerTest extends UnitTestCase {
   }
 
   public function testPrepareDemoNoUrl(): void {
-    $dst = self::$sut;
-    file_put_contents($dst . '/.env', '');
+    $destination = self::$sut;
+    file_put_contents($destination . '/.env', '');
 
-    $config = new Config('/tmp/root', $dst, '/tmp/tmp');
+    $config = new Config('/tmp/root', $destination, '/tmp/tmp');
     $config->set(Config::IS_DEMO, TRUE);
     $fm = new FileManager($config);
 
@@ -238,13 +238,13 @@ class FileManagerTest extends UnitTestCase {
   }
 
   public function testPrepareDemoExistingDatabaseFile(): void {
-    $dst = self::$sut;
-    $data_dir = $dst . '/.data';
+    $destination = self::$sut;
+    $data_dir = $destination . '/.data';
     mkdir($data_dir, 0777, TRUE);
     file_put_contents($data_dir . '/db.sql', 'existing');
-    file_put_contents($dst . '/.env', "VORTEX_FETCH_DB_URL=https://example.com/db.sql\nVORTEX_DB_DIR=./.data\nVORTEX_DB_FILE=db.sql\n");
+    file_put_contents($destination . '/.env', "VORTEX_FETCH_DB_URL=https://example.com/db.sql\nVORTEX_DB_DIR=./.data\nVORTEX_DB_FILE=db.sql\n");
 
-    $config = new Config('/tmp/root', $dst, '/tmp/tmp');
+    $config = new Config('/tmp/root', $destination, '/tmp/tmp');
     $config->set(Config::IS_DEMO, TRUE);
     $fm = new FileManager($config);
 
@@ -256,10 +256,10 @@ class FileManagerTest extends UnitTestCase {
   }
 
   public function testPrepareDemoFetchesDatabase(): void {
-    $dst = self::$sut;
-    file_put_contents($dst . '/.env', "VORTEX_FETCH_DB_URL=https://example.com/db.sql\nVORTEX_DB_DIR=./.data\nVORTEX_DB_FILE=db.sql\n");
+    $destination = self::$sut;
+    file_put_contents($destination . '/.env', "VORTEX_FETCH_DB_URL=https://example.com/db.sql\nVORTEX_DB_DIR=./.data\nVORTEX_DB_FILE=db.sql\n");
 
-    $config = new Config('/tmp/root', $dst, '/tmp/tmp');
+    $config = new Config('/tmp/root', $destination, '/tmp/tmp');
     $config->set(Config::IS_DEMO, TRUE);
     $fm = new FileManager($config);
 
@@ -283,10 +283,10 @@ class FileManagerTest extends UnitTestCase {
   }
 
   public function testPrepareDemoCreatesDataDir(): void {
-    $dst = self::$sut;
-    file_put_contents($dst . '/.env', "VORTEX_FETCH_DB_URL=https://example.com/db.sql\nVORTEX_DB_DIR=./.data\nVORTEX_DB_FILE=db.sql\n");
+    $destination = self::$sut;
+    file_put_contents($destination . '/.env', "VORTEX_FETCH_DB_URL=https://example.com/db.sql\nVORTEX_DB_DIR=./.data\nVORTEX_DB_FILE=db.sql\n");
 
-    $config = new Config('/tmp/root', $dst, '/tmp/tmp');
+    $config = new Config('/tmp/root', $destination, '/tmp/tmp');
     $config->set(Config::IS_DEMO, TRUE);
     $fm = new FileManager($config);
 
@@ -294,7 +294,7 @@ class FileManagerTest extends UnitTestCase {
     $result = $fm->prepareDemo($downloader);
 
     $this->assertIsArray($result);
-    $this->assertDirectoryExists($dst . '/.data');
+    $this->assertDirectoryExists($destination . '/.data');
 
     $has_created_msg = FALSE;
     foreach ($result as $msg) {

--- a/.vortex/installer/tests/Unit/Utils/OptionsResolverTest.php
+++ b/.vortex/installer/tests/Unit/Utils/OptionsResolverTest.php
@@ -100,12 +100,12 @@ class OptionsResolverTest extends UnitTestCase {
   }
 
   public function testResolveSetsDestination(): void {
-    $dst = self::$sut;
-    $options = self::defaultOptions(['destination' => $dst]);
+    $destination = self::$sut;
+    $options = self::defaultOptions(['destination' => $destination]);
 
     [$config] = OptionsResolver::resolve($options);
 
-    $this->assertEquals($dst, $config->getDst());
+    $this->assertEquals($destination, $config->getDestination());
   }
 
   public function testResolveSetsRoot(): void {
@@ -229,15 +229,15 @@ class OptionsResolverTest extends UnitTestCase {
 
   public function testResolveDestinationPriority(): void {
     // Option takes priority over root.
-    $dst = self::$sut;
+    $destination = self::$sut;
     $options = self::defaultOptions([
-      'destination' => $dst,
+      'destination' => $destination,
       'root' => '/some/other/root',
     ]);
 
     [$config] = OptionsResolver::resolve($options);
 
-    $this->assertEquals($dst, $config->getDst());
+    $this->assertEquals($destination, $config->getDestination());
   }
 
   /**

--- a/.vortex/installer/tests/Unit/ValidatorTest.php
+++ b/.vortex/installer/tests/Unit/ValidatorTest.php
@@ -14,12 +14,12 @@ use DrevOps\VortexInstaller\Utils\Validator;
 #[CoversClass(Validator::class)]
 class ValidatorTest extends UnitTestCase {
 
-  #[DataProvider('dataProviderContainerImage')]
-  public function testContainerImage(string $input, bool $expected): void {
-    $this->assertSame($expected, Validator::containerImage($input));
+  #[DataProvider('dataProviderIsContainerImage')]
+  public function testIsContainerImage(string $input, bool $expected): void {
+    $this->assertSame($expected, Validator::isContainerImage($input));
   }
 
-  public static function dataProviderContainerImage(): \Iterator {
+  public static function dataProviderIsContainerImage(): \Iterator {
     yield ['myregistryhost:5000/fedora/httpd:version', TRUE];
     yield ['fedora/httpd:version1.0.test', TRUE];
     yield ['fedora/httpd:version1.0', TRUE];
@@ -37,12 +37,12 @@ class ValidatorTest extends UnitTestCase {
     yield ['test:super-long-tag-that-exceeds-128-characters-aaaaaaaaaabbbbbbbbbbbbccccccccccddddddddddeeeeeeeeeeaaaaaaaaaabbbbbbbbbbbbccccccccccddddddddddeeeeeeeeee', FALSE];
   }
 
-  #[DataProvider('dataProviderDomain')]
-  public function testDomain(string $domain, bool $expected): void {
-    $this->assertSame($expected, Validator::domain($domain));
+  #[DataProvider('dataProviderIsDomain')]
+  public function testIsDomain(string $domain, bool $expected): void {
+    $this->assertSame($expected, Validator::isDomain($domain));
   }
 
-  public static function dataProviderDomain(): \Iterator {
+  public static function dataProviderIsDomain(): \Iterator {
     yield 'valid domain with TLD' => ['example.com', TRUE];
     yield 'valid subdomain' => ['sub.example.com', TRUE];
     yield 'valid domain with multiple dots' => ['example.co.uk', TRUE];
@@ -55,12 +55,12 @@ class ValidatorTest extends UnitTestCase {
     yield 'invalid domain with spaces' => ['example .com', FALSE];
   }
 
-  #[DataProvider('dataProviderGithubProject')]
-  public function testGithubProject(string $value, bool $expected): void {
-    $this->assertSame($expected, Validator::githubProject($value));
+  #[DataProvider('dataProviderIsGithubProject')]
+  public function testIsGithubProject(string $value, bool $expected): void {
+    $this->assertSame($expected, Validator::isGithubProject($value));
   }
 
-  public static function dataProviderGithubProject(): \Iterator {
+  public static function dataProviderIsGithubProject(): \Iterator {
     yield 'valid project' => ['user/repo', TRUE];
     yield 'valid project with numbers' => ['user123/repo456', TRUE];
     yield 'valid project with hyphens and underscores' => ['user-name/repo_name', TRUE];
@@ -74,12 +74,12 @@ class ValidatorTest extends UnitTestCase {
     yield 'invalid special characters' => ['user!@#/repo$', FALSE];
   }
 
-  #[DataProvider('dataProviderDirname')]
-  public function testDirname(string $input, bool $expected): void {
-    $this->assertSame($expected, Validator::dirname($input));
+  #[DataProvider('dataProviderIsDirname')]
+  public function testIsDirname(string $input, bool $expected): void {
+    $this->assertSame($expected, Validator::isDirname($input));
   }
 
-  public static function dataProviderDirname(): \Iterator {
+  public static function dataProviderIsDirname(): \Iterator {
     yield 'valid folder name' => ['valid_folder', TRUE];
     yield 'valid with hyphen' => ['my-folder', TRUE];
     yield 'valid with dot' => ['another.folder', TRUE];
@@ -97,12 +97,12 @@ class ValidatorTest extends UnitTestCase {
     yield 'invalid double dot' => ['..', FALSE];
   }
 
-  #[DataProvider('dataProviderGitCommitSha')]
-  public function testGitCommitSha(string $sha, bool $expected): void {
-    $this->assertSame($expected, Validator::gitCommitSha($sha));
+  #[DataProvider('dataProviderIsGitCommitSha')]
+  public function testIsGitCommitSha(string $sha, bool $expected): void {
+    $this->assertSame($expected, Validator::isGitCommitSha($sha));
   }
 
-  public static function dataProviderGitCommitSha(): \Iterator {
+  public static function dataProviderIsGitCommitSha(): \Iterator {
     // Valid SHA-1 hashes (40 hexadecimal characters)
     yield 'valid lowercase SHA' => ['a1b2c3d4e5f6789012345678901234567890abcd', TRUE];
     yield 'valid uppercase SHA' => ['A1B2C3D4E5F6789012345678901234567890ABCD', TRUE];
@@ -122,12 +122,12 @@ class ValidatorTest extends UnitTestCase {
     yield 'invalid null characters' => ["a1b2c3d4e5f6789012345678901234567890abc\0", FALSE];
   }
 
-  #[DataProvider('dataProviderGitCommitShaShort')]
-  public function testGitCommitShaShort(string $sha_short, bool $expected): void {
-    $this->assertSame($expected, Validator::gitCommitShaShort($sha_short));
+  #[DataProvider('dataProviderIsGitCommitShaShort')]
+  public function testIsGitCommitShaShort(string $sha_short, bool $expected): void {
+    $this->assertSame($expected, Validator::isGitCommitShaShort($sha_short));
   }
 
-  public static function dataProviderGitCommitShaShort(): \Iterator {
+  public static function dataProviderIsGitCommitShaShort(): \Iterator {
     // Valid short SHA-1 hashes (7 hexadecimal characters)
     yield 'valid lowercase short SHA' => ['a1b2c3d', TRUE];
     yield 'valid uppercase short SHA' => ['A1B2C3D', TRUE];
@@ -153,12 +153,12 @@ class ValidatorTest extends UnitTestCase {
     yield 'invalid null characters' => ["a1b2c3\0", FALSE];
   }
 
-  #[DataProvider('dataProviderGitRef')]
-  public function testGitRef(string $ref, bool $expected): void {
-    $this->assertSame($expected, Validator::gitRef($ref));
+  #[DataProvider('dataProviderIsGitRef')]
+  public function testIsGitRef(string $ref, bool $expected): void {
+    $this->assertSame($expected, Validator::isGitRef($ref));
   }
 
-  public static function dataProviderGitRef(): \Iterator {
+  public static function dataProviderIsGitRef(): \Iterator {
     // Special keywords.
     yield 'special keyword stable' => ['stable', TRUE];
     yield 'special keyword HEAD' => ['HEAD', TRUE];

--- a/.vortex/installer/tests/Unit/YamlTest.php
+++ b/.vortex/installer/tests/Unit/YamlTest.php
@@ -29,7 +29,7 @@ class YamlTest extends UnitTestCase {
   }
 
   public function testValidateFileNonExistent(): void {
-    $this->expectException(\InvalidArgumentException::class);
+    $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('File does not exist or is not readable');
 
     $non_existent_file = sys_get_temp_dir() . '/non_existent_file.yml';

--- a/.vortex/tests/phpunit/Functional/DeploymentTest.php
+++ b/.vortex/tests/phpunit/Functional/DeploymentTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace DrevOps\Vortex\Tests\Functional;
 
 use AlexSkrypnyk\File\File;
+use DrevOps\Vortex\Tests\Traits\DeploymentTrait;
 use DrevOps\Vortex\Tests\Traits\Subtests\SubtestAhoyTrait;
-use DrevOps\Vortex\Tests\Traits\Subtests\SubtestDeploymentTrait;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -14,8 +14,8 @@ use PHPUnit\Framework\Attributes\Group;
  */
 class DeploymentTest extends FunctionalTestCase {
 
+  use DeploymentTrait;
   use SubtestAhoyTrait;
-  use SubtestDeploymentTrait;
 
   protected function setUp(): void {
     parent::setUp();

--- a/.vortex/tests/phpunit/Functional/DockerComposeWorkflowTest.php
+++ b/.vortex/tests/phpunit/Functional/DockerComposeWorkflowTest.php
@@ -40,7 +40,7 @@ class DockerComposeWorkflowTest extends FunctionalTestCase {
 
     $this->subtestDockerComposeDrushPhpIni();
 
-    $this->subtestSolr();
+    $this->subtestDockerComposeSolr();
 
     $this->logSubstep('Installing development dependencies');
     $this->cmd('docker compose exec -T cli composer install --prefer-dist', txt: 'Install development dependencies with Composer', tio: 10 * 60);

--- a/.vortex/tests/phpunit/Functional/FunctionalTestCase.php
+++ b/.vortex/tests/phpunit/Functional/FunctionalTestCase.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace DrevOps\Vortex\Tests\Functional;
 
 use AlexSkrypnyk\File\File;
+use AlexSkrypnyk\File\Testing\DirectoryAssertionsTrait;
+use AlexSkrypnyk\File\Testing\FileAssertionsTrait;
 use AlexSkrypnyk\PhpunitHelpers\Traits\AssertArrayTrait;
 use AlexSkrypnyk\PhpunitHelpers\Traits\EnvTrait;
 use AlexSkrypnyk\PhpunitHelpers\Traits\LocationsTrait;
@@ -22,7 +24,9 @@ use PHPUnit\Framework\TestStatus\Failure;
 class FunctionalTestCase extends UnitTestCase {
 
   use AssertArrayTrait;
+  use DirectoryAssertionsTrait;
   use EnvTrait;
+  use FileAssertionsTrait;
   use GitTrait;
   use LocationsTrait;
   use ProcessTrait;
@@ -174,7 +178,7 @@ class FunctionalTestCase extends UnitTestCase {
   }
 
   public function dockerCleanup(): void {
-    shell_exec('docker compose -p star_wars down --remove-orphans --volumes --timeout 1 > /dev/null 2>&1');
+    shell_exec(sprintf('docker compose -p %s down --remove-orphans --volumes --timeout 1 > /dev/null 2>&1', escapeshellarg(basename(static::$sut))));
   }
 
 }

--- a/.vortex/tests/phpunit/Functional/InstallerTest.php
+++ b/.vortex/tests/phpunit/Functional/InstallerTest.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace DrevOps\Vortex\Tests\Functional;
 
 use AlexSkrypnyk\File\File;
-use DrevOps\Vortex\Tests\Traits\Subtests\SubtestAhoyTrait;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests Installer.
  */
 class InstallerTest extends FunctionalTestCase {
-
-  use SubtestAhoyTrait;
 
   protected function setUp(): void {
     parent::setUp();

--- a/.vortex/tests/phpunit/Functional/PostBuildTest.php
+++ b/.vortex/tests/phpunit/Functional/PostBuildTest.php
@@ -51,6 +51,7 @@ class PostBuildTest extends FunctionalTestCase {
    *   on runner 0 but not runner 1, search.feature on runner 1 but not
    *   runner 0)
    */
+  #[Group('p0')]
   #[Group('postbuild')]
   public function testCircleCiArtifactsAreSaved(): void {
     $current_job_number = (int) getenv('CIRCLE_BUILD_NUM');
@@ -95,6 +96,7 @@ class PostBuildTest extends FunctionalTestCase {
    * - PHPUnit test results from various test suites are recorded
    * - Behat feature test results are recorded.
    */
+  #[Group('p0')]
   #[Group('postbuild')]
   public function testCircleCiTestResultsAreSaved(): void {
     $current_job_number = (int) getenv('CIRCLE_BUILD_NUM');

--- a/.vortex/tests/phpunit/Functional/ToolingBootstrapTest.php
+++ b/.vortex/tests/phpunit/Functional/ToolingBootstrapTest.php
@@ -55,8 +55,8 @@ class ToolingBootstrapTest extends FunctionalTestCase {
     }
   }
 
-  #[DataProvider('dataProviderBootstrap')]
   #[Group('p1')]
+  #[DataProvider('dataProviderBootstrap')]
   public function testBootstrap(bool $package_present, bool $binaries_present): void {
     $this->logStepStart();
 

--- a/.vortex/tests/phpunit/Traits/CircleCiTrait.php
+++ b/.vortex/tests/phpunit/Traits/CircleCiTrait.php
@@ -89,7 +89,8 @@ trait CircleCiTrait {
         continue;
       }
 
-      if (($item['job_number'] ?? '') == $current_job_number) {
+      $job_number = $item['job_number'] ?? '';
+      if (is_numeric($job_number) && (int) $job_number === $current_job_number) {
         $dependencies_job_ids = is_array($item['dependencies'] ?? []) ? $item['dependencies'] : [];
         break;
       }

--- a/.vortex/tests/phpunit/Traits/DeploymentTrait.php
+++ b/.vortex/tests/phpunit/Traits/DeploymentTrait.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace DrevOps\Vortex\Tests\Traits\Subtests;
+namespace DrevOps\Vortex\Tests\Traits;
 
 use AlexSkrypnyk\File\File;
 
 /**
  * Steps and assertions for testing deployment workflows.
  */
-trait SubtestDeploymentTrait {
+trait DeploymentTrait {
 
   /**
    * Prepare deployment source directory.

--- a/.vortex/tests/phpunit/Traits/HelpersTrait.php
+++ b/.vortex/tests/phpunit/Traits/HelpersTrait.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace DrevOps\Vortex\Tests\Traits;
 
 use AlexSkrypnyk\File\File;
-use AlexSkrypnyk\File\Testing\DirectoryAssertionsTrait;
-use AlexSkrypnyk\File\Testing\FileAssertionsTrait;
 
 /**
  * Helper methods for functional tests.
@@ -15,11 +13,8 @@ use AlexSkrypnyk\File\Testing\FileAssertionsTrait;
  */
 trait HelpersTrait {
 
-  use DirectoryAssertionsTrait;
-  use FileAssertionsTrait;
-
   public function volumesMounted(): bool {
-    return getenv('VORTEX_DEV_VOLUMES_SKIP_MOUNT') != 1;
+    return getenv('VORTEX_DEV_VOLUMES_SKIP_MOUNT') !== '1';
   }
 
   public function forceVolumesUnmounted(): void {

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestDockerComposeTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestDockerComposeTrait.php
@@ -322,7 +322,7 @@ trait SubtestDockerComposeTrait {
     $this->logStepFinish();
   }
 
-  protected function subtestSolr(): void {
+  protected function subtestDockerComposeSolr(): void {
     $this->logStepStart();
 
     $this->cmd(

--- a/.vortex/tests/phpunit/Traits/SutTrait.php
+++ b/.vortex/tests/phpunit/Traits/SutTrait.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace DrevOps\Vortex\Tests\Traits;
 
 use AlexSkrypnyk\File\File;
-use AlexSkrypnyk\File\Testing\DirectoryAssertionsTrait;
-use AlexSkrypnyk\File\Testing\FileAssertionsTrait;
 
 /**
  * Generic methods for setting up and testing SUT.
@@ -14,9 +12,6 @@ use AlexSkrypnyk\File\Testing\FileAssertionsTrait;
  * Workflow-specific methods live in the Subtests\Subtest*Trait traits.
  */
 trait SutTrait {
-
-  use DirectoryAssertionsTrait;
-  use FileAssertionsTrait;
 
   /**
    * URL to the test demo database.

--- a/.vortex/tests/phpunit/Traits/SutTrait.php
+++ b/.vortex/tests/phpunit/Traits/SutTrait.php
@@ -11,7 +11,7 @@ use AlexSkrypnyk\File\Testing\FileAssertionsTrait;
 /**
  * Generic methods for setting up and testing SUT.
  *
- * Workflow-specific methods are withing Subtest\*Trait traits.
+ * Workflow-specific methods live in the Subtests\Subtest*Trait traits.
  */
 trait SutTrait {
 


### PR DESCRIPTION
Closes #2925
Closes #2926
Closes #2927
Closes #2928
Closes #2929
Closes #2930
Closes #2931
Closes #2932
Closes #2933
Closes #2934
Closes #2935
Closes #2936
Closes #2937
Closes #2938
Closes #2939
Closes #2940
Closes #2941
Closes #2942
Closes #2943
Closes #2944
Closes #2945

## Summary

A convergence pass that removes internal inconsistencies from the Vortex installer and its `.vortex/tests` harness - the kind of drift that accumulates when many contributors and agents touch the same codebase over time.

Eleven Fable readers read every first-party file in full and produced a structured map of divergent naming, API shapes, and idioms; a single Fable planner reviewed the whole map and decided one canonical form per inconsistency class; the user then reviewed and approved every decision across six rounds of questions before anything was applied.

This PR contains 19 commits, one per convergence class, each gated on lint plus the full 1618-test installer suite. Scope is installer internals and the `.vortex/tests` harness only - no shipped template file was touched, so no snapshot regeneration was required and consumer projects are unaffected.

## Changes

Grouped by theme; commits listed oldest to newest within each group.

**Visibility and casing**
- Replaced `private` visibility with `protected` across the installer (`a798bce5`).
- Renamed camelCase method arguments to snake_case in the installer (`87185636`).
- Replaced double-quoted plain strings with single quotes where no escaping is needed (`20d2cb8b`).

**Naming vocabulary**
- Renamed `dst` to `destination` throughout the installer, 251 occurrences across 53 files (`92c476b6`).
- Prefixed `Validator` boolean predicates with `is` (`b8b272ee`).
- Replaced `static::` with `self::` for own-member references (`edccabc9`).
- Aligned subtest helper naming in the template test harness (`79c85c0f`).

**Docblock and import hygiene**
- Removed inconsistent `@package` docblock tags from the installer (`e10c870f`).
- Merged split `use` blocks into a single sorted block (`0334adfa`).

**Comparison and null-check idioms**
- Converged null checks and comparison strictness in the installer (`6631fa27`).
- Converged lazy initialisation on the null-coalescing assignment (`5594f842`).
- Made loose comparisons strict in the template test harness (`cd017c04`).

**Handler lifecycle API shapes**
- Converged handler lifecycle API shapes (`f74fbeb8`): removed lifecycle overrides (`postInstall()`, `hint()`) that only repeated `AbstractHandler`'s own `NULL` default, widened `description()` to its declared `?string` return type across five handlers, and switched `PromptManager` to call `description()` through the class (`$handler::description()`) rather than through an instance.

**Dead-code removal**
- Removed verified-unreferenced declarations from the installer (`e28225aa`).

**File, exception and temp-directory mechanisms**
- Converged `Archiver` on the local `File` wrapper and its temp-dir helper, replacing hand-rolled `sys_get_temp_dir()` / `uniqid()` / `mkdir()` calls with `File::tmpdir()` (`c589540b`).
- Unified the exception type for file failures on `RuntimeException` (`38f2c07b`).
- Converged file deletion on `File::remove()`, replacing `@unlink()` calls and existence-then-remove pairs (`e29085ac`).

**Test-harness composition**
- Added missing CI `#[Group]` attributes and fixed attribute ordering (`d82de6e8`).
- Composed shared assertion traits (`DirectoryAssertionsTrait`, `FileAssertionsTrait`) once on the base functional test case instead of duplicating them across two traits, and derived the Docker Compose project name from the system-under-test path instead of a hardcoded name (`4a4fc050`).

## Not applied

Three decisions from the plan were not carried out; reviewers should see why.

- **`File::exists()` to native `file_exists()`** - the plan's majority was miscounted (actual: 17 files call the native function versus 5 files / 15 call sites using the wrapper). `File::exists()` is the project's own facade alongside `File::remove()`, `File::copy()`, `File::mkdir()`, and `File::dump()`, with a broader `string|array` contract that `file_exists()` does not share. Converging would strip a member out of a deliberate abstraction on a miscounted majority.
- **Typed response getters in `DatabaseImage`, `MigrationImage`, and `MigrationFetchSource`** - their `process()` runs unconditionally via `PromptManager::runProcessors()` even when `->addIf()` skipped the prompt, so `$this->response` is `NULL` on the ordinary path. `getResponseAsString()` throws on a non-scalar value, so converting to it would crash the installer whenever a user picks a database fetch source other than the container registry. The raw `!empty($this->response)` guards are load-bearing, not drift.
- **Converting repeated sibling tests into data providers** - declined by the user during review.

## Remaining work

Roughly 37 further convergence classes were reviewed and approved during the judgment-call rounds but are not part of this PR. Every decision is already made; what is left is applying it. The full specification lives in `.artifacts/tmp/convergence-map/GLOBAL-MAP.md` (the per-class map) and its `PROGRESS.md` ledger.

The main groups still outstanding:

- Remaining installer-internals classes (api-shape and module-pattern): exception types, fluent setters, the Tui output channel, runner invocation, the Logger-aware pattern, composer.json manipulation, path joining, file deletion, temp creation, `Utils\File` in `Archiver`, the queue-vs-execute LAW fix, guard clauses, dead declarations, deduplication, process execution, `dataProvider` placement, dataset keys, test path mirroring, and functional/unit test scaffolding.
- The remaining `.vortex/tests` harness classes: `cmd()` named-tail style, output-assertion style, trait composition, harness drift, `lint.*.sh` alignment, and `#[Group('pN')]` coverage.
- Tooling shell scripts (`drevops/vortex-tooling`): message vocabulary, mechanics, the doc-skeleton rewrite, stray markers, and BATS mechanics/filenames.
- Shipped-template classes, each needing a snapshot regeneration and diff review: em dashes, issue references, final newlines, a dead `.ignorecontent` entry, the `.env` banner, fence tokens, vocabulary, CI step names, the CI safe subset, settings guards, the trusted-host list, scaffold test naming, scaffold extension patterns, demo JS, provision/hook conventions, and the README badge normalizer.
- Four approved behaviour changes: root-ops latent-bug fixes, the timezone-into-CI gap, loosened `=== '1'` env-truthiness checks, and the `your_site_theme` JS behaviour key.

## Related

- #2888 - unify the public `VORTEX_*` environment variable vocabulary.
- #2889 - unify CI job identifiers across CircleCI and GitHub Actions.

Both are filed against milestone 2.0 rather than folded into this PR: they rename consumer-facing contracts and need a deprecation cycle, not an in-place rename.

## Before / After

```
BEFORE - one concept, several spellings               AFTER - one canonical form per class
┌───────────────────────────────────────────┐          ┌─────────────────────────────────────────────┐
│ function download(?string $dst)           │          │ function download(?string $destination)     │
│ private function resolvePromptOverrides() │ ───────► │ protected function resolvePromptOverrides() │
│ static::OPTION_PROFILE                    │          │ self::OPTION_PROFILE                        │
│ Validator::domain() / githubProject()     │          │ Validator::isDomain() / isGithubProject()   │
│ !is_null($discovered)                     │          │ $discovered !== NULL                        │
│ @unlink($f) / exists-then-remove($f)      │          │ File::remove($f)                            │
│ throw new InvalidArgumentException(...)   │          │ throw new RuntimeException(...)              │
└───────────────────────────────────────────┘          └─────────────────────────────────────────────┘
  19 divergent local conventions,                     1 canonical form per class, applied
  scattered across 97 files                            consistently, across the same 97 files
```

