### PR TITLE
Bumped CI database cache key to 'v26.8.0'.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,10 +278,10 @@ jobs:
             # Bump the last segment of the version prefix below to force a cache reset.
             # Lookup cache based on the default branch and a timestamp. Allows
             # to use cache from the very first build on the day (sanitized database dump, for example).
-            - v26.7.2-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+            - v26.8.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
             # Fallback to caching by default branch name only. Allows to use
             # cache from the branch build on the previous day.
-            - v26.7.2-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
+            - v26.8.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
 
       - run:
           name: Fetch DB
@@ -331,7 +331,7 @@ jobs:
           # The cache will not be saved if it already exists.
           # Note that the cache fallback flag is enabled for this case in order
           # to save cache even if the fallback is not used when restoring it.
-          key: v26.7.2-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          key: v26.8.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
 
@@ -385,8 +385,8 @@ jobs:
           keys:
             # Use cached artifacts from previous builds of this branch.
             # https://circleci.com/docs/2.0/caching/#restoring-cache
-            - v26.7.2-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            - v26.7.2-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-
+            - v26.8.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+            - v26.8.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-
       #;> !PROVISION_TYPE_PROFILE
 
       - *step_setup_remote_docker

--- a/.circleci/vortex-test-common.yml
+++ b/.circleci/vortex-test-common.yml
@@ -135,10 +135,10 @@ jobs:
             # Bump the last segment of the version prefix below to force a cache reset.
             # Lookup cache based on the default branch and a timestamp. Allows
             # to use cache from the very first build on the day (sanitized database dump, for example).
-            - v26.7.2-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+            - v26.8.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-{{ checksum "/tmp/db_cache_timestamp" }}
             # Fallback to caching by default branch name only. Allows to use
             # cache from the branch build on the previous day.
-            - v26.7.2-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
+            - v26.8.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback" }}-
 
       - run:
           name: Fetch DB
@@ -188,7 +188,7 @@ jobs:
           # The cache will not be saved if it already exists.
           # Note that the cache fallback flag is enabled for this case in order
           # to save cache even if the fallback is not used when restoring it.
-          key: v26.7.2-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+          key: v26.8.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
           paths:
             - /root/project/.data
 
@@ -223,8 +223,8 @@ jobs:
           keys:
             # Use cached artifacts from previous builds of this branch.
             # https://circleci.com/docs/2.0/caching/#restoring-cache
-            - v26.7.2-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
-            - v26.7.2-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-
+            - v26.8.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-{{ checksum "/tmp/db_cache_timestamp" }}
+            - v26.8.0-{{ checksum "/tmp/db_cache_branch" }}-{{ checksum "/tmp/db_cache_fallback_yes" }}-
       #;> !PROVISION_TYPE_PROFILE
 
       - *step_setup_remote_docker

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -275,11 +275,11 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .data
-          key: v26.7.2-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback') }}-${{ hashFiles('db_cache_timestamp') }}
+          key: v26.8.0-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback') }}-${{ hashFiles('db_cache_timestamp') }}
           # Fallback to caching by default branch name only. Allows to use
           # cache from the branch build on the previous day.
           restore-keys: |
-            v26.7.2-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback') }}-
+            v26.8.0-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback') }}-
 
       - name: Fetch DB
         run: |
@@ -317,7 +317,7 @@ jobs:
         if: env.db_hash != hashFiles('.data')
         with:
           path: .data
-          key: v26.7.2-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
+          key: v26.8.0-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
   #;> !PROVISION_TYPE_PROFILE
 
   build:
@@ -395,7 +395,7 @@ jobs:
           date "${VORTEX_CI_DB_CACHE_TIMESTAMP}" | tee db_cache_timestamp
 
       - name: Show cache key for database caching
-        run: echo 'v26.7.2-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}'
+        run: echo 'v26.8.0-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}'
 
       # Restore DB cache based on the cache strategy set by the cache keys below.
       # Bump the last segment of the version prefix below to force a cache reset.
@@ -407,9 +407,9 @@ jobs:
           path: .data
           fail-on-cache-miss: true
           # Use cached database from previous builds of this branch.
-          key: v26.7.2-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
+          key: v26.8.0-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-${{ hashFiles('db_cache_timestamp') }}
           restore-keys: |
-            v26.7.2-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-
+            v26.8.0-${{ hashFiles('db_cache_branch') }}-${{ hashFiles('db_cache_fallback_yes') }}-
       #;> !PROVISION_TYPE_PROFILE
 
       - name: Login to container registry


### PR DESCRIPTION
## Summary

Bumps the CI database cache key prefix from `v26.7.2` to `v26.8.0` across every CI configuration that reads or writes the database cache. Bumping the prefix invalidates all existing database caches, forcing the next run of each affected job to rebuild the cached database from scratch rather than restoring a stale entry.

The prefix is the only part of the key that is hand-controlled - the remaining segments are checksums of the cache branch, the fallback flag, and the daily timestamp - so changing it is the sanctioned mechanism for a cache reset.

## Changes

**CircleCI (`.circleci/config.yml`)** - updated the prefix on all five key occurrences: the two `restore_cache` lookup keys in the `database` job (timestamped key plus the branch-only fallback), the `save_cache` key that writes the fetched database, and the two `restore_cache` keys in the `build` job.

**CircleCI shared test config (`.circleci/vortex-test-common.yml`)** - the same five occurrences. This file is a derived copy validated by `ahoy lint-ci`, so it has to move in lockstep with `config.yml` or the lint gate fails.

**GitHub Actions (`.github/workflows/build-test-deploy.yml`)** - all six occurrences: the `actions/cache/restore` key and `restore-keys` fallback in the `database` job, the `actions/cache/save` key, the diagnostic `Show cache key` echo, and the `key` plus `restore-keys` pair in the `build` job.

No other file in the repository referenced the old prefix. Installer snapshot fixtures are unaffected: they normalize every version-like string to `__VERSION__`, so both the old and new prefix render identically and no fixture regeneration is required.

## Before / After

```
                    CI DATABASE CACHE KEY

  BEFORE                            AFTER
  ┌──────────────────────────────┐  ┌──────────────────────────────┐
  │ v26.7.2-<branch>-<fb>-<ts>   │  │ v26.8.0-<branch>-<fb>-<ts>   │
  │ ▲                            │  │ ▲                            │
  │ └─ prefix (hand-controlled)  │  │ └─ prefix (bumped)           │
  └──────────────────────────────┘  └──────────────────────────────┘

  restore_cache ──► HIT             restore_cache ──► MISS
       │                                 │
       ▼                                 ▼
  reuses existing cached DB          rebuilds DB from scratch,
  (possibly stale)                   saves under the new prefix


  FILES CARRYING THE PREFIX

  .circleci/config.yml ─────────────────────► 5 occurrences
  .circleci/vortex-test-common.yml ─────────► 5 occurrences  (derived; kept
                                              in sync by ahoy lint-ci)
  .github/workflows/build-test-deploy.yml ──► 6 occurrences
                                              ────────────
                                              16 total
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and database cache versions to improve cache consistency across automated build, test, and deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->