### PR TITLE
[#2891] Split CircleCI deploy branch filter into per-pattern list.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -692,17 +692,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/123.456.789, release/123.456.789-rc.123 (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/123.456.789, hotfix/123.456.789-rc.1213 (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$|^[0-9]+\.x$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/123.456.789, release/123.456.789-rc.123 (per https://semver.org/)
+                # hotfix/123.456.789, hotfix/123.456.789-rc.123 (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -709,7 +709,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -558,17 +558,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -575,7 +575,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
@@ -566,17 +566,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
@@ -583,7 +583,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -558,17 +558,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -575,7 +575,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -558,17 +558,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -575,7 +575,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -558,17 +558,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -575,7 +575,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -568,17 +568,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -585,7 +585,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -558,17 +558,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -575,7 +575,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -546,17 +546,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -563,7 +563,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -17,6 +17,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -28,11 +33,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -42,9 +58,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -250,6 +274,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -521,7 +521,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -504,17 +504,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
@@ -548,17 +548,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
@@ -565,7 +565,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
@@ -530,17 +530,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
@@ -547,7 +547,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -544,17 +544,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -561,7 +561,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/.circleci/config.yml
@@ -554,17 +554,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/.circleci/config.yml
@@ -571,7 +571,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/.circleci/config.yml
@@ -564,7 +564,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/.circleci/config.yml
@@ -547,17 +547,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
@@ -570,7 +570,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
@@ -553,17 +553,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/.circleci/config.yml
@@ -568,7 +568,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/.circleci/config.yml
@@ -551,17 +551,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
@@ -570,7 +570,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
@@ -553,17 +553,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -554,17 +554,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -571,7 +571,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -17,6 +17,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -28,11 +33,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -42,9 +58,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -250,6 +274,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -554,17 +554,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -571,7 +571,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -535,7 +535,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -518,17 +518,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -554,17 +554,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -571,7 +571,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
@@ -558,17 +558,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
@@ -575,7 +575,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
@@ -554,17 +554,25 @@ workflows:
             - lint
           filters:
             branches:
-              # Allowed branches:
-              # - production, main, master, develop, ci, cisomething
-              # - project/description
-              # - deps/*
-              # - feature/description, feature/123-description
-              # - bugfix/description, bugfix/123-description
-              # - release/__VERSION__, release/__VERSION__ (per https://semver.org/)
-              # - release/2023-04-17, release/2023-04-17.123 (date-based)
-              # - hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
-              # - hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
-              only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+              # A branch is deployed when it matches any of the patterns below.
+              only:
+                # production, main, master, develop
+                - /^(production|main|master|develop)$/
+                # project/description
+                - /^project\/[a-zA-Z0-9\-\.]+/
+                # feature/description, feature/123-description
+                # bugfix/description, bugfix/123-description
+                - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/
+                # ci, cisomething
+                - /^ci.*/
+                # release/__VERSION__, release/__VERSION__ (per https://semver.org/)
+                # hotfix/__VERSION__, hotfix/__VERSION__ (per https://semver.org/)
+                - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+                # release/2023-04-17, release/2023-04-17.123 (date-based)
+                # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
+                - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
+                # 1.x, 2.x
+                - /^[0-9]+\.x$/
             tags:
               ignore: /.*/
       - deploy-tags:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
@@ -571,7 +571,7 @@ workflows:
                 # release/2023-04-17, release/2023-04-17.123 (date-based)
                 # hotfix/2023-04-17, hotfix/2023-04-17.123 (date-based)
                 - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/
-                # 1.x, 2.x
+                # Major version branches.
                 - /^[0-9]+\.x$/
             tags:
               ignore: /.*/

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/tests/phpunit/CircleCiConfigTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -254,6 +278,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }

--- a/tests/phpunit/CircleCiConfigTest.php
+++ b/tests/phpunit/CircleCiConfigTest.php
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
 class CircleCiConfigTest extends TestCase {
 
   /**
+   * Maximum length of a filter pattern accepted by the CircleCI compiler.
+   */
+  const FILTER_PATTERN_MAX_LENGTH = 128;
+
+  /**
    * CircleCI loaded config.
    *
    * @var mixed
@@ -32,11 +37,22 @@ class CircleCiConfigTest extends TestCase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->config = static::loadConfig();
+  }
+
+  /**
+   * Loads the CircleCI config.
+   *
+   * @return array<mixed>
+   *   Decoded config.
+   */
+  protected static function loadConfig(): array {
     $file = file_get_contents(__DIR__ . '/../../.circleci/config.yml');
     if (!$file) {
       throw new \RuntimeException('Unable to read CircleCI config file.');
     }
-    $this->config = Yaml::decode($file);
+
+    return Yaml::decode($file);
   }
 
   /**
@@ -46,9 +62,17 @@ class CircleCiConfigTest extends TestCase {
    */
   #[DataProvider('dataProviderDeployBranchRegex')]
   public function testDeployBranchRegex(string $branch, bool $expected = TRUE): void {
-    $pattern = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
-    $result = preg_match($pattern, $branch);
-    $this->assertEquals($expected, $result);
+    $patterns = $this->config['workflows']['commit']['jobs'][3]['deploy']['filters']['branches']['only'];
+
+    $result = FALSE;
+    foreach ($patterns as $pattern) {
+      if (preg_match($pattern, $branch)) {
+        $result = TRUE;
+        break;
+      }
+    }
+
+    $this->assertSame($expected, $result);
   }
 
   /**
@@ -260,6 +284,53 @@ class CircleCiConfigTest extends TestCase {
     yield ['2023-04-17.pre123', FALSE];
     yield ['2023-04-17.pre123post', FALSE];
     yield ['2023-04-17.123post', FALSE];
+  }
+
+  /**
+   * Tests that filter patterns are within the supported length.
+   */
+  #[DataProvider('dataProviderFilterPatternLength')]
+  public function testFilterPatternLength(string $pattern): void {
+    $regex = preg_match('#^/(.*)/$#', $pattern, $matches) === 1 ? $matches[1] : $pattern;
+
+    $this->assertLessThanOrEqual(static::FILTER_PATTERN_MAX_LENGTH, strlen($regex));
+  }
+
+  /**
+   * Data provider for testFilterPatternLength().
+   */
+  public static function dataProviderFilterPatternLength(): \Iterator {
+    foreach (static::collectFilterPatterns(static::loadConfig()) as $path => $pattern) {
+      yield $path => [$pattern];
+    }
+  }
+
+  /**
+   * Collects the patterns of every workflow filter in the config.
+   *
+   * @param mixed $config
+   *   Config structure to traverse.
+   * @param string $path
+   *   Path of the structure within the config, used to label the patterns.
+   * @param bool $is_filter
+   *   Whether the structure is within a filter.
+   *
+   * @return array<string, string>
+   *   Patterns keyed by their path within the config.
+   */
+  protected static function collectFilterPatterns(mixed $config, string $path = '', bool $is_filter = FALSE): array {
+    if (!is_array($config)) {
+      return $is_filter ? [$path . ': ' . $config => (string) $config] : [];
+    }
+
+    $patterns = [];
+
+    foreach ($config as $key => $value) {
+      $child = $path === '' ? (string) $key : $path . '.' . $key;
+      $patterns += static::collectFilterPatterns($value, $child, $is_filter || $key === 'filters');
+    }
+
+    return $patterns;
   }
 
 }


### PR DESCRIPTION
Closes #2891

## Summary

CircleCI is replacing its config compiler on 21 September 2026 (see the [announcement](https://discuss.circleci.com/t/breaking-changes-config-compilation-updates-september-21-2026/54719)), and Vortex's `.circleci/config.yml` fails to compile under the new compiler because the `deploy` job's `branches.only` filter is a single 231-character regex, which exceeds the new compiler's undocumented 128-character pattern length cap.

## Changes

CircleCI announced three breaking changes for the new compiler: undeclared pipeline parameters fail compilation, a new regex engine, and the end of `version: 2.0` support. All CircleCI configs in the repo were audited against all three using `circleci config validate --next`, which compiles a config with the new compiler.

- Undeclared parameters: clean. `.circleci/config.yml` and `.circleci/vortex-test-common.yml` reference no parameters; `.circleci/update-dependencies.yml` declares `run_update_dependencies` and uses it in the same file, which is what the new rule requires.
- `version: 2.0`: clean. All three configs already declare `version: '2.1'`.
- Regex engine: broken, but not for any of the four banned constructs - no negative lookaheads, lookbehinds, possessive quantifiers or backreferences appear anywhere in the repo's CircleCI configs. The new engine imposes a length cap the old one did not, and the `deploy` job's `branches.only` filter was 231 characters, failing with `Invalid regular expression: ... Pattern too long.`

The cap is 128 characters, established by binary-searching `circleci config validate --next` (128 accepted, 129 rejected) - worth stating explicitly since CircleCI's announcement does not document a number. The cap applies to the regex body, not to the serialized `/.../` value: a 128-character body serializes to 130 characters and is accepted, while a 129-character body is rejected.

The filter encoded seven independent branch rules as one alternation. Each rule now sits on its own line as a list entry under `branches.only`, which CircleCI evaluates with the same OR semantics. The seven patterns are 34, 26, 39, 5, 53, 57 and 11 characters. The regex text itself is unchanged, character for character - only the container shape changed. No pattern was modernised, shortened or re-escaped, so this is a pure compliance fix, not a behaviour change.

The comment block above the filter was redistributed so each rule is documented on the line it applies to. Two details worth noting while reviewing that hunk:

- The old block listed `deps/*` as an allowed branch, but no such rule exists in the regex and `CircleCiConfigTest` asserts `deps/something` is **not** deployable. That line was dropped rather than carried over.
- The rule for major version branches is described rather than exemplified. Every other rule lists example branch names, but this one cannot: the installer asserts that a generated consumer `.circleci/config.yml` contains no Vortex version branch names, so using them as examples fails `CiProviderHandlerProcessTest`.

The `deploy-tags` tag filter was deliberately left as a single regex - at 75 characters it is under the cap, and splitting it would churn two dozen generated fixtures without fixing anything.

`tests/phpunit/CircleCiConfigTest.php` (shipped to every generated project) changed accordingly:

- `testDeployBranchRegex()` now matches a branch against every list entry and passes if any matches, mirroring CircleCI's own evaluation. All 160 existing branch cases and the tag cases are unchanged and still pass.
- New `testFilterPatternLength()` asserts every filter pattern in the config stays within the cap. It walks the whole config and collects any value under a `filters` key, so it covers all 16 patterns across every workflow - including ones that do not exist yet - and strips the `/.../` delimiters before measuring, matching where the compiler applies the cap. This is what makes a future over-long pattern fail locally rather than silently at CircleCI after the cutover.

Of the 47 changed files, 45 are generated copies of the two source files above, under `.vortex/installer/tests/Fixtures/handler_process/*_circleci/`. They were regenerated via `ahoy update-snapshots` and not hand-edited.

## Verification

All 28 CircleCI configs in the repo (the three real ones plus 25 installer fixtures) compile under `--next`. The full shipped unit suite passes (318 tests). The regenerated fixture scenarios are exactly the `*_circleci` ones - no unrelated drift. `.circleci/vortex-test-common.yml` is generated from `.circleci/config.yml` and confirmed in sync via `php .vortex/tests/generate-vortex-dev-circleci --check`; it carries no deploy job so it did not change.

The `testFilterPatternLength()` guard was confirmed non-vacuous by temporarily lowering the cap to 50 and checking that it failed on the 53-character `release|hotfix` semver pattern, reporting 53 for a value whose serialized length is 55 - which also confirms the delimiter stripping.

## Follow-ups

1. CI does not validate against the new compiler. Adding `circleci config validate --next` as a lint step would catch all three breaking changes rather than just pattern length, but it needs the CircleCI CLI added to the `drevops/ci-runner` image and would make every build depend on CircleCI's compiler API - a separate change to a separate repo.
2. `CircleCiConfigTest` matches patterns with a partial `preg_match`, which predates this change. Under a full-match reading, `project/a/b` would not be deployable, whereas the test currently treats it as deployable because `^project\/[a-zA-Z0-9\-\.]+` has no end anchor. Worth settling separately - it is a question about the filter's intent, not about compiler compliance, and was left untouched here so this PR stays a pure compliance fix.

## Before / After

```
BEFORE: one alternation, 231 chars - rejected by the new compiler (cap is 128)

  branches:
    only: /^(production|main|master|develop)$|^project\/[a-zA-Z0-9\-\.]+|^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$|^ci.*|^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$|^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$|^[0-9]+\.x$/

AFTER: same seven patterns, each its own list entry - all under the cap

  branches:
    only:
      - /^(production|main|master|develop)$/                        34 chars
      - /^project\/[a-zA-Z0-9\-\.]+/                                26 chars
      - /^(feature|bugfix)\/[a-zA-Z0-9\-\.\,_]+$/                   39 chars
      - /^ci.*/                                                      5 chars
      - /^(release|hotfix)\/[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/     53 chars
      - /^(release|hotfix)\/[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9]+)?$/ 57 chars
      - /^[0-9]+\.x$/                                               11 chars
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment branch filtering to reliably recognize production, development, project, feature, bugfix, CI, release, hotfix, date-based, and numeric branch patterns.
  - Added validation to ensure configured branch patterns remain within supported length limits, reducing the risk of deployment configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
