### PR TITLE
Upgraded the BATS tests to 'bats-helpers' 2.0.

### DIFF
--- a/.vortex/tooling/package.json
+++ b/.vortex/tooling/package.json
@@ -4,6 +4,6 @@
     "description": "Packages used for testing the drevops/vortex-tooling shell scripts.",
     "license": "GPL-3.0-or-later",
     "devDependencies": {
-        "bats-helpers": "github:drevops/bats-helpers#main"
+        "bats-helpers": "npm:@drevops/bats-helpers@^2.0"
     }
 }

--- a/.vortex/tooling/package.json
+++ b/.vortex/tooling/package.json
@@ -4,6 +4,6 @@
     "description": "Packages used for testing the drevops/vortex-tooling shell scripts.",
     "license": "GPL-3.0-or-later",
     "devDependencies": {
-        "bats-helpers": "npm:@drevops/bats-helpers@^1.5.1"
+        "bats-helpers": "github:drevops/bats-helpers#main"
     }
 }

--- a/.vortex/tooling/tests/_helper.bash
+++ b/.vortex/tooling/tests/_helper.bash
@@ -37,8 +37,8 @@ setup() {
   export BATS_LIB_PATH="${ROOT_DIR}/.vortex/tooling/node_modules"
 
   # Load 'bats-helpers' library.
-  ASSERT_DIR_EXCLUDE=("vortex" ".data")
-  export ASSERT_DIR_EXCLUDE
+  BATS_HELPERS_ASSERT_DIR_EXCLUDE=("vortex" ".data")
+  export BATS_HELPERS_ASSERT_DIR_EXCLUDE
   bats_load_library bats-helpers
 
   # Setup command mocking.
@@ -175,7 +175,7 @@ setup() {
   if [ "${BATS_VERBOSE_RUN:-}" = "1" ] || [ "${TEST_VORTEX_DEBUG:-}" = "1" ]; then
     echo "Verbose run enabled." >&3
     echo "BUILD_DIR: ${BUILD_DIR}" >&3
-    export RUN_STEPS_DEBUG=1
+    export BATS_HELPERS_STEPS_DEBUG=1
   fi
 
   # Change directory to the current project directory for each test. Tests
@@ -201,7 +201,7 @@ fixture_local_repo() {
 
   if [ "${do_copy_code:-}" -eq 1 ]; then
     fixture_prepare_dir "${dir}"
-    export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
+    export BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
     fixture_export_codebase "${dir}" "${ROOT_DIR}"
   fi
 

--- a/.vortex/tooling/tests/_helper.bash
+++ b/.vortex/tooling/tests/_helper.bash
@@ -42,14 +42,14 @@ setup() {
   bats_load_library bats-helpers
 
   # Setup command mocking.
-  setup_mock
+  mock_setup
 
   # Isolate the SSH agent from tests. Scripts under test call `ssh-add`, which
   # reaches the agent via the inherited SSH_AUTH_SOCK - a socket the HOME
   # override does not sandbox. Stub `ssh-add` (the only agent-mutating command)
   # so a test can never read, pollute or, with VORTEX_SSH_REMOVE_ALL_KEYS=1,
   # wipe the real agent of the developer running the suite. Tests that assert
-  # specific `ssh-add` calls override this with their own mock via run_steps.
+  # specific `ssh-add` calls override this with their own mock via steps_run.
   mock_command "ssh-add" >/dev/null
 
   ##
@@ -333,7 +333,7 @@ git_init() {
   local allow_receive_update="${1:-0}"
   local dir="${2:-$(pwd)}"
 
-  assert_not_git_repo "${dir}"
+  assert_git_not_repo "${dir}"
   git --work-tree="${dir}" --git-dir="${dir}/.git" init >/dev/null
 
   if [ "${allow_receive_update:-}" -eq 1 ]; then

--- a/.vortex/tooling/tests/unit/deploy-artifact.bats
+++ b/.vortex/tooling/tests/unit/deploy-artifact.bats
@@ -95,12 +95,12 @@ load ../_helper.bash
     "SHA256 checksum verification failed for git-artifact binary."
     "- Finished artifact deployment."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-artifact
   assert_failure
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -153,7 +153,7 @@ load ../_helper.bash
     "Running artifact builder."
     "Finished artifact deployment."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-artifact
   assert_success
@@ -162,7 +162,7 @@ load ../_helper.bash
   assert_output_not_contains "--cleanup-pattern"
   assert_output_not_contains "--cleanup-age"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
   assert_equal "2" "$(mock_get_call_num "${mock_realpath}" 1)"
 
   popd >/dev/null
@@ -204,7 +204,7 @@ load ../_helper.bash
     "Running artifact builder."
     "Finished artifact deployment."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-artifact
   assert_success
@@ -213,7 +213,7 @@ load ../_helper.bash
   assert_output_contains "--cleanup-pattern=feature/*,bugfix/*"
   assert_output_contains "--cleanup-age=3"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }

--- a/.vortex/tooling/tests/unit/deploy-lagoon.bats
+++ b/.vortex/tooling/tests/unit/deploy-lagoon.bats
@@ -83,11 +83,11 @@ load ../_helper.bash
     "Finished Lagoon deployment."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -123,11 +123,11 @@ load ../_helper.bash
     "Finished Lagoon deployment."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -173,13 +173,13 @@ load ../_helper.bash
     "Finished Lagoon deployment."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   # Mock commands are handled by the steps
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -212,13 +212,13 @@ load ../_helper.bash
     "Finished Lagoon deployment."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   # Mock commands are handled by the steps
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -257,13 +257,13 @@ load ../_helper.bash
     "Finished Lagoon deployment."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   # Mock commands are handled by the steps
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -312,12 +312,12 @@ load ../_helper.bash
     "Finished Lagoon deployment."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   # Mock commands are handled by the steps
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -345,13 +345,13 @@ load ../_helper.bash
     "Finished Lagoon deployment."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   # Mock commands are handled by the steps
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -387,11 +387,11 @@ load ../_helper.bash
     "Finished Lagoon deployment."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -427,11 +427,11 @@ load ../_helper.bash
     "would exceed the configured limit"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_failure
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -470,11 +470,11 @@ load ../_helper.bash
     "Finished Lagoon deployment."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -499,11 +499,11 @@ load ../_helper.bash
     "Finished Lagoon deployment."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -531,11 +531,11 @@ load ../_helper.bash
     "[FAIL] Lagoon deployment completed with errors."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_failure
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -564,11 +564,11 @@ load ../_helper.bash
     "Error: deployment rejected by policy."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_failure
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -604,11 +604,11 @@ load ../_helper.bash
     "Error: deployment rejected by policy."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_failure
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -631,11 +631,11 @@ load ../_helper.bash
     "[FAIL] Lagoon deployment completed with errors."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_failure
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -660,11 +660,11 @@ load ../_helper.bash
     "Finished Lagoon deployment."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-deploy-lagoon
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }

--- a/.vortex/tooling/tests/unit/fetch-db-acquia.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-acquia.bats
@@ -65,9 +65,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ACQUIA_DB_DIR=".data"
   export VORTEX_FETCH_DB_ACQUIA_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -127,9 +127,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ACQUIA_DB_DIR=".data"
   export VORTEX_FETCH_DB_ACQUIA_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -190,9 +190,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ACQUIA_DB_DIR=".data"
   export VORTEX_FETCH_DB_ACQUIA_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -254,9 +254,9 @@ bats_require_minimum_version 1.5.0
   # Don't set VORTEX_FETCH_DB_ACQUIA_DB_DIR and VORTEX_FETCH_DB_ACQUIA_DB_FILE to test defaults
   unset VORTEX_FETCH_DB_ACQUIA_DB_DIR VORTEX_FETCH_DB_ACQUIA_DB_FILE
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -284,9 +284,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ENVIRONMENT="prod"
   export VORTEX_FETCH_DB_ACQUIA_DB_NAME="testdb"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -318,9 +318,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ENVIRONMENT="prod"
   export VORTEX_FETCH_DB_ACQUIA_DB_NAME="testdb"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -356,9 +356,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ENVIRONMENT="nonexistent-env"
   export VORTEX_FETCH_DB_ACQUIA_DB_NAME="testdb"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -398,9 +398,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ENVIRONMENT="prod"
   export VORTEX_FETCH_DB_ACQUIA_DB_NAME="nonexistent-db"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -440,9 +440,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ENVIRONMENT="prod"
   export VORTEX_FETCH_DB_ACQUIA_DB_NAME="testdb"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -518,9 +518,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ACQUIA_DB_FILE="db.sql"
   export VORTEX_FETCH_DB_FRESH="1"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
   assert_file_exists ".data/db.sql"
@@ -565,9 +565,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ACQUIA_DB_FILE="db.sql"
   export VORTEX_FETCH_DB_FRESH="1"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -609,9 +609,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ACQUIA_DB_FILE="db.sql"
   export VORTEX_FETCH_DB_FRESH="1"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -658,9 +658,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ACQUIA_DB_FILE="db.sql"
   export VORTEX_FETCH_DB_FRESH="1"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -716,9 +716,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ACQUIA_BACKUP_MAX_WAIT="15"
   export VORTEX_FETCH_DB_ACQUIA_BACKUP_WAIT_INTERVAL="5"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -768,9 +768,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ACQUIA_DB_DIR=".data"
   export VORTEX_FETCH_DB_ACQUIA_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -820,9 +820,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ACQUIA_DB_DIR=".data"
   export VORTEX_FETCH_DB_ACQUIA_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -872,9 +872,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ACQUIA_DB_DIR=".data"
   export VORTEX_FETCH_DB_ACQUIA_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -930,9 +930,9 @@ bats_require_minimum_version 1.5.0
   export VORTEX_FETCH_DB_ACQUIA_DB_DIR=".data"
   export VORTEX_FETCH_DB_ACQUIA_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run --separate-stderr .vortex/tooling/src/vortex-fetch-db-acquia
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 

--- a/.vortex/tooling/tests/unit/fetch-db-container-registry.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-container-registry.bats
@@ -10,13 +10,12 @@ load ../_helper.bash
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
   mock_docker=$(mock_command "docker")
-  # First call to image inspect fails (image not found), second succeeds (after load/pull)
+  # The image is absent from the host, so the inspect is followed by a registry
+  # login and a pull. The login script is invoked by its own path rather than
+  # through PATH, so it runs for real and its own 'docker login' is call 2.
   mock_set_side_effect "${mock_docker}" "exit 1" 1
-  mock_set_side_effect "${mock_docker}" "echo 'image loaded'" 2
+  mock_set_side_effect "${mock_docker}" "echo 'logged in'" 2
   mock_set_side_effect "${mock_docker}" "echo 'pulled image'" 3
-
-  # Mock the login script
-  mock_set_side_effect "$(mock_command "./.vortex/tooling/src/vortex-login-container-registry")" "echo 'logged in'" 1
 
   export VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE="myorg/myapp"
   export VORTEX_FETCH_DB_CONTAINER_REGISTRY="registry.example.com"
@@ -72,10 +71,8 @@ load ../_helper.bash
 
   mock_docker=$(mock_command "docker")
   mock_set_side_effect "${mock_docker}" "exit 1" 1
-  mock_set_side_effect "${mock_docker}" "echo 'pulled base image'" 2
-
-  # Mock the login script
-  mock_set_side_effect "$(mock_command "./.vortex/tooling/src/vortex-login-container-registry")" "echo 'logged in'" 1
+  mock_set_side_effect "${mock_docker}" "echo 'logged in'" 2
+  mock_set_side_effect "${mock_docker}" "echo 'pulled base image'" 3
 
   export VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE="myorg/myapp"
   export VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE_BASE="myorg/base"
@@ -98,8 +95,11 @@ load ../_helper.bash
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
   mock_docker=$(mock_command "docker")
-  # First call to image inspect succeeds (image found on host)
+  # The image is found on the host, but the fetch is not skipped: without an
+  # expanded archive the script still logs in and pulls.
   mock_set_side_effect "${mock_docker}" "echo 'image exists'" 1
+  mock_set_side_effect "${mock_docker}" "echo 'logged in'" 2
+  mock_set_side_effect "${mock_docker}" "echo 'pulled image'" 3
 
   export VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE="myorg/myapp"
   export VORTEX_FETCH_DB_CONTAINER_REGISTRY="registry.example.com"
@@ -121,10 +121,8 @@ load ../_helper.bash
 
   mock_docker=$(mock_command "docker")
   mock_set_side_effect "${mock_docker}" "exit 1" 1
-  mock_set_side_effect "${mock_docker}" "echo 'pulled from docker.io'" 2
-
-  # Mock the login script
-  mock_set_side_effect "$(mock_command "./.vortex/tooling/src/vortex-login-container-registry")" "echo 'logged in'" 1
+  mock_set_side_effect "${mock_docker}" "echo 'logged in'" 2
+  mock_set_side_effect "${mock_docker}" "echo 'pulled from docker.io'" 3
 
   export VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE="myorg/myapp"
   # Don't set VORTEX_FETCH_DB_CONTAINER_REGISTRY to test default
@@ -147,10 +145,8 @@ load ../_helper.bash
 
   mock_docker=$(mock_command "docker")
   mock_set_side_effect "${mock_docker}" "exit 1" 1
-  mock_set_side_effect "${mock_docker}" "echo 'pulled image'" 2
-
-  # Mock the login script.
-  mock_set_side_effect "$(mock_command "./.vortex/tooling/src/vortex-login-container-registry")" "echo 'logged in'" 1
+  mock_set_side_effect "${mock_docker}" "echo 'logged in'" 2
+  mock_set_side_effect "${mock_docker}" "echo 'pulled image'" 3
 
   # Set database index as used in CI: VORTEX_DB_INDEX=2.
   export VORTEX_DB_INDEX="2"

--- a/.vortex/tooling/tests/unit/fetch-db-container-registry.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-container-registry.bats
@@ -91,7 +91,7 @@ load ../_helper.bash
   popd >/dev/null
 }
 
-@test "fetch-db-container-registry: Skip fetch when image already exists on host" {
+@test "fetch-db-container-registry: Fetch image when it exists on host and no archive exists" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
   mock_docker=$(mock_command "docker")
@@ -111,6 +111,7 @@ load ../_helper.bash
   assert_success
   assert_output_contains "[INFO] Started database data container image fetch."
   assert_output_contains "Found myorg/myapp image on host."
+  assert_output_contains "Fetching myorg/myapp image from the registry."
   assert_output_contains "[ OK ] Finished database data container image fetch."
 
   popd >/dev/null
@@ -135,6 +136,9 @@ load ../_helper.bash
   assert_success
   assert_output_contains "[INFO] Started database data container image fetch."
   assert_output_contains "Fetching myorg/myapp image from the registry."
+  # The registry reaches the pull target but never the output, so only the
+  # recorded arguments show that it defaulted to docker.io.
+  assert_string_contains "$(mock_get_call_args "${mock_docker}" 3)" "pull docker.io/myorg/myapp"
   assert_output_contains "[ OK ] Finished database data container image fetch."
 
   popd >/dev/null

--- a/.vortex/tooling/tests/unit/fetch-db-lagoon.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-lagoon.bats
@@ -42,10 +42,10 @@ load ../_helper.bash
   export VORTEX_SSH_PREFIX="TEST"
   export VORTEX_FETCH_DB_SSH_FILE=false
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-fetch-db-lagoon
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -95,9 +95,9 @@ load ../_helper.bash
   export VORTEX_SSH_PREFIX="TEST"
   export VORTEX_FETCH_DB_SSH_FILE=false
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-lagoon
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -148,9 +148,9 @@ load ../_helper.bash
   export VORTEX_SSH_PREFIX="TEST"
   export VORTEX_FETCH_DB_SSH_FILE=false
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-lagoon
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 

--- a/.vortex/tooling/tests/unit/fetch-db-s3.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-s3.bats
@@ -35,9 +35,9 @@ load ../_helper.bash
   export VORTEX_FETCH_DB_S3_DB_DIR=".data"
   export VORTEX_FETCH_DB_S3_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -78,9 +78,9 @@ load ../_helper.bash
   # Don't set VORTEX_FETCH_DB_S3_DB_DIR and VORTEX_FETCH_DB_S3_DB_FILE to test defaults.
   unset VORTEX_FETCH_DB_S3_DB_DIR VORTEX_FETCH_DB_S3_DB_FILE
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -121,9 +121,9 @@ load ../_helper.bash
   export VORTEX_FETCH_DB_S3_DB_DIR=".data"
   export VORTEX_FETCH_DB_S3_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -160,9 +160,9 @@ load ../_helper.bash
   export VORTEX_FETCH_DB_S3_DB_DIR=".data"
   export VORTEX_FETCH_DB_S3_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -200,9 +200,9 @@ load ../_helper.bash
   export VORTEX_FETCH_DB_S3_DB_DIR=".data"
   export VORTEX_FETCH_DB_S3_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -227,9 +227,9 @@ load ../_helper.bash
   export VORTEX_FETCH_DB_S3_BUCKET="test-bucket"
   export VORTEX_FETCH_DB_S3_REGION="ap-southeast-2"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -252,9 +252,9 @@ load ../_helper.bash
   export VORTEX_FETCH_DB_S3_BUCKET="test-bucket"
   export VORTEX_FETCH_DB_S3_REGION="ap-southeast-2"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -277,9 +277,9 @@ load ../_helper.bash
   export VORTEX_FETCH_DB_S3_BUCKET=""
   export VORTEX_FETCH_DB_S3_REGION="ap-southeast-2"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -302,9 +302,9 @@ load ../_helper.bash
   export VORTEX_FETCH_DB_S3_BUCKET="test-bucket"
   export VORTEX_FETCH_DB_S3_REGION=""
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-fetch-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 

--- a/.vortex/tooling/tests/unit/fetch-db-url.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-url.bats
@@ -40,7 +40,7 @@ load ../_helper.bash
   run .vortex/tooling/src/vortex-fetch-db-url
   assert_success
   # curl writes into custom_data, resolved via the plain VORTEX_DB_DIR fallback.
-  assert_contains "custom_data/" "$(mock_get_call_args "${mock_curl}" 1)"
+  assert_string_contains "$(mock_get_call_args "${mock_curl}" 1)" "custom_data/"
 
   popd >/dev/null
 }
@@ -60,7 +60,7 @@ load ../_helper.bash
   run .vortex/tooling/src/vortex-fetch-db-url
   assert_success
   # curl writes custom.sql, resolved via the plain VORTEX_DB_FILE fallback.
-  assert_contains "/custom.sql" "$(mock_get_call_args "${mock_curl}" 1)"
+  assert_string_contains "$(mock_get_call_args "${mock_curl}" 1)" "/custom.sql"
 
   popd >/dev/null
 }
@@ -161,7 +161,7 @@ load ../_helper.bash
   assert_success
   # The -f flag makes curl exit non-zero on HTTP 4xx/5xx instead of writing
   # the error body into the dump file and reporting success.
-  assert_contains "-fLs" "$(mock_get_call_args "${mock_curl}" 1)"
+  assert_string_contains "$(mock_get_call_args "${mock_curl}" 1)" "-fLs"
 
   popd >/dev/null
 }

--- a/.vortex/tooling/tests/unit/helpers.bats
+++ b/.vortex/tooling/tests/unit/helpers.bats
@@ -26,25 +26,25 @@ load ../_helper.bash
 
   [ "${ROOT_DIR}" != "" ]
   echo "     > Current dir:        ${ROOT_DIR}" >&3
-  assert_not_contains "//" "${ROOT_DIR}"
+  assert_string_not_contains "${ROOT_DIR}" "//"
 
   [ "${BUILD_DIR}" != "" ]
   echo "     > Build dir:          ${BUILD_DIR}" >&3
-  assert_not_contains "//" "${BUILD_DIR}"
+  assert_string_not_contains "${BUILD_DIR}" "//"
 
   [ "${CURRENT_PROJECT_DIR}" != "" ]
   echo "     > Project dir:        ${CURRENT_PROJECT_DIR}" >&3
-  assert_not_contains "//" "${CURRENT_PROJECT_DIR}"
+  assert_string_not_contains "${CURRENT_PROJECT_DIR}" "//"
 
   [ "${DST_PROJECT_DIR}" != "" ]
   echo "     > DST dir:            ${DST_PROJECT_DIR}" >&3
-  assert_not_contains "//" "${DST_PROJECT_DIR}"
+  assert_string_not_contains "${DST_PROJECT_DIR}" "//"
 
   [ "${LOCAL_REPO_DIR}" != "" ]
   echo "     > Local repo dir:     ${LOCAL_REPO_DIR}" >&3
-  assert_not_contains "//" "${LOCAL_REPO_DIR}"
+  assert_string_not_contains "${LOCAL_REPO_DIR}" "//"
 
   [ "${APP_TMP_DIR}" != "" ]
   echo "     > App temp dir:       ${APP_TMP_DIR}" >&3
-  assert_not_contains "//" "${APP_TMP_DIR}"
+  assert_string_not_contains "${APP_TMP_DIR}" "//"
 }

--- a/.vortex/tooling/tests/unit/import-db-file.bats
+++ b/.vortex/tooling/tests/unit/import-db-file.bats
@@ -23,12 +23,12 @@ load ../_helper.bash
     "- Unable to import database from file."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-import-db-file .data/db_custom.sql
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -53,12 +53,12 @@ load ../_helper.bash
     "Finished database file import."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-import-db-file
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }

--- a/.vortex/tooling/tests/unit/login-container-registry.bats
+++ b/.vortex/tooling/tests/unit/login-container-registry.bats
@@ -75,10 +75,10 @@ load ../_helper.bash
     'Logging in to registry "https://www.example.com".'
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-login-container-registry
   assert_success
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   popd >/dev/null
 }
@@ -98,7 +98,7 @@ load ../_helper.bash
     "@docker login --username test_user --password-stdin https://www.example.com # 0 # Login Succeeded"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-login-container-registry
   assert_success
   assert_output_not_contains "supersecretpass"

--- a/.vortex/tooling/tests/unit/notify-github.bats
+++ b/.vortex/tooling/tests/unit/notify-github.bats
@@ -20,7 +20,7 @@ load ../_helper.bash
     "Finished dispatching notifications."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   export VORTEX_NOTIFY_CHANNELS="github"
   export VORTEX_NOTIFY_EVENT="pre_deployment"
@@ -33,7 +33,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/vortex-notify
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -52,7 +52,7 @@ load ../_helper.bash
     "Finished dispatching notifications."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   export VORTEX_NOTIFY_CHANNELS="github"
   export VORTEX_NOTIFY_EVENT="pre_deployment"
@@ -66,7 +66,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/vortex-notify
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -85,7 +85,7 @@ load ../_helper.bash
     "Finished dispatching notifications."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   export VORTEX_NOTIFY_CHANNELS="github"
   export VORTEX_NOTIFY_EVENT="pre_deployment"
@@ -98,7 +98,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/vortex-notify
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -115,7 +115,7 @@ load ../_helper.bash
     "-Marked deployment as finished."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   export VORTEX_NOTIFY_CHANNELS="github"
   export VORTEX_NOTIFY_EVENT="pre_deployment"
@@ -128,7 +128,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/vortex-notify
   assert_failure
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -148,7 +148,7 @@ load ../_helper.bash
     "Finished GitHub notification for post_deployment event."
     "Finished dispatching notifications."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   export VORTEX_NOTIFY_CHANNELS="github"
   export VORTEX_NOTIFY_EVENT="post_deployment"
@@ -161,7 +161,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/vortex-notify
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -181,7 +181,7 @@ load ../_helper.bash
     "Finished GitHub notification for post_deployment event."
     "Finished dispatching notifications."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   export VORTEX_NOTIFY_CHANNELS="github"
   export VORTEX_NOTIFY_EVENT="post_deployment"
@@ -194,7 +194,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/vortex-notify
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -212,7 +212,7 @@ load ../_helper.bash
     "Check that a pre_deployment notification was dispatched."
     "-Marked deployment as finished."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   export VORTEX_NOTIFY_CHANNELS="github"
   export VORTEX_NOTIFY_EVENT="post_deployment"
@@ -225,7 +225,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/vortex-notify
   assert_failure
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -313,7 +313,7 @@ load ../_helper.bash
     "Previous deployment was found, but was unable to update the deployment status. Payload:"
     "-Marked deployment as finished."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   export VORTEX_NOTIFY_CHANNELS="github"
   export VORTEX_NOTIFY_EVENT="post_deployment"
@@ -326,7 +326,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/vortex-notify
   assert_failure
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }

--- a/.vortex/tooling/tests/unit/notify-jira.bats
+++ b/.vortex/tooling/tests/unit/notify-jira.bats
@@ -37,7 +37,7 @@ load ../_helper.bash
     '@curl -s -X PUT -H Authorization: Basic am9obi5kb2VAZXhhbXBsZS5jb206dG9rZW4xMjM0NQ== -H Content-Type: application/json --url https://jira.atlassian.com/rest/api/3/issue/proj-1234/assignee --data { "accountId": "987654321c20165700ede21g"} # '
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   export VORTEX_NOTIFY_CHANNELS="jira"
   export VORTEX_NOTIFY_JIRA_USER_EMAIL="john.doe@example.com"
@@ -53,7 +53,7 @@ load ../_helper.bash
   run ./.vortex/tooling/src/vortex-notify
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -140,7 +140,7 @@ load ../_helper.bash
     "@curl * # {\"id\": \"${comment_id}\", \"othervar\": \"54321\"}"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   # Attempt shell injection through project name with PHP code that would create a file
   export VORTEX_NOTIFY_CHANNELS="jira"
@@ -164,7 +164,7 @@ load ../_helper.bash
   # Verify the malicious string is treated as literal text
   assert_output_contains "test'); file_put_contents('/tmp/injected_jira_test', 'HACKED'); //"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }

--- a/.vortex/tooling/tests/unit/notify-newrelic.bats
+++ b/.vortex/tooling/tests/unit/notify-newrelic.bats
@@ -66,10 +66,10 @@ load ../_helper.bash
   assert_output_contains "Creating a deployment notification"
 
   # Verify the call structure without checking exact revision value
-  assert_contains "-X POST https://api.newrelic.com/v2/applications/9876543210/deployments.json" "${actual_curl_call}"
-  assert_contains "-H Api-Key: key1234" "${actual_curl_call}"
-  assert_contains '"revision":' "${actual_curl_call}"
-  assert_contains '"user": "Deployment robot"' "${actual_curl_call}"
+  assert_string_contains "${actual_curl_call}" "-X POST https://api.newrelic.com/v2/applications/9876543210/deployments.json"
+  assert_string_contains "${actual_curl_call}" "-H Api-Key: key1234"
+  assert_string_contains "${actual_curl_call}" '"revision":'
+  assert_string_contains "${actual_curl_call}" '"user": "Deployment robot"'
 
   assert_output_contains "Finished New Relic notification."
 

--- a/.vortex/tooling/tests/unit/post-coverage-comment.bats
+++ b/.vortex/tooling/tests/unit/post-coverage-comment.bats
@@ -79,7 +79,7 @@ load ../_helper.bash
     '@curl * # {"id": 1}'
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   export CIRCLE_PULL_REQUEST="https://github.com/myorg/myrepo/pull/123"
   export GITHUB_TOKEN="token12345"
@@ -89,7 +89,7 @@ load ../_helper.bash
   run .circleci/post-coverage-comment.sh .logs/coverage/phpunit/coverage.txt
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -109,7 +109,7 @@ load ../_helper.bash
     '@curl * # {"id": 2}'
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   export CIRCLE_PULL_REQUEST="https://github.com/myorg/myrepo/pull/456"
   export GITHUB_TOKEN="token12345"
@@ -119,7 +119,7 @@ load ../_helper.bash
   run .circleci/post-coverage-comment.sh .logs/coverage/phpunit/coverage.txt
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }

--- a/.vortex/tooling/tests/unit/provision-enable-demo-modules.bats
+++ b/.vortex/tooling/tests/unit/provision-enable-demo-modules.bats
@@ -30,12 +30,12 @@ load ../_helper.bash
     "- Finished demo modules operations."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-00-enable-demo-modules.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }

--- a/.vortex/tooling/tests/unit/provision-enable-dev-modules.bats
+++ b/.vortex/tooling/tests/unit/provision-enable-dev-modules.bats
@@ -32,12 +32,12 @@ load ../_helper.bash
     "- Skipped installing development modules in production environment."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-10-enable-dev-modules.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -62,12 +62,12 @@ load ../_helper.bash
     "- Finished development modules operations."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-10-enable-dev-modules.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -92,12 +92,12 @@ load ../_helper.bash
     "- Finished development modules operations."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-10-enable-dev-modules.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }

--- a/.vortex/tooling/tests/unit/provision-example.bats
+++ b/.vortex/tooling/tests/unit/provision-example.bats
@@ -29,12 +29,12 @@ load ../_helper.bash
     "- Finished example operations."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-40-example.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }

--- a/.vortex/tooling/tests/unit/provision-migration.bats
+++ b/.vortex/tooling/tests/unit/provision-migration.bats
@@ -61,12 +61,12 @@ load ../_helper.bash
     "- Migration source database file not found."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-20-migration.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -94,12 +94,12 @@ load ../_helper.bash
     "- Finished migration operations."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-20-migration.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -124,12 +124,12 @@ load ../_helper.bash
     "- Finished migration operations."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-20-migration.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -169,12 +169,12 @@ load ../_helper.bash
     "- Migration source database is corrupted or empty."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-20-migration.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -221,12 +221,12 @@ load ../_helper.bash
     "- Using existing migration source database."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-20-migration.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -253,12 +253,12 @@ load ../_helper.bash
     "- Finished migration operations."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-20-migration.sh
   assert_failure
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -298,12 +298,12 @@ load ../_helper.bash
     "- Finished migration operations."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-20-migration.sh
   assert_failure
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -344,12 +344,12 @@ load ../_helper.bash
     "- Skipped rollback of all migrations."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-20-migration.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }

--- a/.vortex/tooling/tests/unit/provision-search-index.bats
+++ b/.vortex/tooling/tests/unit/provision-search-index.bats
@@ -38,12 +38,12 @@ load ../_helper.bash
     "- Skipped search indexing in non-development environment."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-30-search-index.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -70,12 +70,12 @@ load ../_helper.bash
     "- Finished search indexing operations."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-30-search-index.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -103,12 +103,12 @@ load ../_helper.bash
     "- Completed search indexing."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-30-search-index.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -136,12 +136,12 @@ load ../_helper.bash
     "- Completed search indexing."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./scripts/provision-30-search-index.sh
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }

--- a/.vortex/tooling/tests/unit/provision.bats
+++ b/.vortex/tooling/tests/unit/provision.bats
@@ -203,12 +203,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_provision_info 0 0 0 1 0 0 0
 
@@ -363,12 +363,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_provision_info 0 0 0 1 0 0 1
 
@@ -532,12 +532,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_provision_info 0 1 0 1 0 0 1
 
@@ -716,12 +716,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_provision_info 0 0 0 1 0 1 0
 
@@ -784,12 +784,12 @@ assert_provision_info() {
     "- Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_failure
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -951,12 +951,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_provision_info 1 0 0 1 0 0 0
 
@@ -1114,12 +1114,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_provision_info 1 0 0 1 0 0 1
 
@@ -1284,12 +1284,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_provision_info 1 1 0 1 0 0 1
 
@@ -1422,12 +1422,12 @@ assert_provision_info() {
 
   export VORTEX_PROVISION_SANITIZE_DB_PASSWORD="MOCK_DB_SANITIZE_PASSWORD"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_provision_info 0 0 0 1 0 0 0
 
@@ -1472,12 +1472,12 @@ assert_provision_info() {
     "- Imported database from the dump file."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_failure
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -1637,12 +1637,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -1804,12 +1804,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -1868,12 +1868,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -1933,12 +1933,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -2091,12 +2091,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -2276,12 +2276,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -2324,12 +2324,12 @@ assert_provision_info() {
     "- Installed a site from the profile."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_failure
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -2513,12 +2513,12 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_provision_info 0 0 0 1 0 1 0
   assert_output_contains "Verify config after update     : Yes"
@@ -2605,12 +2605,12 @@ assert_provision_info() {
     "- Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_failure
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null || exit 1
 }
@@ -2837,14 +2837,14 @@ assert_provision_info() {
     "Finished site provisioning"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-provision
   assert_success
   console_output="${output}"
 
   # The re-dispatch streams the full run to the console (asserted here)...
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   # ...and captures the identical output to the owner-only log file.
   assert_file_exists "${VORTEX_NOTIFY_LOG_DIR}/provision.log"

--- a/.vortex/tooling/tests/unit/push-container-registry.bats
+++ b/.vortex/tooling/tests/unit/push-container-registry.bats
@@ -97,11 +97,11 @@ setup_robo_fixture() {
     "Finished container registry push."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-push-container-registry
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -128,11 +128,11 @@ setup_robo_fixture() {
     'Service "service1" is not running.'
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-push-container-registry
   assert_failure
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -217,11 +217,11 @@ setup_robo_fixture() {
     "Finished container registry push."
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-push-container-registry
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -246,7 +246,7 @@ setup_robo_fixture() {
     "@docker push registry.example.com/image1:test_latest"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run ./.vortex/tooling/src/vortex-push-container-registry
   assert_success

--- a/.vortex/tooling/tests/unit/push-db-s3.bats
+++ b/.vortex/tooling/tests/unit/push-db-s3.bats
@@ -36,9 +36,9 @@ load ../_helper.bash
   export VORTEX_PUSH_DB_S3_DB_DIR=".data"
   export VORTEX_PUSH_DB_S3_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-push-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -75,9 +75,9 @@ load ../_helper.bash
   # Don't set VORTEX_PUSH_DB_S3_DB_DIR and VORTEX_PUSH_DB_S3_DB_FILE to test defaults.
   unset VORTEX_PUSH_DB_S3_DB_DIR VORTEX_PUSH_DB_S3_DB_FILE
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-push-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -118,9 +118,9 @@ load ../_helper.bash
   export VORTEX_PUSH_DB_S3_DB_DIR=".data"
   export VORTEX_PUSH_DB_S3_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-push-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -156,9 +156,9 @@ load ../_helper.bash
   export VORTEX_PUSH_DB_S3_DB_FILE="db.sql"
   export VORTEX_PUSH_DB_S3_REMOTE_FILE="backup/db_latest.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-push-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -195,9 +195,9 @@ load ../_helper.bash
   export VORTEX_PUSH_DB_S3_DB_DIR=".data"
   export VORTEX_PUSH_DB_S3_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-push-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -235,9 +235,9 @@ load ../_helper.bash
   export VORTEX_PUSH_DB_S3_DB_DIR=".data"
   export VORTEX_PUSH_DB_S3_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-push-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_success
 
@@ -271,9 +271,9 @@ load ../_helper.bash
   export VORTEX_PUSH_DB_S3_DB_DIR=".data"
   export VORTEX_PUSH_DB_S3_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-push-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -298,9 +298,9 @@ load ../_helper.bash
   export VORTEX_PUSH_DB_S3_BUCKET="test-bucket"
   export VORTEX_PUSH_DB_S3_REGION="ap-southeast-2"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-push-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -323,9 +323,9 @@ load ../_helper.bash
   export VORTEX_PUSH_DB_S3_BUCKET="test-bucket"
   export VORTEX_PUSH_DB_S3_REGION="ap-southeast-2"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-push-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -348,9 +348,9 @@ load ../_helper.bash
   export VORTEX_PUSH_DB_S3_BUCKET=""
   export VORTEX_PUSH_DB_S3_REGION="ap-southeast-2"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-push-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -373,9 +373,9 @@ load ../_helper.bash
   export VORTEX_PUSH_DB_S3_BUCKET="test-bucket"
   export VORTEX_PUSH_DB_S3_REGION=""
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-push-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 
@@ -403,9 +403,9 @@ load ../_helper.bash
   export VORTEX_PUSH_DB_S3_DB_DIR=".data"
   export VORTEX_PUSH_DB_S3_DB_FILE="db.sql"
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-push-db-s3
-  run_steps "assert" "${mocks}"
+  steps_run "assert" "${mocks}"
 
   assert_failure
 

--- a/.vortex/tooling/tests/unit/push-db-s3.bats
+++ b/.vortex/tooling/tests/unit/push-db-s3.bats
@@ -252,10 +252,16 @@ load ../_helper.bash
   mkdir -p .data
   echo "CREATE TABLE test (id INT);" >.data/db.sql
 
+  # The script reads the status from the last line of the response, so the mock
+  # has to answer with a body above it. A step cannot carry that response: the
+  # step string is split with 'read', which stops at the first newline.
+  mock_curl="$(mock_command "curl")"
+  mock_set_output "${mock_curl}" $'AccessDenied\n403' 1
+
   declare -a STEPS=(
     "[INFO] Started database dump push to S3."
 
-    "@curl * # 0 # AccessDenied\n403"
+    "@curl *"
 
     "ERROR: S3 push failed with HTTP status 403."
     "- [ OK ] Finished database dump push to S3."
@@ -271,7 +277,7 @@ load ../_helper.bash
   export VORTEX_PUSH_DB_S3_DB_DIR=".data"
   export VORTEX_PUSH_DB_S3_DB_FILE="db.sql"
 
-  mocks="$(steps_run "setup")"
+  mocks="$(steps_run "setup" "curl=${mock_curl}")"
   run .vortex/tooling/src/vortex-push-db-s3
   steps_run "assert" "${mocks}"
 

--- a/.vortex/tooling/tests/unit/push-db-s3.bats
+++ b/.vortex/tooling/tests/unit/push-db-s3.bats
@@ -252,16 +252,10 @@ load ../_helper.bash
   mkdir -p .data
   echo "CREATE TABLE test (id INT);" >.data/db.sql
 
-  # The script reads the status from the last line of the response, so the mock
-  # has to answer with a body above it. A step cannot carry that response: the
-  # step string is split with 'read', which stops at the first newline.
-  mock_curl="$(mock_command "curl")"
-  mock_set_output "${mock_curl}" $'AccessDenied\n403' 1
-
   declare -a STEPS=(
     "[INFO] Started database dump push to S3."
 
-    "@curl *"
+    "@curl * # 0 # AccessDenied\n403"
 
     "ERROR: S3 push failed with HTTP status 403."
     "- [ OK ] Finished database dump push to S3."
@@ -277,7 +271,7 @@ load ../_helper.bash
   export VORTEX_PUSH_DB_S3_DB_DIR=".data"
   export VORTEX_PUSH_DB_S3_DB_FILE="db.sql"
 
-  mocks="$(steps_run "setup" "curl=${mock_curl}")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-push-db-s3
   steps_run "assert" "${mocks}"
 

--- a/.vortex/tooling/tests/unit/setup-ssh.bats
+++ b/.vortex/tooling/tests/unit/setup-ssh.bats
@@ -80,11 +80,11 @@ load ../_helper.bash
     "- Removing all keys from the SSH agent."
     "- Disabling strict host key checking."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-setup-ssh
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -114,10 +114,10 @@ load ../_helper.bash
     "- Disabling strict host key checking."
     "Finished SSH setup"
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run .vortex/tooling/src/vortex-setup-ssh
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -169,11 +169,11 @@ load ../_helper.bash
     "- Removing all keys from the SSH agent."
     "- Disabling strict host key checking."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-setup-ssh
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -209,11 +209,11 @@ load ../_helper.bash
     "Disabling strict host key checking."
     "Finished SSH setup."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-setup-ssh
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -243,11 +243,11 @@ load ../_helper.bash
     "Pinning SSH host keys to known_hosts."
     "- Disabling strict host key checking."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-setup-ssh
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   run cat "${HOME}/.ssh/known_hosts"
   assert_output_contains "example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY"
@@ -281,11 +281,11 @@ load ../_helper.bash
     "Pinning SSH host keys to known_hosts."
     "- Disabling strict host key checking."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-setup-ssh
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -319,11 +319,11 @@ load ../_helper.bash
     "Pinning SSH host keys to known_hosts."
     "- Disabling strict host key checking."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-setup-ssh
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   run cat "${HOME}/.ssh/known_hosts"
   assert_output_contains "example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY"
@@ -367,11 +367,11 @@ load ../_helper.bash
     "- Disabling strict host key checking."
     "Finished SSH setup."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-setup-ssh
   assert_success
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -403,11 +403,11 @@ load ../_helper.bash
     "- Removing all keys from the SSH agent."
     "- Disabling strict host key checking."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-setup-ssh
   assert_failure
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }
@@ -443,11 +443,11 @@ load ../_helper.bash
     "- Removing all keys from the SSH agent."
     "- Disabling strict host key checking."
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   run .vortex/tooling/src/vortex-setup-ssh
   assert_failure
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   popd >/dev/null
 }

--- a/.vortex/tooling/tests/unit/update-vortex.bats
+++ b/.vortex/tooling/tests/unit/update-vortex.bats
@@ -24,9 +24,9 @@ load ../_helper.bash
     "Downloading installer to installer.php"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run "${ROOT_DIR}/.vortex/tooling/src/vortex-update"
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_success
 
@@ -48,9 +48,9 @@ load ../_helper.bash
     "Downloading installer to installer.php"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run "${ROOT_DIR}/.vortex/tooling/src/vortex-update" "https://github.com/custom/repo.git#main"
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_success
 
@@ -74,9 +74,9 @@ load ../_helper.bash
     "Using installer script from local path: ${test_installer}"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run "${ROOT_DIR}/.vortex/tooling/src/vortex-update"
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_success
 
@@ -99,9 +99,9 @@ load ../_helper.bash
     "[FAIL] Installer script not found at /nonexistent/path/installer.php"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run "${ROOT_DIR}/.vortex/tooling/src/vortex-update"
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_failure
 
@@ -123,9 +123,9 @@ load ../_helper.bash
     "Downloading installer to installer.php"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run "${ROOT_DIR}/.vortex/tooling/src/vortex-update" "file:///local/path/to/vortex"
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_success
 
@@ -147,9 +147,9 @@ load ../_helper.bash
     "Downloading installer to installer.php"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run "${ROOT_DIR}/.vortex/tooling/src/vortex-update" "/local/path/to/vortex#stable"
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_success
 
@@ -171,9 +171,9 @@ load ../_helper.bash
     "Downloading installer to installer.php"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run "${ROOT_DIR}/.vortex/tooling/src/vortex-update" "git@github.com:drevops/vortex.git#v1.2.3"
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_success
 
@@ -195,9 +195,9 @@ load ../_helper.bash
     "Downloading installer to installer.php"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run "${ROOT_DIR}/.vortex/tooling/src/vortex-update"
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_failure
 
@@ -219,9 +219,9 @@ load ../_helper.bash
     "Downloading installer to installer.php"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run "${ROOT_DIR}/.vortex/tooling/src/vortex-update" --interactive
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_success
 
@@ -243,9 +243,9 @@ load ../_helper.bash
     "Downloading installer to installer.php"
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
   run "${ROOT_DIR}/.vortex/tooling/src/vortex-update" --interactive https://github.com/custom/repo.git#main
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 
   assert_success
 

--- a/.vortex/tooling/yarn.lock
+++ b/.vortex/tooling/yarn.lock
@@ -2,14 +2,13 @@
 # yarn lockfile v1
 
 
-"bats-helpers@npm:@drevops/bats-helpers@^1.5.1":
+"bats-helpers@github:drevops/bats-helpers#main":
   version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@drevops/bats-helpers/-/bats-helpers-1.6.0.tgz#0f157bd80ef232995a835a3662c28ac448938b01"
-  integrity sha512-/42f8udsjX6zPdOS1XzZrVKBj/Ixin777n0kePYwxPGqoE78+nh7aHwSNlQ4iR8DeFVz22fDe+gEUDYBT25UaQ==
+  resolved "https://codeload.github.com/drevops/bats-helpers/tar.gz/1a9668363e377bb60ccc8472ec2cbca5de7c5851"
   dependencies:
-    bats "^1"
+    bats "^1.10"
 
-bats@^1:
+bats@^1.10:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/bats/-/bats-1.13.0.tgz#b90aa4434832fc80458ade07ebdeecee0925d8ae"
   integrity sha512-giSYKGTOcPZyJDbfbTtzAedLcNWdjCLbXYU3/MwPnjyvDXzu6Dgw8d2M+8jHhZXSmsCMSQqCp+YBsJ603UO4vQ==

--- a/.vortex/tooling/yarn.lock
+++ b/.vortex/tooling/yarn.lock
@@ -2,9 +2,10 @@
 # yarn lockfile v1
 
 
-"bats-helpers@github:drevops/bats-helpers#main":
-  version "1.6.0"
-  resolved "https://codeload.github.com/drevops/bats-helpers/tar.gz/a4b0f44d49aaf25c7b84deec3a3fc25601bb8c4b"
+"bats-helpers@npm:@drevops/bats-helpers@^2.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@drevops/bats-helpers/-/bats-helpers-2.0.0.tgz#29cc602da7b0d1c237107216e809b466c55509c9"
+  integrity sha512-2oxr9SXOnogwBd+pB7sRP0LviP9Y7ReeRRlEa0cI9PHprhbd9Vm9Rv1NTdL2i8IxvktuQFtvCi25PkzihNxa7w==
   dependencies:
     bats "^1.13"
 

--- a/.vortex/tooling/yarn.lock
+++ b/.vortex/tooling/yarn.lock
@@ -4,11 +4,11 @@
 
 "bats-helpers@github:drevops/bats-helpers#main":
   version "1.6.0"
-  resolved "https://codeload.github.com/drevops/bats-helpers/tar.gz/20e96def540ba1ac2b5d2cb8487b64ee7b5f310e"
+  resolved "https://codeload.github.com/drevops/bats-helpers/tar.gz/66a9ad8b33b50bd9917f105fd5f859643492fe5b"
   dependencies:
-    bats "^1.10"
+    bats "^1.13"
 
-bats@^1.10:
+bats@^1.13:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/bats/-/bats-1.13.0.tgz#b90aa4434832fc80458ade07ebdeecee0925d8ae"
   integrity sha512-giSYKGTOcPZyJDbfbTtzAedLcNWdjCLbXYU3/MwPnjyvDXzu6Dgw8d2M+8jHhZXSmsCMSQqCp+YBsJ603UO4vQ==

--- a/.vortex/tooling/yarn.lock
+++ b/.vortex/tooling/yarn.lock
@@ -4,7 +4,7 @@
 
 "bats-helpers@github:drevops/bats-helpers#main":
   version "1.6.0"
-  resolved "https://codeload.github.com/drevops/bats-helpers/tar.gz/6dbd48363106eb06dcd903ba641cfe3ee8ad1aeb"
+  resolved "https://codeload.github.com/drevops/bats-helpers/tar.gz/20e96def540ba1ac2b5d2cb8487b64ee7b5f310e"
   dependencies:
     bats "^1.10"
 

--- a/.vortex/tooling/yarn.lock
+++ b/.vortex/tooling/yarn.lock
@@ -4,7 +4,7 @@
 
 "bats-helpers@github:drevops/bats-helpers#main":
   version "1.6.0"
-  resolved "https://codeload.github.com/drevops/bats-helpers/tar.gz/1a9668363e377bb60ccc8472ec2cbca5de7c5851"
+  resolved "https://codeload.github.com/drevops/bats-helpers/tar.gz/6dbd48363106eb06dcd903ba641cfe3ee8ad1aeb"
   dependencies:
     bats "^1.10"
 

--- a/.vortex/tooling/yarn.lock
+++ b/.vortex/tooling/yarn.lock
@@ -4,7 +4,7 @@
 
 "bats-helpers@github:drevops/bats-helpers#main":
   version "1.6.0"
-  resolved "https://codeload.github.com/drevops/bats-helpers/tar.gz/66a9ad8b33b50bd9917f105fd5f859643492fe5b"
+  resolved "https://codeload.github.com/drevops/bats-helpers/tar.gz/a4b0f44d49aaf25c7b84deec3a3fc25601bb8c4b"
   dependencies:
     bats "^1.13"
 


### PR DESCRIPTION
## Summary

This upgrades the BATS suite in `.vortex/tooling/tests/` from `bats-helpers` 1.6.0 to 2.0.0 and migrates every call site off the functions and variables that release deprecates. It touches 25 files, renaming 290 deprecated call sites, moving three environment variables onto the `BATS_HELPERS_` prefix, and correcting four container registry tests whose mocking assumptions turned out to be wrong under the stricter defaults 2.0 introduces. The full suite passes 309/309 with zero deprecation notices, matching a 1.6.0 baseline also run at 309/309.

The suite was tracked against the unreleased development branch throughout 2.0's stabilisation, which is where the upstream fixes listed below came from. It now pins the published release.

## Changes

- Moved `.vortex/tooling/package.json` from `npm:@drevops/bats-helpers@^1.5.1` to `npm:@drevops/bats-helpers@^2.0` and migrated 290 deprecated call sites across 25 files: `run_steps` to `steps_run` (277 sites), `assert_contains` to `assert_string_contains` (7 sites) and `assert_not_contains` to `assert_string_not_contains` (6 sites) - both of which also swap their arguments to haystack-first - `setup_mock` to `mock_setup`, and `assert_not_git_repo` to `assert_git_not_repo`.
- Renamed three variables in `_helper.bash` onto the `BATS_HELPERS_` prefix: `ASSERT_DIR_EXCLUDE`, `RUN_STEPS_DEBUG`, and `BATS_FIXTURE_EXPORT_CODEBASE_ENABLED`.
- Adapted `fetch-db-container-registry.bats` to the new strict-mock default, in which a mock carrying indexed responses but no default response rejects any call its expectations do not cover.
- Resolved `yarn.lock` to the published `2.0.0` tarball with its integrity hash.

## Verification

- Full BATS suite: 309/309 passing with zero deprecation notices.
- The deprecation-notice detector was itself validated with a positive control before trusting a clean run.
- `ahoy lint-scripts` passes.
- A 1.6.0 baseline run also comes back at 309/309, giving a clean before/after comparison.

## Findings

- Four `fetch-db-container-registry` tests mocked the login script by path via `mock_command "./.vortex/tooling/src/vortex-login-container-registry"`, but the script invokes it as `"$(dirname "${BASH_SOURCE[0]}")/vortex-login-container-registry"` - a direct path rather than a PATH lookup - so the mock never intercepted it. The real login script always ran, and its `docker login` landed as call 2 while the tests assumed call 2 was the pull. The dead mock lines are removed and the expectations now match the real `inspect` -> `login` -> `pull` sequence.
- The test formerly named "Skip fetch when image already exists on host" does not actually skip: `image_expanded_successfully` only becomes `1` through the `db.tar` branch, so without an expanded archive the script logs in and pulls regardless of the image being present. Nothing in the test required the fetch path, so the misleading name went unnoticed. It is now named "Fetch image when it exists on host and no archive exists" and asserts the fetch it triggers. That records the current behaviour rather than endorsing it - `vortex-fetch-db-container-registry` is unchanged here, and whether it should short-circuit when the image is already on the host is tracked separately in #2896.
- The test covering the default registry never checked that `docker.io` reached the pull, because the registry appears in the pull target and nowhere in the script output. It now asserts the recorded arguments of the pull call.
- Two upstream issues came out of testing this version against the suite, and both were fixed before the branch settled: [drevops/bats-helpers#178](https://github.com/drevops/bats-helpers/issues/178) moved the library's environment variables onto the `BATS_HELPERS_` prefix, and [drevops/bats-helpers#209](https://github.com/drevops/bats-helpers/issues/209) documented the mock behaviour changes that previously reached consumers with no notice and restored multi-line responses in command steps. The suite also surfaced a shared-state bug upstream fixed by anchoring the mock directory to the per-test sandbox, which had been making the suite fail non-deterministically at full-suite scale while every file passed in isolation.

## Before / After

```
BEFORE
┌─────────────────────────────────────┐
│ .vortex/tooling/package.json        │
│                                     │
│ "bats-helpers":                     │
│   "npm:@drevops/bats-helpers@^1.5.1"│
└─────────────────────────────────────┘
                  │
                  ▼
AFTER
┌─────────────────────────────────────┐
│ .vortex/tooling/package.json        │
│                                     │
│ "bats-helpers":                     │
│   "npm:@drevops/bats-helpers@^2.0"  │
└─────────────────────────────────────┘

fetch-db-container-registry.bats -- "image already on host" test

BEFORE: asserted only 1 mock call (docker inspect), so the script
        logging in and pulling anyway went unchecked.

  docker inspect  (1, image found) ──▶ [assertions stop here]

AFTER: dead/misleading mock lines removed, all 3 real calls asserted.

  docker inspect  (1, image found)
        │
        ▼
  docker login    (2, real login still runs - fetch is not skipped)
        │
        ▼
  docker pull     (3, real pull still runs)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the test suite for the latest helper-library APIs and configuration.
  * Improved container registry test coverage for login, image pulls, existing images, and default registry targets.
  * Refined string and path assertions while preserving existing scenarios and expected outcomes.

* **Chores**
  * Upgraded the development testing helper dependency to version 2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->