### PR TITLE
[#2896] Skipped database image fetch when the image already exists on the host.

### DIFF
--- a/.vortex/tooling/src/vortex-fetch-db-container-registry
+++ b/.vortex/tooling/src/vortex-fetch-db-container-registry
@@ -45,6 +45,10 @@ _v="VORTEX_FETCH_DB${_db_index}_CONTAINER_REGISTRY_IMAGE_BASE"
 _vs="VORTEX_DB${_db_index}_IMAGE_BASE"
 VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE_BASE="${!_v:-${!_vs:-}}"
 
+# Force fetch even if the image already exists on the host.
+_v="VORTEX_FETCH_DB${_db_index}_FORCE"
+VORTEX_FETCH_DB_FORCE="${!_v:-}"
+
 #-------------------------------------------------------------------------------
 
 # @formatter:off
@@ -68,15 +72,21 @@ info "Started database data container image fetch."
 [ -z "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_PASS}" ] && fail "Missing required value for VORTEX_FETCH_DB_CONTAINER_REGISTRY_PASS or VORTEX_CONTAINER_REGISTRY_PASS." && exit 1
 [ -z "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE}" ] && fail "Destination image name is not specified. Please provide VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE or VORTEX_DB_IMAGE in a format <org>/<repository>." && exit 1
 
-docker image inspect "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE}" >/dev/null 2>&1 &&
-  note "Found ${VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE} image on host." ||
+archive_file="${VORTEX_FETCH_DB_CONTAINER_REGISTRY_DB_DIR}/db.tar"
+
+image_found_on_host=0
+if docker image inspect "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE}" >/dev/null 2>&1; then
+  note "Found ${VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE} image on host."
+  image_found_on_host=1
+else
   note "Not found ${VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE} image on host."
+fi
 
 image_expanded_successfully=0
-if [ -f "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_DB_DIR}/db.tar" ]; then
-  task "Found archived database container image file ${VORTEX_FETCH_DB_CONTAINER_REGISTRY_DB_DIR}/db.tar. Expanding..."
+if [ -f "${archive_file}" ]; then
+  task "Found archived database container image file ${archive_file}. Expanding..."
   # Always use archived image, even if such image already exists on the host.
-  docker load -q --input "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_DB_DIR}/db.tar"
+  docker load -q --input "${archive_file}"
 
   # Check that image was expanded and now exists on the host or notify
   # that it will be downloaded from the registry.
@@ -88,8 +98,20 @@ if [ -f "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_DB_DIR}/db.tar" ]; then
   fi
 fi
 
-if [ "${image_expanded_successfully}" -eq 0 ]; then
-  if [ ! -f "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_DB_DIR}/db.tar" ] && [ -n "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE_BASE:-}" ]; then
+# An expanded archive always wins over the image on the host, so the host image
+# is only reused when there is no archive to expand.
+should_fetch=1
+if [ "${image_expanded_successfully}" -eq 1 ]; then
+  should_fetch=0
+elif [ ! -f "${archive_file}" ] && [ "${image_found_on_host}" -eq 1 ] && [ "${VORTEX_FETCH_DB_FORCE}" != "1" ]; then
+  note "Using existing ${VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE} image on host."
+  note "Fetch will not proceed."
+  note "Remove existing image or set VORTEX_FETCH_DB${_db_index}_FORCE value to 1 to force fetch."
+  should_fetch=0
+fi
+
+if [ "${should_fetch}" -eq 1 ]; then
+  if [ ! -f "${archive_file}" ] && [ -n "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE_BASE:-}" ]; then
     # If the image archive does not exist and base image was provided - use the
     # base image which allows "clean slate" for the database.
     note "Database container image was not found. Using base image ${VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE_BASE}."

--- a/.vortex/tooling/tests/unit/fetch-db-container-registry.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-container-registry.bats
@@ -143,6 +143,9 @@ load ../_helper.bash
   assert_output_contains "Fetching myorg/myapp image from the registry."
   assert_output_contains "[ OK ] Finished database data container image fetch."
 
+  # The inspect, the login and the pull.
+  assert_equal "3" "$(mock_get_call_num "${mock_docker}")"
+
   popd >/dev/null
 }
 
@@ -194,6 +197,9 @@ load ../_helper.bash
   assert_output_contains "Fetching myorg/migration-db image from the registry."
   assert_output_contains "[ OK ] Finished database data container image fetch."
 
+  # The inspect, the login and the pull.
+  assert_equal "3" "$(mock_get_call_num "${mock_docker}")"
+
   popd >/dev/null
 }
 
@@ -226,6 +232,9 @@ load ../_helper.bash
   assert_output_not_contains "Using existing myorg/myapp image on host."
   assert_output_contains "Fetching myorg/myapp image from the registry."
   assert_output_contains "[ OK ] Finished database data container image fetch."
+
+  # The inspect, the load, the second inspect, the login and the pull.
+  assert_equal "5" "$(mock_get_call_num "${mock_docker}")"
 
   rm -f .data/db.tar
 

--- a/.vortex/tooling/tests/unit/fetch-db-container-registry.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-container-registry.bats
@@ -91,15 +91,13 @@ load ../_helper.bash
   popd >/dev/null
 }
 
-@test "fetch-db-container-registry: Fetch image when it exists on host and no archive exists" {
+@test "fetch-db-container-registry: Skip fetch when image exists on host and no archive exists" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
   mock_docker=$(mock_command "docker")
-  # The image is found on the host, but the fetch is not skipped: without an
-  # expanded archive the script still logs in and pulls.
+  # The image is found on the host and there is no archive to expand, so the
+  # inspect is the only call - no registry login and no pull follow it.
   mock_set_side_effect "${mock_docker}" "echo 'image exists'" 1
-  mock_set_side_effect "${mock_docker}" "echo 'logged in'" 2
-  mock_set_side_effect "${mock_docker}" "echo 'pulled image'" 3
 
   export VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE="myorg/myapp"
   export VORTEX_FETCH_DB_CONTAINER_REGISTRY="registry.example.com"
@@ -111,8 +109,125 @@ load ../_helper.bash
   assert_success
   assert_output_contains "[INFO] Started database data container image fetch."
   assert_output_contains "Found myorg/myapp image on host."
+  assert_output_contains "Using existing myorg/myapp image on host."
+  assert_output_contains "Fetch will not proceed."
+  assert_output_contains "Remove existing image or set VORTEX_FETCH_DB_FORCE value to 1 to force fetch."
+  assert_output_not_contains "Fetching myorg/myapp image from the registry."
+  assert_output_contains "[ OK ] Finished database data container image fetch."
+
+  assert_equal "1" "$(mock_get_call_num "${mock_docker}")"
+
+  popd >/dev/null
+}
+
+@test "fetch-db-container-registry: Fetch image when it exists on host and fetch is forced" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  mock_docker=$(mock_command "docker")
+  mock_set_side_effect "${mock_docker}" "echo 'image exists'" 1
+  mock_set_side_effect "${mock_docker}" "echo 'logged in'" 2
+  mock_set_side_effect "${mock_docker}" "echo 'pulled image'" 3
+
+  export VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE="myorg/myapp"
+  export VORTEX_FETCH_DB_CONTAINER_REGISTRY="registry.example.com"
+  export VORTEX_FETCH_DB_CONTAINER_REGISTRY_USER="testuser"
+  export VORTEX_FETCH_DB_CONTAINER_REGISTRY_PASS="testpass"
+  export VORTEX_FETCH_DB_CONTAINER_REGISTRY_DB_DIR=".data"
+  export VORTEX_FETCH_DB_FORCE=1
+
+  run .vortex/tooling/src/vortex-fetch-db-container-registry
+  assert_success
+  assert_output_contains "[INFO] Started database data container image fetch."
+  assert_output_contains "Found myorg/myapp image on host."
+  assert_output_not_contains "Using existing myorg/myapp image on host."
   assert_output_contains "Fetching myorg/myapp image from the registry."
   assert_output_contains "[ OK ] Finished database data container image fetch."
+
+  popd >/dev/null
+}
+
+@test "fetch-db-container-registry: Skip fetch when image exists on host and indexed fetch is not forced" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  mock_docker=$(mock_command "docker")
+  mock_set_side_effect "${mock_docker}" "echo 'image exists'" 1
+
+  export VORTEX_DB_INDEX="2"
+  export VORTEX_DB2_IMAGE="myorg/migration-db"
+  export VORTEX_FETCH_DB2_CONTAINER_REGISTRY="registry.example.com"
+  export VORTEX_FETCH_DB2_CONTAINER_REGISTRY_USER="testuser"
+  export VORTEX_FETCH_DB2_CONTAINER_REGISTRY_PASS="testpass"
+  export VORTEX_FETCH_DB2_CONTAINER_REGISTRY_DB_DIR=".data"
+
+  run .vortex/tooling/src/vortex-fetch-db-container-registry
+  assert_success
+  assert_output_contains "Using existing myorg/migration-db image on host."
+  # The message names the indexed variable that the script actually reads.
+  assert_output_contains "Remove existing image or set VORTEX_FETCH_DB2_FORCE value to 1 to force fetch."
+  assert_output_not_contains "Fetching myorg/migration-db image from the registry."
+  assert_output_contains "[ OK ] Finished database data container image fetch."
+
+  assert_equal "1" "$(mock_get_call_num "${mock_docker}")"
+
+  popd >/dev/null
+}
+
+@test "fetch-db-container-registry: Fetch image when it exists on host and indexed fetch is forced" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  mock_docker=$(mock_command "docker")
+  mock_set_side_effect "${mock_docker}" "echo 'image exists'" 1
+  mock_set_side_effect "${mock_docker}" "echo 'logged in'" 2
+  mock_set_side_effect "${mock_docker}" "echo 'pulled image'" 3
+
+  export VORTEX_DB_INDEX="2"
+  export VORTEX_DB2_IMAGE="myorg/migration-db"
+  export VORTEX_FETCH_DB2_CONTAINER_REGISTRY="registry.example.com"
+  export VORTEX_FETCH_DB2_CONTAINER_REGISTRY_USER="testuser"
+  export VORTEX_FETCH_DB2_CONTAINER_REGISTRY_PASS="testpass"
+  export VORTEX_FETCH_DB2_CONTAINER_REGISTRY_DB_DIR=".data"
+  export VORTEX_FETCH_DB2_FORCE=1
+
+  run .vortex/tooling/src/vortex-fetch-db-container-registry
+  assert_success
+  assert_output_not_contains "Using existing myorg/migration-db image on host."
+  assert_output_contains "Fetching myorg/migration-db image from the registry."
+  assert_output_contains "[ OK ] Finished database data container image fetch."
+
+  popd >/dev/null
+}
+
+@test "fetch-db-container-registry: Fetch image when archive expansion fails and image exists on host" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  mkdir -p .data
+  touch .data/db.tar
+
+  mock_docker=$(mock_command "docker")
+  # The archive is authoritative when present, so a failed expansion falls
+  # through to the registry rather than reusing the image already on the host.
+  mock_set_side_effect "${mock_docker}" "echo 'image exists'" 1
+  mock_set_side_effect "${mock_docker}" "echo 'Loaded image: myorg/myapp'" 2
+  mock_set_side_effect "${mock_docker}" "exit 1" 3
+  mock_set_side_effect "${mock_docker}" "echo 'logged in'" 4
+  mock_set_side_effect "${mock_docker}" "echo 'pulled image'" 5
+
+  export VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE="myorg/myapp"
+  export VORTEX_FETCH_DB_CONTAINER_REGISTRY="registry.example.com"
+  export VORTEX_FETCH_DB_CONTAINER_REGISTRY_USER="testuser"
+  export VORTEX_FETCH_DB_CONTAINER_REGISTRY_PASS="testpass"
+  export VORTEX_FETCH_DB_CONTAINER_REGISTRY_DB_DIR=".data"
+
+  run .vortex/tooling/src/vortex-fetch-db-container-registry
+  assert_success
+  assert_output_contains "Found myorg/myapp image on host."
+  assert_output_contains "Found archived database container image file .data/db.tar. Expanding..."
+  assert_output_contains "Not found expanded myorg/myapp image on host."
+  assert_output_not_contains "Using existing myorg/myapp image on host."
+  assert_output_contains "Fetching myorg/myapp image from the registry."
+  assert_output_contains "[ OK ] Finished database data container image fetch."
+
+  rm -f .data/db.tar
 
   popd >/dev/null
 }


### PR DESCRIPTION
Closes #2896

## Summary
`.vortex/tooling/src/vortex-fetch-db-container-registry` inspected the database image on the host, printed `Found <image> image on host.`, then discarded that result, logged in to the container registry, and pulled the image anyway. The only variable gating the fetch was `image_expanded_successfully`, set exclusively inside the `db.tar` archive branch, so image presence on the host never skipped anything, and every run in that state cost a needless registry authentication and a full multi-hundred-megabyte image pull while replacing whatever image was already on the host.

The fetch is now skipped when the image is already on the host and no archive exists, with `VORTEX_FETCH_DB<index>_FORCE=1` as the override - the same shape the `vortex-fetch-db` router already uses for file-based sources. This makes the documented cache contract true for the `container_registry` source for the first time: `ahoy fetch-db` documents `--fresh` as forcing a fresh database backup and maps it to `VORTEX_FETCH_DB_FRESH=1 VORTEX_FETCH_DB_FORCE=1` (`.ahoy.yml`), and `.vortex/docs/content/development/database.mdx` documents plain `ahoy fetch-db` as using the cache and `--fresh` as bypassing it. Until now `--fresh` was a no-op on this path because the fetch always happened regardless.

Supporting evidence that the always-pull was unintended: the router `vortex-fetch-db` skips its own file-existence cache check only for the `container_registry` source, because the database is an image rather than a file, delegating the caching decision to this script - which then never made it; the archive branch's own comment reads `Always use archived image, even if such image already exists on the host`, which is only meaningful if a host image would otherwise be reused; and `.circleci/vortex-test-common.yml` already sets `VORTEX_FETCH_DB_FORCE: 1` on the job that uses this source, where it was until now a no-op.

Resolution order is now: an expanded `db.tar` archive wins, otherwise an image already on the host is reused, otherwise the image is pulled from the registry with the existing base-image fallback. The archive keeps precedence even when its expansion fails, so that case still fetches rather than silently serving a stale host image.

## Changes
- Added an `archive_file` variable holding the `db.tar` path, replacing four repetitions of the same path expression.
- Converted the host image inspection from an `a && b || c` chain into an explicit `if`/`else` that stores the result in `image_found_on_host`, since the chain could not capture its result without aborting under `set -eu`.
- Read a new `VORTEX_FETCH_DB_FORCE` value from the indexed `VORTEX_FETCH_DB<index>_FORCE` variable, matching the indexing convention the script already uses for its other settings.
- Introduced `should_fetch`, decided once the archive branch has run: `0` when the archive expanded successfully, `0` when the image was found on the host with no archive present and no force flag, `1` otherwise - leaving the existing fetch and base-image-fallback logic unchanged in the branch where it still applies.
- Inverted the unit test that recorded the old always-fetch behaviour and added four tests covering a forced fetch, the indexed `VORTEX_FETCH_DB2_FORCE` variable in both directions, and the failed-archive-expansion fallthrough.
- The skip and fetch tests now assert the exact `docker` call count via `mock_get_call_num` rather than just log output - the original test asserted only the message, which is why the bug survived.

CI impact is nil: `vortex-dev-database-ii`, the only CI job that fetches via the `container_registry` source, already sets `VORTEX_FETCH_DB_FORCE: 1` in `.circleci/vortex-test-common.yml`, and CI build containers start with no local images anyway and consume the database through the cached `.data/db.tar` archive, which retains precedence regardless.

Note, left out of scope so this change stays reviewable against a single issue: `.circleci/vortex-test-common.yml` line 409 sets `VORTEX_FETCH_DB_SOURCE: VORTEX_CONTAINER_REGISTRY`, where every other site uses the lowercase `container_registry` token this router actually matches on - this looks like a separate pre-existing defect.

## Before / After
```
BEFORE ----------------------------------------------------------------
  docker image inspect --> found on host? (logged, then discarded)

  db.tar exists? --yes--> docker load --> expanded ok? --yes--> done
         |no                                    |no
         v                                      v
  ALWAYS --> registry login --> docker pull <----+
  (host image is discarded and replaced, every run)
-------------------------------------------------------------------------

AFTER -----------------------------------------------------------------
  docker image inspect --> image_found_on_host = 0 or 1

  db.tar exists? --yes--> docker load --> expanded ok? --yes--> done
         |no                                    |no
         v                                      v
  image_found_on_host=1 and no archive and FORCE!=1 ?
         |yes --> SKIP fetch, reuse host image
         |no  --> registry login --> docker pull
-------------------------------------------------------------------------
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to force database container image retrieval, even when an image already exists locally.
  * Automatically uses available extracted archives before fetching from the registry.
  * Skips unnecessary registry downloads when a suitable local image is available.

* **Bug Fixes**
  * Falls back to registry retrieval when archive extraction fails.
  * Improved handling for indexed database configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->