### PR TITLE
[#2967] Moved 'exit 1' into the 'fail()' helper across the shell tooling.

### DIFF
--- a/.vortex/docs/content/contributing/maintenance/script-boilerplate.sh
+++ b/.vortex/docs/content/contributing/maintenance/script-boilerplate.sh
@@ -18,13 +18,13 @@ VORTEX_EXAMPLE_URL="${VORTEX_EXAMPLE_URL:-http://example.com}"
 info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[INFO] %s\033[0m\n" "${1}" || printf "[INFO] %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 pass() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s\033[0m\n" "${1}" || printf "[ OK ] %s\n" "${1}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 info "Started Vortex operations."
 
-[ -z "${VORTEX_EXAMPLE_URL}" ] && fail "Missing required value for VORTEX_EXAMPLE_URL." && exit 1
-command -v curl >/dev/null || (fail "curl command is not available." && exit 1)
+[ -z "${VORTEX_EXAMPLE_URL}" ] && fail "Missing required value for VORTEX_EXAMPLE_URL."
+command -v curl >/dev/null || fail "curl command is not available."
 
 # Example of the script body.
 curl -L -s -o /dev/null -w "%{http_code}" "${VORTEX_EXAMPLE_URL}" | grep -q '200\|403' && note "Requested example page."

--- a/.vortex/docs/content/contributing/maintenance/script-boilerplate.sh
+++ b/.vortex/docs/content/contributing/maintenance/script-boilerplate.sh
@@ -18,7 +18,7 @@ VORTEX_EXAMPLE_URL="${VORTEX_EXAMPLE_URL:-http://example.com}"
 info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[INFO] %s\033[0m\n" "${1}" || printf "[INFO] %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 pass() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s\033[0m\n" "${1}" || printf "[ OK ] %s\n" "${1}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 info "Started Vortex operations."

--- a/.vortex/docs/content/contributing/maintenance/template.mdx
+++ b/.vortex/docs/content/contributing/maintenance/template.mdx
@@ -56,15 +56,16 @@ Please refer to [RFC2119](https://www.ietf.org/rfc/rfc2119.txt) for meaning of w
     ```
 
 6. SHOULD include formatting helper functions. `fail` prints the message and
-   terminates the script, so it is always the last statement of a failure
-   branch - anything that explains the failure runs before it:
+   terminates the script with status `1`, or with the status passed as its
+   second argument. It is always the last statement of a failure branch -
+   anything that explains the failure runs before it:
 
     ```shell
     # @formatter:off
     note() { printf "       %s\n" "${1}"; }
     info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[INFO] %s\033[0m\n" "${1}" || printf "[INFO] %s\n" "${1}"; }
     pass() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s\033[0m\n" "${1}" || printf "[ OK ] %s\n" "${1}"; }
-    fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+    fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
     # @formatter:on
     ```
 

--- a/.vortex/docs/content/contributing/maintenance/template.mdx
+++ b/.vortex/docs/content/contributing/maintenance/template.mdx
@@ -55,27 +55,29 @@ Please refer to [RFC2119](https://www.ietf.org/rfc/rfc2119.txt) for meaning of w
     # ------------------------------------------------------------------------------
     ```
 
-6. SHOULD include formatting helper functions:
+6. SHOULD include formatting helper functions. `fail` prints the message and
+   terminates the script, so it is always the last statement of a failure
+   branch - anything that explains the failure runs before it:
 
     ```shell
     # @formatter:off
     note() { printf "       %s\n" "${1}"; }
     info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[INFO] %s\033[0m\n" "${1}" || printf "[INFO] %s\n" "${1}"; }
     pass() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s\033[0m\n" "${1}" || printf "[ OK ] %s\n" "${1}"; }
-    fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+    fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
     # @formatter:on
     ```
 
 7. SHOULD include variable values checks with errors and early exit, i.e.:
 
     ```shell
-    [ -z "${VORTEX_NOTIFY_REF}" ] && fail "Missing required value for VORTEX_NOTIFY_REF." && exit 1
+    [ -z "${VORTEX_NOTIFY_REF}" ] && fail "Missing required value for VORTEX_NOTIFY_REF."
     ```
 
 8. SHOULD include binaries checks if the script relies on them, i.e.:
 
     ```shell
-    command -v curl > /dev/null || ( fail "curl command is not available." && exit 1 )
+    command -v curl > /dev/null || fail "curl command is not available."
     ```
 
 9. MUST contain an `info` message about the start of the script body, e.g.:

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-00-enable-demo-modules.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-00-enable-demo-modules.sh
@@ -19,7 +19,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-00-enable-demo-modules.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-00-enable-demo-modules.sh
@@ -19,7 +19,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-10-enable-dev-modules.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-10-enable-dev-modules.sh
@@ -17,7 +17,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-10-enable-dev-modules.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-10-enable-dev-modules.sh
@@ -17,7 +17,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-30-search-index.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-30-search-index.sh
@@ -17,7 +17,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-30-search-index.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-30-search-index.sh
@@ -17,7 +17,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-40-example.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-40-example.sh
@@ -22,7 +22,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-40-example.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-40-example.sh
@@ -22,7 +22,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
@@ -28,7 +28,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 # Run Composer with its progress output suppressed - it is an internal detail
@@ -45,13 +45,11 @@ composer_run() {
   output=$(composer "$@" 2>&1) || status=$?
 
   if [ "${status}" -ne 0 ]; then
-    fail "Composer command failed."
-
     if [ -n "${output}" ]; then
       printf "%s\n" "${output}" >&2
     fi
 
-    return "${status}"
+    fail "Composer command failed."
   fi
 }
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/vortex-tooling.sh
@@ -28,7 +28,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 # Run Composer with its progress output suppressed - it is an internal detail
@@ -49,7 +49,7 @@ composer_run() {
       printf "%s\n" "${output}" >&2
     fi
 
-    fail "Composer command failed."
+    fail "Composer command failed." "${status}"
   fi
 }
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }
@@ -79,10 +79,7 @@ run_migration() {
   local migration_name="${1}"
   shift
 
-  drush migrate:reset-status "${migration_name}" || {
-    fail "Failed to reset migration status for ${migration_name}."
-    exit 1
-  }
+  drush migrate:reset-status "${migration_name}" || fail "Failed to reset migration status for ${migration_name}."
 
   task "Running migration: ${migration_name}."
   local opts=()
@@ -102,7 +99,7 @@ run_migration() {
 
   drush migrate:import "${opts[@]}" "${migration_name}" || {
     drush migrate:messages "${migration_name}"
-    exit 1
+    fail "Failed to run migration ${migration_name}."
   }
 
   pass "Migrated: ${migration_name}."
@@ -124,7 +121,7 @@ fi
 if [ "${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}" = "1" ]; then
   task "Importing migration source database."
 
-  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'." && exit 1
+  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'."
 
   drush sql:drop --database=migrate
   # shellcheck disable=SC2091
@@ -137,9 +134,8 @@ fi
 
 task "Verifying migration source database."
 if ! drush sql:query --database=migrate "SELECT COUNT(*) FROM ${DRUPAL_MIGRATION_SOURCE_DB_PROBE_TABLE}" >/dev/null 2>&1; then
-  fail "Migration source database is corrupted."
   drush sql:query --database=migrate "SHOW TABLES;"
-  exit 1
+  fail "Migration source database is corrupted."
 fi
 pass "Verified migration source database."
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }
@@ -79,10 +79,7 @@ run_migration() {
   local migration_name="${1}"
   shift
 
-  drush migrate:reset-status "${migration_name}" || {
-    fail "Failed to reset migration status for ${migration_name}."
-    exit 1
-  }
+  drush migrate:reset-status "${migration_name}" || fail "Failed to reset migration status for ${migration_name}."
 
   task "Running migration: ${migration_name}."
   local opts=()
@@ -102,7 +99,7 @@ run_migration() {
 
   drush migrate:import "${opts[@]}" "${migration_name}" || {
     drush migrate:messages "${migration_name}"
-    exit 1
+    fail "Failed to run migration ${migration_name}."
   }
 
   pass "Migrated: ${migration_name}."
@@ -124,7 +121,7 @@ fi
 if [ "${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}" = "1" ]; then
   task "Importing migration source database."
 
-  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'." && exit 1
+  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'."
 
   drush sql:drop --database=migrate
   # shellcheck disable=SC2091
@@ -137,9 +134,8 @@ fi
 
 task "Verifying migration source database."
 if ! drush sql:query --database=migrate "SELECT COUNT(*) FROM ${DRUPAL_MIGRATION_SOURCE_DB_PROBE_TABLE}" >/dev/null 2>&1; then
-  fail "Migration source database is corrupted."
   drush sql:query --database=migrate "SHOW TABLES;"
-  exit 1
+  fail "Migration source database is corrupted."
 fi
 pass "Verified migration source database."
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }
@@ -79,10 +79,7 @@ run_migration() {
   local migration_name="${1}"
   shift
 
-  drush migrate:reset-status "${migration_name}" || {
-    fail "Failed to reset migration status for ${migration_name}."
-    exit 1
-  }
+  drush migrate:reset-status "${migration_name}" || fail "Failed to reset migration status for ${migration_name}."
 
   task "Running migration: ${migration_name}."
   local opts=()
@@ -102,7 +99,7 @@ run_migration() {
 
   drush migrate:import "${opts[@]}" "${migration_name}" || {
     drush migrate:messages "${migration_name}"
-    exit 1
+    fail "Failed to run migration ${migration_name}."
   }
 
   pass "Migrated: ${migration_name}."
@@ -124,7 +121,7 @@ fi
 if [ "${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}" = "1" ]; then
   task "Importing migration source database."
 
-  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'." && exit 1
+  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'."
 
   drush sql:drop --database=migrate
   # shellcheck disable=SC2091
@@ -137,9 +134,8 @@ fi
 
 task "Verifying migration source database."
 if ! drush sql:query --database=migrate "SELECT COUNT(*) FROM ${DRUPAL_MIGRATION_SOURCE_DB_PROBE_TABLE}" >/dev/null 2>&1; then
-  fail "Migration source database is corrupted."
   drush sql:query --database=migrate "SHOW TABLES;"
-  exit 1
+  fail "Migration source database is corrupted."
 fi
 pass "Verified migration source database."
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }
@@ -79,10 +79,7 @@ run_migration() {
   local migration_name="${1}"
   shift
 
-  drush migrate:reset-status "${migration_name}" || {
-    fail "Failed to reset migration status for ${migration_name}."
-    exit 1
-  }
+  drush migrate:reset-status "${migration_name}" || fail "Failed to reset migration status for ${migration_name}."
 
   task "Running migration: ${migration_name}."
   local opts=()
@@ -102,7 +99,7 @@ run_migration() {
 
   drush migrate:import "${opts[@]}" "${migration_name}" || {
     drush migrate:messages "${migration_name}"
-    exit 1
+    fail "Failed to run migration ${migration_name}."
   }
 
   pass "Migrated: ${migration_name}."
@@ -124,7 +121,7 @@ fi
 if [ "${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}" = "1" ]; then
   task "Importing migration source database."
 
-  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'." && exit 1
+  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'."
 
   drush sql:drop --database=migrate
   # shellcheck disable=SC2091
@@ -137,9 +134,8 @@ fi
 
 task "Verifying migration source database."
 if ! drush sql:query --database=migrate "SELECT COUNT(*) FROM ${DRUPAL_MIGRATION_SOURCE_DB_PROBE_TABLE}" >/dev/null 2>&1; then
-  fail "Migration source database is corrupted."
   drush sql:query --database=migrate "SHOW TABLES;"
-  exit 1
+  fail "Migration source database is corrupted."
 fi
 pass "Verified migration source database."
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }
@@ -79,10 +79,7 @@ run_migration() {
   local migration_name="${1}"
   shift
 
-  drush migrate:reset-status "${migration_name}" || {
-    fail "Failed to reset migration status for ${migration_name}."
-    exit 1
-  }
+  drush migrate:reset-status "${migration_name}" || fail "Failed to reset migration status for ${migration_name}."
 
   task "Running migration: ${migration_name}."
   local opts=()
@@ -102,7 +99,7 @@ run_migration() {
 
   drush migrate:import "${opts[@]}" "${migration_name}" || {
     drush migrate:messages "${migration_name}"
-    exit 1
+    fail "Failed to run migration ${migration_name}."
   }
 
   pass "Migrated: ${migration_name}."
@@ -124,7 +121,7 @@ fi
 if [ "${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}" = "1" ]; then
   task "Importing migration source database."
 
-  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'." && exit 1
+  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'."
 
   drush sql:drop --database=migrate
   # shellcheck disable=SC2091
@@ -137,9 +134,8 @@ fi
 
 task "Verifying migration source database."
 if ! drush sql:query --database=migrate "SELECT COUNT(*) FROM ${DRUPAL_MIGRATION_SOURCE_DB_PROBE_TABLE}" >/dev/null 2>&1; then
-  fail "Migration source database is corrupted."
   drush sql:query --database=migrate "SHOW TABLES;"
-  exit 1
+  fail "Migration source database is corrupted."
 fi
 pass "Verified migration source database."
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }
@@ -79,10 +79,7 @@ run_migration() {
   local migration_name="${1}"
   shift
 
-  drush migrate:reset-status "${migration_name}" || {
-    fail "Failed to reset migration status for ${migration_name}."
-    exit 1
-  }
+  drush migrate:reset-status "${migration_name}" || fail "Failed to reset migration status for ${migration_name}."
 
   task "Running migration: ${migration_name}."
   local opts=()
@@ -102,7 +99,7 @@ run_migration() {
 
   drush migrate:import "${opts[@]}" "${migration_name}" || {
     drush migrate:messages "${migration_name}"
-    exit 1
+    fail "Failed to run migration ${migration_name}."
   }
 
   pass "Migrated: ${migration_name}."
@@ -124,7 +121,7 @@ fi
 if [ "${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}" = "1" ]; then
   task "Importing migration source database."
 
-  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'." && exit 1
+  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'."
 
   drush sql:drop --database=migrate
   # shellcheck disable=SC2091
@@ -137,9 +134,8 @@ fi
 
 task "Verifying migration source database."
 if ! drush sql:query --database=migrate "SELECT COUNT(*) FROM ${DRUPAL_MIGRATION_SOURCE_DB_PROBE_TABLE}" >/dev/null 2>&1; then
-  fail "Migration source database is corrupted."
   drush sql:query --database=migrate "SHOW TABLES;"
-  exit 1
+  fail "Migration source database is corrupted."
 fi
 pass "Verified migration source database."
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }
@@ -79,10 +79,7 @@ run_migration() {
   local migration_name="${1}"
   shift
 
-  drush migrate:reset-status "${migration_name}" || {
-    fail "Failed to reset migration status for ${migration_name}."
-    exit 1
-  }
+  drush migrate:reset-status "${migration_name}" || fail "Failed to reset migration status for ${migration_name}."
 
   task "Running migration: ${migration_name}."
   local opts=()
@@ -102,7 +99,7 @@ run_migration() {
 
   drush migrate:import "${opts[@]}" "${migration_name}" || {
     drush migrate:messages "${migration_name}"
-    exit 1
+    fail "Failed to run migration ${migration_name}."
   }
 
   pass "Migrated: ${migration_name}."
@@ -124,7 +121,7 @@ fi
 if [ "${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}" = "1" ]; then
   task "Importing migration source database."
 
-  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'." && exit 1
+  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'."
 
   drush sql:drop --database=migrate
   # shellcheck disable=SC2091
@@ -137,9 +134,8 @@ fi
 
 task "Verifying migration source database."
 if ! drush sql:query --database=migrate "SELECT COUNT(*) FROM ${DRUPAL_MIGRATION_SOURCE_DB_PROBE_TABLE}" >/dev/null 2>&1; then
-  fail "Migration source database is corrupted."
   drush sql:query --database=migrate "SHOW TABLES;"
-  exit 1
+  fail "Migration source database is corrupted."
 fi
 pass "Verified migration source database."
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }
@@ -79,10 +79,7 @@ run_migration() {
   local migration_name="${1}"
   shift
 
-  drush migrate:reset-status "${migration_name}" || {
-    fail "Failed to reset migration status for ${migration_name}."
-    exit 1
-  }
+  drush migrate:reset-status "${migration_name}" || fail "Failed to reset migration status for ${migration_name}."
 
   task "Running migration: ${migration_name}."
   local opts=()
@@ -102,7 +99,7 @@ run_migration() {
 
   drush migrate:import "${opts[@]}" "${migration_name}" || {
     drush migrate:messages "${migration_name}"
-    exit 1
+    fail "Failed to run migration ${migration_name}."
   }
 
   pass "Migrated: ${migration_name}."
@@ -124,7 +121,7 @@ fi
 if [ "${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}" = "1" ]; then
   task "Importing migration source database."
 
-  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'." && exit 1
+  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'."
 
   drush sql:drop --database=migrate
   # shellcheck disable=SC2091
@@ -137,9 +134,8 @@ fi
 
 task "Verifying migration source database."
 if ! drush sql:query --database=migrate "SELECT COUNT(*) FROM ${DRUPAL_MIGRATION_SOURCE_DB_PROBE_TABLE}" >/dev/null 2>&1; then
-  fail "Migration source database is corrupted."
   drush sql:query --database=migrate "SHOW TABLES;"
-  exit 1
+  fail "Migration source database is corrupted."
 fi
 pass "Verified migration source database."
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }
@@ -79,10 +79,7 @@ run_migration() {
   local migration_name="${1}"
   shift
 
-  drush migrate:reset-status "${migration_name}" || {
-    fail "Failed to reset migration status for ${migration_name}."
-    exit 1
-  }
+  drush migrate:reset-status "${migration_name}" || fail "Failed to reset migration status for ${migration_name}."
 
   task "Running migration: ${migration_name}."
   local opts=()
@@ -102,7 +99,7 @@ run_migration() {
 
   drush migrate:import "${opts[@]}" "${migration_name}" || {
     drush migrate:messages "${migration_name}"
-    exit 1
+    fail "Failed to run migration ${migration_name}."
   }
 
   pass "Migrated: ${migration_name}."
@@ -124,7 +121,7 @@ fi
 if [ "${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}" = "1" ]; then
   task "Importing migration source database."
 
-  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'." && exit 1
+  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'."
 
   drush sql:drop --database=migrate
   # shellcheck disable=SC2091
@@ -137,9 +134,8 @@ fi
 
 task "Verifying migration source database."
 if ! drush sql:query --database=migrate "SELECT COUNT(*) FROM ${DRUPAL_MIGRATION_SOURCE_DB_PROBE_TABLE}" >/dev/null 2>&1; then
-  fail "Migration source database is corrupted."
   drush sql:query --database=migrate "SHOW TABLES;"
-  exit 1
+  fail "Migration source database is corrupted."
 fi
 pass "Verified migration source database."
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/tooling/src/vortex-deploy
+++ b/.vortex/tooling/src/vortex-deploy
@@ -71,7 +71,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 info "Started deployment."
@@ -84,7 +84,7 @@ if [ "${VORTEX_DEPLOY_SKIP:-}" = "1" ]; then
   exit 0
 fi
 
-[ -z "${VORTEX_DEPLOY_TYPES}" ] && fail "Missing required value for VORTEX_DEPLOY_TYPES. Must be a combination of comma-separated values (to support multiple deployments): artifact, webhook, lagoon." && exit 1
+[ -z "${VORTEX_DEPLOY_TYPES}" ] && fail "Missing required value for VORTEX_DEPLOY_TYPES. Must be a combination of comma-separated values (to support multiple deployments): artifact, webhook, lagoon."
 
 if [ "${VORTEX_DEPLOY_ALLOW_SKIP:-}" = "1" ]; then
   note "Found flag to skip a deployment."

--- a/.vortex/tooling/src/vortex-deploy
+++ b/.vortex/tooling/src/vortex-deploy
@@ -71,7 +71,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 info "Started deployment."

--- a/.vortex/tooling/src/vortex-deploy-artifact
+++ b/.vortex/tooling/src/vortex-deploy-artifact
@@ -73,7 +73,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 info "Started artifact deployment."

--- a/.vortex/tooling/src/vortex-deploy-artifact
+++ b/.vortex/tooling/src/vortex-deploy-artifact
@@ -73,25 +73,22 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 info "Started artifact deployment."
 
 # shellcheck disable=SC2043
-for cmd in curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 # Check all required values.
-[ -z "${VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE." && exit 1
-[ -z "${VORTEX_DEPLOY_ARTIFACT_DST_BRANCH}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_DST_BRANCH." && exit 1
-[ -z "${VORTEX_DEPLOY_ARTIFACT_SRC}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_SRC." && exit 1
-[ -z "${VORTEX_DEPLOY_ARTIFACT_ROOT}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_ROOT." && exit 1
-[ -z "${VORTEX_DEPLOY_ARTIFACT_LOG}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_LOG." && exit 1
-[ -z "${VORTEX_DEPLOY_ARTIFACT_GIT_USER_NAME}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_GIT_USER_NAME." && exit 1
-[ -z "${VORTEX_DEPLOY_ARTIFACT_GIT_USER_EMAIL}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_GIT_USER_EMAIL." && exit 1
+[ -z "${VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_GIT_REMOTE."
+[ -z "${VORTEX_DEPLOY_ARTIFACT_DST_BRANCH}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_DST_BRANCH."
+[ -z "${VORTEX_DEPLOY_ARTIFACT_SRC}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_SRC."
+[ -z "${VORTEX_DEPLOY_ARTIFACT_ROOT}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_ROOT."
+[ -z "${VORTEX_DEPLOY_ARTIFACT_LOG}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_LOG."
+[ -z "${VORTEX_DEPLOY_ARTIFACT_GIT_USER_NAME}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_GIT_USER_NAME."
+[ -z "${VORTEX_DEPLOY_ARTIFACT_GIT_USER_EMAIL}" ] && fail "Missing required value for VORTEX_DEPLOY_ARTIFACT_GIT_USER_EMAIL."
 
 # Configure global git settings, if they do not exist.
 [ -z "$(git config --global user.name)" ] && task "Configuring global git user name." && git config --global user.name "${VORTEX_DEPLOY_ARTIFACT_GIT_USER_NAME}"
@@ -104,7 +101,6 @@ task "Installing artifact builder."
 curl -sS -L "https://github.com/drevops/git-artifact/releases/download/${VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_VERSION}/git-artifact" -o "${TMPDIR:-/tmp}"/git-artifact
 if ! echo "${VORTEX_DEPLOY_ARTIFACT_GIT_ARTIFACT_SHA256}  ${TMPDIR:-/tmp}/git-artifact" | sha256sum -c; then
   fail "SHA256 checksum verification failed for git-artifact binary."
-  exit 1
 fi
 chmod +x "${TMPDIR:-/tmp}"/git-artifact
 

--- a/.vortex/tooling/src/vortex-deploy-lagoon
+++ b/.vortex/tooling/src/vortex-deploy-lagoon
@@ -85,7 +85,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 
 # Check if error output contains Lagoon environment limit exceeded message.
 # Returns 0 if limit exceeded error found, 1 otherwise.
@@ -128,7 +128,7 @@ run_lagoon_deploy() {
   return 0
 }
 
-# Track exit status to return at the end.
+# Track deploy status to report at the end.
 exit_code=0
 
 # Raw CLI output of a failed deploy, printed with the final status.
@@ -144,8 +144,8 @@ if [ "${VORTEX_DEPLOY_MODE}" = "tag" ]; then
 fi
 
 ## Check all required values.
-[ -z "${VORTEX_DEPLOY_LAGOON_PROJECT}" ] && fail "Missing required value for VORTEX_DEPLOY_LAGOON_PROJECT or LAGOON_PROJECT." && exit 1
-{ [ -z "${VORTEX_DEPLOY_LAGOON_BRANCH}" ] && [ -z "${VORTEX_DEPLOY_LAGOON_PR}" ]; } && fail "Missing required value for VORTEX_DEPLOY_LAGOON_BRANCH or VORTEX_DEPLOY_BRANCH or VORTEX_DEPLOY_LAGOON_PR or VORTEX_DEPLOY_PR." && exit 1
+[ -z "${VORTEX_DEPLOY_LAGOON_PROJECT}" ] && fail "Missing required value for VORTEX_DEPLOY_LAGOON_PROJECT or LAGOON_PROJECT."
+{ [ -z "${VORTEX_DEPLOY_LAGOON_BRANCH}" ] && [ -z "${VORTEX_DEPLOY_LAGOON_PR}" ]; } && fail "Missing required value for VORTEX_DEPLOY_LAGOON_BRANCH or VORTEX_DEPLOY_BRANCH or VORTEX_DEPLOY_LAGOON_PR or VORTEX_DEPLOY_PR."
 
 export VORTEX_SSH_PREFIX="DEPLOY_LAGOON"
 . "$(dirname "${BASH_SOURCE[0]}")/vortex-setup-ssh"
@@ -167,10 +167,7 @@ if ! command -v lagoon >/dev/null || [ -n "${VORTEX_DEPLOY_LAGOON_LAGOONCLI_FORC
   pass "Installed Lagoon CLI."
 fi
 
-for cmd in lagoon curl jq; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in lagoon curl jq; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 task "Configuring Lagoon instance."
 # shellcheck disable=SC2218
@@ -306,14 +303,12 @@ else
   fi
 fi
 
-if [ "${exit_code}" = "0" ]; then
-  pass "Finished Lagoon deployment."
-else
-  fail "Lagoon deployment completed with errors."
-
+if [ "${exit_code}" != "0" ]; then
   if [ -n "${deploy_error}" ]; then
     printf '%s\n' "${deploy_error}"
   fi
+
+  fail "Lagoon deployment completed with errors."
 fi
 
-exit "${exit_code}"
+pass "Finished Lagoon deployment."

--- a/.vortex/tooling/src/vortex-deploy-lagoon
+++ b/.vortex/tooling/src/vortex-deploy-lagoon
@@ -85,7 +85,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 
 # Check if error output contains Lagoon environment limit exceeded message.
 # Returns 0 if limit exceeded error found, 1 otherwise.
@@ -308,7 +308,7 @@ if [ "${exit_code}" != "0" ]; then
     printf '%s\n' "${deploy_error}"
   fi
 
-  fail "Lagoon deployment completed with errors."
+  fail "Lagoon deployment completed with errors." "${exit_code}"
 fi
 
 pass "Finished Lagoon deployment."

--- a/.vortex/tooling/src/vortex-deploy-webhook
+++ b/.vortex/tooling/src/vortex-deploy-webhook
@@ -27,27 +27,23 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 # shellcheck disable=SC2043
-for cmd in curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 info "Started webhook deployment."
 
 # Check all required values.
-[ -z "${VORTEX_DEPLOY_WEBHOOK_URL}" ] && fail "Missing required value for VORTEX_DEPLOY_WEBHOOK_URL." && exit 1
-[ -z "${VORTEX_DEPLOY_WEBHOOK_METHOD}" ] && fail "Missing required value for VORTEX_DEPLOY_WEBHOOK_METHOD." && exit 1
-[ -z "${VORTEX_DEPLOY_WEBHOOK_RESPONSE_STATUS}" ] && fail "Missing required value for VORTEX_DEPLOY_WEBHOOK_RESPONSE_STATUS." && exit 1
+[ -z "${VORTEX_DEPLOY_WEBHOOK_URL}" ] && fail "Missing required value for VORTEX_DEPLOY_WEBHOOK_URL."
+[ -z "${VORTEX_DEPLOY_WEBHOOK_METHOD}" ] && fail "Missing required value for VORTEX_DEPLOY_WEBHOOK_METHOD."
+[ -z "${VORTEX_DEPLOY_WEBHOOK_RESPONSE_STATUS}" ] && fail "Missing required value for VORTEX_DEPLOY_WEBHOOK_RESPONSE_STATUS."
 
 if curl --request "${VORTEX_DEPLOY_WEBHOOK_METHOD}" --location --silent --output /dev/null --write-out "%{http_code}" "${VORTEX_DEPLOY_WEBHOOK_URL}" | grep --quiet "${VORTEX_DEPLOY_WEBHOOK_RESPONSE_STATUS}"; then
   note "Webhook call completed."
 else
   fail "Unable to complete webhook deployment."
-  exit 1
 fi
 
 pass "Finished webhook deployment."

--- a/.vortex/tooling/src/vortex-deploy-webhook
+++ b/.vortex/tooling/src/vortex-deploy-webhook
@@ -27,7 +27,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 # shellcheck disable=SC2043

--- a/.vortex/tooling/src/vortex-doctor
+++ b/.vortex/tooling/src/vortex-doctor
@@ -69,14 +69,11 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 warn() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[33m[WARN] %s\033[0m\n" "${1}" || printf "[WARN] %s\n" "${1}"; }
 # @formatter:on
 
-for cmd in docker pygmy ahoy; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in docker pygmy ahoy; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 #
 # Main entry point.
@@ -87,17 +84,16 @@ main() {
   info "Checking project requirements."
 
   if [ "${VORTEX_DOCTOR_CHECK_TOOLS}" = "1" ]; then
-    [ "$(command_exists docker)" = "1" ] && fail "Please install Docker (https://www.docker.com/get-started)." && exit 1
-    [ "$(command_exists docker compose)" = "1" ] && fail "Please install docker compose (https://docs.docker.com/compose/install/)." && exit 1
-    [ "$(command_exists pygmy)" = "1" ] && fail "Please install Pygmy (https://pygmy.readthedocs.io/)." && exit 1
-    [ "$(command_exists ahoy)" = "1" ] && fail "Please install Ahoy (https://ahoy-cli.readthedocs.io/)." && exit 1
+    [ "$(command_exists docker)" = "1" ] && fail "Please install Docker (https://www.docker.com/get-started)."
+    [ "$(command_exists docker compose)" = "1" ] && fail "Please install docker compose (https://docs.docker.com/compose/install/)."
+    [ "$(command_exists pygmy)" = "1" ] && fail "Please install Pygmy (https://pygmy.readthedocs.io/)."
+    [ "$(command_exists ahoy)" = "1" ] && fail "Please install Ahoy (https://ahoy-cli.readthedocs.io/)."
     pass "All required tools are present."
   fi
 
   if [ "${VORTEX_DOCTOR_CHECK_PORT}" = "1" ] && [ "${OSTYPE}" != "linux-gnu" ]; then
     if lsof -i :80 | grep -v 'CLOSED' | grep 'LISTEN' | grep -vq 'om.docke'; then
       fail "Port 80 is occupied by a service other than Docker. Stop this service and run 'pygmy up'."
-      exit 1
     fi
     pass "Port 80 is available."
   fi
@@ -114,7 +110,6 @@ main() {
     for pygmy_service in "${pygmy_services[@]}"; do
       if ! echo "${pygmy_status}" | grep -q "${pygmy_service}: Running"; then
         fail "Pygmy service ${pygmy_service} is not running. Run 'pygmy up' or 'pygmy restart' to fix."
-        exit 1
       fi
     done
     pass "Pygmy is running."
@@ -125,10 +120,9 @@ main() {
     container_services=(cli php nginx database)
     for container_service in "${container_services[@]}"; do
       if ! docker compose ps --status=running --services | grep -q "${container_service}"; then
-        fail "${container_service} container is not running."
         note "Run 'ahoy up'."
         note "Run 'ahoy logs ${container_service}' to see error logs."
-        exit 1
+        fail "${container_service} container is not running."
       fi
     done
     pass "All containers are running."
@@ -185,7 +179,6 @@ main() {
     if [ "${ssh_key_added_to_pygmy}" = "1" ] && [ "${ssh_key_volume_mounted}" = "1" ]; then
       if ! docker compose exec -T cli bash -c "ssh-add -l >/dev/null 2>&1"; then
         fail "SSH key was not added to the container. Run 'pygmy restart'."
-        exit 1
       else
         pass "SSH key is available within the CLI container."
       fi
@@ -198,14 +191,12 @@ main() {
       # Depending on the type of installation, the homepage may return 200 or 403.
       if ! curl -L -s -o /dev/null -w "%{http_code}" "${local_dev_url}" | grep -q '200\|403'; then
         fail "Web server is not accessible at http://${local_dev_url}."
-        exit 1
       fi
       pass "Web server is running and accessible at http://${local_dev_url}."
 
       if [ "${VORTEX_DOCTOR_CHECK_BOOTSTRAP}" = "1" ]; then
         if ! curl -L -s -N "${local_dev_url}" | grep -q -i "charset="; then
           fail "Website is running, but cannot be bootstrapped. Check web-server configuration."
-          exit 1
         fi
         pass "Bootstrapped website at http://${local_dev_url}."
       fi

--- a/.vortex/tooling/src/vortex-doctor
+++ b/.vortex/tooling/src/vortex-doctor
@@ -69,7 +69,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 warn() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[33m[WARN] %s\033[0m\n" "${1}" || printf "[WARN] %s\n" "${1}"; }
 # @formatter:on
 

--- a/.vortex/tooling/src/vortex-export-db
+++ b/.vortex/tooling/src/vortex-export-db
@@ -26,7 +26,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 is_host() { [ "${RUN_ON_HOST:-$(command -v docker >/dev/null 2>&1 && echo 1 || echo 0)}" = "1" ]; }
 # @formatter:on
 

--- a/.vortex/tooling/src/vortex-export-db
+++ b/.vortex/tooling/src/vortex-export-db
@@ -26,7 +26,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 is_host() { [ "${RUN_ON_HOST:-$(command -v docker >/dev/null 2>&1 && echo 1 || echo 0)}" = "1" ]; }
 # @formatter:on
 

--- a/.vortex/tooling/src/vortex-export-db-file
+++ b/.vortex/tooling/src/vortex-export-db-file
@@ -19,7 +19,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 info "Started database file export."
@@ -45,7 +45,7 @@ drush sql:dump --skip-tables-key=common --result-file="${dump_file_drush}" -q
 if [ -f "${dump_file}" ] && [ -s "${dump_file}" ]; then
   note "Exported database dump saved ${dump_file}."
 else
-  fail "Unable to save dump file ${dump_file}." && exit 1
+  fail "Unable to save dump file ${dump_file}."
 fi
 
 pass "Finished database file export."

--- a/.vortex/tooling/src/vortex-export-db-file
+++ b/.vortex/tooling/src/vortex-export-db-file
@@ -19,7 +19,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 info "Started database file export."

--- a/.vortex/tooling/src/vortex-export-db-image
+++ b/.vortex/tooling/src/vortex-export-db-image
@@ -33,18 +33,15 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 # shellcheck disable=SC2043
-for cmd in docker; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in docker; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 info "Started database data container image export."
 
-[ -z "${VORTEX_EXPORT_DB_IMAGE}" ] && fail "Destination image name is not specified. Please provide container image as a variable VORTEX_EXPORT_DB_IMAGE in a format <org>/<repository>." && exit 1
+[ -z "${VORTEX_EXPORT_DB_IMAGE}" ] && fail "Destination image name is not specified. Please provide container image as a variable VORTEX_EXPORT_DB_IMAGE in a format <org>/<repository>."
 
 cid="$(docker compose ps -q "${VORTEX_EXPORT_DB_SERVICE_NAME}")"
 note "Found ${VORTEX_EXPORT_DB_SERVICE_NAME} service container with id ${cid}."
@@ -85,7 +82,7 @@ if [ -f "${archive_file}" ] && [ -s "${archive_file}" ]; then
   note "Exported database image saved to archive file ${archive_file}."
 else
   # LCOV_EXCL_START
-  fail "Unable to save database image archive file ${archive_file}." && exit 1
+  fail "Unable to save database image archive file ${archive_file}."
   # LCOV_EXCL_STOP
 fi
 

--- a/.vortex/tooling/src/vortex-export-db-image
+++ b/.vortex/tooling/src/vortex-export-db-image
@@ -33,7 +33,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 # shellcheck disable=SC2043

--- a/.vortex/tooling/src/vortex-fetch-db
+++ b/.vortex/tooling/src/vortex-fetch-db
@@ -49,7 +49,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 info "Started database${_db_index:+ ${_db_index}} fetch."

--- a/.vortex/tooling/src/vortex-fetch-db
+++ b/.vortex/tooling/src/vortex-fetch-db
@@ -49,7 +49,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 info "Started database${_db_index:+ ${_db_index}} fetch."

--- a/.vortex/tooling/src/vortex-fetch-db-acquia
+++ b/.vortex/tooling/src/vortex-fetch-db-acquia
@@ -80,13 +80,10 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
-for cmd in php curl gunzip; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in php curl gunzip; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 info "Started database dump fetch from Acquia."
 
@@ -107,11 +104,11 @@ extract_json_value() {
 }
 
 # Check that all required variables are present.
-[ -z "${VORTEX_FETCH_DB_ACQUIA_KEY}" ] && fail "Missing required value for VORTEX_FETCH_DB_ACQUIA_KEY or VORTEX_ACQUIA_KEY." && exit 1
-[ -z "${VORTEX_FETCH_DB_ACQUIA_SECRET}" ] && fail "Missing required value for VORTEX_FETCH_DB_ACQUIA_SECRET or VORTEX_ACQUIA_SECRET." && exit 1
-[ -z "${VORTEX_FETCH_DB_ACQUIA_APP_NAME}" ] && fail "Missing required value for VORTEX_FETCH_DB_ACQUIA_APP_NAME or VORTEX_ACQUIA_APP_NAME." && exit 1
-[ -z "${VORTEX_FETCH_DB_ENVIRONMENT}" ] && fail "Missing required value for VORTEX_FETCH_DB_ENVIRONMENT." && exit 1
-[ -z "${VORTEX_FETCH_DB_ACQUIA_DB_NAME}" ] && fail "Missing required value for VORTEX_FETCH_DB_ACQUIA_DB_NAME." && exit 1
+[ -z "${VORTEX_FETCH_DB_ACQUIA_KEY}" ] && fail "Missing required value for VORTEX_FETCH_DB_ACQUIA_KEY or VORTEX_ACQUIA_KEY."
+[ -z "${VORTEX_FETCH_DB_ACQUIA_SECRET}" ] && fail "Missing required value for VORTEX_FETCH_DB_ACQUIA_SECRET or VORTEX_ACQUIA_SECRET."
+[ -z "${VORTEX_FETCH_DB_ACQUIA_APP_NAME}" ] && fail "Missing required value for VORTEX_FETCH_DB_ACQUIA_APP_NAME or VORTEX_ACQUIA_APP_NAME."
+[ -z "${VORTEX_FETCH_DB_ENVIRONMENT}" ] && fail "Missing required value for VORTEX_FETCH_DB_ENVIRONMENT."
+[ -z "${VORTEX_FETCH_DB_ACQUIA_DB_NAME}" ] && fail "Missing required value for VORTEX_FETCH_DB_ACQUIA_DB_NAME."
 
 mkdir -p "${VORTEX_FETCH_DB_ACQUIA_DB_DIR}"
 
@@ -122,12 +119,11 @@ token_json=$(curl -s -L https://accounts.acquia.com/api/auth/oauth/token --data-
 # Check for HTTP errors in response
 if echo "${token_json}" | grep -q '"error"'; then
   fail "Authentication failed. Check VORTEX_FETCH_DB_ACQUIA_KEY or VORTEX_ACQUIA_KEY and VORTEX_FETCH_DB_ACQUIA_SECRET or VORTEX_ACQUIA_SECRET. API response: ${token_json}"
-  exit 1
 fi
 
 token="$(echo "${token_json}" | extract_json_value "access_token")"
 [ "${VORTEX_DEBUG-}" = "1" ] && note "Access token extracted (value redacted)."
-[ -z "${token}" ] && fail "Unable to retrieve a token. API response: ${token_json}" && exit 1
+[ -z "${token}" ] && fail "Unable to retrieve a token. API response: ${token_json}"
 
 task "Retrieving ${VORTEX_FETCH_DB_ACQUIA_APP_NAME} application UUID."
 app_uuid_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications?filter=name%3D${VORTEX_FETCH_DB_ACQUIA_APP_NAME/ /%20}")
@@ -136,12 +132,11 @@ app_uuid_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authoriz
 # Check for empty items array (application not found)
 if echo "${app_uuid_json}" | grep -q '"items":\[\]'; then
   fail "Application \"${VORTEX_FETCH_DB_ACQUIA_APP_NAME}\" not found. Check application name and access permissions."
-  exit 1
 fi
 
 app_uuid=$(echo "${app_uuid_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "uuid")
 [ "${VORTEX_DEBUG-}" = "1" ] && note "Extracted app UUID: ${app_uuid}"
-[ -z "${app_uuid}" ] && fail "Unable to retrieve an application UUID for \"${VORTEX_FETCH_DB_ACQUIA_APP_NAME}\". API response: ${app_uuid_json}" && exit 1
+[ -z "${app_uuid}" ] && fail "Unable to retrieve an application UUID for \"${VORTEX_FETCH_DB_ACQUIA_APP_NAME}\". API response: ${app_uuid_json}"
 
 task "Retrieving ${VORTEX_FETCH_DB_ENVIRONMENT} environment ID."
 envs_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications/${app_uuid}/environments?filter=name%3D${VORTEX_FETCH_DB_ENVIRONMENT}")
@@ -150,12 +145,11 @@ envs_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorizatio
 # Check for empty items array (environment not found)
 if echo "${envs_json}" | grep -q '"items":\[\]'; then
   fail "Environment \"${VORTEX_FETCH_DB_ENVIRONMENT}\" not found in application \"${VORTEX_FETCH_DB_ACQUIA_APP_NAME}\". Check environment name."
-  exit 1
 fi
 
 env_id=$(echo "${envs_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "id")
 [ "${VORTEX_DEBUG-}" = "1" ] && note "Extracted environment ID: ${env_id}"
-[ -z "${env_id}" ] && fail "Unable to retrieve an environment ID for \"${VORTEX_FETCH_DB_ENVIRONMENT}\". API response: ${envs_json}" && exit 1
+[ -z "${env_id}" ] && fail "Unable to retrieve an environment ID for \"${VORTEX_FETCH_DB_ENVIRONMENT}\". API response: ${envs_json}"
 
 # If fresh backup requested, create a new backup and wait for it to complete.
 if [ "${VORTEX_FETCH_DB_FRESH}" = "1" ]; then
@@ -168,7 +162,6 @@ if [ "${VORTEX_FETCH_DB_FRESH}" = "1" ]; then
   # Check for errors
   if echo "${create_backup_json}" | grep -q '"error"'; then
     fail "Unable to create backup for database \"${VORTEX_FETCH_DB_ACQUIA_DB_NAME}\". API response: ${create_backup_json}"
-    exit 1
   fi
 
   # Extract notification URL for status checking
@@ -177,7 +170,6 @@ if [ "${VORTEX_FETCH_DB_FRESH}" = "1" ]; then
 
   if [ -z "${notification_url}" ]; then
     fail "Unable to get notification URL for backup creation. API response: ${create_backup_json}"
-    exit 1
   fi
 
   task "Waiting for backup to complete."
@@ -200,7 +192,6 @@ if [ "${VORTEX_FETCH_DB_FRESH}" = "1" ]; then
       break
     elif [ "${status}" = "failed" ]; then
       fail "Backup creation failed. API response: ${status_json}"
-      exit 1
     fi
 
     note "Backup in progress (${elapsed}s elapsed)..."
@@ -208,7 +199,6 @@ if [ "${VORTEX_FETCH_DB_FRESH}" = "1" ]; then
 
   if [ ${elapsed} -ge "${max_wait}" ]; then
     fail "Backup creation timed out after ${max_wait} seconds."
-    exit 1
   fi
 
   note "Fresh backup will be fetched."
@@ -221,19 +211,17 @@ backups_json=$(curl --progress-bar -L -H 'Accept: application/json, version=2' -
 # Check for HTTP errors or database not found
 if echo "${backups_json}" | grep -q '"error"'; then
   fail "Database \"${VORTEX_FETCH_DB_ACQUIA_DB_NAME}\" not found in environment \"${VORTEX_FETCH_DB_ENVIRONMENT}\". Check database name. API response: ${backups_json}"
-  exit 1
 fi
 
 # Check for empty items array (no backups found)
 if echo "${backups_json}" | grep -q '"items":\[\]'; then
   fail "No backups found for database \"${VORTEX_FETCH_DB_ACQUIA_DB_NAME}\" in environment \"${VORTEX_FETCH_DB_ENVIRONMENT}\". Try creating a backup first."
-  exit 1
 fi
 
 # Acquia response has all backups sorted chronologically by created date.
 backup_id=$(echo "${backups_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "id")
 [ "${VORTEX_DEBUG-}" = "1" ] && note "Extracted backup ID: ${backup_id}"
-[ -z "${backup_id}" ] && fail "Unable to discover backup ID for database \"${VORTEX_FETCH_DB_ACQUIA_DB_NAME}\". API response: ${backups_json}" && exit 1
+[ -z "${backup_id}" ] && fail "Unable to discover backup ID for database \"${VORTEX_FETCH_DB_ACQUIA_DB_NAME}\". API response: ${backups_json}"
 
 # Insert backup id as a suffix.
 file_extension="${VORTEX_FETCH_DB_ACQUIA_DB_FILE##*.}"
@@ -264,20 +252,19 @@ else
     [ "${VORTEX_DEBUG-}" = "1" ] && note "Download action API response: ${backup_url_json}"
     backup_url=$(echo "${backup_url_json}" | extract_json_value "url")
     [ "${VORTEX_DEBUG-}" = "1" ] && note "Extracted backup URL: ${backup_url}"
-    [ -z "${backup_url}" ] && fail "Unable to discover backup URL for backup ID \"${backup_id}\". API response: ${backup_url_json}" && exit 1
+    [ -z "${backup_url}" ] && fail "Unable to discover backup URL for backup ID \"${backup_id}\". API response: ${backup_url_json}"
 
     task "Fetching database dump into file ${file_name_compressed}."
     curl --progress-bar -L "${backup_url}" -o "${file_name_compressed}"
     download_result=$?
 
     # shellcheck disable=SC2181
-    [ "${download_result}" -ne 0 ] && fail "Unable to fetch database ${VORTEX_FETCH_DB_ACQUIA_DB_NAME}. curl exit code: ${download_result}" && exit 1
+    [ "${download_result}" -ne 0 ] && fail "Unable to fetch database ${VORTEX_FETCH_DB_ACQUIA_DB_NAME}. curl exit code: ${download_result}"
 
     # Check if the fetched file exists and has content. Leave the file in
     # place on failure so it can be inspected.
     if [ ! -f "${file_name_compressed}" ] || [ ! -s "${file_name_compressed}" ]; then
       fail "Fetched file is empty or missing: ${file_name_compressed}"
-      exit 1
     fi
 
     [ "${VORTEX_DEBUG-}" = "1" ] && note "Fetch completed successfully."
@@ -292,7 +279,6 @@ else
   # on failure so it can be inspected.
   if ! gunzip -t "${file_name_compressed}" 2>/dev/null; then
     fail "Fetched file is not a valid gzip archive: ${file_name_compressed}"
-    exit 1
   fi
 
   gunzip -c "${file_name_compressed}" >"${file_name}"
@@ -303,7 +289,6 @@ else
   # on failure so they can be inspected.
   if [ "${decompress_result}" != 0 ] || [ ! -f "${file_name}" ] || [ ! -s "${file_name}" ]; then
     fail "Unable to process database dump file \"${file_name}\". Decompression exit code: ${decompress_result}"
-    exit 1
   fi
 
   rm "${file_name_compressed}"
@@ -316,7 +301,7 @@ task "Renaming file \"${file_name}\" to \"${VORTEX_FETCH_DB_ACQUIA_DB_DIR}/${VOR
 [ "${VORTEX_DEBUG-}" = "1" ] && note "Moving to: ${VORTEX_FETCH_DB_ACQUIA_DB_DIR}/${VORTEX_FETCH_DB_ACQUIA_DB_FILE}"
 mv "${file_name}" "${VORTEX_FETCH_DB_ACQUIA_DB_DIR}/${VORTEX_FETCH_DB_ACQUIA_DB_FILE}"
 mv_result=$?
-[ "${mv_result}" -ne 0 ] && fail "Unable to rename file from \"${file_name}\" to \"${VORTEX_FETCH_DB_ACQUIA_DB_DIR}/${VORTEX_FETCH_DB_ACQUIA_DB_FILE}\". mv exit code: ${mv_result}" && exit 1
+[ "${mv_result}" -ne 0 ] && fail "Unable to rename file from \"${file_name}\" to \"${VORTEX_FETCH_DB_ACQUIA_DB_DIR}/${VORTEX_FETCH_DB_ACQUIA_DB_FILE}\". mv exit code: ${mv_result}"
 [ "${VORTEX_DEBUG-}" = "1" ] && note "File rename completed successfully."
 
 pass "Finished database dump fetch from Acquia."

--- a/.vortex/tooling/src/vortex-fetch-db-acquia
+++ b/.vortex/tooling/src/vortex-fetch-db-acquia
@@ -80,7 +80,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 for cmd in php curl gunzip; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done

--- a/.vortex/tooling/src/vortex-fetch-db-container-registry
+++ b/.vortex/tooling/src/vortex-fetch-db-container-registry
@@ -56,7 +56,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 # shellcheck disable=SC2043

--- a/.vortex/tooling/src/vortex-fetch-db-container-registry
+++ b/.vortex/tooling/src/vortex-fetch-db-container-registry
@@ -56,21 +56,18 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 # shellcheck disable=SC2043
-for cmd in docker; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in docker; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 info "Started database data container image fetch."
 
-[ -z "${VORTEX_FETCH_DB_CONTAINER_REGISTRY}" ] && fail "Missing required value for VORTEX_FETCH_DB_CONTAINER_REGISTRY or VORTEX_CONTAINER_REGISTRY." && exit 1
-[ -z "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_USER}" ] && fail "Missing required value for VORTEX_FETCH_DB_CONTAINER_REGISTRY_USER or VORTEX_CONTAINER_REGISTRY_USER." && exit 1
-[ -z "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_PASS}" ] && fail "Missing required value for VORTEX_FETCH_DB_CONTAINER_REGISTRY_PASS or VORTEX_CONTAINER_REGISTRY_PASS." && exit 1
-[ -z "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE}" ] && fail "Missing required value for VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE or VORTEX_DB_IMAGE." && exit 1
+[ -z "${VORTEX_FETCH_DB_CONTAINER_REGISTRY}" ] && fail "Missing required value for VORTEX_FETCH_DB_CONTAINER_REGISTRY or VORTEX_CONTAINER_REGISTRY."
+[ -z "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_USER}" ] && fail "Missing required value for VORTEX_FETCH_DB_CONTAINER_REGISTRY_USER or VORTEX_CONTAINER_REGISTRY_USER."
+[ -z "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_PASS}" ] && fail "Missing required value for VORTEX_FETCH_DB_CONTAINER_REGISTRY_PASS or VORTEX_CONTAINER_REGISTRY_PASS."
+[ -z "${VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE}" ] && fail "Missing required value for VORTEX_FETCH_DB_CONTAINER_REGISTRY_IMAGE or VORTEX_DB_IMAGE."
 
 archive_file="${VORTEX_FETCH_DB_CONTAINER_REGISTRY_DB_DIR}/db.tar"
 

--- a/.vortex/tooling/src/vortex-fetch-db-ftp
+++ b/.vortex/tooling/src/vortex-fetch-db-ftp
@@ -54,7 +54,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 # shellcheck disable=SC2043

--- a/.vortex/tooling/src/vortex-fetch-db-ftp
+++ b/.vortex/tooling/src/vortex-fetch-db-ftp
@@ -54,21 +54,18 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 # shellcheck disable=SC2043
-for cmd in curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 # Check all required values.
-[ -z "${VORTEX_FETCH_DB_FTP_USER}" ] && fail "Missing required value for VORTEX_FETCH_DB_FTP_USER." && exit 1
-[ -z "${VORTEX_FETCH_DB_FTP_PASS}" ] && fail "Missing required value for VORTEX_FETCH_DB_FTP_PASS." && exit 1
-[ -z "${VORTEX_FETCH_DB_FTP_HOST}" ] && fail "Missing required value for VORTEX_FETCH_DB_FTP_HOST." && exit 1
-[ -z "${VORTEX_FETCH_DB_FTP_PORT}" ] && fail "Missing required value for VORTEX_FETCH_DB_FTP_PORT." && exit 1
-[ -z "${VORTEX_FETCH_DB_FTP_FILE}" ] && fail "Missing required value for VORTEX_FETCH_DB_FTP_FILE." && exit 1
+[ -z "${VORTEX_FETCH_DB_FTP_USER}" ] && fail "Missing required value for VORTEX_FETCH_DB_FTP_USER."
+[ -z "${VORTEX_FETCH_DB_FTP_PASS}" ] && fail "Missing required value for VORTEX_FETCH_DB_FTP_PASS."
+[ -z "${VORTEX_FETCH_DB_FTP_HOST}" ] && fail "Missing required value for VORTEX_FETCH_DB_FTP_HOST."
+[ -z "${VORTEX_FETCH_DB_FTP_PORT}" ] && fail "Missing required value for VORTEX_FETCH_DB_FTP_PORT."
+[ -z "${VORTEX_FETCH_DB_FTP_FILE}" ] && fail "Missing required value for VORTEX_FETCH_DB_FTP_FILE."
 
 info "Started database dump fetch from FTP."
 

--- a/.vortex/tooling/src/vortex-fetch-db-lagoon
+++ b/.vortex/tooling/src/vortex-fetch-db-lagoon
@@ -94,7 +94,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 for cmd in ssh rsync; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done

--- a/.vortex/tooling/src/vortex-fetch-db-lagoon
+++ b/.vortex/tooling/src/vortex-fetch-db-lagoon
@@ -94,13 +94,10 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
-for cmd in ssh rsync; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in ssh rsync; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 info "Started database dump fetch from Lagoon."
 

--- a/.vortex/tooling/src/vortex-fetch-db-s3
+++ b/.vortex/tooling/src/vortex-fetch-db-s3
@@ -56,18 +56,15 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
-for cmd in curl openssl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in curl openssl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
-[ -z "${VORTEX_FETCH_DB_S3_ACCESS_KEY}" ] && fail "Missing required value for VORTEX_FETCH_DB_S3_ACCESS_KEY." && exit 1
-[ -z "${VORTEX_FETCH_DB_S3_SECRET_KEY}" ] && fail "Missing required value for VORTEX_FETCH_DB_S3_SECRET_KEY." && exit 1
-[ -z "${VORTEX_FETCH_DB_S3_BUCKET}" ] && fail "Missing required value for VORTEX_FETCH_DB_S3_BUCKET." && exit 1
-[ -z "${VORTEX_FETCH_DB_S3_REGION}" ] && fail "Missing required value for VORTEX_FETCH_DB_S3_REGION." && exit 1
+[ -z "${VORTEX_FETCH_DB_S3_ACCESS_KEY}" ] && fail "Missing required value for VORTEX_FETCH_DB_S3_ACCESS_KEY."
+[ -z "${VORTEX_FETCH_DB_S3_SECRET_KEY}" ] && fail "Missing required value for VORTEX_FETCH_DB_S3_SECRET_KEY."
+[ -z "${VORTEX_FETCH_DB_S3_BUCKET}" ] && fail "Missing required value for VORTEX_FETCH_DB_S3_BUCKET."
+[ -z "${VORTEX_FETCH_DB_S3_REGION}" ] && fail "Missing required value for VORTEX_FETCH_DB_S3_REGION."
 
 info "Started database dump fetch from S3."
 

--- a/.vortex/tooling/src/vortex-fetch-db-s3
+++ b/.vortex/tooling/src/vortex-fetch-db-s3
@@ -56,7 +56,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 for cmd in curl openssl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done

--- a/.vortex/tooling/src/vortex-fetch-db-url
+++ b/.vortex/tooling/src/vortex-fetch-db-url
@@ -43,18 +43,15 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
-for cmd in curl unzip; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in curl unzip; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 info "Started database dump fetch from URL."
 
 # Check all required values.
-[ -z "${VORTEX_FETCH_DB_URL}" ] && fail "Missing required value for VORTEX_FETCH_DB_URL." && exit 1
+[ -z "${VORTEX_FETCH_DB_URL}" ] && fail "Missing required value for VORTEX_FETCH_DB_URL."
 
 mkdir -p "${VORTEX_FETCH_DB_URL_DB_DIR}"
 
@@ -82,10 +79,9 @@ if [ "${VORTEX_FETCH_DB_URL%*.zip}" != "${VORTEX_FETCH_DB_URL}" ]; then
   extracted_file=$(find "${temp_extract_dir}" -type f -print | head -n 1)
 
   if [ -z "${extracted_file}" ]; then
-    fail "No files found in the zip archive."
     rm -rf "${temp_extract_dir}" >/dev/null
     rm -f "${VORTEX_FETCH_DB_URL_DB_DIR}/${VORTEX_FETCH_DB_URL_DB_FILE}.zip" >/dev/null
-    exit 1
+    fail "No files found in the zip archive."
   fi
 
   note "Moving extracted file to target location."

--- a/.vortex/tooling/src/vortex-fetch-db-url
+++ b/.vortex/tooling/src/vortex-fetch-db-url
@@ -43,7 +43,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 for cmd in curl unzip; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done

--- a/.vortex/tooling/src/vortex-import-db
+++ b/.vortex/tooling/src/vortex-import-db
@@ -21,7 +21,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 is_host() { [ "${RUN_ON_HOST:-$(command -v docker >/dev/null 2>&1 && echo 1 || echo 0)}" = "1" ]; }
 # @formatter:on
 

--- a/.vortex/tooling/src/vortex-import-db
+++ b/.vortex/tooling/src/vortex-import-db
@@ -21,7 +21,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 is_host() { [ "${RUN_ON_HOST:-$(command -v docker >/dev/null 2>&1 && echo 1 || echo 0)}" = "1" ]; }
 # @formatter:on
 

--- a/.vortex/tooling/src/vortex-import-db-file
+++ b/.vortex/tooling/src/vortex-import-db-file
@@ -22,7 +22,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 info "Started database file import."

--- a/.vortex/tooling/src/vortex-import-db-file
+++ b/.vortex/tooling/src/vortex-import-db-file
@@ -22,7 +22,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 info "Started database file import."
@@ -34,19 +34,17 @@ drush() { ./vendor/bin/drush -y "$@"; }
 dump_file="${1:-${VORTEX_IMPORT_DB_FILE_DIR}/${VORTEX_IMPORT_DB_FILE}}"
 
 if [ ! -f "${dump_file}" ]; then
-  fail "Unable to import database from file."
   note "Dump file ${dump_file} does not exist."
   note "Site content was not changed."
-  exit 1
+  fail "Unable to import database from file."
 fi
 
 # Confirm the dump is readable before dropping the database, so an unreadable
 # file cannot leave the site with no database and no import.
 if [ ! -r "${dump_file}" ]; then
-  fail "Unable to import database from file."
   note "Dump file ${dump_file} is not readable."
   note "Site content was not changed."
-  exit 1
+  fail "Unable to import database from file."
 fi
 
 drush sql:drop

--- a/.vortex/tooling/src/vortex-info
+++ b/.vortex/tooling/src/vortex-info
@@ -22,7 +22,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 [ -n "${VORTEX_HOST_HAS_SEQUELACE:-}" ] && sequelace="('ahoy db' to start SequelAce)" || sequelace=""

--- a/.vortex/tooling/src/vortex-info
+++ b/.vortex/tooling/src/vortex-info
@@ -22,7 +22,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 [ -n "${VORTEX_HOST_HAS_SEQUELACE:-}" ] && sequelace="('ahoy db' to start SequelAce)" || sequelace=""

--- a/.vortex/tooling/src/vortex-login
+++ b/.vortex/tooling/src/vortex-login
@@ -19,7 +19,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/tooling/src/vortex-login
+++ b/.vortex/tooling/src/vortex-login
@@ -19,7 +19,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/tooling/src/vortex-login-container-registry
+++ b/.vortex/tooling/src/vortex-login-container-registry
@@ -46,7 +46,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 # shellcheck disable=SC2043

--- a/.vortex/tooling/src/vortex-login-container-registry
+++ b/.vortex/tooling/src/vortex-login-container-registry
@@ -46,16 +46,13 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 # shellcheck disable=SC2043
-for cmd in docker; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in docker; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
-[ -z "$(echo "${VORTEX_LOGIN_CONTAINER_REGISTRY}" | xargs)" ] && fail "VORTEX_LOGIN_CONTAINER_REGISTRY or VORTEX_CONTAINER_REGISTRY should not be empty." && exit 1
+[ -z "$(echo "${VORTEX_LOGIN_CONTAINER_REGISTRY}" | xargs)" ] && fail "VORTEX_LOGIN_CONTAINER_REGISTRY or VORTEX_CONTAINER_REGISTRY should not be empty."
 
 if [ -f "${VORTEX_LOGIN_CONTAINER_REGISTRY_DOCKER_CONFIG}/config.json" ] && grep -q "${VORTEX_LOGIN_CONTAINER_REGISTRY}" "${VORTEX_LOGIN_CONTAINER_REGISTRY_DOCKER_CONFIG}/config.json"; then
   note "Already logged in to the registry \"${VORTEX_LOGIN_CONTAINER_REGISTRY}\"."

--- a/.vortex/tooling/src/vortex-logout
+++ b/.vortex/tooling/src/vortex-logout
@@ -19,7 +19,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/tooling/src/vortex-logout
+++ b/.vortex/tooling/src/vortex-logout
@@ -19,7 +19,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/tooling/src/vortex-notify
+++ b/.vortex/tooling/src/vortex-notify
@@ -60,7 +60,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 info "Started dispatching notifications."

--- a/.vortex/tooling/src/vortex-notify
+++ b/.vortex/tooling/src/vortex-notify
@@ -60,7 +60,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 info "Started dispatching notifications."
@@ -68,10 +68,10 @@ info "Started dispatching notifications."
 [ -n "${VORTEX_NOTIFY_SKIP:-}" ] && pass "Skipped dispatching notifications." && exit 0
 
 # Validate required variables.
-[ -z "${VORTEX_NOTIFY_BRANCH}" ] && fail "Missing required value for VORTEX_NOTIFY_BRANCH." && exit 1
-[ -z "${VORTEX_NOTIFY_SHA}" ] && fail "Missing required value for VORTEX_NOTIFY_SHA." && exit 1
-[ -z "${VORTEX_NOTIFY_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_LABEL." && exit 1
-[ -z "${VORTEX_NOTIFY_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_ENVIRONMENT_URL." && exit 1
+[ -z "${VORTEX_NOTIFY_BRANCH}" ] && fail "Missing required value for VORTEX_NOTIFY_BRANCH."
+[ -z "${VORTEX_NOTIFY_SHA}" ] && fail "Missing required value for VORTEX_NOTIFY_SHA."
+[ -z "${VORTEX_NOTIFY_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_LABEL."
+[ -z "${VORTEX_NOTIFY_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_ENVIRONMENT_URL."
 
 # Auto-generate LOGIN_URL if not provided.
 if [ -z "${VORTEX_NOTIFY_LOGIN_URL}" ]; then
@@ -116,7 +116,7 @@ export VORTEX_NOTIFY_LOG_FILE
 
 # Validate event type (scripts will handle event-specific logic).
 if [ "${VORTEX_NOTIFY_EVENT}" != "pre_deployment" ] && [ "${VORTEX_NOTIFY_EVENT}" != "post_deployment" ]; then
-  fail "Unsupported event ${VORTEX_NOTIFY_EVENT} provided." && exit 1
+  fail "Unsupported event ${VORTEX_NOTIFY_EVENT} provided."
 fi
 
 info "Notification summary:"

--- a/.vortex/tooling/src/vortex-notify-diffy
+++ b/.vortex/tooling/src/vortex-notify-diffy
@@ -65,7 +65,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 for cmd in curl php; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done

--- a/.vortex/tooling/src/vortex-notify-diffy
+++ b/.vortex/tooling/src/vortex-notify-diffy
@@ -65,13 +65,10 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
-for cmd in curl php; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in curl php; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 info "Started Diffy notification."
 
@@ -91,11 +88,11 @@ if [ -n "${VORTEX_NOTIFY_DIFFY_BRANCHES}" ]; then
 fi
 
 # Validate required values.
-[ -z "${VORTEX_NOTIFY_DIFFY_TOKEN}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_TOKEN." && exit 1
-[ -z "${VORTEX_NOTIFY_DIFFY_REPOSITORY}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_REPOSITORY." && exit 1
-[ -z "${VORTEX_NOTIFY_DIFFY_BRANCH}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_BRANCH." && exit 1
-[ -z "${VORTEX_NOTIFY_DIFFY_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_ENVIRONMENT_URL." && exit 1
-[ -z "${VORTEX_NOTIFY_DIFFY_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_LABEL." && exit 1
+[ -z "${VORTEX_NOTIFY_DIFFY_TOKEN}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_TOKEN."
+[ -z "${VORTEX_NOTIFY_DIFFY_REPOSITORY}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_REPOSITORY."
+[ -z "${VORTEX_NOTIFY_DIFFY_BRANCH}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_BRANCH."
+[ -z "${VORTEX_NOTIFY_DIFFY_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_ENVIRONMENT_URL."
+[ -z "${VORTEX_NOTIFY_DIFFY_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_DIFFY_LABEL."
 
 # Sanitize repository (extract owner/repo, hide host if any).
 repository_sanitized=$(echo "${VORTEX_NOTIFY_DIFFY_REPOSITORY}" | sed -E 's|^https?://[^/]+/||; s|\.git$||')
@@ -146,7 +143,6 @@ response_code=$(curl \
 
 if [ "${response_code}" != "204" ]; then
   fail "Unable to send GitHub repository_dispatch: HTTP ${response_code}."
-  exit 1
 fi
 
 pass "Finished Diffy notification."

--- a/.vortex/tooling/src/vortex-notify-email
+++ b/.vortex/tooling/src/vortex-notify-email
@@ -68,7 +68,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 if [ -n "${VORTEX_NOTIFY_EMAIL_BRANCHES}" ]; then

--- a/.vortex/tooling/src/vortex-notify-email
+++ b/.vortex/tooling/src/vortex-notify-email
@@ -68,7 +68,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 if [ -n "${VORTEX_NOTIFY_EMAIL_BRANCHES}" ]; then
@@ -78,12 +78,12 @@ if [ -n "${VORTEX_NOTIFY_EMAIL_BRANCHES}" ]; then
   fi
 fi
 
-[ -z "${VORTEX_NOTIFY_EMAIL_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_EMAIL_PROJECT." && exit 1
-[ -z "${VORTEX_NOTIFY_EMAIL_FROM}" ] && fail "Missing required value for VORTEX_NOTIFY_EMAIL_FROM." && exit 1
-[ -z "${VORTEX_NOTIFY_EMAIL_RECIPIENTS}" ] && fail "Missing required value for VORTEX_NOTIFY_EMAIL_RECIPIENTS." && exit 1
-[ -z "${VORTEX_NOTIFY_EMAIL_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_EMAIL_LABEL." && exit 1
-[ -z "${VORTEX_NOTIFY_EMAIL_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_EMAIL_ENVIRONMENT_URL." && exit 1
-[ -z "${VORTEX_NOTIFY_EMAIL_LOGIN_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_EMAIL_LOGIN_URL." && exit 1
+[ -z "${VORTEX_NOTIFY_EMAIL_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_EMAIL_PROJECT."
+[ -z "${VORTEX_NOTIFY_EMAIL_FROM}" ] && fail "Missing required value for VORTEX_NOTIFY_EMAIL_FROM."
+[ -z "${VORTEX_NOTIFY_EMAIL_RECIPIENTS}" ] && fail "Missing required value for VORTEX_NOTIFY_EMAIL_RECIPIENTS."
+[ -z "${VORTEX_NOTIFY_EMAIL_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_EMAIL_LABEL."
+[ -z "${VORTEX_NOTIFY_EMAIL_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_EMAIL_ENVIRONMENT_URL."
+[ -z "${VORTEX_NOTIFY_EMAIL_LOGIN_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_EMAIL_LOGIN_URL."
 
 info "Started email notification."
 
@@ -114,7 +114,6 @@ elif command -v mail >/dev/null 2>&1; then
   has_mail=1
 else
   fail "Neither mail nor sendmail commands are available."
-  exit 1
 fi
 
 # Build message by replacing tokens.

--- a/.vortex/tooling/src/vortex-notify-github
+++ b/.vortex/tooling/src/vortex-notify-github
@@ -61,13 +61,10 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
-for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in php curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 if [ -n "${VORTEX_NOTIFY_GITHUB_BRANCHES}" ]; then
   if ! echo ",${VORTEX_NOTIFY_GITHUB_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
@@ -76,11 +73,11 @@ if [ -n "${VORTEX_NOTIFY_GITHUB_BRANCHES}" ]; then
   fi
 fi
 
-[ -z "${VORTEX_NOTIFY_GITHUB_TOKEN}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_TOKEN." && exit 1
-[ -z "${VORTEX_NOTIFY_GITHUB_REPOSITORY}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_REPOSITORY." && exit 1
-[ -z "${VORTEX_NOTIFY_GITHUB_BRANCH}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_BRANCH." && exit 1
-[ -z "${VORTEX_NOTIFY_GITHUB_EVENT}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_EVENT." && exit 1
-[ -z "${VORTEX_NOTIFY_GITHUB_ENVIRONMENT_TYPE}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_ENVIRONMENT_TYPE." && exit 1
+[ -z "${VORTEX_NOTIFY_GITHUB_TOKEN}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_TOKEN."
+[ -z "${VORTEX_NOTIFY_GITHUB_REPOSITORY}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_REPOSITORY."
+[ -z "${VORTEX_NOTIFY_GITHUB_BRANCH}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_BRANCH."
+[ -z "${VORTEX_NOTIFY_GITHUB_EVENT}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_EVENT."
+[ -z "${VORTEX_NOTIFY_GITHUB_ENVIRONMENT_TYPE}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_ENVIRONMENT_TYPE."
 
 info "Started GitHub notification for ${VORTEX_NOTIFY_GITHUB_EVENT} event."
 
@@ -128,14 +125,13 @@ echo json_encode([
 
   # Check deployment ID.
   if [ -z "${deployment_id}" ] || [ "${#deployment_id}" -lt 9 ] || [ "${#deployment_id}" -gt 11 ] || [ "$(expr "x${deployment_id}" : "x[0-9]*$")" -eq 0 ]; then
+    note "Wait for GitHub checks to finish and try again."
     fail "Unable to get a deployment ID for a ${VORTEX_NOTIFY_GITHUB_EVENT} operation. Payload: ${payload}"
-    fail "Wait for GitHub checks to finish and try again."
-    exit 1
   fi
 
   note "Marked deployment as started."
 else
-  [ -z "${VORTEX_NOTIFY_GITHUB_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_ENVIRONMENT_URL." && exit 1
+  [ -z "${VORTEX_NOTIFY_GITHUB_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_GITHUB_ENVIRONMENT_URL."
 
   # Returns all deployment for this ref sorted from the latest to the oldest.
   payload="$(curl \
@@ -149,9 +145,8 @@ else
 
   # Check deployment ID.
   if [ -z "${deployment_id}" ] || [ "${#deployment_id}" -lt 9 ] || [ "${#deployment_id}" -gt 11 ] || [ "$(expr "x${deployment_id}" : "x[0-9]*$")" -eq 0 ]; then
+    note "Check that a pre_deployment notification was dispatched."
     fail "Unable to get a deployment ID for a ${VORTEX_NOTIFY_GITHUB_EVENT} operation. Payload: ${payload}"
-    fail "Check that a pre_deployment notification was dispatched."
-    exit 1
   fi
 
   info "GitHub post-deployment notification summary:"
@@ -182,7 +177,6 @@ echo json_encode([
 
   if [ "${status}" != "success" ]; then
     fail "Previous deployment was found, but was unable to update the deployment status. Payload: ${payload}"
-    exit 1
   fi
 
   note "Marked deployment as finished."

--- a/.vortex/tooling/src/vortex-notify-github
+++ b/.vortex/tooling/src/vortex-notify-github
@@ -61,7 +61,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 for cmd in php curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done

--- a/.vortex/tooling/src/vortex-notify-jira
+++ b/.vortex/tooling/src/vortex-notify-jira
@@ -85,7 +85,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 for cmd in php curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done

--- a/.vortex/tooling/src/vortex-notify-jira
+++ b/.vortex/tooling/src/vortex-notify-jira
@@ -85,13 +85,10 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
-for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in php curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 if [ -n "${VORTEX_NOTIFY_JIRA_BRANCHES}" ]; then
   if ! echo ",${VORTEX_NOTIFY_JIRA_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
@@ -100,10 +97,10 @@ if [ -n "${VORTEX_NOTIFY_JIRA_BRANCHES}" ]; then
   fi
 fi
 
-[ -z "${VORTEX_NOTIFY_JIRA_USER_EMAIL}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_USER_EMAIL." && exit 1
-[ -z "${VORTEX_NOTIFY_JIRA_TOKEN}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_TOKEN." && exit 1
-[ -z "${VORTEX_NOTIFY_JIRA_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_LABEL." && exit 1
-[ -z "${VORTEX_NOTIFY_JIRA_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_PROJECT." && exit 1
+[ -z "${VORTEX_NOTIFY_JIRA_USER_EMAIL}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_USER_EMAIL."
+[ -z "${VORTEX_NOTIFY_JIRA_TOKEN}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_TOKEN."
+[ -z "${VORTEX_NOTIFY_JIRA_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_LABEL."
+[ -z "${VORTEX_NOTIFY_JIRA_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_PROJECT."
 
 info "Started JIRA notification."
 
@@ -166,13 +163,13 @@ payload="$(curl \
 
 account_id="$(echo "${payload}" | extract_json_value "accountId" || echo "error")"
 
-[ "${#account_id}" -lt 24 ] && fail "Unable to authenticate." && echo "${payload}" && exit 1
+[ "${#account_id}" -lt 24 ] && fail "Unable to authenticate." && echo "${payload}"
 echo "success"
 
 task "Posting a comment."
 
-[ -z "${VORTEX_NOTIFY_JIRA_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_ENVIRONMENT_URL." && exit 1
-[ -z "${VORTEX_NOTIFY_JIRA_LOGIN_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_LOGIN_URL." && exit 1
+[ -z "${VORTEX_NOTIFY_JIRA_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_ENVIRONMENT_URL."
+[ -z "${VORTEX_NOTIFY_JIRA_LOGIN_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_JIRA_LOGIN_URL."
 
 # Generate timestamp.
 timestamp=$(date '+%d/%m/%Y %H:%M:%S %Z')
@@ -271,9 +268,8 @@ payload="$(curl \
 
 comment_id="$(echo "${payload}" | extract_json_value "id" || echo "error")"
 if [ "$(expr "x${comment_id}" : "x[0-9]*$")" -eq 0 ]; then
+  note "API Response: ${payload}"
   fail "Unable to create a comment."
-  echo "API Response: ${payload}"
-  exit 1
 fi
 
 pass "Posted comment with ID ${comment_id}."
@@ -290,7 +286,7 @@ if [ -n "${VORTEX_NOTIFY_JIRA_TRANSITION}" ]; then
     --url "${VORTEX_NOTIFY_JIRA_ENDPOINT}/rest/api/3/issue/${issue}/transitions")"
 
   transition_id="$(echo "${payload}" | extract_json_value "transitions" | extract_json_value_by_value "name" "${VORTEX_NOTIFY_JIRA_TRANSITION}" "id" || echo "error")"
-  { [ -z "${transition_id}" ] || [ "$(expr "x${transition_id}" : "x[0-9]*$")" -eq 0 ]; } && fail "Unable to retrieve transition ID." && exit 1
+  { [ -z "${transition_id}" ] || [ "$(expr "x${transition_id}" : "x[0-9]*$")" -eq 0 ]; } && fail "Unable to retrieve transition ID."
   echo "success"
 
   payload="$(curl \
@@ -316,7 +312,7 @@ if [ -n "${VORTEX_NOTIFY_JIRA_ASSIGNEE_EMAIL:-}" ]; then
     --url "${VORTEX_NOTIFY_JIRA_ENDPOINT}/rest/api/3/user/assignable/search?query=${VORTEX_NOTIFY_JIRA_ASSIGNEE_EMAIL}&issueKey=${issue}")"
 
   account_id="$(echo "${payload}" | extract_json_first_value "accountId" || echo "error")"
-  [ "${#account_id}" -lt 24 ] && fail "Unable to retrieve assignee account ID." && echo "${payload}" && exit 1
+  [ "${#account_id}" -lt 24 ] && fail "Unable to retrieve assignee account ID." && echo "${payload}"
   echo "success"
 
   payload="$(curl \

--- a/.vortex/tooling/src/vortex-notify-jira
+++ b/.vortex/tooling/src/vortex-notify-jira
@@ -163,7 +163,7 @@ payload="$(curl \
 
 account_id="$(echo "${payload}" | extract_json_value "accountId" || echo "error")"
 
-[ "${#account_id}" -lt 24 ] && fail "Unable to authenticate." && echo "${payload}"
+[ "${#account_id}" -lt 24 ] && echo "${payload}" && fail "Unable to authenticate."
 echo "success"
 
 task "Posting a comment."
@@ -268,7 +268,7 @@ payload="$(curl \
 
 comment_id="$(echo "${payload}" | extract_json_value "id" || echo "error")"
 if [ "$(expr "x${comment_id}" : "x[0-9]*$")" -eq 0 ]; then
-  note "API Response: ${payload}"
+  echo "API Response: ${payload}"
   fail "Unable to create a comment."
 fi
 
@@ -312,7 +312,7 @@ if [ -n "${VORTEX_NOTIFY_JIRA_ASSIGNEE_EMAIL:-}" ]; then
     --url "${VORTEX_NOTIFY_JIRA_ENDPOINT}/rest/api/3/user/assignable/search?query=${VORTEX_NOTIFY_JIRA_ASSIGNEE_EMAIL}&issueKey=${issue}")"
 
   account_id="$(echo "${payload}" | extract_json_first_value "accountId" || echo "error")"
-  [ "${#account_id}" -lt 24 ] && fail "Unable to retrieve assignee account ID." && echo "${payload}"
+  [ "${#account_id}" -lt 24 ] && echo "${payload}" && fail "Unable to retrieve assignee account ID."
   echo "success"
 
   payload="$(curl \

--- a/.vortex/tooling/src/vortex-notify-newrelic
+++ b/.vortex/tooling/src/vortex-notify-newrelic
@@ -83,7 +83,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 if [ -z "${VORTEX_NOTIFY_NEWRELIC_ENABLED}" ]; then

--- a/.vortex/tooling/src/vortex-notify-newrelic
+++ b/.vortex/tooling/src/vortex-notify-newrelic
@@ -83,7 +83,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 if [ -z "${VORTEX_NOTIFY_NEWRELIC_ENABLED}" ]; then
@@ -98,16 +98,13 @@ if [ -n "${VORTEX_NOTIFY_NEWRELIC_BRANCHES}" ]; then
   fi
 fi
 
-for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in php curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
-[ -z "${VORTEX_NOTIFY_NEWRELIC_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_PROJECT." && exit 1
-[ -z "${VORTEX_NOTIFY_NEWRELIC_USER_KEY}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_USER_KEY." && exit 1
-[ -z "${VORTEX_NOTIFY_NEWRELIC_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_LABEL." && exit 1
-[ -z "${VORTEX_NOTIFY_NEWRELIC_APP_NAME}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_APP_NAME." && exit 1
-[ -z "${VORTEX_NOTIFY_NEWRELIC_USER}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_USER." && exit 1
+[ -z "${VORTEX_NOTIFY_NEWRELIC_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_PROJECT."
+[ -z "${VORTEX_NOTIFY_NEWRELIC_USER_KEY}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_USER_KEY."
+[ -z "${VORTEX_NOTIFY_NEWRELIC_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_LABEL."
+[ -z "${VORTEX_NOTIFY_NEWRELIC_APP_NAME}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_APP_NAME."
+[ -z "${VORTEX_NOTIFY_NEWRELIC_USER}" ] && fail "Missing required value for VORTEX_NOTIFY_NEWRELIC_USER."
 
 info "Started New Relic notification."
 
@@ -194,7 +191,6 @@ if ! curl -X POST "${VORTEX_NOTIFY_NEWRELIC_ENDPOINT}/applications/${VORTEX_NOTI
   -H 'Content-Type: application/json' \
   -d "${body}" | grep -q '201'; then
   fail "Unable to create a deployment notification for application ${VORTEX_NOTIFY_NEWRELIC_APP_NAME} with ID ${VORTEX_NOTIFY_NEWRELIC_APPID}."
-  exit 1
 fi
 
 pass "Finished New Relic notification."

--- a/.vortex/tooling/src/vortex-notify-slack
+++ b/.vortex/tooling/src/vortex-notify-slack
@@ -72,13 +72,10 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
-for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in php curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 if [ -n "${VORTEX_NOTIFY_SLACK_BRANCHES}" ]; then
   if ! echo ",${VORTEX_NOTIFY_SLACK_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
@@ -87,11 +84,11 @@ if [ -n "${VORTEX_NOTIFY_SLACK_BRANCHES}" ]; then
   fi
 fi
 
-[ -z "${VORTEX_NOTIFY_SLACK_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_PROJECT." && exit 1
-[ -z "${VORTEX_NOTIFY_SLACK_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_LABEL." && exit 1
-[ -z "${VORTEX_NOTIFY_SLACK_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_ENVIRONMENT_URL." && exit 1
-[ -z "${VORTEX_NOTIFY_SLACK_LOGIN_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_LOGIN_URL." && exit 1
-[ -z "${VORTEX_NOTIFY_SLACK_WEBHOOK}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_WEBHOOK." && exit 1
+[ -z "${VORTEX_NOTIFY_SLACK_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_PROJECT."
+[ -z "${VORTEX_NOTIFY_SLACK_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_LABEL."
+[ -z "${VORTEX_NOTIFY_SLACK_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_ENVIRONMENT_URL."
+[ -z "${VORTEX_NOTIFY_SLACK_LOGIN_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_LOGIN_URL."
+[ -z "${VORTEX_NOTIFY_SLACK_WEBHOOK}" ] && fail "Missing required value for VORTEX_NOTIFY_SLACK_WEBHOOK."
 
 info "Started Slack notification."
 
@@ -206,7 +203,6 @@ response=$(curl -s -o /dev/null -w "%{http_code}" \
 
 if [ "${response}" != "200" ]; then
   fail "Unable to send notification to Slack. HTTP status: ${response}."
-  exit 1
 fi
 
 note "Notification sent to Slack."

--- a/.vortex/tooling/src/vortex-notify-slack
+++ b/.vortex/tooling/src/vortex-notify-slack
@@ -72,7 +72,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 for cmd in php curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done

--- a/.vortex/tooling/src/vortex-notify-webhook
+++ b/.vortex/tooling/src/vortex-notify-webhook
@@ -62,13 +62,10 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
-for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in php curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 if [ -n "${VORTEX_NOTIFY_WEBHOOK_BRANCHES}" ]; then
   if ! echo ",${VORTEX_NOTIFY_WEBHOOK_BRANCHES}," | grep -qF ",${VORTEX_NOTIFY_BRANCH-},"; then
@@ -77,13 +74,13 @@ if [ -n "${VORTEX_NOTIFY_WEBHOOK_BRANCHES}" ]; then
   fi
 fi
 
-[ -z "${VORTEX_NOTIFY_WEBHOOK_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_PROJECT." && exit 1
-[ -z "${VORTEX_NOTIFY_WEBHOOK_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_LABEL." && exit 1
-[ -z "${VORTEX_NOTIFY_WEBHOOK_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_ENVIRONMENT_URL." && exit 1
-[ -z "${VORTEX_NOTIFY_WEBHOOK_LOGIN_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_LOGIN_URL." && exit 1
-[ -z "${VORTEX_NOTIFY_WEBHOOK_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_URL." && exit 1
-[ -z "${VORTEX_NOTIFY_WEBHOOK_METHOD}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_METHOD." && exit 1
-[ -z "${VORTEX_NOTIFY_WEBHOOK_HEADERS}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_HEADERS." && exit 1
+[ -z "${VORTEX_NOTIFY_WEBHOOK_PROJECT}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_PROJECT."
+[ -z "${VORTEX_NOTIFY_WEBHOOK_LABEL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_LABEL."
+[ -z "${VORTEX_NOTIFY_WEBHOOK_ENVIRONMENT_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_ENVIRONMENT_URL."
+[ -z "${VORTEX_NOTIFY_WEBHOOK_LOGIN_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_LOGIN_URL."
+[ -z "${VORTEX_NOTIFY_WEBHOOK_URL}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_URL."
+[ -z "${VORTEX_NOTIFY_WEBHOOK_METHOD}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_METHOD."
+[ -z "${VORTEX_NOTIFY_WEBHOOK_HEADERS}" ] && fail "Missing required value for VORTEX_NOTIFY_WEBHOOK_HEADERS."
 
 info "Started webhook notification."
 
@@ -145,7 +142,6 @@ if ! curl -L -s -o /dev/null -w '%{http_code}' \
   -d "${VORTEX_NOTIFY_WEBHOOK_PAYLOAD}" \
   "${VORTEX_NOTIFY_WEBHOOK_URL}" | grep -q "${VORTEX_NOTIFY_WEBHOOK_RESPONSE_STATUS}"; then
   fail "Unable to send notification to webhook ${VORTEX_NOTIFY_WEBHOOK_URL}."
-  exit 1
 fi
 
 pass "Finished webhook notification."

--- a/.vortex/tooling/src/vortex-notify-webhook
+++ b/.vortex/tooling/src/vortex-notify-webhook
@@ -62,7 +62,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 for cmd in php curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done

--- a/.vortex/tooling/src/vortex-provision
+++ b/.vortex/tooling/src/vortex-provision
@@ -111,7 +111,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/.vortex/tooling/src/vortex-provision
+++ b/.vortex/tooling/src/vortex-provision
@@ -111,7 +111,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }
@@ -142,8 +142,8 @@ site_is_installed="$(drush status --fields=bootstrap 2>/dev/null | grep -q "Succ
 
 # Discover the configuration directory path from the Drupal settings.
 config_path="$(drush php:eval 'print realpath(\Drupal\Core\Site\Settings::get("config_sync_directory"));')"
-[ -z "${config_path}" ] && fail "Config directory was not found in the Drupal settings." && exit 1
-[ ! -d "${config_path}" ] && fail "Config directory \"${config_path:-<empty>}\" does not exist." && exit 1
+[ -z "${config_path}" ] && fail "Config directory was not found in the Drupal settings."
+[ ! -d "${config_path}" ] && fail "Config directory \"${config_path:-<empty>}\" does not exist."
 site_has_config_files="$(test "$(ls -1 ${config_path}/*.yml 2>/dev/null | wc -l | tr -d ' ')" -gt 0 && echo "1" || echo "0")"
 
 # Normalize the provision type.
@@ -181,10 +181,7 @@ echo
 ################################################################################
 
 if [ "${VORTEX_PROVISION_VERIFY_CONFIG_UNCHANGED_AFTER_UPDATE}" = "1" ]; then
-  for cmd in diff mktemp; do command -v "${cmd}" >/dev/null || {
-    fail "Command ${cmd} is not available."
-    exit 1
-  }; done
+  for cmd in diff mktemp; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 fi
 
 #
@@ -199,11 +196,10 @@ provision_from_db() {
     fi
 
     echo
-    fail "Unable to import database from file."
     note "Dump file ${VORTEX_PROVISION_DB} does not exist."
     note "Site content was not changed."
 
-    exit 1
+    fail "Unable to import database from file."
   fi
 
   "$(dirname "${BASH_SOURCE[0]}")/vortex-import-db-file" "${VORTEX_PROVISION_DB}"
@@ -281,9 +277,8 @@ if [ "${VORTEX_PROVISION_TYPE}" = "database" ]; then
         provision_from_profile 1 "${site_has_config_files}"
         export VORTEX_PROVISION_OVERRIDE_DB=1
       else
-        note "Looks like the database in the container image is corrupted."
         note "Site content was not changed."
-        exit 1
+        fail "Looks like the database in the container image is corrupted."
       fi
     else
       note "Fresh site content will be imported from the database dump file."
@@ -345,7 +340,6 @@ if [ "${site_has_config_files}" = "1" ]; then
 
     if [ -z "${config_uuid}" ]; then
       fail "Could not read site UUID from ${config_path}/system.site.yml."
-      exit 1
     fi
 
     drush config:set system.site uuid "${config_uuid}"
@@ -368,13 +362,12 @@ if [ "${VORTEX_PROVISION_VERIFY_CONFIG_UNCHANGED_AFTER_UPDATE}" = "1" ] && [ "${
   config_diff=$(diff -rq "${config_before}" "${config_after}" || true)
 
   if [ -n "${config_diff}" ]; then
-    fail "Configuration was changed by database updates."
     note "The following configuration files were changed:"
     echo "${config_diff}"
     note "Configuration before updates: ${config_before}"
     note "Configuration after updates:  ${config_after}"
     note "Review the update hooks and manually export updated configuration."
-    exit 1
+    fail "Configuration was changed by database updates."
   fi
 
   rm -rf "${config_before}" "${config_after}"

--- a/.vortex/tooling/src/vortex-provision-sanitize-db
+++ b/.vortex/tooling/src/vortex-provision-sanitize-db
@@ -31,7 +31,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 info "Sanitizing database."

--- a/.vortex/tooling/src/vortex-provision-sanitize-db
+++ b/.vortex/tooling/src/vortex-provision-sanitize-db
@@ -31,7 +31,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 info "Sanitizing database."

--- a/.vortex/tooling/src/vortex-push-container-registry
+++ b/.vortex/tooling/src/vortex-push-container-registry
@@ -41,7 +41,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 # shellcheck disable=SC2043

--- a/.vortex/tooling/src/vortex-push-container-registry
+++ b/.vortex/tooling/src/vortex-push-container-registry
@@ -41,14 +41,11 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 # shellcheck disable=SC2043
-for cmd in docker; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in docker; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 info "Started container registry push."
 
@@ -60,9 +57,9 @@ if [ -z "${VORTEX_PUSH_CONTAINER_REGISTRY_MAP}" ]; then
   exit 0
 fi
 
-[ -z "${VORTEX_PUSH_CONTAINER_REGISTRY}" ] && fail "Missing required value for VORTEX_PUSH_CONTAINER_REGISTRY." && exit 1
-[ -z "${VORTEX_PUSH_CONTAINER_REGISTRY_USER}" ] && fail "Missing required value for VORTEX_PUSH_CONTAINER_REGISTRY_USER." && exit 1
-[ -z "${VORTEX_PUSH_CONTAINER_REGISTRY_PASS}" ] && fail "Missing required value for VORTEX_PUSH_CONTAINER_REGISTRY_PASS." && exit 1
+[ -z "${VORTEX_PUSH_CONTAINER_REGISTRY}" ] && fail "Missing required value for VORTEX_PUSH_CONTAINER_REGISTRY."
+[ -z "${VORTEX_PUSH_CONTAINER_REGISTRY_USER}" ] && fail "Missing required value for VORTEX_PUSH_CONTAINER_REGISTRY_USER."
+[ -z "${VORTEX_PUSH_CONTAINER_REGISTRY_PASS}" ] && fail "Missing required value for VORTEX_PUSH_CONTAINER_REGISTRY_PASS."
 
 services=()
 images=()
@@ -70,8 +67,8 @@ images=()
 IFS=',' read -r -a values <<<"${VORTEX_PUSH_CONTAINER_REGISTRY_MAP}"
 for value in "${values[@]}"; do
   IFS='=' read -r -a parts <<<"${value}"
-  [ "${#parts[@]}" -ne 2 ] && fail "Invalid key/value pair \"${value}\" provided." && exit 1
-  { [ -z "${parts[0]}" ] || [ -z "${parts[1]}" ]; } && fail "Invalid key/value pair \"${value}\" provided." && exit 1
+  [ "${#parts[@]}" -ne 2 ] && fail "Invalid key/value pair \"${value}\" provided."
+  { [ -z "${parts[0]}" ] || [ -z "${parts[1]}" ]; } && fail "Invalid key/value pair \"${value}\" provided."
   services+=("${parts[0]}")
   images+=("${parts[1]}")
 done
@@ -92,7 +89,7 @@ for key in "${!services[@]}"; do
   # Check if the service is running.
   cid=$(docker compose ps -q "${service}")
 
-  [ -z "${cid}" ] && fail "Service \"${service}\" is not running." && exit 1
+  [ -z "${cid}" ] && fail "Service \"${service}\" is not running."
   note "Found \"${service}\" service container with id \"${cid}\"."
 
   # Only treat a ':' or '@' in the final reference segment as an existing tag or

--- a/.vortex/tooling/src/vortex-push-db-image
+++ b/.vortex/tooling/src/vortex-push-db-image
@@ -21,7 +21,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 info "Started database container image push."

--- a/.vortex/tooling/src/vortex-push-db-image
+++ b/.vortex/tooling/src/vortex-push-db-image
@@ -21,14 +21,14 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 info "Started database container image push."
 
 [ "${VORTEX_EXPORT_DB_CONTAINER_REGISTRY_PUSH_PROCEED:-}" != "1" ] && pass "Skipped database container image push as VORTEX_EXPORT_DB_CONTAINER_REGISTRY_PUSH_PROCEED is not set to 1." && exit 0
 
-[ -z "${VORTEX_EXPORT_DB_IMAGE}" ] && fail "Container image name is not specified. Please provide container image as a variable VORTEX_EXPORT_DB_IMAGE in a format <org>/<repository>." && exit 1
+[ -z "${VORTEX_EXPORT_DB_IMAGE}" ] && fail "Container image name is not specified. Please provide container image as a variable VORTEX_EXPORT_DB_IMAGE in a format <org>/<repository>."
 
 VORTEX_PUSH_CONTAINER_REGISTRY_MAP="database=${VORTEX_EXPORT_DB_IMAGE}" "$(dirname "${BASH_SOURCE[0]}")/vortex-push-container-registry"
 

--- a/.vortex/tooling/src/vortex-push-db-s3
+++ b/.vortex/tooling/src/vortex-push-db-s3
@@ -47,7 +47,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 for cmd in curl openssl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done

--- a/.vortex/tooling/src/vortex-push-db-s3
+++ b/.vortex/tooling/src/vortex-push-db-s3
@@ -47,21 +47,18 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
-for cmd in curl openssl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in curl openssl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
-[ -z "${VORTEX_PUSH_DB_S3_ACCESS_KEY}" ] && fail "Missing required value for VORTEX_PUSH_DB_S3_ACCESS_KEY." && exit 1
-[ -z "${VORTEX_PUSH_DB_S3_SECRET_KEY}" ] && fail "Missing required value for VORTEX_PUSH_DB_S3_SECRET_KEY." && exit 1
-[ -z "${VORTEX_PUSH_DB_S3_BUCKET}" ] && fail "Missing required value for VORTEX_PUSH_DB_S3_BUCKET." && exit 1
-[ -z "${VORTEX_PUSH_DB_S3_REGION}" ] && fail "Missing required value for VORTEX_PUSH_DB_S3_REGION." && exit 1
+[ -z "${VORTEX_PUSH_DB_S3_ACCESS_KEY}" ] && fail "Missing required value for VORTEX_PUSH_DB_S3_ACCESS_KEY."
+[ -z "${VORTEX_PUSH_DB_S3_SECRET_KEY}" ] && fail "Missing required value for VORTEX_PUSH_DB_S3_SECRET_KEY."
+[ -z "${VORTEX_PUSH_DB_S3_BUCKET}" ] && fail "Missing required value for VORTEX_PUSH_DB_S3_BUCKET."
+[ -z "${VORTEX_PUSH_DB_S3_REGION}" ] && fail "Missing required value for VORTEX_PUSH_DB_S3_REGION."
 
 local_file="${VORTEX_PUSH_DB_S3_DB_DIR}/${VORTEX_PUSH_DB_S3_DB_FILE}"
-[ ! -f "${local_file}" ] && fail "Database dump file ${local_file} does not exist." && exit 1
+[ ! -f "${local_file}" ] && fail "Database dump file ${local_file} does not exist."
 
 info "Started database dump push to S3."
 
@@ -162,7 +159,7 @@ set -e
 # signature are never written to the trace output.
 [ "${VORTEX_DEBUG-}" = "1" ] && set -x
 
-[ "${curl_status}" -ne 0 ] && fail "S3 push request failed with curl exit ${curl_status}." && exit 1
+[ "${curl_status}" -ne 0 ] && fail "S3 push request failed with curl exit ${curl_status}."
 
 http_code=$(echo "${response}" | tail -1)
 response_body=$(echo "${response}" | sed '$d')
@@ -170,9 +167,8 @@ response_body=$(echo "${response}" | sed '$d')
 case "${http_code}" in
   2*) ;;
   *)
-    echo "ERROR: Unable to push to S3: HTTP status ${http_code}."
-    [ -n "${response_body}" ] && echo "Response: ${response_body}"
-    exit 1
+    [ -n "${response_body}" ] && note "Response: ${response_body}"
+    fail "Unable to push to S3: HTTP status ${http_code}."
     ;;
 esac
 

--- a/.vortex/tooling/src/vortex-push-db-s3
+++ b/.vortex/tooling/src/vortex-push-db-s3
@@ -167,7 +167,7 @@ response_body=$(echo "${response}" | sed '$d')
 case "${http_code}" in
   2*) ;;
   *)
-    [ -n "${response_body}" ] && note "Response: ${response_body}"
+    [ -n "${response_body}" ] && echo "Response: ${response_body}"
     fail "Unable to push to S3: HTTP status ${http_code}."
     ;;
 esac

--- a/.vortex/tooling/src/vortex-reset
+++ b/.vortex/tooling/src/vortex-reset
@@ -16,7 +16,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 # shellcheck disable=SC2043

--- a/.vortex/tooling/src/vortex-reset
+++ b/.vortex/tooling/src/vortex-reset
@@ -16,14 +16,11 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 # shellcheck disable=SC2043
-for cmd in git; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in git; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 is_hard_reset=0
 for arg in "$@"; do

--- a/.vortex/tooling/src/vortex-setup-ssh
+++ b/.vortex/tooling/src/vortex-setup-ssh
@@ -45,7 +45,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 info "Started SSH setup."
@@ -96,7 +96,6 @@ fi
 
 if [ ! -f "${file}" ]; then
   fail "SSH key file ${file} does not exist."
-  exit 1
 fi
 
 note "Using SSH key file ${file}."

--- a/.vortex/tooling/src/vortex-setup-ssh
+++ b/.vortex/tooling/src/vortex-setup-ssh
@@ -45,7 +45,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 info "Started SSH setup."

--- a/.vortex/tooling/src/vortex-task
+++ b/.vortex/tooling/src/vortex-task
@@ -25,7 +25,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 operation="${1:-}"

--- a/.vortex/tooling/src/vortex-task
+++ b/.vortex/tooling/src/vortex-task
@@ -25,26 +25,26 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 operation="${1:-}"
-[ -z "${operation}" ] && fail "Missing task operation." && exit 1
+[ -z "${operation}" ] && fail "Missing task operation."
 shift
 
 case "${operation}" in
   copy-db | copy-files | purge-cache | custom) ;;
-  *) fail "Unsupported task operation \"${operation}\"." && exit 1 ;;
+  *) fail "Unsupported task operation \"${operation}\"." ;;
 esac
 
-[ -z "${VORTEX_TASK_PLATFORM}" ] && fail "Missing hosting platform. Set VORTEX_PLATFORM or VORTEX_TASK_PLATFORM." && exit 1
+[ -z "${VORTEX_TASK_PLATFORM}" ] && fail "Missing hosting platform. Set VORTEX_PLATFORM or VORTEX_TASK_PLATFORM."
 
 case "${VORTEX_TASK_PLATFORM}" in
   acquia | lagoon) ;;
-  *) fail "Unsupported hosting platform \"${VORTEX_TASK_PLATFORM}\"." && exit 1 ;;
+  *) fail "Unsupported hosting platform \"${VORTEX_TASK_PLATFORM}\"." ;;
 esac
 
 task_script="$(dirname "${BASH_SOURCE[0]}")/vortex-task-${operation}-${VORTEX_TASK_PLATFORM}"
-[ ! -x "${task_script}" ] && fail "Operation \"${operation}\" is not supported on the \"${VORTEX_TASK_PLATFORM}\" platform." && exit 1
+[ ! -x "${task_script}" ] && fail "Operation \"${operation}\" is not supported on the \"${VORTEX_TASK_PLATFORM}\" platform."
 
 "${task_script}" "$@"

--- a/.vortex/tooling/src/vortex-task-copy-db-acquia
+++ b/.vortex/tooling/src/vortex-task-copy-db-acquia
@@ -50,7 +50,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 info "Started database copying between environments in Acquia."

--- a/.vortex/tooling/src/vortex-task-copy-db-acquia
+++ b/.vortex/tooling/src/vortex-task-copy-db-acquia
@@ -50,7 +50,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 info "Started database copying between environments in Acquia."
@@ -72,40 +72,37 @@ extract_json_value() {
 }
 
 # Pre-flight checks.
-for cmd in curl php; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in curl php; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 # Check that all required variables are present.
-[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_KEY}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_KEY or VORTEX_ACQUIA_KEY." && exit 1
-[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_SECRET}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_SECRET or VORTEX_ACQUIA_SECRET." && exit 1
-[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_APP_NAME}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_APP_NAME or VORTEX_ACQUIA_APP_NAME." && exit 1
-[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_SRC}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_SRC." && exit 1
-[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_DST}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_DST." && exit 1
-[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_NAME}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_NAME." && exit 1
-[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_STATUS_RETRIES}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_STATUS_RETRIES." && exit 1
-[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_STATUS_INTERVAL}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_STATUS_INTERVAL." && exit 1
+[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_KEY}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_KEY or VORTEX_ACQUIA_KEY."
+[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_SECRET}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_SECRET or VORTEX_ACQUIA_SECRET."
+[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_APP_NAME}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_APP_NAME or VORTEX_ACQUIA_APP_NAME."
+[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_SRC}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_SRC."
+[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_DST}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_DST."
+[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_NAME}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_NAME."
+[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_STATUS_RETRIES}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_STATUS_RETRIES."
+[ -z "${VORTEX_TASK_COPY_DB_ACQUIA_STATUS_INTERVAL}" ] && fail "Missing required value for VORTEX_TASK_COPY_DB_ACQUIA_STATUS_INTERVAL."
 
 task "Retrieving authentication token."
 token_json=$(curl -s -L https://accounts.acquia.com/api/auth/oauth/token --data-urlencode "client_id=${VORTEX_TASK_COPY_DB_ACQUIA_KEY}" --data-urlencode "client_secret=${VORTEX_TASK_COPY_DB_ACQUIA_SECRET}" --data-urlencode "grant_type=client_credentials")
 token=$(echo "${token_json}" | extract_json_value "access_token")
-[ -z "${token}" ] && fail "Unable to retrieve a token." && exit 1
+[ -z "${token}" ] && fail "Unable to retrieve a token."
 
 task "Retrieving ${VORTEX_TASK_COPY_DB_ACQUIA_APP_NAME} application UUID."
 app_uuid_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications?filter=name%3D${VORTEX_TASK_COPY_DB_ACQUIA_APP_NAME/ /%20}")
 app_uuid=$(echo "${app_uuid_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "uuid")
-[ -z "${app_uuid}" ] && fail "Unable to retrieve an application UUID." && exit 1
+[ -z "${app_uuid}" ] && fail "Unable to retrieve an application UUID."
 
 task "Retrieving source environment ID."
 envs_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications/${app_uuid}/environments?filter=name%3D${VORTEX_TASK_COPY_DB_ACQUIA_SRC}")
 src_env_id=$(echo "${envs_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "id")
-[ -z "${src_env_id}" ] && fail "Unable to retrieve source environment ID." && exit 1
+[ -z "${src_env_id}" ] && fail "Unable to retrieve source environment ID."
 
 task "Retrieving destination environment ID."
 envs_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications/${app_uuid}/environments?filter=name%3D${VORTEX_TASK_COPY_DB_ACQUIA_DST}")
 dst_env_id=$(echo "${envs_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "id")
-[ -z "${dst_env_id}" ] && fail "Unable to retrieve destination environment ID." && exit 1
+[ -z "${dst_env_id}" ] && fail "Unable to retrieve destination environment ID."
 
 task "Copying database from ${VORTEX_TASK_COPY_DB_ACQUIA_SRC} to ${VORTEX_TASK_COPY_DB_ACQUIA_DST} environment."
 task_status_json=$(curl -X POST -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" -d "{\"source\":\"${src_env_id}\", \"name\":\"${VORTEX_TASK_COPY_DB_ACQUIA_NAME}\"}" "https://cloud.acquia.com/api/environments/${dst_env_id}/databases")
@@ -124,14 +121,13 @@ for i in $(seq 1 "${VORTEX_TASK_COPY_DB_ACQUIA_STATUS_RETRIES}"); do
   task "Retrieving authentication token."
   token_json=$(curl -s -L https://accounts.acquia.com/api/auth/oauth/token --data-urlencode "client_id=${VORTEX_TASK_COPY_DB_ACQUIA_KEY}" --data-urlencode "client_secret=${VORTEX_TASK_COPY_DB_ACQUIA_SECRET}" --data-urlencode "grant_type=client_credentials")
   token=$(echo "${token_json}" | extract_json_value "access_token")
-  [ -z "${token}" ] && fail "Unable to retrieve a token." && exit 1
+  [ -z "${token}" ] && fail "Unable to retrieve a token."
 done
 
 echo
 
 if [ "${task_completed}" = "0" ]; then
   fail "Unable to copy database from ${VORTEX_TASK_COPY_DB_ACQUIA_SRC} to ${VORTEX_TASK_COPY_DB_ACQUIA_DST} environment."
-  exit 1
 fi
 
 note "Copied database from ${VORTEX_TASK_COPY_DB_ACQUIA_SRC} to ${VORTEX_TASK_COPY_DB_ACQUIA_DST} environment."

--- a/.vortex/tooling/src/vortex-task-copy-files-acquia
+++ b/.vortex/tooling/src/vortex-task-copy-files-acquia
@@ -47,14 +47,11 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 # Pre-flight checks.
-for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in php curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 info "Started files copying between environments in Acquia."
 
@@ -75,33 +72,33 @@ extract_json_value() {
 }
 
 # Check that all required variables are present.
-[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_KEY}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_KEY or VORTEX_ACQUIA_KEY." && exit 1
-[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_SECRET}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_SECRET or VORTEX_ACQUIA_SECRET." && exit 1
-[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_APP_NAME}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_APP_NAME or VORTEX_ACQUIA_APP_NAME." && exit 1
-[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_SRC}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_SRC." && exit 1
-[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_DST}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_DST." && exit 1
-[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_STATUS_RETRIES}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_STATUS_RETRIES." && exit 1
-[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_STATUS_INTERVAL}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_STATUS_INTERVAL." && exit 1
+[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_KEY}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_KEY or VORTEX_ACQUIA_KEY."
+[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_SECRET}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_SECRET or VORTEX_ACQUIA_SECRET."
+[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_APP_NAME}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_APP_NAME or VORTEX_ACQUIA_APP_NAME."
+[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_SRC}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_SRC."
+[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_DST}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_DST."
+[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_STATUS_RETRIES}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_STATUS_RETRIES."
+[ -z "${VORTEX_TASK_COPY_FILES_ACQUIA_STATUS_INTERVAL}" ] && fail "Missing required value for VORTEX_TASK_COPY_FILES_ACQUIA_STATUS_INTERVAL."
 
 task "Retrieving authentication token."
 token_json=$(curl -s -L https://accounts.acquia.com/api/auth/oauth/token --data-urlencode "client_id=${VORTEX_TASK_COPY_FILES_ACQUIA_KEY}" --data-urlencode "client_secret=${VORTEX_TASK_COPY_FILES_ACQUIA_SECRET}" --data-urlencode "grant_type=client_credentials")
 token=$(echo "${token_json}" | extract_json_value "access_token")
-[ -z "${token}" ] && fail "Unable to retrieve a token." && exit 1
+[ -z "${token}" ] && fail "Unable to retrieve a token."
 
 task "Retrieving ${VORTEX_TASK_COPY_FILES_ACQUIA_APP_NAME} application UUID."
 app_uuid_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications?filter=name%3D${VORTEX_TASK_COPY_FILES_ACQUIA_APP_NAME/ /%20}")
 app_uuid=$(echo "${app_uuid_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "uuid")
-[ -z "${app_uuid}" ] && fail "Unable to retrieve an application UUID." && exit 1
+[ -z "${app_uuid}" ] && fail "Unable to retrieve an application UUID."
 
 task "Retrieving source environment ID."
 envs_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications/${app_uuid}/environments?filter=name%3D${VORTEX_TASK_COPY_FILES_ACQUIA_SRC}")
 src_env_id=$(echo "${envs_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "id")
-[ -z "${src_env_id}" ] && fail "Unable to retrieve source environment ID." && exit 1
+[ -z "${src_env_id}" ] && fail "Unable to retrieve source environment ID."
 
 task "Retrieving destination environment ID."
 envs_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications/${app_uuid}/environments?filter=name%3D${VORTEX_TASK_COPY_FILES_ACQUIA_DST}")
 dst_env_id=$(echo "${envs_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "id")
-[ -z "${dst_env_id}" ] && fail "Unable to retrieve destination environment ID." && exit 1
+[ -z "${dst_env_id}" ] && fail "Unable to retrieve destination environment ID."
 
 task "Copying files from ${VORTEX_TASK_COPY_FILES_ACQUIA_SRC} to ${VORTEX_TASK_COPY_FILES_ACQUIA_DST} environment."
 task_status_json=$(curl -X POST -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" -d "{\"source\":\"${src_env_id}\"}" "https://cloud.acquia.com/api/environments/${dst_env_id}/files")
@@ -120,14 +117,13 @@ for i in $(seq 1 "${VORTEX_TASK_COPY_FILES_ACQUIA_STATUS_RETRIES}"); do
   task "Retrieving authentication token."
   token_json=$(curl -s -L https://accounts.acquia.com/api/auth/oauth/token --data-urlencode "client_id=${VORTEX_TASK_COPY_FILES_ACQUIA_KEY}" --data-urlencode "client_secret=${VORTEX_TASK_COPY_FILES_ACQUIA_SECRET}" --data-urlencode "grant_type=client_credentials")
   token=$(echo "${token_json}" | extract_json_value "access_token")
-  [ -z "${token}" ] && fail "Unable to retrieve a token." && exit 1
+  [ -z "${token}" ] && fail "Unable to retrieve a token."
 done
 
 echo
 
 if [ "${task_completed}" = "0" ]; then
   fail "Unable to copy files from ${VORTEX_TASK_COPY_FILES_ACQUIA_SRC} to ${VORTEX_TASK_COPY_FILES_ACQUIA_DST} environment."
-  exit 1
 fi
 
 note "Copied files from ${VORTEX_TASK_COPY_FILES_ACQUIA_SRC} to ${VORTEX_TASK_COPY_FILES_ACQUIA_DST} environment."

--- a/.vortex/tooling/src/vortex-task-copy-files-acquia
+++ b/.vortex/tooling/src/vortex-task-copy-files-acquia
@@ -47,7 +47,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 # Pre-flight checks.

--- a/.vortex/tooling/src/vortex-task-custom-lagoon
+++ b/.vortex/tooling/src/vortex-task-custom-lagoon
@@ -57,16 +57,16 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 info "Started Lagoon task ${VORTEX_TASK_CUSTOM_LAGOON_NAME}."
 
 ## Check all required values.
-[ -z "${VORTEX_TASK_CUSTOM_LAGOON_NAME}" ] && fail "Missing required value for VORTEX_TASK_CUSTOM_LAGOON_NAME." && exit 1
-[ -z "${VORTEX_TASK_CUSTOM_LAGOON_BRANCH}" ] && fail "Missing required value for VORTEX_TASK_CUSTOM_LAGOON_BRANCH." && exit 1
-[ -z "${VORTEX_TASK_CUSTOM_LAGOON_COMMAND}" ] && fail "Missing required value for VORTEX_TASK_CUSTOM_LAGOON_COMMAND." && exit 1
-[ -z "${VORTEX_TASK_CUSTOM_LAGOON_PROJECT}" ] && fail "Missing required value for VORTEX_TASK_CUSTOM_LAGOON_PROJECT." && exit 1
+[ -z "${VORTEX_TASK_CUSTOM_LAGOON_NAME}" ] && fail "Missing required value for VORTEX_TASK_CUSTOM_LAGOON_NAME."
+[ -z "${VORTEX_TASK_CUSTOM_LAGOON_BRANCH}" ] && fail "Missing required value for VORTEX_TASK_CUSTOM_LAGOON_BRANCH."
+[ -z "${VORTEX_TASK_CUSTOM_LAGOON_COMMAND}" ] && fail "Missing required value for VORTEX_TASK_CUSTOM_LAGOON_COMMAND."
+[ -z "${VORTEX_TASK_CUSTOM_LAGOON_PROJECT}" ] && fail "Missing required value for VORTEX_TASK_CUSTOM_LAGOON_PROJECT."
 
 export VORTEX_SSH_PREFIX="TASK_CUSTOM_LAGOON"
 . "$(dirname "${BASH_SOURCE[0]}")/vortex-setup-ssh"
@@ -86,10 +86,7 @@ if ! command -v lagoon >/dev/null || [ -n "${VORTEX_TASK_CUSTOM_LAGOON_CLI_FORCE
   export PATH="${PATH}:${VORTEX_TASK_CUSTOM_LAGOON_CLI_PATH}"
 fi
 
-for cmd in curl lagoon; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in curl lagoon; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 task "Configuring Lagoon instance."
 # shellcheck disable=SC2218

--- a/.vortex/tooling/src/vortex-task-custom-lagoon
+++ b/.vortex/tooling/src/vortex-task-custom-lagoon
@@ -57,7 +57,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 info "Started Lagoon task ${VORTEX_TASK_CUSTOM_LAGOON_NAME}."

--- a/.vortex/tooling/src/vortex-task-purge-cache-acquia
+++ b/.vortex/tooling/src/vortex-task-purge-cache-acquia
@@ -47,14 +47,11 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 # Pre-flight checks.
-for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in php curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 info "Started cache purging in Acquia."
 
@@ -75,28 +72,28 @@ extract_json_value() {
 }
 
 # Check that all required variables are present.
-[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_KEY}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_KEY or VORTEX_ACQUIA_KEY." && exit 1
-[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_SECRET}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_SECRET or VORTEX_ACQUIA_SECRET." && exit 1
-[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_APP_NAME}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_APP_NAME or VORTEX_ACQUIA_APP_NAME." && exit 1
-[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV." && exit 1
-[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE." && exit 1
-[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_STATUS_RETRIES}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_STATUS_RETRIES." && exit 1
-[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_STATUS_INTERVAL}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_STATUS_INTERVAL." && exit 1
+[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_KEY}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_KEY or VORTEX_ACQUIA_KEY."
+[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_SECRET}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_SECRET or VORTEX_ACQUIA_SECRET."
+[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_APP_NAME}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_APP_NAME or VORTEX_ACQUIA_APP_NAME."
+[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV."
+[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_DOMAINS_FILE."
+[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_STATUS_RETRIES}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_STATUS_RETRIES."
+[ -z "${VORTEX_TASK_PURGE_CACHE_ACQUIA_STATUS_INTERVAL}" ] && fail "Missing required value for VORTEX_TASK_PURGE_CACHE_ACQUIA_STATUS_INTERVAL."
 
 task "Retrieving authentication token."
 token_json=$(curl -s -L https://accounts.acquia.com/api/auth/oauth/token --data-urlencode "client_id=${VORTEX_TASK_PURGE_CACHE_ACQUIA_KEY}" --data-urlencode "client_secret=${VORTEX_TASK_PURGE_CACHE_ACQUIA_SECRET}" --data-urlencode "grant_type=client_credentials")
 token=$(echo "${token_json}" | extract_json_value "access_token")
-[ -z "${token}" ] && fail "Unable to retrieve a token." && exit 1
+[ -z "${token}" ] && fail "Unable to retrieve a token."
 
 task "Retrieving ${VORTEX_TASK_PURGE_CACHE_ACQUIA_APP_NAME} application UUID."
 app_uuid_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications?filter=name%3D${VORTEX_TASK_PURGE_CACHE_ACQUIA_APP_NAME/ /%20}")
 app_uuid=$(echo "${app_uuid_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "uuid")
-[ -z "${app_uuid}" ] && fail "Unable to retrieve an application UUID." && exit 1
+[ -z "${app_uuid}" ] && fail "Unable to retrieve an application UUID."
 
 task "Retrieving environment ID."
 envs_json=$(curl -s -L -H 'Accept: application/json, version=2' -H "Authorization: Bearer ${token}" "https://cloud.acquia.com/api/applications/${app_uuid}/environments?filter=name%3D${VORTEX_TASK_PURGE_CACHE_ACQUIA_ENV}")
 ENV_ID=$(echo "${envs_json}" | extract_json_value "_embedded" | extract_json_value "items" | extract_json_last_value "id")
-[ -z "${ENV_ID}" ] && fail "Unable to retrieve environment ID." && exit 1
+[ -z "${ENV_ID}" ] && fail "Unable to retrieve environment ID."
 
 task "Compiling a list of domains."
 
@@ -163,7 +160,7 @@ if [ "${#domain_list[@]}" -gt 0 ]; then
       task "Retrieving authentication token."
       token_json=$(curl -s -L https://accounts.acquia.com/api/auth/oauth/token --data-urlencode "client_id=${VORTEX_TASK_PURGE_CACHE_ACQUIA_KEY}" --data-urlencode "client_secret=${VORTEX_TASK_PURGE_CACHE_ACQUIA_SECRET}" --data-urlencode "grant_type=client_credentials")
       token=$(echo "${token_json}" | extract_json_value "access_token")
-      [ -z "${token}" ] && fail "Unable to retrieve a token." && exit 1
+      [ -z "${token}" ] && fail "Unable to retrieve a token."
     done
     echo
 

--- a/.vortex/tooling/src/vortex-task-purge-cache-acquia
+++ b/.vortex/tooling/src/vortex-task-purge-cache-acquia
@@ -47,7 +47,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 # Pre-flight checks.

--- a/.vortex/tooling/src/vortex-update
+++ b/.vortex/tooling/src/vortex-update
@@ -52,7 +52,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 # Pre-flight checks.

--- a/.vortex/tooling/src/vortex-update
+++ b/.vortex/tooling/src/vortex-update
@@ -52,14 +52,11 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 # Pre-flight checks.
-for cmd in php curl; do command -v "${cmd}" >/dev/null || {
-  fail "Command ${cmd} is not available."
-  exit 1
-}; done
+for cmd in php curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done
 
 for arg in "$@"; do
   if [ "${arg}" = "--interactive" ]; then
@@ -73,7 +70,6 @@ if [ -n "${VORTEX_INSTALLER_PATH}" ]; then
   note "Using installer script from local path: ${VORTEX_INSTALLER_PATH}"
   if [ ! -f "${VORTEX_INSTALLER_PATH}" ]; then
     fail "Installer script not found at ${VORTEX_INSTALLER_PATH}."
-    exit 1
   fi
 else
   note "Using installer script from URL: ${VORTEX_INSTALLER_URL}"
@@ -81,7 +77,6 @@ else
   note "Downloading installer to ${VORTEX_INSTALLER_PATH}"
   if ! curl -fsSL "${VORTEX_INSTALLER_URL}?${VORTEX_INSTALLER_URL_CACHE_BUST}" -o "${VORTEX_INSTALLER_PATH}"; then
     fail "Unable to download installer from ${VORTEX_INSTALLER_URL}."
-    exit 1
   fi
 fi
 

--- a/.vortex/tooling/tests/unit/push-db-s3.bats
+++ b/.vortex/tooling/tests/unit/push-db-s3.bats
@@ -257,7 +257,7 @@ load ../_helper.bash
 
     "@curl * # 0 # AccessDenied\n403"
 
-    "ERROR: Unable to push to S3: HTTP status 403."
+    "[FAIL] Unable to push to S3: HTTP status 403."
     "- [ OK ] Finished database dump push to S3."
   )
 

--- a/scripts/provision-00-enable-demo-modules.sh
+++ b/scripts/provision-00-enable-demo-modules.sh
@@ -19,7 +19,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/scripts/provision-00-enable-demo-modules.sh
+++ b/scripts/provision-00-enable-demo-modules.sh
@@ -19,7 +19,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/scripts/provision-10-enable-dev-modules.sh
+++ b/scripts/provision-10-enable-dev-modules.sh
@@ -17,7 +17,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/scripts/provision-10-enable-dev-modules.sh
+++ b/scripts/provision-10-enable-dev-modules.sh
@@ -17,7 +17,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/scripts/provision-20-migration.sh
+++ b/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }
@@ -79,10 +79,7 @@ run_migration() {
   local migration_name="${1}"
   shift
 
-  drush migrate:reset-status "${migration_name}" || {
-    fail "Failed to reset migration status for ${migration_name}."
-    exit 1
-  }
+  drush migrate:reset-status "${migration_name}" || fail "Failed to reset migration status for ${migration_name}."
 
   task "Running migration: ${migration_name}."
   local opts=()
@@ -102,7 +99,7 @@ run_migration() {
 
   drush migrate:import "${opts[@]}" "${migration_name}" || {
     drush migrate:messages "${migration_name}"
-    exit 1
+    fail "Failed to run migration ${migration_name}."
   }
 
   pass "Migrated: ${migration_name}."
@@ -124,7 +121,7 @@ fi
 if [ "${DRUPAL_MIGRATION_SOURCE_DB_IMPORT}" = "1" ]; then
   task "Importing migration source database."
 
-  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'." && exit 1
+  [ ! -f "${VORTEX_DB_DIR}/${VORTEX_FETCH_DB2_FILE}" ] && fail "Migration source database file not found. Please run 'ahoy fetch-db2'."
 
   drush sql:drop --database=migrate
   # shellcheck disable=SC2091
@@ -137,9 +134,8 @@ fi
 
 task "Verifying migration source database."
 if ! drush sql:query --database=migrate "SELECT COUNT(*) FROM ${DRUPAL_MIGRATION_SOURCE_DB_PROBE_TABLE}" >/dev/null 2>&1; then
-  fail "Migration source database is corrupted."
   drush sql:query --database=migrate "SHOW TABLES;"
-  exit 1
+  fail "Migration source database is corrupted."
 fi
 pass "Verified migration source database."
 

--- a/scripts/provision-20-migration.sh
+++ b/scripts/provision-20-migration.sh
@@ -44,7 +44,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/scripts/provision-30-search-index.sh
+++ b/scripts/provision-30-search-index.sh
@@ -17,7 +17,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/scripts/provision-30-search-index.sh
+++ b/scripts/provision-30-search-index.sh
@@ -17,7 +17,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/scripts/provision-40-example.sh
+++ b/scripts/provision-40-example.sh
@@ -22,7 +22,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; }
+fail() { printf "     ! %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/scripts/provision-40-example.sh
+++ b/scripts/provision-40-example.sh
@@ -22,7 +22,7 @@ info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
 pass() { printf "     < %s\n" "${1}"; }
-fail() { printf "     ! %s\n" "${1}"; exit 1; }
+fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 drush() { ./vendor/bin/drush -y "$@"; }

--- a/scripts/vortex-tooling.sh
+++ b/scripts/vortex-tooling.sh
@@ -28,7 +28,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
 # @formatter:on
 
 # Run Composer with its progress output suppressed - it is an internal detail
@@ -45,13 +45,11 @@ composer_run() {
   output=$(composer "$@" 2>&1) || status=$?
 
   if [ "${status}" -ne 0 ]; then
-    fail "Composer command failed."
-
     if [ -n "${output}" ]; then
       printf "%s\n" "${output}" >&2
     fi
 
-    return "${status}"
+    fail "Composer command failed."
   fi
 }
 

--- a/scripts/vortex-tooling.sh
+++ b/scripts/vortex-tooling.sh
@@ -28,7 +28,7 @@ info() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\03
 note() { printf "       %s\n" "${1}"; }
 task() { _TASK_START=$(date +%s); [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[34m[TASK] %s\033[0m\n" "${1}" || printf "[TASK] %s\n" "${1}"; }
 pass() { _d=""; [ -n "${_TASK_START:-}" ] && _d=" ($(($(date +%s) - _TASK_START))s)" && unset _TASK_START; [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[32m[ OK ] %s%s\033[0m\n" "${1}" "${_d}" || printf "[ OK ] %s%s\n" "${1}" "${_d}"; }
-fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit 1; }
+fail() { [ "${TERM:-}" != "dumb" ] && tput colors >/dev/null 2>&1 && printf "\033[31m[FAIL] %s\033[0m\n" "${1}" || printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 
 # Run Composer with its progress output suppressed - it is an internal detail
@@ -49,7 +49,7 @@ composer_run() {
       printf "%s\n" "${output}" >&2
     fi
 
-    fail "Composer command failed."
+    fail "Composer command failed." "${status}"
   fi
 }
 


### PR DESCRIPTION
Closes #2967

## Summary

Every Vortex shell script declared its own single-line `fail()` helper that only printed a `[FAIL] ...` message, leaving termination to the call site, so `exit 1` was hand-written roughly 230 times across the 49 scripts that define it: the 42 shipped tooling scripts in `.vortex/tooling/src/`, the 6 `scripts/*.sh` template scripts, and the documented boilerplate example. `fail()` now ends with `exit "${2:-1}"`, so a single call both prints the message and terminates the script, defaulting to status 1 with an optional second argument for a caller-supplied status, and every redundant `exit 1` that used to follow a `fail()` call has been removed. A handful of failure blocks were also reordered so `fail()` always runs last, and three failure paths that previously exited silently with no `[FAIL]` line now route through it.

## Changes

- Added `exit "${2:-1}"` to the end of `fail()` in all 42 shipped tooling scripts under `.vortex/tooling/src/`, the 6 `scripts/*.sh` template scripts, and the documented boilerplate at `.vortex/docs/content/contributing/maintenance/script-boilerplate.sh` - including the differently-formatted `fail() { printf "     ! %s\n" "${1}"; }` variant used by the `provision-*.sh` subscripts.
- Removed the now-redundant `&& exit 1` suffix from roughly 160 inline `<condition> && fail "..." && exit 1` guards; under `set -e` a false condition was never the last command of the AND-OR list either before or after this change, so failure behaviour is unchanged.
- Collapsed 26 `for cmd in ...; do command -v "${cmd}" >/dev/null || { fail "..."; exit 1; }; done` command-availability guards from four lines to one.
- Removed dozens of standalone `exit 1` lines that immediately followed a `fail()` call.
- Reordered several failure blocks so `fail()` runs last: explanatory `note` lines, cleanup `rm` calls, payload dumps, and `drush` diagnostics now all run before the terminating `fail()`, so nothing that used to print is now unreachable. Affects `vortex-doctor`, `vortex-import-db-file`, `vortex-provision`, `vortex-fetch-db-url`, `vortex-notify-jira`, `vortex-notify-github`, and `scripts/provision-20-migration.sh` (and its 9 installer-fixture copies).
- In `vortex-notify-github`, a second consecutive `fail()` call that was really an advisory follow-up line - a workaround for `fail()` previously not being terminal - is now a `note`, printed before the real `fail()` call.
- Routed three failure paths that previously exited with no `[FAIL]` line through `fail()`: `vortex-provision` (a corrupted container-image database), `vortex-push-db-s3` (a raw `echo "ERROR: ..."` is now `fail "..."`, with the message text unchanged apart from the prefix), and `scripts/provision-20-migration.sh` (a silent `exit 1` after a `drush migrate:messages` dump now gets a `[FAIL]` headline).
- `vortex-deploy-lagoon` captured a deployment's exit status and re-raised it as the script's own exit code in a final check, and `scripts/vortex-tooling.sh`'s `composer_run()` helper returned a captured status for `set -e` to propagate immediately; both now pass that status to `fail()` as its second argument instead, so the exit code in either case is preserved exactly.
- Updated `.vortex/docs/content/contributing/maintenance/template.mdx` (rules 6-8) and its companion `script-boilerplate.sh` example to the new helper and idiom, including fixing the boilerplate's `command -v curl >/dev/null || ( fail "..." && exit 1 )` subshell form - whose `exit` only ever killed the subshell, never the script - to a plain `|| fail "..."`.
- Updated `.vortex/tooling/tests/unit/push-db-s3.bats` for the `ERROR: ` to `[FAIL] ` prefix change, and regenerated 14 installer test fixtures via `ahoy update-snapshots` to match the simplified scripts they embed.

## Screenshots

N/A

## Before / After

```
BEFORE - fail() only prints; every call site repeats the termination ───────

  fail() { ...; printf "[FAIL] %s\n" "${1}"; }

  [ -z "${VAR}" ] && fail "Missing VAR." && exit 1

  for cmd in curl; do command -v "${cmd}" >/dev/null || {
    fail "Command ${cmd} is not available."
    exit 1
  }; done

  if [ ! -f "${dump_file}" ]; then
    fail "Unable to import database from file."     # [FAIL] printed here
    note "Dump file ${dump_file} does not exist."
    exit 1                                           # context printed after
  fi

AFTER - fail() prints and terminates; call sites stop repeating it ─────────

  fail() { ...; printf "[FAIL] %s\n" "${1}"; exit "${2:-1}"; }

  [ -z "${VAR}" ] && fail "Missing VAR."

  for cmd in curl; do command -v "${cmd}" >/dev/null || fail "Command ${cmd} is not available."; done

  if [ ! -f "${dump_file}" ]; then
    note "Dump file ${dump_file} does not exist."    # context printed first
    fail "Unable to import database from file."      # [FAIL] + exit, last
  fi
```
