### PR TITLE
[#2975] Replaced versioned Drupal Rector sets with the composer-based set.

### DIFF
--- a/.vortex/cli/tests/Fixtures/handler_process/_baseline/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/_baseline/rector.php
@@ -17,8 +17,6 @@
 declare(strict_types=1);
 
 use DrupalFinder\DrupalFinderComposerRuntime;
-use DrupalRector\Set\Drupal10SetList;
-use DrupalRector\Set\Drupal9SetList;
 use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector;
 use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
@@ -99,11 +97,10 @@ return RectorConfig::configure()
     privatization: TRUE,
     typeDeclarations: TRUE,
   )
-  // Drupal-specific deprecation fixes.
-  ->withSets([
-    Drupal9SetList::DRUPAL_9,
-    Drupal10SetList::DRUPAL_10,
-  ])
+  // Drupal-specific deprecation fixes. Each rule is bound to a `drupal/core`
+  // version and runs only when the installed core matches, so the set tracks
+  // core upgrades without changing this configuration.
+  ->withComposerBased(drupal: TRUE)
   // Additional rules.
   ->withRules([
     DeclareStrictTypesRector::class,

--- a/.vortex/cli/tests/Fixtures/handler_process/hosting_acquia/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/hosting_acquia/rector.php
@@ -1,4 +1,4 @@
-@@ -48,10 +48,10 @@
+@@ -46,10 +46,10 @@
  
  return RectorConfig::configure()
    ->withPaths([
@@ -13,7 +13,7 @@
      __DIR__ . '/tests',
    ])
    ->withSkip([
-@@ -79,7 +79,7 @@
+@@ -77,7 +77,7 @@
      RenameVariableToMatchNewTypeRector::class,
      SimplifyEmptyCheckOnEmptyArrayRector::class,
      StringClassNameToClassConstantRector::class => [

--- a/.vortex/cli/tests/Fixtures/handler_process/hosting_project_name___acquia/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/hosting_project_name___acquia/rector.php
@@ -1,4 +1,4 @@
-@@ -48,10 +48,10 @@
+@@ -46,10 +46,10 @@
  
  return RectorConfig::configure()
    ->withPaths([
@@ -13,7 +13,7 @@
      __DIR__ . '/tests',
    ])
    ->withSkip([
-@@ -79,7 +79,7 @@
+@@ -77,7 +77,7 @@
      RenameVariableToMatchNewTypeRector::class,
      SimplifyEmptyCheckOnEmptyArrayRector::class,
      StringClassNameToClassConstantRector::class => [

--- a/.vortex/cli/tests/Fixtures/handler_process/theme_claro/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/theme_claro/rector.php
@@ -1,4 +1,4 @@
-@@ -49,7 +49,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/.vortex/cli/tests/Fixtures/handler_process/theme_olivero/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/theme_olivero/rector.php
@@ -1,4 +1,4 @@
-@@ -49,7 +49,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/.vortex/cli/tests/Fixtures/handler_process/theme_stark/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/theme_stark/rector.php
@@ -1,4 +1,4 @@
-@@ -49,7 +49,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/.vortex/cli/tests/Fixtures/handler_process/tools_groups_no_be_tests/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/tools_groups_no_be_tests/rector.php
@@ -1,4 +1,4 @@
-@@ -38,7 +38,6 @@
+@@ -36,7 +36,6 @@
  use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
  use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
  use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
@@ -6,7 +6,7 @@
  use Rector\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector;
  use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
  use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
-@@ -88,8 +87,6 @@
+@@ -86,8 +85,6 @@
    // PHP version upgrade sets - modernizes syntax to PHP 8.4.
    // Includes all rules from PHP 5.3 through 8.4.
    ->withPhpSets(php84: TRUE)
@@ -15,7 +15,7 @@
    // Code quality improvement sets.
    ->withPreparedSets(
      codeQuality: TRUE,
-@@ -107,7 +104,6 @@
+@@ -104,7 +101,6 @@
    // Additional rules.
    ->withRules([
      DeclareStrictTypesRector::class,

--- a/.vortex/cli/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/rector.php
@@ -1,4 +1,4 @@
-@@ -38,7 +38,6 @@
+@@ -36,7 +36,6 @@
  use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
  use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
  use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
@@ -6,7 +6,7 @@
  use Rector\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector;
  use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
  use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
-@@ -88,8 +87,6 @@
+@@ -86,8 +85,6 @@
    // PHP version upgrade sets - modernizes syntax to PHP 8.4.
    // Includes all rules from PHP 5.3 through 8.4.
    ->withPhpSets(php84: TRUE)
@@ -15,7 +15,7 @@
    // Code quality improvement sets.
    ->withPreparedSets(
      codeQuality: TRUE,
-@@ -107,7 +104,6 @@
+@@ -104,7 +101,6 @@
    // Additional rules.
    ->withRules([
      DeclareStrictTypesRector::class,

--- a/.vortex/cli/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/rector.php
@@ -1,4 +1,4 @@
-@@ -49,7 +49,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/.vortex/cli/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/rector.php
@@ -1,4 +1,4 @@
-@@ -49,7 +49,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/.vortex/cli/tests/Fixtures/handler_process/tools_no_behat/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/tools_no_behat/rector.php
@@ -1,4 +1,4 @@
-@@ -88,8 +88,6 @@
+@@ -86,8 +86,6 @@
    // PHP version upgrade sets - modernizes syntax to PHP 8.4.
    // Includes all rules from PHP 5.3 through 8.4.
    ->withPhpSets(php84: TRUE)

--- a/.vortex/cli/tests/Fixtures/handler_process/tools_no_behat_circleci/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/tools_no_behat_circleci/rector.php
@@ -1,4 +1,4 @@
-@@ -88,8 +88,6 @@
+@@ -86,8 +86,6 @@
    // PHP version upgrade sets - modernizes syntax to PHP 8.4.
    // Includes all rules from PHP 5.3 through 8.4.
    ->withPhpSets(php84: TRUE)

--- a/.vortex/cli/tests/Fixtures/handler_process/tools_no_eslint_no_theme/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/tools_no_eslint_no_theme/rector.php
@@ -1,4 +1,4 @@
-@@ -49,7 +49,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/.vortex/cli/tests/Fixtures/handler_process/tools_no_phpunit/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/tools_no_phpunit/rector.php
@@ -1,4 +1,4 @@
-@@ -38,7 +38,6 @@
+@@ -36,7 +36,6 @@
  use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
  use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
  use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
@@ -6,7 +6,7 @@
  use Rector\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector;
  use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
  use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
-@@ -107,7 +106,6 @@
+@@ -104,7 +103,6 @@
    // Additional rules.
    ->withRules([
      DeclareStrictTypesRector::class,

--- a/.vortex/cli/tests/Fixtures/handler_process/tools_no_phpunit_circleci/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/tools_no_phpunit_circleci/rector.php
@@ -1,4 +1,4 @@
-@@ -38,7 +38,6 @@
+@@ -36,7 +36,6 @@
  use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
  use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
  use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
@@ -6,7 +6,7 @@
  use Rector\Privatization\Rector\ClassConst\PrivatizeFinalClassConstantRector;
  use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
  use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
-@@ -107,7 +106,6 @@
+@@ -104,7 +103,6 @@
    // Additional rules.
    ->withRules([
      DeclareStrictTypesRector::class,

--- a/.vortex/cli/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/rector.php
+++ b/.vortex/cli/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/rector.php
@@ -1,4 +1,4 @@
-@@ -49,7 +49,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/rector.php
+++ b/rector.php
@@ -17,8 +17,6 @@
 declare(strict_types=1);
 
 use DrupalFinder\DrupalFinderComposerRuntime;
-use DrupalRector\Set\Drupal10SetList;
-use DrupalRector\Set\Drupal9SetList;
 use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector;
 use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
@@ -101,11 +99,10 @@ return RectorConfig::configure()
     privatization: TRUE,
     typeDeclarations: TRUE,
   )
-  // Drupal-specific deprecation fixes.
-  ->withSets([
-    Drupal9SetList::DRUPAL_9,
-    Drupal10SetList::DRUPAL_10,
-  ])
+  // Drupal-specific deprecation fixes. Each rule is bound to a `drupal/core`
+  // version and runs only when the installed core matches, so the set tracks
+  // core upgrades without changing this configuration.
+  ->withComposerBased(drupal: TRUE)
   // Additional rules.
   ->withRules([
     DeclareStrictTypesRector::class,


### PR DESCRIPTION
Closes #2975

## Summary

rector/rector 2.6.2 (published 2026-08-12) removed the versioned `Rector\PHPUnit\Set\PHPUnitSetList::PHPUNIT_40` through `PHPUNIT_130` constants in favor of composer-based sets, but `palantirnet/drupal-rector` 1.1.2 still references `PHPUnitSetList::PHPUNIT_90` from its Drupal 8/9/10 deprecation configs, which `rector.php` loaded via `Drupal9SetList::DRUPAL_9` and `Drupal10SetList::DRUPAL_10`. Because the template commits no lock file, CI resolved rector/rector 2.6.2 fresh and Rector aborted with `Undefined constant Rector\PHPUnit\Set\PHPUnitSetList::PHPUNIT_90` before analysing anything, failing the `lint` and `vortex-test-workflow` checks on every branch regardless of what changed in that branch. This replaces the two versioned set lists with `->withComposerBased(drupal: TRUE)`, which loads Drupal sets through `palantirnet/drupal-rector`'s `DrupalSetProvider` and binds each set to the installed `drupal/core` version instead of a hardcoded major-version list. The `withComposerBased()` call exists in both rector/rector 2.6.1 and 2.6.2, so the fix is safe across the whole `^2.6.1` constraint range; the tradeoff is that Drupal 9 and 10 deprecation rules no longer run against a Drupal 11 site, which is the intended behavior of the composer-based provider rather than a regression.

## Changes

- Replaced `->withSets([Drupal9SetList::DRUPAL_9, Drupal10SetList::DRUPAL_10])` with `->withComposerBased(drupal: TRUE)` in the root `rector.php`, and removed the now-unused `DrupalRector\Set\Drupal9SetList` / `DrupalRector\Set\Drupal10SetList` imports.
- Regenerated the installer snapshot fixtures with `composer update-snapshots`. That rewrites `.vortex/cli/tests/Fixtures/handler_process/_baseline/rector.php`, which mirrors the generated project's `rector.php`, and shifts the stored diff-hunk line offsets in the 15 scenario fixtures under `.vortex/cli/tests/Fixtures/handler_process/*/rector.php` that record their deltas against that baseline.

## Before / After

```
BEFORE
┌───────────────────────────────────────┐
│ rector.php                            │
│ ->withSets([Drupal9SetList::DRUPAL_9, │
│  Drupal10SetList::DRUPAL_10])         │
└───────────────────────────────────────┘
        │
        ▼
┌─────────────────────────────────────────────────────────┐
│ palantirnet/drupal-rector Drupal 8/9/10 configs         │
│ reference Rector\PHPUnit\Set\PHPUnitSetList::PHPUNIT_90 │
└─────────────────────────────────────────────────────────┘
        │
        ▼
┌──────────────────────────────────────────────────────┐
│ PHPUNIT_90 removed in rector/rector 2.6.2            │
│ FATAL: Undefined constant PHPUnitSetList::PHPUNIT_90 │
│ Rector aborts before analysing any file              │
└──────────────────────────────────────────────────────┘

Result: lint and vortex-test-workflow fail on every branch

AFTER
┌───────────────────────────────────┐
│ rector.php                        │
│ ->withComposerBased(drupal: TRUE) │
└───────────────────────────────────┘
        │
        ▼
┌───────────────────────────────────────────────────┐
│ palantirnet/drupal-rector DrupalSetProvider binds │
│ each set to the installed drupal/core version     │
│ (ComposerTriggeredSet)                            │
└───────────────────────────────────────────────────┘
        │
        ▼
┌─────────────────────────────────────────────────────┐
│ drupal/core 11.4.5 resolves to the Drupal 11.0-11.4 │
│ sets plus matching breaking-change sets;            │
│ Drupal 9/10 configs (and PHPUNIT_90) never load     │
└─────────────────────────────────────────────────────┘
        │
        ▼
┌────────────────────────────────────┐
│ Rector completes analysis normally │
│ dry-run exits 0                    │
└────────────────────────────────────┘

Result: lint and vortex-test-workflow pass
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated code-quality configuration to detect applicable Drupal rules from the project’s Composer metadata.
  * Adjusted Acquia project paths to use the `docroot` directory.
  * Simplified analysis scope by excluding custom theme directories where appropriate.
  * Removed optional Behat and PHPUnit transformations when those tools are not enabled.

* **Tests**
  * Updated configuration fixtures to reflect the revised Drupal detection, project paths, and tool-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->