### PR TITLE
[#2980] Raised the InnoDB redo log capacity so large database dumps import.

### DIFF
--- a/.docker/config/database/my.cnf
+++ b/.docker/config/database/my.cnf
@@ -1,1 +1,9 @@
-# Custom configuration for database clients.
+# Custom configuration for the database service.
+
+[mysqld]
+# The image default of 128MB is exhausted during a large dump import faster
+# than the log checkpointer reclaims it, aborting the import with
+# "ERROR 1114 ... table is full".
+# MariaDB images abort at startup on this MySQL-only variable, so the
+# "loose-" prefix downgrades that to a warning.
+loose-innodb_redo_log_capacity = 1073741824

--- a/.docker/database.dockerfile
+++ b/.docker/database.dockerfile
@@ -10,8 +10,9 @@ FROM ${IMAGE}
 
 # hadolint ignore=DL3066 # named account provided by the base image
 USER root
-COPY ./.docker/config/database/my.cnf /etc/my.cnf.d/server.cnf
-RUN fix-permissions /etc/my.cnf.d/
+COPY ./.docker/config/database/my.cnf /etc/mysql/conf.d/server.cnf
+# The entrypoint rewrites files in this directory before starting the server.
+RUN fix-permissions /etc/mysql/conf.d/
 
 # hadolint ignore=DL3064 # local development credentials only
 ENV MYSQL_DATABASE=drupal \

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.docker/config/database/my.cnf
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.docker/config/database/my.cnf
@@ -1,1 +1,9 @@
-# Custom configuration for database clients.
+# Custom configuration for the database service.
+
+[mysqld]
+# The image default of 128MB is exhausted during a large dump import faster
+# than the log checkpointer reclaims it, aborting the import with
+# "ERROR 1114 ... table is full".
+# MariaDB images abort at startup on this MySQL-only variable, so the
+# "loose-" prefix downgrades that to a warning.
+loose-innodb_redo_log_capacity = 1073741824

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.docker/database.dockerfile
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.docker/database.dockerfile
@@ -10,8 +10,9 @@ FROM ${IMAGE}
 
 # hadolint ignore=DL3066 # named account provided by the base image
 USER root
-COPY ./.docker/config/database/my.cnf /etc/my.cnf.d/server.cnf
-RUN fix-permissions /etc/my.cnf.d/
+COPY ./.docker/config/database/my.cnf /etc/mysql/conf.d/server.cnf
+# The entrypoint rewrites files in this directory before starting the server.
+RUN fix-permissions /etc/mysql/conf.d/
 
 # hadolint ignore=DL3064 # local development credentials only
 ENV MYSQL_DATABASE=drupal \

--- a/.vortex/tests/phpunit/Functional/DockerComposeWorkflowTest.php
+++ b/.vortex/tests/phpunit/Functional/DockerComposeWorkflowTest.php
@@ -40,6 +40,8 @@ class DockerComposeWorkflowTest extends FunctionalTestCase {
 
     $this->subtestDockerComposeDrushPhpIni();
 
+    $this->subtestDockerComposeDatabaseConfig();
+
     $this->subtestDockerComposeSolr();
 
     $this->logSubstep('Installing development dependencies');

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestDockerComposeTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestDockerComposeTrait.php
@@ -322,6 +322,21 @@ trait SubtestDockerComposeTrait {
     $this->logStepFinish();
   }
 
+  protected function subtestDockerComposeDatabaseConfig(): void {
+    $this->logStepStart();
+
+    // Asserting the effective value rather than the file contents: the config
+    // file is copied to a path the database image reads only if the copy
+    // destination in the Dockerfile matches the engine's include directory.
+    $this->cmd(
+      'docker compose exec -T database mysql -udrupal -pdrupal -e "SHOW VARIABLES LIKE \'innodb_redo_log_capacity\';"',
+      '1073741824',
+      'Database applies the InnoDB redo log capacity from the shipped my.cnf'
+    );
+
+    $this->logStepFinish();
+  }
+
   protected function subtestDockerComposeSolr(): void {
     $this->logStepStart();
 


### PR DESCRIPTION
Closes #2980

## Summary

The issue asked for an `innodb_redo_log_capacity` setting in the shipped `my.cnf` so large database dumps stop failing with `ERROR 1114 (HY000): The table '...' is full` during import. Adding the setting to the existing file alone would've been a silent no-op, so this PR also fixes the wiring that was quietly dropping it.

`.docker/database.dockerfile` copied `my.cnf` to `/etc/my.cnf.d/server.cnf`, but neither image Vortex can run for the `database` service reads that path. Both `uselagoon/mysql-8.4:26.8.0` (the default) and the MariaDB database-in-image (`drevops/vortex-dev-mariadb-drupal-data-demo-11.x`, selected via `VORTEX_DB_IMAGE`) load `/etc/mysql/my.cnf`, which ends with `!includedir /etc/mysql/conf.d`. `/etc/my.cnf.d/` doesn't exist in either base image, so the `COPY` instruction was silently creating a directory nothing ever reads. Verified by running both images: with the setting at the old path, a live MySQL 8.4 container still reported the image default of `134217728`; after moving the copy to `/etc/mysql/conf.d/server.cnf`, it reports `1073741824`. Both images ship an empty `conf.d`, so the new copy destination doesn't clobber anything else.

`fix-permissions` had to move with the file. The Lagoon entrypoint parses and rewrites files under `conf.d` before starting the server, so a non-writable file there fails the container at boot with `Error while parsing '/etc/mysql/conf.d/server.cnf': ... read-only file system`.

The MariaDB question the issue raised is settled too. Once the copy path is fixed, the same file reaches MariaDB as well. A plain `innodb_redo_log_capacity` line makes MariaDB 10.11 abort at startup (`unknown variable 'innodb_redo_log_capacity=1073741824'`, then `Aborting`), so the setting uses the standard `loose-` prefix, which downgrades an unrecognised option to a warning instead of a fatal error. Verified on both engines by building the real `.docker/database.dockerfile`: MySQL 8.4 applies the value in full, and MariaDB logs a `loose-innodb_redo_log_capacity` warning and still reaches `ready for connections`.

The value is `1073741824` (1GB), as proposed in the issue and validated downstream against the ~1.5GB dump that triggered the report. MySQL 8.0.30+ preallocates the redo log capacity up front, measured at 1.1G under `#innodb_redo` after the change, so this costs roughly +900MB of disk per database container against the 128MB default. The file stays consumer-editable under `.docker/config/database/`, so a project that doesn't want the extra disk usage can lower it.

The only existing test coverage was `SutTrait.php` asserting that `.docker/config/database/my.cnf` exists on disk, which passed throughout the entire period the file was being copied to a path nothing reads. `subtestDockerComposeDatabaseConfig()` now queries the running `database` container for the effective `innodb_redo_log_capacity`, so a regression in the copy destination, the `loose-` prefix, or the value itself fails the build instead of passing silently.

Deliberately left out: MariaDB-side `innodb_log_file_size` tuning, since no MariaDB import failure has been reported and MariaDB doesn't exhibit the MySQL "table is full" pathology this issue describes; a `.env` variable for the value, since the file is copied at build time so a variable would only take effect on rebuild, and `.docker/config/database/` already exists for consumers who want to override it; and changes to `nginx-drupal.dockerfile`, which copies its config to a path its image does read, so it doesn't share this defect.

## Changes

- Moved the `my.cnf` copy destination in `.docker/database.dockerfile` from `/etc/my.cnf.d/server.cnf` to `/etc/mysql/conf.d/server.cnf`, and updated the `fix-permissions` target to match.
- Added a `[mysqld]` section to `.docker/config/database/my.cnf` with `loose-innodb_redo_log_capacity = 1073741824`, and updated the file's header comment from "Custom configuration for database clients." to "Custom configuration for the database service." now that it carries a server-side setting.
- Added `subtestDockerComposeDatabaseConfig()` to `SubtestDockerComposeTrait.php`, which asserts the running database container reports the effective `innodb_redo_log_capacity`, and wired it into `DockerComposeWorkflowTest::testDockerComposeWorkflowFull()`.
- Regenerated the installer snapshot fixtures under `.vortex/installer/tests/Fixtures/handler_process/_baseline/` to match the two `.docker/` changes.

## Before / After

```
BEFORE
┌───────────────────────────────────────────────┐
│ my.cnf: innodb_redo_log_capacity = 1073741824 │
└───────────────────────────────────────────────┘
                        │  COPY in database.dockerfile
                        ▼
┌───────────────────────────────────────────────────┐
│ /etc/my.cnf.d/server.cnf                          │
│ (directory the COPY instruction creates; no image │
│ reads this path - a dead end)                     │
└───────────────────────────────────────────────────┘
                        │
           ┌────────────┴─────────────┐
           ▼                          ▼
┌────────────────────────────┐    ┌────────────────────────────┐
│ MySQL 8.4                  │    │ MariaDB 10.11              │
│ reads /etc/mysql/my.cnf    │    │ reads /etc/mysql/my.cnf    │
│ -> conf.d/*                │    │ -> conf.d/*                │
│ server.cnf: never included │    │ server.cnf: never included │
└────────────────────────────┘    └────────────────────────────┘
           │                          │
           ▼                          ▼
redo log stays at 128MB        setting never reaches
large dump import fails:       MariaDB either way
ERROR 1114: table is full

AFTER
┌─────────────────────────────────────────────┐
│ my.cnf: [mysqld]                            │
│ loose-innodb_redo_log_capacity = 1073741824 │
└─────────────────────────────────────────────┘
                        │  COPY in database.dockerfile
                        ▼
┌────────────────────────────────────────────┐
│ /etc/mysql/conf.d/server.cnf               │
│ fix-permissions target moved here to match │
└────────────────────────────────────────────┘
                        │
           ┌────────────┴─────────────┐
           ▼                          ▼
┌─────────────────────┐    ┌────────────────────────┐
│ MySQL 8.4           │    │ MariaDB 10.11          │
│ includedir picks up │    │ includedir picks up    │
│ server.cnf, applies │    │ server.cnf, "loose-"   │
│ the value in full   │    │ downgrades the unknown │
└─────────────────────┘    │ option to a warning    │
                           └────────────────────────┘
           │                          │
           ▼                          ▼
SHOW VARIABLES reports          logs a warning, still
1073741824; large dumps         reaches "ready for
import cleanly                  connections"
```
