### PR TITLE
[#2981] Completed the Rector rename-skip family and audited the skip list.

### DIFF
--- a/.vortex/installer/rector.php
+++ b/.vortex/installer/rector.php
@@ -18,13 +18,14 @@ use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\ClassLike\NewlineBetweenClassLikeStmtsRector;
 use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
-use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector;
 use Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
 use Rector\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchMethodCallReturnTypeRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
@@ -47,7 +48,6 @@ return RectorConfig::configure()
     CatchExceptionNameMatchingTypeRector::class,
     ChangeSwitchToMatchRector::class,
     CompleteDynamicPropertiesRector::class,
-    CountArrayToEmptyArrayComparisonRector::class,
     DisallowedEmptyRuleFixerRector::class,
     InlineArrayReturnAssignRector::class,
     NewlineAfterStatementRector::class,
@@ -57,6 +57,8 @@ return RectorConfig::configure()
     PrivatizeFinalClassPropertyRector::class,
     PrivatizeLocalGetterToPropertyRector::class,
     RemoveAlwaysTrueIfConditionRector::class,
+    RenameForeachValueVariableToMatchExprVariableRector::class,
+    RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
     RenameParamToMatchTypeRector::class,
     RenameVariableToMatchMethodCallReturnTypeRector::class,
     RenameVariableToMatchNewTypeRector::class,

--- a/.vortex/installer/src/Prompts/Handlers/Theme.php
+++ b/.vortex/installer/src/Prompts/Handlers/Theme.php
@@ -195,6 +195,7 @@ class Theme extends AbstractHandler {
     File::removeLineInFile($tmp_dir . '/phpunit.xml', '<directory>web/themes/custom/**/node_modules</directory>');
 
     File::removeLineInFile($tmp_dir . '/rector.php', "__DIR__ . '/web/themes/custom',");
+    File::removeLineInFile($tmp_dir . '/rector.php', "__DIR__ . '/web/themes/custom/*/src/Hook/*',");
 
     File::removeLineInFile($tmp_dir . '/.twig-cs-fixer.php', "\$finder->in(__DIR__ . '/web/themes/custom');");
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/rector.php
@@ -24,13 +24,15 @@ use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\ClassLike\NewlineBetweenClassLikeStmtsRector;
 use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
-use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector;
 use Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
 use Rector\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchMethodCallReturnTypeRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
@@ -51,29 +53,49 @@ return RectorConfig::configure()
     __DIR__ . '/tests',
   ])
   ->withSkip([
-    // Specific rules to skip based on project coding standards.
-    AddOverrideAttributeToOverriddenMethodsRector::class,
-    ArrayToFirstClassCallableRector::class,
+    // Rules that rename variables and parameters after their type. The
+    // project names local variables and method arguments in snake_case.
     CatchExceptionNameMatchingTypeRector::class,
-    ChangeSwitchToMatchRector::class,
-    CompleteDynamicPropertiesRector::class,
-    CountArrayToEmptyArrayComparisonRector::class,
-    DisallowedEmptyRuleFixerRector::class,
-    InlineArrayReturnAssignRector::class,
-    NewlineAfterStatementRector::class,
-    NewlineBeforeNewAssignSetRector::class,
-    NewlineBetweenClassLikeStmtsRector::class,
-    PrivatizeFinalClassMethodRector::class,
-    PrivatizeFinalClassPropertyRector::class,
-    PrivatizeLocalGetterToPropertyRector::class,
-    RemoveAlwaysTrueIfConditionRector::class,
+    RenameForeachValueVariableToMatchExprVariableRector::class,
+    RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
     RenameParamToMatchTypeRector::class,
     RenameVariableToMatchMethodCallReturnTypeRector::class,
     RenameVariableToMatchNewTypeRector::class,
+    // Rules that narrow class members to private. The project declares
+    // members protected.
+    PrivatizeFinalClassMethodRector::class,
+    PrivatizeFinalClassPropertyRector::class,
+    PrivatizeLocalGetterToPropertyRector::class,
+    // Rules that replace empty() checks with explicit comparisons.
+    DisallowedEmptyRuleFixerRector::class,
     SimplifyEmptyCheckOnEmptyArrayRector::class,
-    StringClassNameToClassConstantRector::class => [
-      __DIR__ . '/web/sites/default/includes/**/*',
+    // Rules that add or move blank lines. PHP_CodeSniffer decides
+    // formatting.
+    NewlineAfterStatementRector::class,
+    NewlineBeforeNewAssignSetRector::class,
+    NewlineBetweenClassLikeStmtsRector::class,
+    // Drupal caches form arrays, and a first-class callable is a Closure.
+    ArrayToFirstClassCallableRector::class,
+    // match() compares strictly and throws when no arm matches.
+    ChangeSwitchToMatchRector::class,
+    // Object-oriented hook implementations keep the signature the hook
+    // declares, including parameters the implementation does not use.
+    RemoveUnusedPublicMethodParameterRector::class => [
+      __DIR__ . '/web/modules/custom/*/src/Hook/*',
+      __DIR__ . '/web/themes/custom/*/src/Hook/*',
     ],
+    // The settings includes name classes from modules that are registered
+    // with the autoloader at runtime.
+    StringClassNameToClassConstantRector::class => [
+      __DIR__ . '/web/sites/default/includes/*',
+    ],
+    // Rules that rewrite working code beyond a syntax upgrade.
+    CompleteDynamicPropertiesRector::class,
+    InlineArrayReturnAssignRector::class,
+    // Drupal core does not use the #[\Override] attribute.
+    AddOverrideAttributeToOverriddenMethodsRector::class,
+    // Docblock type inference is not a runtime guarantee.
+    RemoveAlwaysTrueIfConditionRector::class,
     // Directories to skip.
     '*/vendor/*',
     '*/node_modules/*',

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/rector.php
@@ -53,49 +53,34 @@ return RectorConfig::configure()
     __DIR__ . '/tests',
   ])
   ->withSkip([
-    // Rules that rename variables and parameters after their type. The
-    // project names local variables and method arguments in snake_case.
+    // Specific rules to skip based on project coding standards.
+    AddOverrideAttributeToOverriddenMethodsRector::class,
+    ArrayToFirstClassCallableRector::class,
     CatchExceptionNameMatchingTypeRector::class,
+    ChangeSwitchToMatchRector::class,
+    CompleteDynamicPropertiesRector::class,
+    DisallowedEmptyRuleFixerRector::class,
+    InlineArrayReturnAssignRector::class,
+    NewlineAfterStatementRector::class,
+    NewlineBeforeNewAssignSetRector::class,
+    NewlineBetweenClassLikeStmtsRector::class,
+    PrivatizeFinalClassMethodRector::class,
+    PrivatizeFinalClassPropertyRector::class,
+    PrivatizeLocalGetterToPropertyRector::class,
+    RemoveAlwaysTrueIfConditionRector::class,
+    RemoveUnusedPublicMethodParameterRector::class => [
+      __DIR__ . '/web/modules/custom/*/src/Hook/*',
+      __DIR__ . '/web/themes/custom/*/src/Hook/*',
+    ],
     RenameForeachValueVariableToMatchExprVariableRector::class,
     RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
     RenameParamToMatchTypeRector::class,
     RenameVariableToMatchMethodCallReturnTypeRector::class,
     RenameVariableToMatchNewTypeRector::class,
-    // Rules that narrow class members to private. The project declares
-    // members protected.
-    PrivatizeFinalClassMethodRector::class,
-    PrivatizeFinalClassPropertyRector::class,
-    PrivatizeLocalGetterToPropertyRector::class,
-    // Rules that replace empty() checks with explicit comparisons.
-    DisallowedEmptyRuleFixerRector::class,
     SimplifyEmptyCheckOnEmptyArrayRector::class,
-    // Rules that add or move blank lines. PHP_CodeSniffer decides
-    // formatting.
-    NewlineAfterStatementRector::class,
-    NewlineBeforeNewAssignSetRector::class,
-    NewlineBetweenClassLikeStmtsRector::class,
-    // Drupal caches form arrays, and a first-class callable is a Closure.
-    ArrayToFirstClassCallableRector::class,
-    // match() compares strictly and throws when no arm matches.
-    ChangeSwitchToMatchRector::class,
-    // Object-oriented hook implementations keep the signature the hook
-    // declares, including parameters the implementation does not use.
-    RemoveUnusedPublicMethodParameterRector::class => [
-      __DIR__ . '/web/modules/custom/*/src/Hook/*',
-      __DIR__ . '/web/themes/custom/*/src/Hook/*',
-    ],
-    // The settings includes name classes from modules that are registered
-    // with the autoloader at runtime.
     StringClassNameToClassConstantRector::class => [
       __DIR__ . '/web/sites/default/includes/*',
     ],
-    // Rules that rewrite working code beyond a syntax upgrade.
-    CompleteDynamicPropertiesRector::class,
-    InlineArrayReturnAssignRector::class,
-    // Drupal core does not use the #[\Override] attribute.
-    AddOverrideAttributeToOverriddenMethodsRector::class,
-    // Docblock type inference is not a runtime guarantee.
-    RemoveAlwaysTrueIfConditionRector::class,
     // Directories to skip.
     '*/vendor/*',
     '*/node_modules/*',

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/rector.php
@@ -13,20 +13,23 @@
      __DIR__ . '/tests',
    ])
    ->withSkip([
-@@ -81,13 +81,13 @@
-     // Object-oriented hook implementations keep the signature the hook
-     // declares, including parameters the implementation does not use.
+@@ -69,8 +69,8 @@
+     PrivatizeLocalGetterToPropertyRector::class,
+     RemoveAlwaysTrueIfConditionRector::class,
      RemoveUnusedPublicMethodParameterRector::class => [
 -      __DIR__ . '/web/modules/custom/*/src/Hook/*',
 -      __DIR__ . '/web/themes/custom/*/src/Hook/*',
 +      __DIR__ . '/docroot/modules/custom/*/src/Hook/*',
 +      __DIR__ . '/docroot/themes/custom/*/src/Hook/*',
      ],
-     // The settings includes name classes from modules that are registered
-     // with the autoloader at runtime.
+     RenameForeachValueVariableToMatchExprVariableRector::class,
+     RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
+@@ -79,7 +79,7 @@
+     RenameVariableToMatchNewTypeRector::class,
+     SimplifyEmptyCheckOnEmptyArrayRector::class,
      StringClassNameToClassConstantRector::class => [
 -      __DIR__ . '/web/sites/default/includes/*',
 +      __DIR__ . '/docroot/sites/default/includes/*',
      ],
-     // Rules that rewrite working code beyond a syntax upgrade.
-     CompleteDynamicPropertiesRector::class,
+     // Directories to skip.
+     '*/vendor/*',

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/rector.php
@@ -1,4 +1,4 @@
-@@ -44,10 +44,10 @@
+@@ -46,10 +46,10 @@
  
  return RectorConfig::configure()
    ->withPaths([
@@ -13,12 +13,20 @@
      __DIR__ . '/tests',
    ])
    ->withSkip([
-@@ -72,7 +72,7 @@
-     RenameVariableToMatchNewTypeRector::class,
-     SimplifyEmptyCheckOnEmptyArrayRector::class,
-     StringClassNameToClassConstantRector::class => [
--      __DIR__ . '/web/sites/default/includes/**/*',
-+      __DIR__ . '/docroot/sites/default/includes/**/*',
+@@ -81,13 +81,13 @@
+     // Object-oriented hook implementations keep the signature the hook
+     // declares, including parameters the implementation does not use.
+     RemoveUnusedPublicMethodParameterRector::class => [
+-      __DIR__ . '/web/modules/custom/*/src/Hook/*',
+-      __DIR__ . '/web/themes/custom/*/src/Hook/*',
++      __DIR__ . '/docroot/modules/custom/*/src/Hook/*',
++      __DIR__ . '/docroot/themes/custom/*/src/Hook/*',
      ],
-     // Directories to skip.
-     '*/vendor/*',
+     // The settings includes name classes from modules that are registered
+     // with the autoloader at runtime.
+     StringClassNameToClassConstantRector::class => [
+-      __DIR__ . '/web/sites/default/includes/*',
++      __DIR__ . '/docroot/sites/default/includes/*',
+     ],
+     // Rules that rewrite working code beyond a syntax upgrade.
+     CompleteDynamicPropertiesRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/rector.php
@@ -13,20 +13,23 @@
      __DIR__ . '/tests',
    ])
    ->withSkip([
-@@ -81,13 +81,13 @@
-     // Object-oriented hook implementations keep the signature the hook
-     // declares, including parameters the implementation does not use.
+@@ -69,8 +69,8 @@
+     PrivatizeLocalGetterToPropertyRector::class,
+     RemoveAlwaysTrueIfConditionRector::class,
      RemoveUnusedPublicMethodParameterRector::class => [
 -      __DIR__ . '/web/modules/custom/*/src/Hook/*',
 -      __DIR__ . '/web/themes/custom/*/src/Hook/*',
 +      __DIR__ . '/docroot/modules/custom/*/src/Hook/*',
 +      __DIR__ . '/docroot/themes/custom/*/src/Hook/*',
      ],
-     // The settings includes name classes from modules that are registered
-     // with the autoloader at runtime.
+     RenameForeachValueVariableToMatchExprVariableRector::class,
+     RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
+@@ -79,7 +79,7 @@
+     RenameVariableToMatchNewTypeRector::class,
+     SimplifyEmptyCheckOnEmptyArrayRector::class,
      StringClassNameToClassConstantRector::class => [
 -      __DIR__ . '/web/sites/default/includes/*',
 +      __DIR__ . '/docroot/sites/default/includes/*',
      ],
-     // Rules that rewrite working code beyond a syntax upgrade.
-     CompleteDynamicPropertiesRector::class,
+     // Directories to skip.
+     '*/vendor/*',

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/rector.php
@@ -1,4 +1,4 @@
-@@ -44,10 +44,10 @@
+@@ -46,10 +46,10 @@
  
  return RectorConfig::configure()
    ->withPaths([
@@ -13,12 +13,20 @@
      __DIR__ . '/tests',
    ])
    ->withSkip([
-@@ -72,7 +72,7 @@
-     RenameVariableToMatchNewTypeRector::class,
-     SimplifyEmptyCheckOnEmptyArrayRector::class,
-     StringClassNameToClassConstantRector::class => [
--      __DIR__ . '/web/sites/default/includes/**/*',
-+      __DIR__ . '/docroot/sites/default/includes/**/*',
+@@ -81,13 +81,13 @@
+     // Object-oriented hook implementations keep the signature the hook
+     // declares, including parameters the implementation does not use.
+     RemoveUnusedPublicMethodParameterRector::class => [
+-      __DIR__ . '/web/modules/custom/*/src/Hook/*',
+-      __DIR__ . '/web/themes/custom/*/src/Hook/*',
++      __DIR__ . '/docroot/modules/custom/*/src/Hook/*',
++      __DIR__ . '/docroot/themes/custom/*/src/Hook/*',
      ],
-     // Directories to skip.
-     '*/vendor/*',
+     // The settings includes name classes from modules that are registered
+     // with the autoloader at runtime.
+     StringClassNameToClassConstantRector::class => [
+-      __DIR__ . '/web/sites/default/includes/*',
++      __DIR__ . '/docroot/sites/default/includes/*',
+     ],
+     // Rules that rewrite working code beyond a syntax upgrade.
+     CompleteDynamicPropertiesRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/rector.php
@@ -6,3 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
+@@ -82,7 +81,6 @@
+     // declares, including parameters the implementation does not use.
+     RemoveUnusedPublicMethodParameterRector::class => [
+       __DIR__ . '/web/modules/custom/*/src/Hook/*',
+-      __DIR__ . '/web/themes/custom/*/src/Hook/*',
+     ],
+     // The settings includes name classes from modules that are registered
+     // with the autoloader at runtime.

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/rector.php
@@ -1,4 +1,4 @@
-@@ -45,7 +45,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/rector.php
@@ -6,11 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
-@@ -82,7 +81,6 @@
-     // declares, including parameters the implementation does not use.
+@@ -70,7 +69,6 @@
+     RemoveAlwaysTrueIfConditionRector::class,
      RemoveUnusedPublicMethodParameterRector::class => [
        __DIR__ . '/web/modules/custom/*/src/Hook/*',
 -      __DIR__ . '/web/themes/custom/*/src/Hook/*',
      ],
-     // The settings includes name classes from modules that are registered
-     // with the autoloader at runtime.
+     RenameForeachValueVariableToMatchExprVariableRector::class,
+     RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/rector.php
@@ -6,3 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
+@@ -82,7 +81,6 @@
+     // declares, including parameters the implementation does not use.
+     RemoveUnusedPublicMethodParameterRector::class => [
+       __DIR__ . '/web/modules/custom/*/src/Hook/*',
+-      __DIR__ . '/web/themes/custom/*/src/Hook/*',
+     ],
+     // The settings includes name classes from modules that are registered
+     // with the autoloader at runtime.

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/rector.php
@@ -1,4 +1,4 @@
-@@ -45,7 +45,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/rector.php
@@ -6,11 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
-@@ -82,7 +81,6 @@
-     // declares, including parameters the implementation does not use.
+@@ -70,7 +69,6 @@
+     RemoveAlwaysTrueIfConditionRector::class,
      RemoveUnusedPublicMethodParameterRector::class => [
        __DIR__ . '/web/modules/custom/*/src/Hook/*',
 -      __DIR__ . '/web/themes/custom/*/src/Hook/*',
      ],
-     // The settings includes name classes from modules that are registered
-     // with the autoloader at runtime.
+     RenameForeachValueVariableToMatchExprVariableRector::class,
+     RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/rector.php
@@ -6,3 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
+@@ -82,7 +81,6 @@
+     // declares, including parameters the implementation does not use.
+     RemoveUnusedPublicMethodParameterRector::class => [
+       __DIR__ . '/web/modules/custom/*/src/Hook/*',
+-      __DIR__ . '/web/themes/custom/*/src/Hook/*',
+     ],
+     // The settings includes name classes from modules that are registered
+     // with the autoloader at runtime.

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/rector.php
@@ -1,4 +1,4 @@
-@@ -45,7 +45,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/rector.php
@@ -6,11 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
-@@ -82,7 +81,6 @@
-     // declares, including parameters the implementation does not use.
+@@ -70,7 +69,6 @@
+     RemoveAlwaysTrueIfConditionRector::class,
      RemoveUnusedPublicMethodParameterRector::class => [
        __DIR__ . '/web/modules/custom/*/src/Hook/*',
 -      __DIR__ . '/web/themes/custom/*/src/Hook/*',
      ],
-     // The settings includes name classes from modules that are registered
-     // with the autoloader at runtime.
+     RenameForeachValueVariableToMatchExprVariableRector::class,
+     RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/rector.php
@@ -6,7 +6,7 @@
  use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
  use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
  use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
-@@ -103,8 +102,6 @@
+@@ -88,8 +87,6 @@
    // PHP version upgrade sets - modernizes syntax to PHP 8.4.
    // Includes all rules from PHP 5.3 through 8.4.
    ->withPhpSets(php84: TRUE)
@@ -15,7 +15,7 @@
    // Code quality improvement sets.
    ->withPreparedSets(
      codeQuality: TRUE,
-@@ -124,7 +121,6 @@
+@@ -109,7 +106,6 @@
    // Additional rules.
    ->withRules([
      DeclareStrictTypesRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/rector.php
@@ -1,4 +1,4 @@
-@@ -35,7 +35,6 @@
+@@ -37,7 +37,6 @@
  use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
  use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
  use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
@@ -6,7 +6,7 @@
  use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
  use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
  use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
-@@ -81,8 +80,6 @@
+@@ -103,8 +102,6 @@
    // PHP version upgrade sets - modernizes syntax to PHP 8.4.
    // Includes all rules from PHP 5.3 through 8.4.
    ->withPhpSets(php84: TRUE)
@@ -15,7 +15,7 @@
    // Code quality improvement sets.
    ->withPreparedSets(
      codeQuality: TRUE,
-@@ -102,7 +99,6 @@
+@@ -124,7 +121,6 @@
    // Additional rules.
    ->withRules([
      DeclareStrictTypesRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/rector.php
@@ -6,7 +6,7 @@
  use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
  use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
  use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
-@@ -103,8 +102,6 @@
+@@ -88,8 +87,6 @@
    // PHP version upgrade sets - modernizes syntax to PHP 8.4.
    // Includes all rules from PHP 5.3 through 8.4.
    ->withPhpSets(php84: TRUE)
@@ -15,7 +15,7 @@
    // Code quality improvement sets.
    ->withPreparedSets(
      codeQuality: TRUE,
-@@ -124,7 +121,6 @@
+@@ -109,7 +106,6 @@
    // Additional rules.
    ->withRules([
      DeclareStrictTypesRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/rector.php
@@ -1,4 +1,4 @@
-@@ -35,7 +35,6 @@
+@@ -37,7 +37,6 @@
  use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
  use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
  use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
@@ -6,7 +6,7 @@
  use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
  use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
  use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
-@@ -81,8 +80,6 @@
+@@ -103,8 +102,6 @@
    // PHP version upgrade sets - modernizes syntax to PHP 8.4.
    // Includes all rules from PHP 5.3 through 8.4.
    ->withPhpSets(php84: TRUE)
@@ -15,7 +15,7 @@
    // Code quality improvement sets.
    ->withPreparedSets(
      codeQuality: TRUE,
-@@ -102,7 +99,6 @@
+@@ -124,7 +121,6 @@
    // Additional rules.
    ->withRules([
      DeclareStrictTypesRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/rector.php
@@ -6,3 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
+@@ -82,7 +81,6 @@
+     // declares, including parameters the implementation does not use.
+     RemoveUnusedPublicMethodParameterRector::class => [
+       __DIR__ . '/web/modules/custom/*/src/Hook/*',
+-      __DIR__ . '/web/themes/custom/*/src/Hook/*',
+     ],
+     // The settings includes name classes from modules that are registered
+     // with the autoloader at runtime.

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/rector.php
@@ -1,4 +1,4 @@
-@@ -45,7 +45,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/rector.php
@@ -6,11 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
-@@ -82,7 +81,6 @@
-     // declares, including parameters the implementation does not use.
+@@ -70,7 +69,6 @@
+     RemoveAlwaysTrueIfConditionRector::class,
      RemoveUnusedPublicMethodParameterRector::class => [
        __DIR__ . '/web/modules/custom/*/src/Hook/*',
 -      __DIR__ . '/web/themes/custom/*/src/Hook/*',
      ],
-     // The settings includes name classes from modules that are registered
-     // with the autoloader at runtime.
+     RenameForeachValueVariableToMatchExprVariableRector::class,
+     RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/rector.php
@@ -6,3 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
+@@ -82,7 +81,6 @@
+     // declares, including parameters the implementation does not use.
+     RemoveUnusedPublicMethodParameterRector::class => [
+       __DIR__ . '/web/modules/custom/*/src/Hook/*',
+-      __DIR__ . '/web/themes/custom/*/src/Hook/*',
+     ],
+     // The settings includes name classes from modules that are registered
+     // with the autoloader at runtime.

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/rector.php
@@ -1,4 +1,4 @@
-@@ -45,7 +45,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/rector.php
@@ -6,11 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
-@@ -82,7 +81,6 @@
-     // declares, including parameters the implementation does not use.
+@@ -70,7 +69,6 @@
+     RemoveAlwaysTrueIfConditionRector::class,
      RemoveUnusedPublicMethodParameterRector::class => [
        __DIR__ . '/web/modules/custom/*/src/Hook/*',
 -      __DIR__ . '/web/themes/custom/*/src/Hook/*',
      ],
-     // The settings includes name classes from modules that are registered
-     // with the autoloader at runtime.
+     RenameForeachValueVariableToMatchExprVariableRector::class,
+     RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/rector.php
@@ -1,4 +1,4 @@
-@@ -103,8 +103,6 @@
+@@ -88,8 +88,6 @@
    // PHP version upgrade sets - modernizes syntax to PHP 8.4.
    // Includes all rules from PHP 5.3 through 8.4.
    ->withPhpSets(php84: TRUE)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/rector.php
@@ -1,4 +1,4 @@
-@@ -81,8 +81,6 @@
+@@ -103,8 +103,6 @@
    // PHP version upgrade sets - modernizes syntax to PHP 8.4.
    // Includes all rules from PHP 5.3 through 8.4.
    ->withPhpSets(php84: TRUE)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/rector.php
@@ -1,4 +1,4 @@
-@@ -103,8 +103,6 @@
+@@ -88,8 +88,6 @@
    // PHP version upgrade sets - modernizes syntax to PHP 8.4.
    // Includes all rules from PHP 5.3 through 8.4.
    ->withPhpSets(php84: TRUE)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/rector.php
@@ -1,4 +1,4 @@
-@@ -81,8 +81,6 @@
+@@ -103,8 +103,6 @@
    // PHP version upgrade sets - modernizes syntax to PHP 8.4.
    // Includes all rules from PHP 5.3 through 8.4.
    ->withPhpSets(php84: TRUE)

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/rector.php
@@ -6,3 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
+@@ -82,7 +81,6 @@
+     // declares, including parameters the implementation does not use.
+     RemoveUnusedPublicMethodParameterRector::class => [
+       __DIR__ . '/web/modules/custom/*/src/Hook/*',
+-      __DIR__ . '/web/themes/custom/*/src/Hook/*',
+     ],
+     // The settings includes name classes from modules that are registered
+     // with the autoloader at runtime.

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/rector.php
@@ -1,4 +1,4 @@
-@@ -45,7 +45,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/rector.php
@@ -6,11 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
-@@ -82,7 +81,6 @@
-     // declares, including parameters the implementation does not use.
+@@ -70,7 +69,6 @@
+     RemoveAlwaysTrueIfConditionRector::class,
      RemoveUnusedPublicMethodParameterRector::class => [
        __DIR__ . '/web/modules/custom/*/src/Hook/*',
 -      __DIR__ . '/web/themes/custom/*/src/Hook/*',
      ],
-     // The settings includes name classes from modules that are registered
-     // with the autoloader at runtime.
+     RenameForeachValueVariableToMatchExprVariableRector::class,
+     RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/rector.php
@@ -1,4 +1,4 @@
-@@ -35,7 +35,6 @@
+@@ -37,7 +37,6 @@
  use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
  use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
  use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
@@ -6,7 +6,7 @@
  use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
  use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
  use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
-@@ -102,7 +101,6 @@
+@@ -124,7 +123,6 @@
    // Additional rules.
    ->withRules([
      DeclareStrictTypesRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/rector.php
@@ -6,7 +6,7 @@
  use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
  use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
  use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
-@@ -124,7 +123,6 @@
+@@ -109,7 +108,6 @@
    // Additional rules.
    ->withRules([
      DeclareStrictTypesRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/rector.php
@@ -1,4 +1,4 @@
-@@ -35,7 +35,6 @@
+@@ -37,7 +37,6 @@
  use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
  use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
  use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
@@ -6,7 +6,7 @@
  use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
  use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
  use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
-@@ -102,7 +101,6 @@
+@@ -124,7 +123,6 @@
    // Additional rules.
    ->withRules([
      DeclareStrictTypesRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/rector.php
@@ -6,7 +6,7 @@
  use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
  use Rector\Privatization\Rector\MethodCall\PrivatizeLocalGetterToPropertyRector;
  use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
-@@ -124,7 +123,6 @@
+@@ -109,7 +108,6 @@
    // Additional rules.
    ->withRules([
      DeclareStrictTypesRector::class,

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/rector.php
@@ -6,3 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
+@@ -82,7 +81,6 @@
+     // declares, including parameters the implementation does not use.
+     RemoveUnusedPublicMethodParameterRector::class => [
+       __DIR__ . '/web/modules/custom/*/src/Hook/*',
+-      __DIR__ . '/web/themes/custom/*/src/Hook/*',
+     ],
+     // The settings includes name classes from modules that are registered
+     // with the autoloader at runtime.

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/rector.php
@@ -1,4 +1,4 @@
-@@ -45,7 +45,6 @@
+@@ -47,7 +47,6 @@
  return RectorConfig::configure()
    ->withPaths([
      __DIR__ . '/web/modules/custom',

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/rector.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/rector.php
@@ -6,11 +6,11 @@
      __DIR__ . '/web/sites/default/settings.php',
      __DIR__ . '/web/sites/default/includes',
      __DIR__ . '/tests',
-@@ -82,7 +81,6 @@
-     // declares, including parameters the implementation does not use.
+@@ -70,7 +69,6 @@
+     RemoveAlwaysTrueIfConditionRector::class,
      RemoveUnusedPublicMethodParameterRector::class => [
        __DIR__ . '/web/modules/custom/*/src/Hook/*',
 -      __DIR__ . '/web/themes/custom/*/src/Hook/*',
      ],
-     // The settings includes name classes from modules that are registered
-     // with the autoloader at runtime.
+     RenameForeachValueVariableToMatchExprVariableRector::class,
+     RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,

--- a/.vortex/tests/rector.php
+++ b/.vortex/tests/rector.php
@@ -16,13 +16,14 @@ use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\ClassLike\NewlineBetweenClassLikeStmtsRector;
 use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
-use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector;
 use Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
 use Rector\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchMethodCallReturnTypeRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
@@ -43,7 +44,6 @@ return RectorConfig::configure()
     CatchExceptionNameMatchingTypeRector::class,
     ChangeSwitchToMatchRector::class,
     CompleteDynamicPropertiesRector::class,
-    CountArrayToEmptyArrayComparisonRector::class,
     DisallowedEmptyRuleFixerRector::class,
     InlineArrayReturnAssignRector::class,
     NewlineAfterStatementRector::class,
@@ -53,6 +53,8 @@ return RectorConfig::configure()
     PrivatizeFinalClassPropertyRector::class,
     PrivatizeLocalGetterToPropertyRector::class,
     RemoveAlwaysTrueIfConditionRector::class,
+    RenameForeachValueVariableToMatchExprVariableRector::class,
+    RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
     RenameParamToMatchTypeRector::class,
     RenameVariableToMatchMethodCallReturnTypeRector::class,
     RenameVariableToMatchNewTypeRector::class,

--- a/rector.php
+++ b/rector.php
@@ -24,13 +24,15 @@ use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\ClassLike\NewlineBetweenClassLikeStmtsRector;
 use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
-use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector;
 use Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
 use Rector\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchMethodCallReturnTypeRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
@@ -51,29 +53,49 @@ return RectorConfig::configure()
     __DIR__ . '/tests',
   ])
   ->withSkip([
-    // Specific rules to skip based on project coding standards.
-    AddOverrideAttributeToOverriddenMethodsRector::class,
-    ArrayToFirstClassCallableRector::class,
+    // Rules that rename variables and parameters after their type. The
+    // project names local variables and method arguments in snake_case.
     CatchExceptionNameMatchingTypeRector::class,
-    ChangeSwitchToMatchRector::class,
-    CompleteDynamicPropertiesRector::class,
-    CountArrayToEmptyArrayComparisonRector::class,
-    DisallowedEmptyRuleFixerRector::class,
-    InlineArrayReturnAssignRector::class,
-    NewlineAfterStatementRector::class,
-    NewlineBeforeNewAssignSetRector::class,
-    NewlineBetweenClassLikeStmtsRector::class,
-    PrivatizeFinalClassMethodRector::class,
-    PrivatizeFinalClassPropertyRector::class,
-    PrivatizeLocalGetterToPropertyRector::class,
-    RemoveAlwaysTrueIfConditionRector::class,
+    RenameForeachValueVariableToMatchExprVariableRector::class,
+    RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
     RenameParamToMatchTypeRector::class,
     RenameVariableToMatchMethodCallReturnTypeRector::class,
     RenameVariableToMatchNewTypeRector::class,
+    // Rules that narrow class members to private. The project declares
+    // members protected.
+    PrivatizeFinalClassMethodRector::class,
+    PrivatizeFinalClassPropertyRector::class,
+    PrivatizeLocalGetterToPropertyRector::class,
+    // Rules that replace empty() checks with explicit comparisons.
+    DisallowedEmptyRuleFixerRector::class,
     SimplifyEmptyCheckOnEmptyArrayRector::class,
-    StringClassNameToClassConstantRector::class => [
-      __DIR__ . '/web/sites/default/includes/**/*',
+    // Rules that add or move blank lines. PHP_CodeSniffer decides
+    // formatting.
+    NewlineAfterStatementRector::class,
+    NewlineBeforeNewAssignSetRector::class,
+    NewlineBetweenClassLikeStmtsRector::class,
+    // Drupal caches form arrays, and a first-class callable is a Closure.
+    ArrayToFirstClassCallableRector::class,
+    // match() compares strictly and throws when no arm matches.
+    ChangeSwitchToMatchRector::class,
+    // Object-oriented hook implementations keep the signature the hook
+    // declares, including parameters the implementation does not use.
+    RemoveUnusedPublicMethodParameterRector::class => [
+      __DIR__ . '/web/modules/custom/*/src/Hook/*',
+      __DIR__ . '/web/themes/custom/*/src/Hook/*',
     ],
+    // The settings includes name classes from modules that are registered
+    // with the autoloader at runtime.
+    StringClassNameToClassConstantRector::class => [
+      __DIR__ . '/web/sites/default/includes/*',
+    ],
+    // Rules that rewrite working code beyond a syntax upgrade.
+    CompleteDynamicPropertiesRector::class,
+    InlineArrayReturnAssignRector::class,
+    // Drupal core does not use the #[\Override] attribute.
+    AddOverrideAttributeToOverriddenMethodsRector::class,
+    // Docblock type inference is not a runtime guarantee.
+    RemoveAlwaysTrueIfConditionRector::class,
     // Directories to skip.
     '*/vendor/*',
     '*/node_modules/*',

--- a/rector.php
+++ b/rector.php
@@ -53,49 +53,34 @@ return RectorConfig::configure()
     __DIR__ . '/tests',
   ])
   ->withSkip([
-    // Rules that rename variables and parameters after their type. The
-    // project names local variables and method arguments in snake_case.
+    // Specific rules to skip based on project coding standards.
+    AddOverrideAttributeToOverriddenMethodsRector::class,
+    ArrayToFirstClassCallableRector::class,
     CatchExceptionNameMatchingTypeRector::class,
+    ChangeSwitchToMatchRector::class,
+    CompleteDynamicPropertiesRector::class,
+    DisallowedEmptyRuleFixerRector::class,
+    InlineArrayReturnAssignRector::class,
+    NewlineAfterStatementRector::class,
+    NewlineBeforeNewAssignSetRector::class,
+    NewlineBetweenClassLikeStmtsRector::class,
+    PrivatizeFinalClassMethodRector::class,
+    PrivatizeFinalClassPropertyRector::class,
+    PrivatizeLocalGetterToPropertyRector::class,
+    RemoveAlwaysTrueIfConditionRector::class,
+    RemoveUnusedPublicMethodParameterRector::class => [
+      __DIR__ . '/web/modules/custom/*/src/Hook/*',
+      __DIR__ . '/web/themes/custom/*/src/Hook/*',
+    ],
     RenameForeachValueVariableToMatchExprVariableRector::class,
     RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
     RenameParamToMatchTypeRector::class,
     RenameVariableToMatchMethodCallReturnTypeRector::class,
     RenameVariableToMatchNewTypeRector::class,
-    // Rules that narrow class members to private. The project declares
-    // members protected.
-    PrivatizeFinalClassMethodRector::class,
-    PrivatizeFinalClassPropertyRector::class,
-    PrivatizeLocalGetterToPropertyRector::class,
-    // Rules that replace empty() checks with explicit comparisons.
-    DisallowedEmptyRuleFixerRector::class,
     SimplifyEmptyCheckOnEmptyArrayRector::class,
-    // Rules that add or move blank lines. PHP_CodeSniffer decides
-    // formatting.
-    NewlineAfterStatementRector::class,
-    NewlineBeforeNewAssignSetRector::class,
-    NewlineBetweenClassLikeStmtsRector::class,
-    // Drupal caches form arrays, and a first-class callable is a Closure.
-    ArrayToFirstClassCallableRector::class,
-    // match() compares strictly and throws when no arm matches.
-    ChangeSwitchToMatchRector::class,
-    // Object-oriented hook implementations keep the signature the hook
-    // declares, including parameters the implementation does not use.
-    RemoveUnusedPublicMethodParameterRector::class => [
-      __DIR__ . '/web/modules/custom/*/src/Hook/*',
-      __DIR__ . '/web/themes/custom/*/src/Hook/*',
-    ],
-    // The settings includes name classes from modules that are registered
-    // with the autoloader at runtime.
     StringClassNameToClassConstantRector::class => [
       __DIR__ . '/web/sites/default/includes/*',
     ],
-    // Rules that rewrite working code beyond a syntax upgrade.
-    CompleteDynamicPropertiesRector::class,
-    InlineArrayReturnAssignRector::class,
-    // Drupal core does not use the #[\Override] attribute.
-    AddOverrideAttributeToOverriddenMethodsRector::class,
-    // Docblock type inference is not a runtime guarantee.
-    RemoveAlwaysTrueIfConditionRector::class,
     // Directories to skip.
     '*/vendor/*',
     '*/node_modules/*',


### PR DESCRIPTION
Closes #2981
Closes #2982

## Summary

Completes an incomplete Rector skip family and audits the entire skip list across the three Rector configs in the repository - the template's `rector.php`, `.vortex/installer/rector.php`, and `.vortex/tests/rector.php`. The two `Foreach_` members of the type-derived rename family were missing from the skip list even though the other rename rules in the same family were already skipped for the project's snake_case convention, so they kept firing; both are now skipped everywhere. The audit also scopes a destructive rule away from Drupal 11 object-oriented hook implementations, drops a skip entry for a rule Rector no longer registers, and widens a path pattern that missed files immediately inside a directory. The skip list keeps its flat alphabetical order. Every change was verified with a Rector dry-run against a fixture, and the installer's fixture snapshots were regenerated to match.

## Changes

- Added `RenameForeachValueVariableToMatchExprVariableRector` and `RenameForeachValueVariableToMatchMethodCallReturnTypeRector` to the skip list in all three configs, completing the family of `Naming` rules already skipped for the project's snake_case variables and parameters; a dry-run over a fixture confirmed both rules fired before the change and neither fires after.
- Scoped `RemoveUnusedPublicMethodParameterRector` (template `rector.php` only) to skip `web/modules/custom/*/src/Hook/*` and `web/themes/custom/*/src/Hook/*`, because Drupal 11 object-oriented hook classes must keep the framework-required method signature regardless of which parameters an implementation uses; a dry-run reproduced the rule stripping `$form_state` and `$form_id` from a `#[Hook('form_alter')]` method before the skip, confirmed the same break in a theme hook class (Drupal 11.4 collects OO hooks from themes too, via `ThemeHookCollectorPass`) and in a nested hook class, and confirmed the rule still removes a genuinely unused parameter from a plain service class after the skip, since the scope is targeted rather than global.
- Taught the installer's `Theme` handler to strip the new theme hook skip path from `rector.php` alongside the existing `web/themes/custom` paths entry. Without it, a site that selects a core theme kept a dangling `themes/custom` reference in its generated `rector.php`, which `ThemeHandlerProcessTest` asserts against.
- Left event subscribers and plugin `create()` factories unskipped: the rule already exempts any class that extends a fully-qualified parent or implements an interface, so `EventSubscriberInterface` implementations and classes extending `PluginBase` are out of its reach; a dry-run left both untouched.
- Removed the skip for `CountArrayToEmptyArrayComparisonRector` (all three configs), which is deprecated in Rector 2.6 and is not registered by any set - Rector itself reports "This skipped rule is never registered." Every remaining skip was checked against a no-skip run of `rector list-rules` under Rector 2.6.1 and confirmed still live.
- Widened `StringClassNameToClassConstantRector`'s scope (template `rector.php` only) from `web/sites/default/includes/**/*` to `web/sites/default/includes/*`, so it also covers files directly inside `includes/`, not only its subdirectories.
- Confirmed `withPhpSets(php84: TRUE)` already matches the template's target - `composer.json` requires `php >=8.4` with `config.platform.php` at `8.4.21`, and `.docker/php.dockerfile` builds on `uselagoon/php-8.4-fpm` - so no change was needed there.
- Regenerated the installer's fixture snapshots (`ahoy update-snapshots`), which is why the `rector.php` files under `.vortex/installer/tests/Fixtures/handler_process/*/` are in the diff; they mirror the root `rector.php` and are not hand-edited.

## Before / After

The template's `rector.php` `withSkip()` list keeps its flat alphabetical order; only the audited rule-level deltas change:

```
┌──────────────────────────────────────────────────────────────────────────────┐
│ BEFORE                                                                       │
├──────────────────────────────────────────────────────────────────────────────┤
│ withSkip([                                                                   │
│   // Specific rules to skip based on project coding standards.               │
│   ...                                                                        │
│   CountArrayToEmptyArrayComparisonRector::class,                             │
│   (deprecated in Rector 2.6, never registered - dead skip)                   │
│   ...                                                                        │
│   RemoveAlwaysTrueIfConditionRector::class,                                  │
│   (no skip for RemoveUnusedPublicMethodParameterRector -                     │
│    strips unused params from OO hook method signatures)                      │
│   RenameParamToMatchTypeRector::class,                                       │
│   (Foreach_ rename pair NOT in the list - still fires)                       │
│   RenameVariableToMatchMethodCallReturnTypeRector::class,                    │
│   RenameVariableToMatchNewTypeRector::class,                                 │
│   ...                                                                        │
│   StringClassNameToClassConstantRector::class => [                           │
│     includes/**/*   (misses files directly in includes/)                     │
│   ],                                                                         │
│ ])                                                                           │
└──────────────────────────────────────────────────────────────────────────────┘
                                      │
                                      ▼
┌──────────────────────────────────────────────────────────────────────────────┐
│ AFTER                                                                        │
├──────────────────────────────────────────────────────────────────────────────┤
│ withSkip([                                                                   │
│   // Specific rules to skip based on project coding standards.               │
│   ...                                                                        │
│   (CountArrayToEmptyArrayComparisonRector)                [REMOVED - stale]  │
│   ...                                                                        │
│   RemoveAlwaysTrueIfConditionRector::class,                                  │
│   RemoveUnusedPublicMethodParameterRector::class => [                [NEW]   │
│     modules/custom/*/src/Hook/*, themes/custom/*/src/Hook/*                  │
│   ],                                                                         │
│   RenameForeachValueVariableToMatchExprVariableRector::class,        [NEW]   │
│   RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,[NEW]   │
│   RenameParamToMatchTypeRector::class,                                       │
│   RenameVariableToMatchMethodCallReturnTypeRector::class,                    │
│   RenameVariableToMatchNewTypeRector::class,                                 │
│   ...                                                                        │
│   StringClassNameToClassConstantRector::class => [                           │
│     includes/*   (now covers files at any depth)          [WIDENED]          │
│   ],                                                                         │
│ ])                                                                           │
└──────────────────────────────────────────────────────────────────────────────┘
```

`.vortex/installer/rector.php` and `.vortex/tests/rector.php` receive only the `Foreach_` additions and the `CountArrayToEmptyArrayComparisonRector` removal; the `RemoveUnusedPublicMethodParameterRector` scope and the widened `StringClassNameToClassConstantRector` scope are specific to the template's `rector.php`.

The installer's `Theme` handler now removes both theme paths when a site selects a core theme, so the generated config stays free of `themes/custom` references:

```
                        rector.php as generated for a core-theme site
┌──────────────────────────────────────────────────────────────────────────────┐
│ BEFORE                                                                       │
├──────────────────────────────────────────────────────────────────────────────┤
│ withPaths([                                                                  │
│   __DIR__ . '/web/modules/custom',                                           │
│   (themes/custom entry stripped by Theme handler)                            │
│ ])                                                                           │
│ ...                                                                          │
│ RemoveUnusedPublicMethodParameterRector::class => [                          │
│   __DIR__ . '/web/modules/custom/*/src/Hook/*',                              │
│   __DIR__ . '/web/themes/custom/*/src/Hook/*',   <-- left behind             │
│ ],                                                                           │
└──────────────────────────────────────────────────────────────────────────────┘
                                      │
                                      ▼
┌──────────────────────────────────────────────────────────────────────────────┐
│ AFTER                                                                        │
├──────────────────────────────────────────────────────────────────────────────┤
│ withPaths([                                                                  │
│   __DIR__ . '/web/modules/custom',                                           │
│ ])                                                                           │
│ ...                                                                          │
│ RemoveUnusedPublicMethodParameterRector::class => [                          │
│   __DIR__ . '/web/modules/custom/*/src/Hook/*',                              │
│ ],                                                                           │
└──────────────────────────────────────────────────────────────────────────────┘
```
