### PR TITLE
[#2986] Raised the default Drush 'memory_limit' to 1G.

### DIFF
--- a/.vortex/docs/content/tools/drush.mdx
+++ b/.vortex/docs/content/tools/drush.mdx
@@ -43,15 +43,16 @@ import TabItem from '@theme/TabItem';
 
 ## PHP runtime configuration
 
-**Vortex** allows you to customize PHP runtime settings for Drush CLI commands
-by editing the `drush/php-ini/drush.ini` file.
+**Vortex** allows you to customize PHP runtime settings for PHP CLI processes,
+including Drush commands, by editing the `drush/php-ini/drush.ini` file.
 
 This file is auto-discovered via the `PHP_INI_SCAN_DIR` environment variable,
 which is pre-configured in both the Docker CLI container and Acquia deployment
-hooks.
+hooks. Every PHP CLI process that loads this scan path picks the file up, not
+only Drush.
 
 Any valid PHP ini directive can be added to this file to adjust the runtime
-behavior of Drush commands.
+behavior of those processes.
 
 :::note
 
@@ -72,8 +73,9 @@ memory_limit = 1G
 ```
 
 This value is sized for database imports and configuration synchronization on
-large sites. It applies to Drush CLI invocations only and does not change the
-memory limit used to serve web requests.
+large sites. It applies to PHP CLI processes that load this scan path,
+including Drush, and does not change the memory limit used to serve web
+requests.
 
 If a Drush command exhausts this limit, profile the command before raising the
 value. An exhausted 1G limit usually points to a memory leak in custom code

--- a/.vortex/docs/content/tools/drush.mdx
+++ b/.vortex/docs/content/tools/drush.mdx
@@ -72,7 +72,7 @@ memory_limit = 1G
 ```
 
 This value is sized for database imports and configuration synchronization on
-large sites. It applies to the CLI container only and does not change the
+large sites. It applies to Drush CLI invocations only and does not change the
 memory limit used to serve web requests.
 
 If a Drush command exhausts this limit, profile the command before raising the

--- a/.vortex/docs/content/tools/drush.mdx
+++ b/.vortex/docs/content/tools/drush.mdx
@@ -43,19 +43,12 @@ import TabItem from '@theme/TabItem';
 
 ## PHP runtime configuration
 
-Vortex allows you to customize PHP runtime settings for Drush CLI commands
+**Vortex** allows you to customize PHP runtime settings for Drush CLI commands
 by editing the `drush/php-ini/drush.ini` file.
 
 This file is auto-discovered via the `PHP_INI_SCAN_DIR` environment variable,
 which is pre-configured in both the Docker CLI container and Acquia deployment
 hooks.
-
-For example, to increase the memory limit for Drush operations:
-
-```ini
-; drush/php-ini/drush.ini
-memory_limit = 512M
-```
 
 Any valid PHP ini directive can be added to this file to adjust the runtime
 behavior of Drush commands.
@@ -67,6 +60,40 @@ directories. On Acquia, this ensures that the hosting provider's own PHP ini
 overrides (such as `sendmail_path`) are not lost.
 
 :::
+
+### Memory limit
+
+The shipped configuration raises the PHP memory limit above the platform
+default:
+
+```ini
+; drush/php-ini/drush.ini
+memory_limit = 1G
+```
+
+This value is sized for database imports and configuration synchronization on
+large sites. It applies to the CLI container only and does not change the
+memory limit used to serve web requests.
+
+If a Drush command exhausts this limit, profile the command before raising the
+value. An exhausted 1G limit usually points to a memory leak in custom code
+rather than a limit set too low, and raising the ceiling hides the leak until a
+larger dataset reaches the new limit.
+
+To grant more memory to a single command without changing the default:
+
+<Tabs>
+  <TabItem value="ahoy" label="Ahoy" default>
+    ```shell
+    ahoy cli php -d memory_limit=2G vendor/bin/drush <command>
+    ```
+  </TabItem>
+  <TabItem value="docker-compose" label="Docker Compose">
+    ```shell
+    docker compose exec cli php -d memory_limit=2G vendor/bin/drush <command>
+    ```
+  </TabItem>
+</Tabs>
 
 ## Aliases
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/drush/php-ini/drush.ini
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/drush/php-ini/drush.ini
@@ -3,5 +3,7 @@
 ; This file is auto-discovered via the PHP_INI_SCAN_DIR environment variable.
 ; Modify the values below to adjust PHP runtime settings for Drush commands.
 
-; Increase memory limit for Drush operations (database imports, config sync).
-memory_limit = 512M
+; Sized for database imports and config sync on large sites. Exceeding it
+; usually indicates a memory leak in custom code rather than a limit set too
+; low.
+memory_limit = 1G

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestDockerComposeTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestDockerComposeTrait.php
@@ -282,11 +282,11 @@ trait SubtestDockerComposeTrait {
 
     $this->logSubstep('Assert default PHP ini values from drush.ini are applied.');
     $this->assertFileExists($ini_file, 'Drush PHP ini file should exist');
-    $this->assertFileContainsString($ini_file, 'memory_limit = 512M', 'Drush PHP ini file should contain default memory_limit');
+    $this->assertFileContainsString($ini_file, 'memory_limit = 1G', 'Drush PHP ini file should contain default memory_limit');
     $this->cmd(
       'docker compose exec -T cli php -r "echo ini_get(\'memory_limit\');"',
-      '512M',
-      'PHP memory_limit should be 512M from drush.ini'
+      '1G',
+      'PHP memory_limit should be 1G from drush.ini'
     );
 
     $this->logSubstep('Assert PHP ini values are updated when drush.ini is changed.');
@@ -300,12 +300,12 @@ trait SubtestDockerComposeTrait {
     );
 
     $this->logSubstep('Assert multiple PHP ini directives are applied.');
-    File::dump($ini_file, "memory_limit = 1024M\nerror_reporting = E_ALL\n");
+    File::dump($ini_file, "memory_limit = 2048M\nerror_reporting = E_ALL\n");
     $this->syncToContainer($ini_file);
     $this->cmd(
       'docker compose exec -T cli php -r "echo ini_get(\'memory_limit\');"',
-      '1024M',
-      'PHP memory_limit should be 1024M after second change'
+      '2048M',
+      'PHP memory_limit should be 2048M after second change'
     );
     $this->processRun('docker compose exec -T cli php -r "echo E_ALL;"');
     $e_all = trim($this->processGet()->getOutput());

--- a/drush/php-ini/drush.ini
+++ b/drush/php-ini/drush.ini
@@ -3,5 +3,7 @@
 ; This file is auto-discovered via the PHP_INI_SCAN_DIR environment variable.
 ; Modify the values below to adjust PHP runtime settings for Drush commands.
 
-; Increase memory limit for Drush operations (database imports, config sync).
-memory_limit = 512M
+; Sized for database imports and config sync on large sites. Exceeding it
+; usually indicates a memory leak in custom code rather than a limit set too
+; low.
+memory_limit = 1G


### PR DESCRIPTION
Closes #2986

## Summary

Raised the default `memory_limit` in `drush/php-ini/drush.ini` from `512M` to `1G`. The Lagoon base image already ships `memory_limit = 400M`, so the file whose stated purpose was raising the ceiling for database imports and configuration synchronization was only adding 112M of headroom - which is why two downstream projects independently worked around it, one by raising the file to `2G` and one by bypassing it per-invocation with `php -d memory_limit=2G`. The new value applies to PHP CLI processes that load the scan path, including Drush; the PHP-FPM web request limit is unchanged at `400M`. The Drush documentation gains a "Memory limit" section stating what the value is sized for, when to investigate a memory leak instead of raising the ceiling further, and how to grant more memory to a single command.

## Changes

- `drush/php-ini/drush.ini`: raised `memory_limit` to `1G` and reworded the comment to state what the value is sized for and that exceeding it usually points to a memory leak in custom code rather than a limit set too low.
- `.vortex/tests/phpunit/Traits/Subtests/SubtestDockerComposeTrait.php`: updated `subtestDockerComposeDrushPhpIni()` to expect `1G` as the default. The second override case moved from `1024M` to `2048M`: with a `1G` default, `1024M` is the same effective value, so that case would no longer prove the file is re-read after an edit.
- `.vortex/docs/content/tools/drush.mdx`: added a "Memory limit" section covering the shipped default, its sizing rationale, guidance to profile before raising it further, and the per-invocation `php -d memory_limit=...` override. Also corrected the section's scope: `PHP_INI_SCAN_DIR` is configured for the whole CLI environment, so the file is loaded by every PHP CLI process that picks up the scan path, not by Drush alone.
- `.vortex/installer/tests/Fixtures/handler_process/_baseline/drush/php-ini/drush.ini`: regenerated via `ahoy update-snapshots`, not hand-edited.

## Points raised in the issue

**Is a middle value better than 512M or 2G?** Yes - `1G` is 2.5x the platform floor, enough headroom for `drush cim` on large config sets and `drush sql:*` on large databases, while remaining a ceiling a runaway allocation still reaches. `2G` is the value most likely to mask a leak on a container that is often laptop-hosted.

**Should it move to an `.env` variable?** Declined. PHP ini files cannot interpolate environment variables, so this would need either rendering the ini at container start or relying on Lagoon's `PHP_MEMORY_LIMIT`. Both work in Docker and Lagoon but not on Acquia, where `hooks/library/provision.sh` exports `PHP_INI_SCAN_DIR` into the hosting provider's own PHP with no Vortex entrypoint - and `PHP_MEMORY_LIMIT` would additionally raise the web request limit as a side effect. Either route replaces one portable mechanism with two hosting-specific ones that disagree. The updater-conflict concern behind the suggestion is real but small: this is a one-line file, and a conflict there surfaces the changed default rather than hiding it.

**Do CI or the hosting environments already override it?** No. `.circleci/config.yml` and the GitHub Actions workflows use `php -d memory_limit=-1` only for Behat, PHPUnit, phpcs, phpstan and rector - test and lint runs. Provisioning and Drush operations read `drush.ini`. Acquia points at the same file via `hooks/library/provision.sh`, and the Lagoon CLI container via `.docker/cli.dockerfile`. `drush.ini` is therefore the single effective ceiling everywhere, which is why this default mattered more than a local-only setting would.

**Should the comment say what the value is sized for?** Done, in both the ini file and the documentation.

## Before / After

```
 BEFORE                                  AFTER
 ┌────────────────────────┐              ┌────────────────────────┐
 │ Lagoon base image      │              │ Lagoon base image      │
 │ 00-lagoon-php.ini      │              │ 00-lagoon-php.ini      │
 │ memory_limit = 400M    │              │ memory_limit = 400M    │
 └────────────────────────┘              └────────────────────────┘
             │                                       │
             │ +112M headroom                        │ +624M headroom
             ▼                                       ▼
 ┌────────────────────────┐              ┌────────────────────────┐
 │ drush/php-ini/         │              │ drush/php-ini/         │
 │ drush.ini              │  ────────▶   │ drush.ini              │
 │ memory_limit = 512M    │              │ memory_limit = 1G      │
 └────────────────────────┘              └────────────────────────┘
             │                                       │
             ▼                                       ▼
 ┌──────────────────────────────────────────────────────────────┐
 │ Appended last to PHP_INI_SCAN_DIR, so it wins:               │
 │   local Docker  .docker/cli.dockerfile                       │
 │   Lagoon        .docker/cli.dockerfile                       │
 │   Acquia        hooks/library/provision.sh                   │
 │                                                              │
 │ Unchanged: PHP-FPM web requests stay at 400M                 │
 └──────────────────────────────────────────────────────────────┘
```
