### PR TITLE
[#2984] Excluded cache table data from the exported database dump.

### DIFF
--- a/.vortex/docs/content/development/database.mdx
+++ b/.vortex/docs/content/development/database.mdx
@@ -95,4 +95,6 @@ Export timestamped database dumps from the local environment.
 You can use these dumps to restore the local environment to a specific state:
 rename the dump file to `.data/db.sql` and run the import command.
 
+Cache tables are exported with their structure but without their data, because Drupal rebuilds them on demand and their contents would only inflate the dump. Set `VORTEX_EXPORT_DB_FILE_STRUCTURE_TABLES` to a comma-separated list of table names, each of which may use the `*` wildcard, to choose which tables are exported this way. Set it to an empty value to export the data of every table.
+
 ➡️ See [Drupal > Provision](../drupal/provision)

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -235,6 +235,8 @@ trait SubtestAhoyTrait {
     $this->assertFileNotContainsString('config/default/core.extension.yml', 'generated_content', 'Excluded module "generated_content" should not appear in the exported extension list');
     $this->assertFileNotContainsString('config/default/core.extension.yml', 'testmode', 'Excluded module "testmode" should not appear in the exported extension list');
 
+    $this->assertCacheTablesHaveRows();
+
     $this->cmd('ahoy export-db db.sql', '* Exported database dump saved', 'Export database should complete successfully');
     $this->syncToHost('.data');
     $this->assertFileExists('.data/db.sql', 'Database dump file should exist after export');
@@ -289,15 +291,19 @@ trait SubtestAhoyTrait {
     $this->logStepFinish();
   }
 
-  protected function assertDumpExcludesCacheTableData(string $file): void {
-    $this->logSubstep('Assert cache tables are exported without their data');
+  protected function assertCacheTablesHaveRows(): void {
+    $this->logSubstep('Assert cache tables hold rows before the export');
 
-    // Prove a cache table held rows when the dump was taken, so that the
-    // absence of cache rows is the export behaviour, not an empty cache.
+    // Establishes that the absence of cache rows from the dump taken next is
+    // the export behaviour, not an already-empty cache.
     $probe_file = '.data/probe-cache-rows.sql';
     File::dump($probe_file, "SELECT 'CACHE_ROWS_PRESENT' FROM cache_bootstrap LIMIT 1;\n");
     $this->syncToContainer($probe_file);
     $this->cmd('ahoy drush sql:query --file=../' . $probe_file, '* CACHE_ROWS_PRESENT', 'Cache table should hold rows before the export');
+  }
+
+  protected function assertDumpExcludesCacheTableData(string $file): void {
+    $this->logSubstep('Assert cache tables are exported without their data');
 
     $this->assertFileContainsString($file, 'CREATE TABLE `cache_bootstrap`', 'Cache table structure should be present in the dump');
     $this->assertFileContainsString($file, 'CREATE TABLE `cache_default`', 'Every cache bin should be matched by the wildcard');

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -239,6 +239,8 @@ trait SubtestAhoyTrait {
     $this->syncToHost('.data');
     $this->assertFileExists('.data/db.sql', 'Database dump file should exist after export');
 
+    $this->assertDumpExcludesCacheTableData('.data/db.sql');
+
     $this->cmd(
       'ahoy provision',
       [
@@ -285,6 +287,27 @@ trait SubtestAhoyTrait {
     );
 
     $this->logStepFinish();
+  }
+
+  protected function assertDumpExcludesCacheTableData(string $file): void {
+    $this->logSubstep('Assert cache tables are exported without their data');
+
+    // Prove the cache tables held rows when the dump was taken, so that their
+    // absence from the dump is the export behaviour rather than an empty cache.
+    $probe_file = '.data/probe-cache-rows.sql';
+    File::dump($probe_file, "SELECT 'CACHE_ROWS_PRESENT' FROM cache_default LIMIT 1;\n");
+    $this->syncToContainer($probe_file);
+    $this->cmd('ahoy drush sql:query --file=../' . $probe_file, '* CACHE_ROWS_PRESENT', 'Cache table should hold rows before the export');
+
+    $this->assertFileContainsString($file, 'CREATE TABLE `cache_default`', 'Cache table structure should be present in the dump');
+    $this->assertFileNotContainsString($file, 'INSERT INTO `cache_default`', 'Cache table rows should be absent from the dump');
+    $this->assertFileContainsString($file, 'CREATE TABLE `cachetags`', 'Cache tags table structure should be present in the dump');
+    $this->assertFileNotContainsString($file, 'INSERT INTO `cachetags`', 'Cache tags table rows should be absent from the dump');
+
+    $this->assertFileContainsString($file, 'CREATE TABLE `users_field_data`', 'Non-cache table structure should be present in the dump');
+    $this->assertFileContainsString($file, 'INSERT INTO `users_field_data`', 'Non-cache table rows should be present in the dump');
+    $this->assertFileContainsString($file, 'CREATE TABLE `config`', 'Configuration table structure should be present in the dump');
+    $this->assertFileContainsString($file, 'INSERT INTO `config`', 'Configuration table rows should be present in the dump');
   }
 
   protected function subtestAhoyExportDb(string $filename = '', bool $is_container_image_archive = FALSE): void {

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -292,24 +292,28 @@ trait SubtestAhoyTrait {
   }
 
   protected function seedCacheTableRow(): void {
-    $this->logSubstep('Seed a cache entry before the export');
+    $this->logSubstep('Seed a cache table row before the export');
 
-    // Drupal creates cache tables lazily, so seeding the default bin is what
-    // guarantees the export has cache rows to leave out.
-    $this->cmd('ahoy drush cache:set vortex_cache_probe probe', txt: 'Cache entry should be written to the default bin');
+    // Drupal creates its cache tables lazily and which bins reach the database
+    // depends on the configured backends, so the row proving that the export
+    // drops cache data is written into a table this suite owns.
+    $seed_file = '.data/probe-cache-seed.sql';
+    File::dump($seed_file, "CREATE TABLE IF NOT EXISTS cache_vortex_probe (cid VARCHAR(255) NOT NULL PRIMARY KEY, data LONGBLOB);\nINSERT INTO cache_vortex_probe (cid, data) VALUES ('SEEDED_CACHE_ROW_MARKER', 'probe');\n");
+    $this->syncToContainer($seed_file);
+    $this->cmd('ahoy drush sql:query --file=../' . $seed_file, txt: 'Seed row should be written into a cache table');
 
     $probe_file = '.data/probe-cache-rows.sql';
-    File::dump($probe_file, "SELECT 'CACHE_ROWS_PRESENT' FROM cache_default WHERE cid = 'vortex_cache_probe';\n");
+    File::dump($probe_file, "SELECT cid FROM cache_vortex_probe;\n");
     $this->syncToContainer($probe_file);
-    $this->cmd('ahoy drush sql:query --file=../' . $probe_file, '* CACHE_ROWS_PRESENT', 'Seeded cache entry should be stored in the database');
+    $this->cmd('ahoy drush sql:query --file=../' . $probe_file, '* SEEDED_CACHE_ROW_MARKER', 'Seeded cache row should be stored in the database');
   }
 
   protected function assertDumpExcludesCacheTableData(string $file): void {
     $this->logSubstep('Assert cache tables are exported without their data');
 
-    $this->assertFileContainsString($file, 'CREATE TABLE `cache_default`', 'Cache table structure should be present in the dump');
+    $this->assertFileContainsString($file, 'CREATE TABLE `cache_vortex_probe`', 'Cache table structure should be present in the dump');
     $this->assertFileNotContainsString($file, 'INSERT INTO `cache', 'No cache table should carry rows into the dump');
-    $this->assertFileNotContainsString($file, 'vortex_cache_probe', 'The seeded cache entry should not appear in the dump');
+    $this->assertFileNotContainsString($file, 'SEEDED_CACHE_ROW_MARKER', 'The seeded cache row should not appear in the dump');
 
     $this->assertFileContainsString($file, 'CREATE TABLE `users_field_data`', 'Non-cache table structure should be present in the dump');
     $this->assertFileContainsString($file, 'INSERT INTO `users_field_data`', 'Non-cache table rows should be present in the dump');

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -295,12 +295,14 @@ trait SubtestAhoyTrait {
     // Prove the cache tables held rows when the dump was taken, so that their
     // absence from the dump is the export behaviour rather than an empty cache.
     $probe_file = '.data/probe-cache-rows.sql';
-    File::dump($probe_file, "SELECT 'CACHE_ROWS_PRESENT' FROM cache_default LIMIT 1;\n");
+    File::dump($probe_file, "SELECT 'CACHE_ROWS_PRESENT' FROM cache_bootstrap LIMIT 1;\n");
     $this->syncToContainer($probe_file);
     $this->cmd('ahoy drush sql:query --file=../' . $probe_file, '* CACHE_ROWS_PRESENT', 'Cache table should hold rows before the export');
 
-    $this->assertFileContainsString($file, 'CREATE TABLE `cache_default`', 'Cache table structure should be present in the dump');
-    $this->assertFileNotContainsString($file, 'INSERT INTO `cache_default`', 'Cache table rows should be absent from the dump');
+    $this->assertFileContainsString($file, 'CREATE TABLE `cache_bootstrap`', 'Cache table structure should be present in the dump');
+    $this->assertFileNotContainsString($file, 'INSERT INTO `cache_bootstrap`', 'Cache table rows should be absent from the dump');
+    $this->assertFileContainsString($file, 'CREATE TABLE `cache_default`', 'Every cache bin should be matched by the wildcard');
+    $this->assertFileNotContainsString($file, 'INSERT INTO `cache_default`', 'Every cache bin should be exported without its rows');
     $this->assertFileContainsString($file, 'CREATE TABLE `cachetags`', 'Cache tags table structure should be present in the dump');
     $this->assertFileNotContainsString($file, 'INSERT INTO `cachetags`', 'Cache tags table rows should be absent from the dump');
 

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -235,7 +235,7 @@ trait SubtestAhoyTrait {
     $this->assertFileNotContainsString('config/default/core.extension.yml', 'generated_content', 'Excluded module "generated_content" should not appear in the exported extension list');
     $this->assertFileNotContainsString('config/default/core.extension.yml', 'testmode', 'Excluded module "testmode" should not appear in the exported extension list');
 
-    $this->assertCacheTablesHaveRows();
+    $this->seedCacheTableRow();
 
     $this->cmd('ahoy export-db db.sql', '* Exported database dump saved', 'Export database should complete successfully');
     $this->syncToHost('.data');
@@ -291,24 +291,25 @@ trait SubtestAhoyTrait {
     $this->logStepFinish();
   }
 
-  protected function assertCacheTablesHaveRows(): void {
-    $this->logSubstep('Assert cache tables hold rows before the export');
+  protected function seedCacheTableRow(): void {
+    $this->logSubstep('Seed a cache entry before the export');
 
-    // Establishes that the absence of cache rows from the dump taken next is
-    // the export behaviour, not an already-empty cache.
+    // Drupal creates cache tables lazily, so seeding the default bin is what
+    // guarantees the export has cache rows to leave out.
+    $this->cmd('ahoy drush cache:set vortex_cache_probe probe', txt: 'Cache entry should be written to the default bin');
+
     $probe_file = '.data/probe-cache-rows.sql';
-    File::dump($probe_file, "SELECT 'CACHE_ROWS_PRESENT' FROM cache_bootstrap LIMIT 1;\n");
+    File::dump($probe_file, "SELECT 'CACHE_ROWS_PRESENT' FROM cache_default WHERE cid = 'vortex_cache_probe';\n");
     $this->syncToContainer($probe_file);
-    $this->cmd('ahoy drush sql:query --file=../' . $probe_file, '* CACHE_ROWS_PRESENT', 'Cache table should hold rows before the export');
+    $this->cmd('ahoy drush sql:query --file=../' . $probe_file, '* CACHE_ROWS_PRESENT', 'Seeded cache entry should be stored in the database');
   }
 
   protected function assertDumpExcludesCacheTableData(string $file): void {
     $this->logSubstep('Assert cache tables are exported without their data');
 
-    $this->assertFileContainsString($file, 'CREATE TABLE `cache_bootstrap`', 'Cache table structure should be present in the dump');
-    $this->assertFileContainsString($file, 'CREATE TABLE `cache_default`', 'Every cache bin should be matched by the wildcard');
-    $this->assertFileContainsString($file, 'CREATE TABLE `cachetags`', 'Cache tags table structure should be present in the dump');
+    $this->assertFileContainsString($file, 'CREATE TABLE `cache_default`', 'Cache table structure should be present in the dump');
     $this->assertFileNotContainsString($file, 'INSERT INTO `cache', 'No cache table should carry rows into the dump');
+    $this->assertFileNotContainsString($file, 'vortex_cache_probe', 'The seeded cache entry should not appear in the dump');
 
     $this->assertFileContainsString($file, 'CREATE TABLE `users_field_data`', 'Non-cache table structure should be present in the dump');
     $this->assertFileContainsString($file, 'INSERT INTO `users_field_data`', 'Non-cache table rows should be present in the dump');

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -292,19 +292,17 @@ trait SubtestAhoyTrait {
   protected function assertDumpExcludesCacheTableData(string $file): void {
     $this->logSubstep('Assert cache tables are exported without their data');
 
-    // Prove the cache tables held rows when the dump was taken, so that their
-    // absence from the dump is the export behaviour rather than an empty cache.
+    // Prove a cache table held rows when the dump was taken, so that the
+    // absence of cache rows is the export behaviour, not an empty cache.
     $probe_file = '.data/probe-cache-rows.sql';
     File::dump($probe_file, "SELECT 'CACHE_ROWS_PRESENT' FROM cache_bootstrap LIMIT 1;\n");
     $this->syncToContainer($probe_file);
     $this->cmd('ahoy drush sql:query --file=../' . $probe_file, '* CACHE_ROWS_PRESENT', 'Cache table should hold rows before the export');
 
     $this->assertFileContainsString($file, 'CREATE TABLE `cache_bootstrap`', 'Cache table structure should be present in the dump');
-    $this->assertFileNotContainsString($file, 'INSERT INTO `cache_bootstrap`', 'Cache table rows should be absent from the dump');
     $this->assertFileContainsString($file, 'CREATE TABLE `cache_default`', 'Every cache bin should be matched by the wildcard');
-    $this->assertFileNotContainsString($file, 'INSERT INTO `cache_default`', 'Every cache bin should be exported without its rows');
     $this->assertFileContainsString($file, 'CREATE TABLE `cachetags`', 'Cache tags table structure should be present in the dump');
-    $this->assertFileNotContainsString($file, 'INSERT INTO `cachetags`', 'Cache tags table rows should be absent from the dump');
+    $this->assertFileNotContainsString($file, 'INSERT INTO `cache', 'No cache table should carry rows into the dump');
 
     $this->assertFileContainsString($file, 'CREATE TABLE `users_field_data`', 'Non-cache table structure should be present in the dump');
     $this->assertFileContainsString($file, 'INSERT INTO `users_field_data`', 'Non-cache table rows should be present in the dump');

--- a/.vortex/tooling/src/vortex-export-db-file
+++ b/.vortex/tooling/src/vortex-export-db-file
@@ -12,6 +12,12 @@ set -eu
 # Directory with database dump file.
 VORTEX_EXPORT_DB_FILE_DIR="${VORTEX_EXPORT_DB_FILE_DIR:-${VORTEX_DB_DIR:-./.data}}"
 
+# Tables to export with their structure but without their data. Accepts a
+# comma-separated list where each entry may use the `*` wildcard. Drupal
+# rebuilds cache tables on demand, so their contents only inflate the dump.
+# Set to an empty value to export the data of every table.
+VORTEX_EXPORT_DB_FILE_STRUCTURE_TABLES="${VORTEX_EXPORT_DB_FILE_STRUCTURE_TABLES-cache*}"
+
 # ------------------------------------------------------------------------------
 
 # @formatter:off
@@ -39,7 +45,7 @@ dump_file_drush="${dump_file/#.\//../}"
 mkdir -p "${VORTEX_EXPORT_DB_FILE_DIR}"
 
 # Dump database into a file.
-drush sql:dump --skip-tables-key=common --result-file="${dump_file_drush}" -q
+drush sql:dump --skip-tables-key=common --structure-tables-list="${VORTEX_EXPORT_DB_FILE_STRUCTURE_TABLES}" --result-file="${dump_file_drush}" -q
 
 # Check that file was saved and output saved dump file name.
 if [ -f "${dump_file}" ] && [ -s "${dump_file}" ]; then

--- a/.vortex/tooling/tests/unit/export-db-file.bats
+++ b/.vortex/tooling/tests/unit/export-db-file.bats
@@ -1,0 +1,147 @@
+#!/usr/bin/env bats
+##
+# Unit tests for export-db-file worker script.
+#
+# shellcheck disable=SC2030,SC2031,SC2034
+
+load ../_helper.bash
+
+# Mocks `drush` and routes the project binary to it.
+#
+# With an argument, the mock writes that content into the file named by the
+# `--result-file` argument; without one it writes no file at all. The path is
+# relative to the Drupal root, so the leading `../` is stripped to resolve it
+# from the project root the mock runs in.
+mock_drush_dump() {
+  local mock
+  mock="$(mock_command "drush")"
+
+  if [ "$#" -gt 0 ]; then
+    # shellcheck disable=SC2016
+    mock_set_side_effect "${mock}" 'for arg in "$@"; do case "${arg}" in --result-file=*) file="${arg#--result-file=}"; printf "%s" "'"${1}"'" >"${file#../}";; esac; done'
+  fi
+
+  create_global_command_wrapper "vendor/bin/drush"
+
+  printf '%s\n' "${mock}"
+}
+
+@test "export-db-file: Exports cache tables without their data by default" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  mock_drush=$(mock_drush_dump "dump")
+
+  run .vortex/tooling/src/vortex-export-db-file db.sql
+  assert_success
+
+  assert_output_contains "Started database file export."
+  assert_output_contains "Exported database dump saved ./.data/db.sql."
+  assert_output_contains "Finished database file export."
+
+  assert_equal "1" "$(mock_get_call_num "${mock_drush}")"
+  assert_equal "-y sql:dump --skip-tables-key=common --structure-tables-list=cache* --result-file=../.data/db.sql -q" "$(mock_get_call_args "${mock_drush}" 1)"
+
+  assert_file_exists ".data/db.sql"
+
+  popd >/dev/null
+}
+
+@test "export-db-file: Exports to a timestamped file when no argument is given" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  mock_drush=$(mock_drush_dump "dump")
+
+  run .vortex/tooling/src/vortex-export-db-file
+  assert_success
+
+  assert_output_contains "Exported database dump saved ./.data/export_db_"
+  assert_output_contains "Finished database file export."
+
+  assert_string_contains "--structure-tables-list=cache*" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_string_contains "--result-file=../.data/export_db_" "$(mock_get_call_args "${mock_drush}" 1)"
+
+  assert_file_exists ".data/export_db_*.sql"
+
+  popd >/dev/null
+}
+
+@test "export-db-file: Honours a custom structure tables list" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_EXPORT_DB_FILE_STRUCTURE_TABLES="cache*,watchdog,sessions"
+
+  mock_drush=$(mock_drush_dump "dump")
+
+  run .vortex/tooling/src/vortex-export-db-file db.sql
+  assert_success
+
+  assert_equal "-y sql:dump --skip-tables-key=common --structure-tables-list=cache*,watchdog,sessions --result-file=../.data/db.sql -q" "$(mock_get_call_args "${mock_drush}" 1)"
+
+  popd >/dev/null
+}
+
+@test "export-db-file: Exports the data of every table when the list is empty" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_EXPORT_DB_FILE_STRUCTURE_TABLES=""
+
+  mock_drush=$(mock_drush_dump "dump")
+
+  run .vortex/tooling/src/vortex-export-db-file db.sql
+  assert_success
+
+  assert_equal "-y sql:dump --skip-tables-key=common --structure-tables-list= --result-file=../.data/db.sql -q" "$(mock_get_call_args "${mock_drush}" 1)"
+
+  popd >/dev/null
+}
+
+@test "export-db-file: Exports into a custom directory" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  export VORTEX_EXPORT_DB_FILE_DIR="./.data/custom"
+
+  mock_drush=$(mock_drush_dump "dump")
+
+  run .vortex/tooling/src/vortex-export-db-file db.sql
+  assert_success
+
+  assert_output_contains "Exported database dump saved ./.data/custom/db.sql."
+  assert_equal "-y sql:dump --skip-tables-key=common --structure-tables-list=cache* --result-file=../.data/custom/db.sql -q" "$(mock_get_call_args "${mock_drush}" 1)"
+
+  assert_file_exists ".data/custom/db.sql"
+
+  popd >/dev/null
+}
+
+@test "export-db-file: Fails when the dump file was not created" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  mock_drush=$(mock_drush_dump)
+
+  run .vortex/tooling/src/vortex-export-db-file db.sql
+  assert_failure
+
+  assert_output_contains "Unable to save dump file ./.data/db.sql."
+  assert_output_not_contains "Exported database dump saved"
+  assert_output_not_contains "Finished database file export."
+
+  assert_file_not_exists ".data/db.sql"
+
+  popd >/dev/null
+}
+
+@test "export-db-file: Fails when the dump file is empty" {
+  pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  mock_drush=$(mock_drush_dump "")
+
+  run .vortex/tooling/src/vortex-export-db-file db.sql
+  assert_failure
+
+  assert_output_contains "Unable to save dump file ./.data/db.sql."
+  assert_output_not_contains "Exported database dump saved"
+
+  assert_file_exists ".data/db.sql"
+
+  popd >/dev/null
+}

--- a/.vortex/tooling/tests/unit/export-db-file.bats
+++ b/.vortex/tooling/tests/unit/export-db-file.bats
@@ -26,8 +26,18 @@ mock_drush_dump() {
   printf '%s\n' "${mock}"
 }
 
+# Drops the export variables inherited from the shell running the suite. The
+# script's `.env` loader restores the saved environment last, so an ambient
+# value would win over `.env` and change the arguments a test asserts on.
+isolate_export_vars() {
+  unset VORTEX_EXPORT_DB_FILE_STRUCTURE_TABLES
+  unset VORTEX_EXPORT_DB_FILE_DIR
+}
+
 @test "export-db-file: Exports cache tables without their data by default" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  isolate_export_vars
 
   mock_drush=$(mock_drush_dump "dump")
 
@@ -49,6 +59,8 @@ mock_drush_dump() {
 @test "export-db-file: Exports to a timestamped file when no argument is given" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
+  isolate_export_vars
+
   mock_drush=$(mock_drush_dump "dump")
 
   run .vortex/tooling/src/vortex-export-db-file
@@ -68,6 +80,7 @@ mock_drush_dump() {
 @test "export-db-file: Honours a custom structure tables list" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
+  isolate_export_vars
   export VORTEX_EXPORT_DB_FILE_STRUCTURE_TABLES="cache*,watchdog,sessions"
 
   mock_drush=$(mock_drush_dump "dump")
@@ -83,6 +96,7 @@ mock_drush_dump() {
 @test "export-db-file: Exports the data of every table when the list is empty" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
+  isolate_export_vars
   export VORTEX_EXPORT_DB_FILE_STRUCTURE_TABLES=""
 
   mock_drush=$(mock_drush_dump "dump")
@@ -98,6 +112,7 @@ mock_drush_dump() {
 @test "export-db-file: Exports into a custom directory" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
+  isolate_export_vars
   export VORTEX_EXPORT_DB_FILE_DIR="./.data/custom"
 
   mock_drush=$(mock_drush_dump "dump")
@@ -116,6 +131,8 @@ mock_drush_dump() {
 @test "export-db-file: Fails when the dump file was not created" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
 
+  isolate_export_vars
+
   mock_drush=$(mock_drush_dump)
 
   run .vortex/tooling/src/vortex-export-db-file db.sql
@@ -132,6 +149,8 @@ mock_drush_dump() {
 
 @test "export-db-file: Fails when the dump file is empty" {
   pushd "${LOCAL_REPO_DIR}" >/dev/null || exit 1
+
+  isolate_export_vars
 
   mock_drush=$(mock_drush_dump "")
 

--- a/.vortex/tooling/tests/unit/export-db-file.bats
+++ b/.vortex/tooling/tests/unit/export-db-file.bats
@@ -57,8 +57,8 @@ mock_drush_dump() {
   assert_output_contains "Exported database dump saved ./.data/export_db_"
   assert_output_contains "Finished database file export."
 
-  assert_string_contains "--structure-tables-list=cache*" "$(mock_get_call_args "${mock_drush}" 1)"
-  assert_string_contains "--result-file=../.data/export_db_" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_string_contains "$(mock_get_call_args "${mock_drush}" 1)" "--structure-tables-list=cache*"
+  assert_string_contains "$(mock_get_call_args "${mock_drush}" 1)" "--result-file=../.data/export_db_"
 
   assert_file_exists ".data/export_db_*.sql"
 


### PR DESCRIPTION
Closes #2984

## Summary

The database export script now passes `--structure-tables-list` to `drush sql:dump`, so cache tables are dumped as empty `CREATE TABLE` statements instead of their full row data. The tables treated this way default to `cache*` and are configurable through the new `VORTEX_EXPORT_DB_FILE_STRUCTURE_TABLES` variable, which can be set to an empty value to restore full-table exports. Because `vortex-export-db-file` is the single export path shared by CI on both providers, `ahoy export-db` locally, and the Lagoon pre-deployment backup in `.lagoon.yml`, this one change removes cache row data from every dump those paths produce without duplicating shell logic across CI configs.

Drush expands the wildcard against the live table list, adds an `--ignore-table` for each match to the data dump, then appends a second `mysqldump --no-data` pass for those tables. The result is that cache tables keep their schema and lose their rows, with no per-table `TRUNCATE` loop and no mutation of the database being exported - the latter matters because this same path takes the Lagoon pre-deployment backup against a live environment.

The script previously had no unit coverage, so this also adds BATS tests for it, plus a functional assertion that inspects a real exported dump.

## Changes

- `.vortex/tooling/src/vortex-export-db-file`: added `VORTEX_EXPORT_DB_FILE_STRUCTURE_TABLES` (default `cache*`), passed to `drush sql:dump` via `--structure-tables-list=`. Uses `${VAR-default}` (no colon) so an explicitly empty value is honoured as "export the data of every table" rather than falling back to the default.
- The existing `--skip-tables-key=common` argument is retained; on a stock Vortex site it resolves to an empty list because `drush/drush.yml` defines no `sql.skip-tables`, but it remains an extension point for consumers that define their own.
- `.vortex/tooling/tests/unit/export-db-file.bats`: new BATS unit test file (7 tests) covering the default `cache*` list, a custom table list, an empty list, a custom export directory, and the existing timestamped-filename, missing-file, and empty-file paths. Each test unsets the two export variables first, because the script's `.env` loader restores the saved environment last, so a value inherited from the shell would otherwise beat `.env` and change the arguments under assertion.
- `.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php`: `subtestAhoyProvision()` now seeds a row into a cache table before `ahoy export-db` and asserts against the resulting dump - the cache table keeps its `CREATE TABLE`, no `INSERT INTO \`cache` appears anywhere, and the seeded row is absent, while `users_field_data` and `config` keep both their structure and their rows.
- `.vortex/docs/content/development/database.mdx`: documented the structure-only export of cache tables and the new variable under "Exporting database".

## Notes for reviewers

The functional test seeds its own `cache_vortex_probe` table rather than asserting against a Drupal cache bin. Drupal creates cache tables lazily and which bins reach the database depends on the configured backends: the CI fixture database ships with no `cache*` tables at all, and in the built site neither `cache_bootstrap` nor `cache_default` exists by the time the export runs. Seeding a table the suite owns exercises the mechanism that actually changed - the `cache*` wildcard expanding against the live table list - without depending on backend wiring that can shift underneath the test.

`VORTEX_EXPORT_DB_FILE_STRUCTURE_TABLES` does not appear in the generated variables table. No variable declared in `.vortex/tooling/src/` does, because shellvar's directory traversal skips those extensionless executables, and the docs CI gate cannot see the omission since regeneration produces no diff either. Tracked separately in #2996.

The default deliberately covers cache tables only. `sessions`, `watchdog`, `flood` and `semaphore` keep their data: this is scoped to cache tables, and `watchdog` is exactly what is wanted in a pre-deployment backup after a bad deploy.

No CI database cache version bump. The existing cache is large rather than poisoned, and the slim dump lands on the next fresh fetch, so a bump would force every consumer project to re-download its database once for an optimization that arrives on its own.

## Before / After

```
BEFORE
┌────────────────────────┐
│ ahoy build (provision) │
│ cache_* tables filled  │
└────────────────────────┘
             │
             ▼
┌────────────────────────────────┐
│         drush sql:dump         │
│    --skip-tables-key=common    │
│                                │
└────────────────────────────────┘
                 │
                 ▼
┌────────────────────────┐
│         db.sql         │
│ cache_*: schema + rows │
└────────────────────────┘
             │
             ▼
┌───────────────────────┐
│   CI database cache   │
│ bloated by cache rows │
└───────────────────────┘

AFTER
┌────────────────────────┐
│ ahoy build (provision) │
│ cache_* tables filled  │
└────────────────────────┘
             │
             ▼
┌────────────────────────────────┐
│         drush sql:dump         │
│    --skip-tables-key=common    │
│ --structure-tables-list=cache* │
└────────────────────────────────┘
                 │
                 ▼
┌────────────────────────┐
│         db.sql         │
│  cache_*: schema only  │
└────────────────────────┘
             │
             ▼
┌───────────────────────┐
│   CI database cache   │
│  lean, no cache rows  │
└───────────────────────┘
```
