### PR TITLE
[#2987] Raised the Prettier 'printWidth' default to 160 and pinned doc comments to 80.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,10 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+# Matches the Prettier 'printWidth' in .prettierrc.json.
+[*.js]
+max_line_length = 160
+
 [*.{json,lock}]
 indent_size = 4
 

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,9 +1,10 @@
 {
-  "printWidth": 80,
+  "printWidth": 160,
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
   "plugins": ["@homer0/prettier-plugin-jsdoc"],
+  "jsdocPrintWidth": 80,
   "jsdocReplaceTagsSynonyms": false,
   "overrides": [
     {

--- a/.vortex/docs/content/tools/eslint.mdx
+++ b/.vortex/docs/content/tools/eslint.mdx
@@ -97,6 +97,14 @@ Prettier is integrated via `eslint-plugin-prettier` and provides automatic code 
 
 When you run `ahoy lint-fe-fix`, both ESLint's `--fix` and Prettier's formatting are applied automatically.
 
+#### Line width
+
+**Vortex** sets `printWidth` to `160` in [`.prettierrc.json`](https://github.com/drevops/vortex/blob/main/.prettierrc.json) instead of the Prettier default of `80`, so a statement stays on one line unless it is genuinely long. Documentation blocks are held to `80` columns through `jsdocPrintWidth`, matching the width the PHP coding standard applies to comments.
+
+CSS carries its own `printWidth` override so that declarations are never wrapped. Prettier only reaches CSS when it is invoked directly, such as from an editor on save - within **Vortex**, stylesheets are linted by Stylelint.
+
+The custom theme ships a second `.prettierrc.json` with the same settings, because a theme carries its own front-end tooling and can be moved into a separate repository.
+
 ## Ignoring
 
 ### Global ignoring

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.editorconfig
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.editorconfig
@@ -13,6 +13,10 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+# Matches the Prettier 'printWidth' in .prettierrc.json.
+[*.js]
+max_line_length = 160
+
 [*.{json,lock}]
 indent_size = 4
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.prettierrc.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.prettierrc.json
@@ -1,9 +1,10 @@
 {
-  "printWidth": 80,
+  "printWidth": 160,
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
   "plugins": ["@homer0/prettier-plugin-jsdoc"],
+  "jsdocPrintWidth": 80,
   "jsdocReplaceTagsSynonyms": false,
   "overrides": [
     {

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/modules/custom/sw_demo/js/sw_demo.js
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/modules/custom/sw_demo/js/sw_demo.js
@@ -26,9 +26,7 @@
 
         block.classList.add('sw-demo-counter-processed');
 
-        const valueElement = block.querySelector(
-          '[data-sw-demo-counter-value]',
-        );
+        const valueElement = block.querySelector('[data-sw-demo-counter-value]');
         const buttons = block.querySelectorAll('[data-sw-demo-counter-action]');
 
         let currentValue = this.getCounterValue();

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/modules/custom/sw_demo/js/tests/sw_demo.test.js
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/modules/custom/sw_demo/js/tests/sw_demo.test.js
@@ -152,9 +152,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');
@@ -165,9 +163,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const decrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="decrement"]',
-      );
+      const decrementBtn = document.querySelector('[data-sw-demo-counter-action="decrement"]');
       decrementBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');
@@ -178,16 +174,12 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
       incrementBtn.click();
       incrementBtn.click();
 
-      const resetBtn = document.querySelector(
-        '[data-sw-demo-counter-action="reset"]',
-      );
+      const resetBtn = document.querySelector('[data-sw-demo-counter-action="reset"]');
       resetBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');
@@ -198,9 +190,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
       incrementBtn.click();
 
@@ -212,9 +202,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');
@@ -239,12 +227,8 @@ describe('Drupal.behaviors.ysDemo', () => {
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
       const blocks = document.querySelectorAll('[data-sw-demo-counter]');
-      expect(blocks[0].classList.contains('sw-demo-counter-processed')).toBe(
-        true,
-      );
-      expect(blocks[1].classList.contains('sw-demo-counter-processed')).toBe(
-        true,
-      );
+      expect(blocks[0].classList.contains('sw-demo-counter-processed')).toBe(true);
+      expect(blocks[1].classList.contains('sw-demo-counter-processed')).toBe(true);
     });
   });
 
@@ -263,9 +247,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.attach(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/themes/custom/star_wars/.prettierrc.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/themes/custom/star_wars/.prettierrc.json
@@ -1,9 +1,10 @@
 {
-  "printWidth": 80,
+  "printWidth": 160,
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
   "plugins": ["@homer0/prettier-plugin-jsdoc"],
+  "jsdocPrintWidth": 80,
   "jsdocReplaceTagsSynonyms": false,
   "overrides": [
     {

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/themes/custom/star_wars/js/star_wars.js
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/web/themes/custom/star_wars/js/star_wars.js
@@ -7,9 +7,7 @@
     attach(context) {
       // The context is the document on load and an element on AJAX, and that
       // element may be the body itself, so resolve through the owning document.
-      const body = context.ownerDocument
-        ? context.ownerDocument.body
-        : document.body;
+      const body = context.ownerDocument ? context.ownerDocument.body : document.body;
 
       if (body.classList.contains('star-wars-theme-processed')) {
         return;

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/modules/custom/sw_demo/js/sw_demo.js
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/modules/custom/sw_demo/js/sw_demo.js
@@ -26,9 +26,7 @@
 
         block.classList.add('sw-demo-counter-processed');
 
-        const valueElement = block.querySelector(
-          '[data-sw-demo-counter-value]',
-        );
+        const valueElement = block.querySelector('[data-sw-demo-counter-value]');
         const buttons = block.querySelectorAll('[data-sw-demo-counter-action]');
 
         let currentValue = this.getCounterValue();

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/modules/custom/sw_demo/js/tests/sw_demo.test.js
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/modules/custom/sw_demo/js/tests/sw_demo.test.js
@@ -152,9 +152,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');
@@ -165,9 +163,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const decrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="decrement"]',
-      );
+      const decrementBtn = document.querySelector('[data-sw-demo-counter-action="decrement"]');
       decrementBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');
@@ -178,16 +174,12 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
       incrementBtn.click();
       incrementBtn.click();
 
-      const resetBtn = document.querySelector(
-        '[data-sw-demo-counter-action="reset"]',
-      );
+      const resetBtn = document.querySelector('[data-sw-demo-counter-action="reset"]');
       resetBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');
@@ -198,9 +190,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
       incrementBtn.click();
 
@@ -212,9 +202,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');
@@ -239,12 +227,8 @@ describe('Drupal.behaviors.ysDemo', () => {
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
       const blocks = document.querySelectorAll('[data-sw-demo-counter]');
-      expect(blocks[0].classList.contains('sw-demo-counter-processed')).toBe(
-        true,
-      );
-      expect(blocks[1].classList.contains('sw-demo-counter-processed')).toBe(
-        true,
-      );
+      expect(blocks[0].classList.contains('sw-demo-counter-processed')).toBe(true);
+      expect(blocks[1].classList.contains('sw-demo-counter-processed')).toBe(true);
     });
   });
 
@@ -263,9 +247,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.attach(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/themes/custom/star_wars/.prettierrc.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/themes/custom/star_wars/.prettierrc.json
@@ -1,9 +1,10 @@
 {
-  "printWidth": 80,
+  "printWidth": 160,
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
   "plugins": ["@homer0/prettier-plugin-jsdoc"],
+  "jsdocPrintWidth": 80,
   "jsdocReplaceTagsSynonyms": false,
   "overrides": [
     {

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/themes/custom/star_wars/js/star_wars.js
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_acquia/docroot/themes/custom/star_wars/js/star_wars.js
@@ -7,9 +7,7 @@
     attach(context) {
       // The context is the document on load and an element on AJAX, and that
       // element may be the body itself, so resolve through the owning document.
-      const body = context.ownerDocument
-        ? context.ownerDocument.body
-        : document.body;
+      const body = context.ownerDocument ? context.ownerDocument.body : document.body;
 
       if (body.classList.contains('star-wars-theme-processed')) {
         return;

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/modules/custom/sw_demo/js/sw_demo.js
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/modules/custom/sw_demo/js/sw_demo.js
@@ -26,9 +26,7 @@
 
         block.classList.add('sw-demo-counter-processed');
 
-        const valueElement = block.querySelector(
-          '[data-sw-demo-counter-value]',
-        );
+        const valueElement = block.querySelector('[data-sw-demo-counter-value]');
         const buttons = block.querySelectorAll('[data-sw-demo-counter-action]');
 
         let currentValue = this.getCounterValue();

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/modules/custom/sw_demo/js/tests/sw_demo.test.js
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/modules/custom/sw_demo/js/tests/sw_demo.test.js
@@ -152,9 +152,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');
@@ -165,9 +163,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const decrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="decrement"]',
-      );
+      const decrementBtn = document.querySelector('[data-sw-demo-counter-action="decrement"]');
       decrementBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');
@@ -178,16 +174,12 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
       incrementBtn.click();
       incrementBtn.click();
 
-      const resetBtn = document.querySelector(
-        '[data-sw-demo-counter-action="reset"]',
-      );
+      const resetBtn = document.querySelector('[data-sw-demo-counter-action="reset"]');
       resetBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');
@@ -198,9 +190,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
       incrementBtn.click();
 
@@ -212,9 +202,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');
@@ -239,12 +227,8 @@ describe('Drupal.behaviors.ysDemo', () => {
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
       const blocks = document.querySelectorAll('[data-sw-demo-counter]');
-      expect(blocks[0].classList.contains('sw-demo-counter-processed')).toBe(
-        true,
-      );
-      expect(blocks[1].classList.contains('sw-demo-counter-processed')).toBe(
-        true,
-      );
+      expect(blocks[0].classList.contains('sw-demo-counter-processed')).toBe(true);
+      expect(blocks[1].classList.contains('sw-demo-counter-processed')).toBe(true);
     });
   });
 
@@ -263,9 +247,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.attach(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-sw-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-sw-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-sw-demo-counter-value]');

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/themes/custom/star_wars/.prettierrc.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/themes/custom/star_wars/.prettierrc.json
@@ -1,9 +1,10 @@
 {
-  "printWidth": 80,
+  "printWidth": 160,
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
   "plugins": ["@homer0/prettier-plugin-jsdoc"],
+  "jsdocPrintWidth": 80,
   "jsdocReplaceTagsSynonyms": false,
   "overrides": [
     {

--- a/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/themes/custom/star_wars/js/star_wars.js
+++ b/.vortex/installer/tests/Fixtures/handler_process/hosting_project_name___acquia/docroot/themes/custom/star_wars/js/star_wars.js
@@ -7,9 +7,7 @@
     attach(context) {
       // The context is the document on load and an element on AJAX, and that
       // element may be the body itself, so resolve through the owning document.
-      const body = context.ownerDocument
-        ? context.ownerDocument.body
-        : document.body;
+      const body = context.ownerDocument ? context.ownerDocument.body : document.body;
 
       if (body.classList.contains('star-wars-theme-processed')) {
         return;

--- a/.vortex/installer/tests/Fixtures/handler_process/names/web/modules/custom/the_force_demo/js/tests/the_force_demo.test.js
+++ b/.vortex/installer/tests/Fixtures/handler_process/names/web/modules/custom/the_force_demo/js/tests/the_force_demo.test.js
@@ -152,9 +152,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-the-force-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-the-force-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-the-force-demo-counter-value]');
@@ -165,9 +163,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const decrementBtn = document.querySelector(
-        '[data-the-force-demo-counter-action="decrement"]',
-      );
+      const decrementBtn = document.querySelector('[data-the-force-demo-counter-action="decrement"]');
       decrementBtn.click();
 
       const value = document.querySelector('[data-the-force-demo-counter-value]');
@@ -178,16 +174,12 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-the-force-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-the-force-demo-counter-action="increment"]');
       incrementBtn.click();
       incrementBtn.click();
       incrementBtn.click();
 
-      const resetBtn = document.querySelector(
-        '[data-the-force-demo-counter-action="reset"]',
-      );
+      const resetBtn = document.querySelector('[data-the-force-demo-counter-action="reset"]');
       resetBtn.click();
 
       const value = document.querySelector('[data-the-force-demo-counter-value]');
@@ -198,9 +190,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-the-force-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-the-force-demo-counter-action="increment"]');
       incrementBtn.click();
       incrementBtn.click();
 
@@ -212,9 +202,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-the-force-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-the-force-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-the-force-demo-counter-value]');
@@ -239,12 +227,8 @@ describe('Drupal.behaviors.ysDemo', () => {
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
       const blocks = document.querySelectorAll('[data-the-force-demo-counter]');
-      expect(blocks[0].classList.contains('the-force-demo-counter-processed')).toBe(
-        true,
-      );
-      expect(blocks[1].classList.contains('the-force-demo-counter-processed')).toBe(
-        true,
-      );
+      expect(blocks[0].classList.contains('the-force-demo-counter-processed')).toBe(true);
+      expect(blocks[1].classList.contains('the-force-demo-counter-processed')).toBe(true);
     });
   });
 
@@ -263,9 +247,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.attach(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-the-force-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-the-force-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-the-force-demo-counter-value]');

--- a/.vortex/installer/tests/Fixtures/handler_process/names/web/modules/custom/the_force_demo/js/the_force_demo.js
+++ b/.vortex/installer/tests/Fixtures/handler_process/names/web/modules/custom/the_force_demo/js/the_force_demo.js
@@ -26,9 +26,7 @@
 
         block.classList.add('the-force-demo-counter-processed');
 
-        const valueElement = block.querySelector(
-          '[data-the-force-demo-counter-value]',
-        );
+        const valueElement = block.querySelector('[data-the-force-demo-counter-value]');
         const buttons = block.querySelectorAll('[data-the-force-demo-counter-action]');
 
         let currentValue = this.getCounterValue();

--- a/.vortex/installer/tests/Fixtures/handler_process/names/web/themes/custom/lightsaber/.prettierrc.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/names/web/themes/custom/lightsaber/.prettierrc.json
@@ -1,9 +1,10 @@
 {
-  "printWidth": 80,
+  "printWidth": 160,
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
   "plugins": ["@homer0/prettier-plugin-jsdoc"],
+  "jsdocPrintWidth": 80,
   "jsdocReplaceTagsSynonyms": false,
   "overrides": [
     {

--- a/.vortex/installer/tests/Fixtures/handler_process/names/web/themes/custom/lightsaber/js/lightsaber.js
+++ b/.vortex/installer/tests/Fixtures/handler_process/names/web/themes/custom/lightsaber/js/lightsaber.js
@@ -7,9 +7,7 @@
     attach(context) {
       // The context is the document on load and an element on AJAX, and that
       // element may be the body itself, so resolve through the owning document.
-      const body = context.ownerDocument
-        ? context.ownerDocument.body
-        : document.body;
+      const body = context.ownerDocument ? context.ownerDocument.body : document.body;
 
       if (body.classList.contains('the-new-hope-theme-processed')) {
         return;

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_custom/web/themes/custom/light_saber/.prettierrc.json
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_custom/web/themes/custom/light_saber/.prettierrc.json
@@ -1,9 +1,10 @@
 {
-  "printWidth": 80,
+  "printWidth": 160,
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
   "plugins": ["@homer0/prettier-plugin-jsdoc"],
+  "jsdocPrintWidth": 80,
   "jsdocReplaceTagsSynonyms": false,
   "overrides": [
     {

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_custom/web/themes/custom/light_saber/js/light_saber.js
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_custom/web/themes/custom/light_saber/js/light_saber.js
@@ -7,9 +7,7 @@
     attach(context) {
       // The context is the document on load and an element on AJAX, and that
       // element may be the body itself, so resolve through the owning document.
-      const body = context.ownerDocument
-        ? context.ownerDocument.body
-        : document.body;
+      const body = context.ownerDocument ? context.ownerDocument.body : document.body;
 
       if (body.classList.contains('star-wars-theme-processed')) {
         return;

--- a/web/modules/custom/ys_demo/js/tests/ys_demo.test.js
+++ b/web/modules/custom/ys_demo/js/tests/ys_demo.test.js
@@ -152,9 +152,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-ys-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-ys-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-ys-demo-counter-value]');
@@ -165,9 +163,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const decrementBtn = document.querySelector(
-        '[data-ys-demo-counter-action="decrement"]',
-      );
+      const decrementBtn = document.querySelector('[data-ys-demo-counter-action="decrement"]');
       decrementBtn.click();
 
       const value = document.querySelector('[data-ys-demo-counter-value]');
@@ -178,16 +174,12 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-ys-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-ys-demo-counter-action="increment"]');
       incrementBtn.click();
       incrementBtn.click();
       incrementBtn.click();
 
-      const resetBtn = document.querySelector(
-        '[data-ys-demo-counter-action="reset"]',
-      );
+      const resetBtn = document.querySelector('[data-ys-demo-counter-action="reset"]');
       resetBtn.click();
 
       const value = document.querySelector('[data-ys-demo-counter-value]');
@@ -198,9 +190,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-ys-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-ys-demo-counter-action="increment"]');
       incrementBtn.click();
       incrementBtn.click();
 
@@ -212,9 +202,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-ys-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-ys-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-ys-demo-counter-value]');
@@ -239,12 +227,8 @@ describe('Drupal.behaviors.ysDemo', () => {
       Drupal.behaviors.ysDemo.initCounterBlock(document);
 
       const blocks = document.querySelectorAll('[data-ys-demo-counter]');
-      expect(blocks[0].classList.contains('ys-demo-counter-processed')).toBe(
-        true,
-      );
-      expect(blocks[1].classList.contains('ys-demo-counter-processed')).toBe(
-        true,
-      );
+      expect(blocks[0].classList.contains('ys-demo-counter-processed')).toBe(true);
+      expect(blocks[1].classList.contains('ys-demo-counter-processed')).toBe(true);
     });
   });
 
@@ -263,9 +247,7 @@ describe('Drupal.behaviors.ysDemo', () => {
       document.body.innerHTML = createCounterBlockHtml();
       Drupal.behaviors.ysDemo.attach(document);
 
-      const incrementBtn = document.querySelector(
-        '[data-ys-demo-counter-action="increment"]',
-      );
+      const incrementBtn = document.querySelector('[data-ys-demo-counter-action="increment"]');
       incrementBtn.click();
 
       const value = document.querySelector('[data-ys-demo-counter-value]');

--- a/web/modules/custom/ys_demo/js/ys_demo.js
+++ b/web/modules/custom/ys_demo/js/ys_demo.js
@@ -26,9 +26,7 @@
 
         block.classList.add('ys-demo-counter-processed');
 
-        const valueElement = block.querySelector(
-          '[data-ys-demo-counter-value]',
-        );
+        const valueElement = block.querySelector('[data-ys-demo-counter-value]');
         const buttons = block.querySelectorAll('[data-ys-demo-counter-action]');
 
         let currentValue = this.getCounterValue();

--- a/web/themes/custom/your_site_theme/.prettierrc.json
+++ b/web/themes/custom/your_site_theme/.prettierrc.json
@@ -1,9 +1,10 @@
 {
-  "printWidth": 80,
+  "printWidth": 160,
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
   "plugins": ["@homer0/prettier-plugin-jsdoc"],
+  "jsdocPrintWidth": 80,
   "jsdocReplaceTagsSynonyms": false,
   "overrides": [
     {

--- a/web/themes/custom/your_site_theme/js/your_site_theme.js
+++ b/web/themes/custom/your_site_theme/js/your_site_theme.js
@@ -7,9 +7,7 @@
     attach(context) {
       // The context is the document on load and an element on AJAX, and that
       // element may be the body itself, so resolve through the owning document.
-      const body = context.ownerDocument
-        ? context.ownerDocument.body
-        : document.body;
+      const body = context.ownerDocument ? context.ownerDocument.body : document.body;
 
       if (body.classList.contains('your-site-theme-processed')) {
         return;


### PR DESCRIPTION
Closes #2987

## Summary

Raises the Prettier `printWidth` from `80` to `160` in both shipped configs (root `.prettierrc.json` and `web/themes/custom/your_site_theme/.prettierrc.json`), and adds `jsdocPrintWidth: 80` so JSDoc blocks keep wrapping at 80 columns while code widens to 160. The deciding factor is internal consistency rather than the downstream-sites signal the issue raised: `.vortex/CLAUDE.md` already documents the house rule as "Code: single lines preferred, no character limit" and "Comments: wrap at 80-120 characters", so shipping `printWidth: 80` had the template contradicting its own maintenance guide. `.editorconfig` gains a `[*.js]` section pinning `max_line_length` to `160` so editors agree with Prettier, and the existing `printWidth: 10000` override for CSS is kept unchanged - it is still needed and still consistent with the new default.

## Changes

- `.prettierrc.json` (root) and `web/themes/custom/your_site_theme/.prettierrc.json`: `printWidth` raised from `80` to `160`; added `jsdocPrintWidth: 80`. Both files were previously a verbatim copy of Drupal core's `web/core/.prettierrc.json` - Prettier resolves config from the nearest ancestor, so `web/core/**` keeps using core's own file and is unaffected by this change.
- `.editorconfig`: added a `[*.js]` section with `max_line_length = 160`, scoped to JS only so Markdown and PHP keep their own conventions, with a comment pointing at `.prettierrc.json` as the source of truth.
- `web/modules/custom/ys_demo/js/ys_demo.js`, `web/modules/custom/ys_demo/js/tests/ys_demo.test.js`, `web/themes/custom/your_site_theme/js/your_site_theme.js`: reformatted by `ahoy lint-fe-fix` - whitespace-only line joins, no behaviour change. No doc comment was reflowed, which confirms `jsdocPrintWidth` is taking effect.
- `.vortex/docs/content/tools/eslint.mdx`: added a "Line width" subsection under "Prettier integration" documenting the 160/80 split and why the CSS override exists, so the question is not rediscovered per site.
- `.vortex/installer/tests/Fixtures/**`: regenerated via `ahoy update-snapshots` (149 scenarios, 5 updated) rather than hand-edited, per `.vortex/CLAUDE.md`.

## Points raised in the issue

**Keep 80, or ship the width users actually keep?** Ships `160`. The three-of-four downstream signal is weaker evidence than it looks - the issue itself notes those sites share a maintainer, so it may reflect one house style rather than three independent judgments - and was not the deciding factor. What decided it is that `.vortex/CLAUDE.md` already states the house rule as "Code: single lines preferred, no character limit" and "Comments: wrap at 80-120 characters"; shipping `printWidth: 80` made the template contradict its own documented style.

**Does `.editorconfig` agree with the outcome?** It does now - a new `[*.js]` section sets `max_line_length = 160`, scoped to JS only, with a comment pointing back at `.prettierrc.json`.

**Is the `printWidth: 10000` CSS override still needed and consistent?** Yes, kept unchanged. Vortex lints CSS with Stylelint, not Prettier, so the override only matters when Prettier is invoked directly, such as an editor formatting on save; at `10000` it means "never wrap", matching Drupal core's own convention. Removing it would change nothing in CI but would let an editor reflow shipped CSS at `160`.

## Before / After

```
┌─ web/modules/custom/ys_demo/js/ys_demo.js ──────────────────────────────

│ BEFORE (printWidth: 80, no jsdocPrintWidth)
│
│   /**
│    * Counter block functionality.
│    *
│    * @param {HTMLElement} context  Context element to search for counter
│    *                               blocks.
│    */
│   const valueElement = block.querySelector(
│     '[data-ys-demo-counter-value]',
│   );
│
│ AFTER (printWidth: 160, jsdocPrintWidth: 80)
│
│   /**
│    * Counter block functionality.
│    *
│    * @param {HTMLElement} context  Context element to search for counter
│    *                               blocks.
│    */
│   const valueElement = block.querySelector('[data-ys-demo-counter-value]');
│
│   Doc comment - unchanged, still wraps at 80 via jsdocPrintWidth.
│   Code - now stays on one line, up to 160 columns before Prettier wraps it.
│
└───────────────────────────────────────────────────────────────────────

┌─ .editorconfig ──────────────────────────────────────────────────────

│ BEFORE
│
│   (no [*.js] section - editors had no JS-specific wrap width,
│    only the generic defaults)
│
│ AFTER
│
│   # Matches the Prettier 'printWidth' in .prettierrc.json.
│   [*.js]
│   max_line_length = 160
│
└───────────────────────────────────────────────────────────────────────
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented the project’s line-width and formatting conventions for JavaScript, JSDoc, CSS, and custom themes.

- **Style**
  - Updated formatting settings to allow wider JavaScript lines while keeping JSDoc comments more compact.
  - Aligned the example theme with the updated formatting standards.
  - Reformatted example code and tests for improved consistency without changing behavior.

- **Tests**
  - Preserved existing test coverage and behavior while standardizing test formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
