### PR TITLE
[#3012] Migrated release drafter's default version resolver to a 'version-resolver' category.

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,8 +2,9 @@ name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  default: minor
+categories:
+  - type: 'version-resolver'
+    semver-increment: 'minor'
 template: |
   ## What's new since $PREVIOUS_TAG
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/release-drafter.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/release-drafter.yml
@@ -2,8 +2,9 @@ name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  default: minor
+categories:
+  - type: 'version-resolver'
+    semver-increment: 'minor'
 template: |
   ## What's new since $PREVIOUS_TAG
 


### PR DESCRIPTION
Closes #3012

## Summary

Release Drafter v7.7.0 (pinned at `34d80673e067bdc0c24568d3af899c216adcfaa9` in `.github/workflows/draft-release-notes.yml`) deprecated the top-level `version-resolver` block, so every `Draft release notes` run logged a warning asking maintainers to migrate `version-resolver.default` into a `categories` entry. This PR migrates `.github/release-drafter.yml` to the new shape, and regenerates the installer's baseline fixture that mirrors this file.

## Changes

- Replaced the deprecated `version-resolver: default: minor` block in `.github/release-drafter.yml` with a `categories` entry of `type: 'version-resolver'` and `semver-increment: 'minor'`. Verified against the pinned action source: `src/actions/drafter/config/parse-categories.ts` translates the legacy `version-resolver.default` key into exactly this shape (`{ type: 'version-resolver', 'semver-increment': <default>, when: [], exclusive: false }`) at parse time, and `when`/`exclusive` are omitted here since they match their defaults (`[]` and `false`), so the new config is the exact semantic equivalent, not an approximation.
- The two forms cannot coexist - the parser throws if `version-resolver.default` is present alongside an empty-`when` `version-resolver` category - so the legacy block was removed rather than left alongside the new one.
- Changelog rendering is unaffected: only `type: changelog` categories produce sections, so the `version-resolver` category adds no heading to the generated release notes.
- The `minor` default is preserved as-is; it matters for consumers on the `semver` release scheme, where `draft-release-notes.yml` passes no explicit version and `resolve-version-increment.ts` uses this category as the fallback bump (on the default `calver` scheme the workflow passes an explicit version instead).
- Single-quoted the new scalar values to match the file's existing style, where every other scalar is single-quoted.
- Regenerated `.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/release-drafter.yml` via `ahoy update-snapshots` so the installer's baseline fixture matches the new config shape.
- Upstream migration reference: https://github.com/release-drafter/release-drafter/pull/1558

## Before / After

```
BEFORE - legacy top-level key, deprecated in v7.7.0

┌──────────────────────────────────────────────────┐
│ version-resolver:                                │
│   default: minor                                 │
└────────────────────────┬─────────────────────────┘
                         │ parse-categories.ts translates it at runtime
                         ▼
┌──────────────────────────────────────────────────┐
│ { type: 'version-resolver',                      │
│   semver-increment: 'minor',                     │
│   when: [], exclusive: false }                   │
└────────────────────────┬─────────────────────────┘
                         │
                         ▼
         resolve-version-increment.ts: fallback bump = minor
                         │
                         ▼
         deprecation warning on every release-notes run


AFTER - explicit category, current shape

┌──────────────────────────────────────────────────┐
│ categories:                                      │
│   - type: 'version-resolver'                     │
│     semver-increment: 'minor'                    │
└────────────────────────┬─────────────────────────┘
                         │ read directly, no translation step
                         ▼
         resolve-version-increment.ts: fallback bump = minor
                         │
                         ▼
         no warning, identical resolution outcome
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release versioning rules so changes categorized under the designated release category trigger a minor version increment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
