### PR TITLE
Required a '~' version constraint when installing the tooling package.

### DIFF
--- a/.vortex/tooling/README.md
+++ b/.vortex/tooling/README.md
@@ -10,7 +10,13 @@ to be added to your Drupal consumer project site.
 ## Installation
 
 ```bash
-composer require drevops/vortex-tooling
+composer require drevops/vortex-tooling:~1.4.0
+```
+
+Always install with a `~` constraint. It accepts patch releases but holds the minor version, so a new minor release cannot reach your deployments until you raise the constraint yourself:
+
+```json
+"drevops/vortex-tooling": "~1.4.0",
 ```
 
 Once installed, you run the shipped scripts as Composer binaries from


### PR DESCRIPTION
## Summary

The Installation section of `.vortex/tooling/README.md` showed an unconstrained `composer require drevops/vortex-tooling`, which lets Composer resolve to whatever version is newest at install time and later pull in a new major or minor release on any `composer update` with no explicit opt-in. The example now pins the package with a `~1.4.0` constraint, and a new paragraph explains that `~` accepts patch releases but holds the minor version, so a new minor release cannot reach a deployment until the constraint is raised deliberately.

## Changes

- `.vortex/tooling/README.md`: changed the Installation section's `composer require` example to `drevops/vortex-tooling:~1.4.0`, added a sentence explaining the patch-only update behavior of the `~` constraint, and added a JSON snippet showing the resulting `composer.json` entry.

## Before / After

```
BEFORE

  Docs showed:
    $ composer require drevops/vortex-tooling
                     |
                     v
       Composer writes a caret constraint by default
                     |
                     v
       composer.json: "drevops/vortex-tooling": "^1.4"   (implicit, undocumented)
                     |
                     v
       composer update ──→ any newer 1.x minor ──→ reaches deployment unreviewed

AFTER

  Docs show:
    $ composer require drevops/vortex-tooling:~1.4.0
                     |
                     v
       composer.json: "drevops/vortex-tooling": "~1.4.0"   (tilde, documented)
                     |
                     v
       composer update ──→ patch releases only within 1.4.x ──→ minor bump
                                                                  needs a manual constraint change
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to use the `drevops/vortex-tooling` package with the `~1.4.0` Composer constraint.
  * Added an equivalent `composer.json` example.
  * Clarified that the constraint allows patch updates while preventing automatic minor-version upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->