### PR TITLE
[#3023] Anchored environment variable prefixes forwarded by 'ahoy cli'.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -107,9 +107,9 @@ commands:
     aliases: [ssh, shell]
     cmd: |
       if [ "${#}" -ne 0 ]; then
-        docker compose exec $(env | cut -f1 -d= | grep "TERM\|COMPOSE_\|GITHUB_\|PACKAGE_\|DOCKER_\|DRUPAL_\|VORTEX_\|ENVIRONMENT_\|LOCALDEV_URL$" | sed 's/^/-e /') cli bash -c "$*"
+        docker compose exec $(env | cut -f1 -d= | grep -E '^(TERM|LOCALDEV_URL)$|^(COMPOSE|GITHUB|PACKAGE|DOCKER|DRUPAL|VORTEX|ENVIRONMENT)_' | sed 's/^/-e /') cli bash -c "$*"
       else
-        docker compose exec $(env | cut -f1 -d= | grep "TERM\|COMPOSE_\|GITHUB_\|PACKAGE_\|DOCKER_\|DRUPAL_\|VORTEX_\|ENVIRONMENT_\|LOCALDEV_URL$" | sed 's/^/-e /') cli bash
+        docker compose exec $(env | cut -f1 -d= | grep -E '^(TERM|LOCALDEV_URL)$|^(COMPOSE|GITHUB|PACKAGE|DOCKER|DRUPAL|VORTEX|ENVIRONMENT)_' | sed 's/^/-e /') cli bash
       fi
 
   composer:

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml
@@ -87,9 +87,9 @@ commands:
     aliases: [ssh, shell]
     cmd: |
       if [ "${#}" -ne 0 ]; then
-        docker compose exec $(env | cut -f1 -d= | grep "TERM\|COMPOSE_\|GITHUB_\|PACKAGE_\|DOCKER_\|DRUPAL_\|VORTEX_\|ENVIRONMENT_\|LOCALDEV_URL$" | sed 's/^/-e /') cli bash -c "$*"
+        docker compose exec $(env | cut -f1 -d= | grep -E '^(TERM|LOCALDEV_URL)$|^(COMPOSE|GITHUB|PACKAGE|DOCKER|DRUPAL|VORTEX|ENVIRONMENT)_' | sed 's/^/-e /') cli bash -c "$*"
       else
-        docker compose exec $(env | cut -f1 -d= | grep "TERM\|COMPOSE_\|GITHUB_\|PACKAGE_\|DOCKER_\|DRUPAL_\|VORTEX_\|ENVIRONMENT_\|LOCALDEV_URL$" | sed 's/^/-e /') cli bash
+        docker compose exec $(env | cut -f1 -d= | grep -E '^(TERM|LOCALDEV_URL)$|^(COMPOSE|GITHUB|PACKAGE|DOCKER|DRUPAL|VORTEX|ENVIRONMENT)_' | sed 's/^/-e /') cli bash
       fi
 
   composer:

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -131,6 +131,40 @@ trait SubtestAhoyTrait {
       txt: '`ahoy cli` forwards a host ENVIRONMENT_TYPE into the container'
     );
 
+    // Prefixes are matched at the start of the name, so a host variable that
+    // merely contains one is not forwarded.
+    $this->cmdFail(
+      'ahoy cli \'printenv MY_DRUPAL_SECRET\'',
+      '! unforwardedvar',
+      env: ['MY_DRUPAL_SECRET' => 'unforwardedvar'],
+      txt: '`ahoy cli` does not forward a host variable that contains an allowed prefix mid-name'
+    );
+
+    // 'LOCALDEV_URL' is matched in full, so a name ending with it is not
+    // forwarded.
+    $this->cmdFail(
+      'ahoy cli \'printenv MY_LOCALDEV_URL\'',
+      '! unforwardedvar',
+      env: ['MY_LOCALDEV_URL' => 'unforwardedvar'],
+      txt: '`ahoy cli` does not forward a host variable that ends with an allowed name'
+    );
+
+    // 'TERM' is matched in full, so terminal variables built around it are not
+    // forwarded, while 'TERM' itself still is.
+    $this->cmdFail(
+      'ahoy cli \'printenv ITERM_PROFILE\'',
+      '! unforwardedvar',
+      env: ['ITERM_PROFILE' => 'unforwardedvar'],
+      txt: '`ahoy cli` does not forward a host variable that contains TERM'
+    );
+
+    $this->cmd(
+      'ahoy cli \'printenv TERM\'',
+      'anchoredtermvar',
+      env: ['TERM' => 'anchoredtermvar'],
+      txt: '`ahoy cli` forwards a host TERM into the container'
+    );
+
     $this->logStepFinish();
   }
 

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -140,13 +140,20 @@ trait SubtestAhoyTrait {
       txt: '`ahoy cli` does not forward a host variable that contains an allowed prefix mid-name'
     );
 
-    // 'LOCALDEV_URL' is matched in full, so a name ending with it is not
-    // forwarded.
+    // 'LOCALDEV_URL' is matched in full: the exact name is forwarded, a name
+    // ending with it is not.
     $this->cmdFail(
       "ahoy cli 'printenv MY_LOCALDEV_URL'",
       '! unforwardedvar',
       env: ['MY_LOCALDEV_URL' => 'unforwardedvar'],
       txt: '`ahoy cli` does not forward a host variable that ends with an allowed name'
+    );
+
+    $this->cmd(
+      "ahoy cli 'printenv LOCALDEV_URL'",
+      'anchoredlocaldevurl',
+      env: ['LOCALDEV_URL' => 'anchoredlocaldevurl'],
+      txt: '`ahoy cli` forwards an exact host LOCALDEV_URL into the container'
     );
 
     // 'TERM' is matched in full, so terminal variables built around it are not

--- a/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
+++ b/.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php
@@ -134,7 +134,7 @@ trait SubtestAhoyTrait {
     // Prefixes are matched at the start of the name, so a host variable that
     // merely contains one is not forwarded.
     $this->cmdFail(
-      'ahoy cli \'printenv MY_DRUPAL_SECRET\'',
+      "ahoy cli 'printenv MY_DRUPAL_SECRET'",
       '! unforwardedvar',
       env: ['MY_DRUPAL_SECRET' => 'unforwardedvar'],
       txt: '`ahoy cli` does not forward a host variable that contains an allowed prefix mid-name'
@@ -143,7 +143,7 @@ trait SubtestAhoyTrait {
     // 'LOCALDEV_URL' is matched in full, so a name ending with it is not
     // forwarded.
     $this->cmdFail(
-      'ahoy cli \'printenv MY_LOCALDEV_URL\'',
+      "ahoy cli 'printenv MY_LOCALDEV_URL'",
       '! unforwardedvar',
       env: ['MY_LOCALDEV_URL' => 'unforwardedvar'],
       txt: '`ahoy cli` does not forward a host variable that ends with an allowed name'
@@ -152,14 +152,14 @@ trait SubtestAhoyTrait {
     // 'TERM' is matched in full, so terminal variables built around it are not
     // forwarded, while 'TERM' itself still is.
     $this->cmdFail(
-      'ahoy cli \'printenv ITERM_PROFILE\'',
+      "ahoy cli 'printenv ITERM_PROFILE'",
       '! unforwardedvar',
       env: ['ITERM_PROFILE' => 'unforwardedvar'],
       txt: '`ahoy cli` does not forward a host variable that contains TERM'
     );
 
     $this->cmd(
-      'ahoy cli \'printenv TERM\'',
+      "ahoy cli 'printenv TERM'",
       'anchoredtermvar',
       env: ['TERM' => 'anchoredtermvar'],
       txt: '`ahoy cli` forwards a host TERM into the container'


### PR DESCRIPTION
Closes #3023

## Summary

`ahoy cli` forwards host environment variables into the container by filtering `env` output through a `grep` pattern of allowed prefixes, but the pattern wasn't anchored, so `grep` matched each token anywhere in a variable name rather than at its start. Any host variable that merely contained a token like `TERM` or `DRUPAL_` got forwarded, not just the variables that actually started with it. We reproduced this live: `MY_DRUPAL_SECRET`, `ITERM_PROFILE`, `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `COLORTERM` and `ZED_TERM` all crossed into the container despite none of them being an intended match. This PR anchors the pattern so only an exact `TERM`/`LOCALDEV_URL` match or a genuine `COMPOSE_`/`GITHUB_`/`PACKAGE_`/`DOCKER_`/`DRUPAL_`/`VORTEX_`/`ENVIRONMENT_` prefix gets through.

The issue proposed an anchored basic regular expression (`grep "^TERM$\|^COMPOSE_\|..."`), but that form isn't portable: in a POSIX BRE, `$` is only an anchor at the very end of the whole expression, so BSD grep (the one macOS ships) reads `^TERM$` as the literal string `TERM$` and silently stops matching `TERM` on every macOS machine, while GNU grep and BusyBox grep both accept it as an anchor. We confirmed this against BSD grep 2.6.0-FreeBSD and BusyBox grep. Switching to an extended regular expression (`grep -E`) sidesteps the problem, since `^` and `$` are anchors everywhere in an ERE and all three implementations agree.

## Changes

- `.ahoy.yml` - both branches of the `cli` command (the `docker compose exec ... bash -c` form and the plain `bash` form) now filter through `grep -E '^(TERM|LOCALDEV_URL)$|^(COMPOSE|GITHUB|PACKAGE|DOCKER|DRUPAL|VORTEX|ENVIRONMENT)_'` instead of the unanchored BRE.
- `.vortex/tests/phpunit/Traits/Subtests/SubtestAhoyTrait.php` - `subtestAhoyCli()` gains 5 assertions covering both directions of the filter. Blocked: `MY_DRUPAL_SECRET` (an allowed prefix in the middle of the name), `MY_LOCALDEV_URL` (an allowed name as a suffix), and `ITERM_PROFILE` (contains `TERM` but isn't `TERM`). Forwarded: an exact `TERM` and an exact `LOCALDEV_URL`. Those last 2 are the regression guard for the BSD/GNU BRE anchoring trap described above - an over-eager anchoring fix would silently drop them, and nothing else in the suite would notice.
- `.vortex/installer/tests/Fixtures/handler_process/_baseline/.ahoy.yml` - regenerated installer snapshot picking up the `.ahoy.yml` fix, via `ahoy update-snapshots`.

The `LOCALDEV_URL` assertion is worth a note, because the container already gets a `LOCALDEV_URL` of its own from `docker-compose.yml` (derived from `COMPOSE_PROJECT_NAME`). The test forwards a distinctive host value and asserts on that value rather than on the variable merely being set, so the compose-provided one can't satisfy it.

## Scope

The issue asks whether the same idiom appears elsewhere, so we swept for it. It doesn't:

- The CI env-forwarding calls in `.circleci/config.yml`, `.circleci/vortex-test-common.yml` and `.github/workflows/build-test-deploy.yml` use `env | cut -f1 -d= | sed 's/^/-e /'` with no `grep` at all - they forward everything on purpose, inside an ephemeral CI container.
- `.lagoon.yml` reads a value out of `.env` with a start-anchored `grep`. Different job, different trust boundary, already anchored where it matters.

One knock-on worth flagging: `COLORTERM`, `TERM_PROGRAM` and friends were only ever forwarded by accident, and they stop being forwarded now. Nothing in the repo reads them, and the container sets no `TERM` of its own, so this shouldn't be noticeable - but if truecolor detection inside the container ever matters, `COLORTERM` should be added to the allowlist deliberately rather than restored by accident.

## Before / After

BEFORE - `grep "TERM\|COMPOSE_\|GITHUB_\|PACKAGE_\|DOCKER_\|DRUPAL_\|VORTEX_\|ENVIRONMENT_\|LOCALDEV_URL$"` matches a listed token anywhere in the variable name.

AFTER - `grep -E '^(TERM|LOCALDEV_URL)$|^(COMPOSE|GITHUB|PACKAGE|DOCKER|DRUPAL|VORTEX|ENVIRONMENT)_'` matches only an exact name or a genuine prefix.

```
                     host environment
                            │
                            ▼
              ┌─────────────────────────┐
              │  env | cut -f1 -d=      │
              │  grep <filter>          │
              │  sed 's/^/-e /'         │
              └─────────────────────────┘
                            │
                            ▼
                docker compose exec cli

┌──────────────────────┬──────────────┬─────────────┐
│ Host variable        │ BEFORE (BRE) │ AFTER (ERE) │
├──────────────────────┼──────────────┼─────────────┤
│ DRUPAL_SHIELD_PASS   │ forwarded    │ forwarded   │
│ TERM                 │ forwarded    │ forwarded   │
│ LOCALDEV_URL         │ forwarded    │ forwarded   │
├──────────────────────┼──────────────┼─────────────┤
│ MY_DRUPAL_SECRET     │ forwarded    │ blocked     │
│ COMPANY_GITHUB_TOKEN │ forwarded    │ blocked     │
│ MY_LOCALDEV_URL      │ forwarded    │ blocked     │
│ ITERM_PROFILE        │ forwarded    │ blocked     │
│ TERM_PROGRAM_VERSION │ forwarded    │ blocked     │
│ COLORTERM            │ forwarded    │ blocked     │
│ ZED_TERM             │ forwarded    │ blocked     │
└──────────────────────┴──────────────┴─────────────┘
```

The top 3 are meant to cross into the container and still do. Everything below the divider only ever matched by accident, because the old pattern had no start anchor.
