### PR TITLE
Replaced per-step CI runner conditions with declared 'CI_IS_*_RUNNER' roles.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,6 +369,33 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              #;< TOOL_JEST
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              #;> TOOL_JEST
+              #;< TOOL_PHPUNIT
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              #;> TOOL_PHPUNIT
+              #;< DRUPAL_THEME
+              #;< MODULE_SDC_DEVEL
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              #;> MODULE_SDC_DEVEL
+              #;> DRUPAL_THEME
+              #;< TOOL_BEHAT
+              echo "export CI_IS_BEHAT_RUNNER=1"
+              #;> TOOL_BEHAT
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -443,20 +470,22 @@ jobs:
       #;< TOOL_JEST
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
       #;> TOOL_JEST
 
       #;< TOOL_PHPUNIT
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -465,7 +494,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -474,7 +503,7 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
@@ -482,7 +511,7 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
@@ -491,7 +520,7 @@ jobs:
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -503,7 +532,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -518,7 +547,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,10 +371,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -391,6 +390,7 @@ jobs:
               #;> MODULE_SDC_DEVEL
               #;> DRUPAL_THEME
               #;< TOOL_BEHAT
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
               #;> TOOL_BEHAT
             } >> "${BASH_ENV}"

--- a/.circleci/vortex-test-common.yml
+++ b/.circleci/vortex-test-common.yml
@@ -206,10 +206,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -226,6 +225,7 @@ jobs:
               #;> MODULE_SDC_DEVEL
               #;> DRUPAL_THEME
               #;< TOOL_BEHAT
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
               #;> TOOL_BEHAT
             } >> "${BASH_ENV}"

--- a/.circleci/vortex-test-common.yml
+++ b/.circleci/vortex-test-common.yml
@@ -204,6 +204,33 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              #;< TOOL_JEST
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              #;> TOOL_JEST
+              #;< TOOL_PHPUNIT
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              #;> TOOL_PHPUNIT
+              #;< DRUPAL_THEME
+              #;< MODULE_SDC_DEVEL
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              #;> MODULE_SDC_DEVEL
+              #;> DRUPAL_THEME
+              #;< TOOL_BEHAT
+              echo "export CI_IS_BEHAT_RUNNER=1"
+              #;> TOOL_BEHAT
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -278,20 +305,22 @@ jobs:
       #;< TOOL_JEST
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
       #;> TOOL_JEST
 
       #;< TOOL_PHPUNIT
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -300,7 +329,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -309,7 +338,7 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
@@ -317,7 +346,7 @@ jobs:
       - run:
           name: Upload code coverage reports to Codecov
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
@@ -326,7 +355,7 @@ jobs:
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -338,7 +367,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -353,7 +382,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -351,10 +351,9 @@ jobs:
       fail-fast: false
 
     env:
-      # Which tools run on this instance. The tools that only need to run once
-      # are pinned to the first instance, while Behat runs on every instance
-      # using the `p<instance index>` profile. Add a line for every additional
-      # tool and reference it in that tool's step.
+      # Which tools run on this instance. Tools that only need to run once are
+      # pinned to the first instance. Add a line for every additional tool and
+      # reference it in that tool's step.
       # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
       CI_RUNNER_INDEX: ${{ strategy.job-index }}
       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
@@ -370,6 +369,7 @@ jobs:
       #;> MODULE_SDC_DEVEL
       #;> DRUPAL_THEME
       #;< TOOL_BEHAT
+      # Runs on every instance, using the `p<instance index>` profile.
       CI_IS_BEHAT_RUNNER: true
       #;> TOOL_BEHAT
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -350,6 +350,29 @@ jobs:
         instance: [0, 1]
       fail-fast: false
 
+    env:
+      # Which tools run on this instance. The tools that only need to run once
+      # are pinned to the first instance, while Behat runs on every instance
+      # using the `p<instance index>` profile. Add a line for every additional
+      # tool and reference it in that tool's step.
+      # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+      CI_RUNNER_INDEX: ${{ strategy.job-index }}
+      CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+      #;< TOOL_JEST
+      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+      #;> TOOL_JEST
+      #;< TOOL_PHPUNIT
+      CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+      #;> TOOL_PHPUNIT
+      #;< DRUPAL_THEME
+      #;< MODULE_SDC_DEVEL
+      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+      #;> MODULE_SDC_DEVEL
+      #;> DRUPAL_THEME
+      #;< TOOL_BEHAT
+      CI_IS_BEHAT_RUNNER: true
+      #;> TOOL_BEHAT
+
     container:
       # https://hub.docker.com/r/drevops/ci-runner
       image: drevops/ci-runner:26.8.0@sha256:80be478cfff66d81fa804ccc707dbeae478655d8b850f1ae06824c194bd6528e
@@ -480,19 +503,19 @@ jobs:
 
       #;< TOOL_JEST
       - name: Test with Jest
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        if: ${{ env.CI_IS_JEST_RUNNER == 'true' }}
         run: docker compose exec -T cli bash -c "yarn test"
         continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
       #;> TOOL_JEST
 
       #;< TOOL_PHPUNIT
       - name: Test with PHPUnit
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         run: docker compose exec -T cli vendor/bin/phpunit
         continue-on-error: ${{ vars.VORTEX_CI_PHPUNIT_IGNORE_FAILURE == '1' }}
 
       - name: Process PHPUnit logs and coverage
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         run: |
           mkdir -p ".logs"
           if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
@@ -500,7 +523,7 @@ jobs:
           fi
 
       - name: Extract code coverage
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         run: |
           RATE=$(grep -om1 'line-rate="[0-9.]*"' .logs/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
           PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
@@ -518,7 +541,7 @@ jobs:
           VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 
       - name: Post coverage summary as PR comment
-        if: ${{ github.event_name == 'pull_request' && (matrix.instance == 0 || strategy.job-total == 1) && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
+        if: ${{ github.event_name == 'pull_request' && env.CI_IS_PHPUNIT_RUNNER == 'true' && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: coverage-gha
@@ -539,7 +562,7 @@ jobs:
       #;< CODE_COVERAGE_PROVIDER_CODECOV
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        if: ${{ (matrix.instance == 0 || strategy.job-total == 1) && env.CODECOV_TOKEN != '' }}
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' && env.CODECOV_TOKEN != '' }}
         continue-on-error: true
         with:
           directory: .logs/coverage
@@ -550,7 +573,7 @@ jobs:
       #;> CODE_COVERAGE_PROVIDER_CODECOV
 
       - name: Check code coverage threshold
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         run: |
           if [ "${COVERAGE_PERCENT//.}" -lt "$((VORTEX_CI_CODE_COVERAGE_THRESHOLD*100))" ]; then
             echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD}%"
@@ -563,7 +586,7 @@ jobs:
       #;< DRUPAL_THEME
       #;< MODULE_SDC_DEVEL
       - name: Validate Single Directory Components
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
         run: |
           [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
           output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
@@ -578,16 +601,15 @@ jobs:
 
       #;< TOOL_BEHAT
       - name: Test with Behat
+        if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}
         run: |
           # shellcheck disable=SC2170
-          if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
+          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
           echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
           docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
         env:
           VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
-          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
-          STRATEGY_JOB_INDEX: ${{ strategy.job-index }}
         continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
         timeout-minutes: 30
       #;> TOOL_BEHAT

--- a/.vortex/docs/content/continuous-integration/README.mdx
+++ b/.vortex/docs/content/continuous-integration/README.mdx
@@ -3,6 +3,9 @@ sidebar_label: Overview
 sidebar_position: 1
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Continuous Integration
 
 **Vortex** offers continuous integration configurations for [GitHub Actions](/docs/continuous-integration/github-actions)
@@ -153,13 +156,99 @@ parallelism settings.
 
 | Task | First container | Other containers |
 |------|:---:|:---:|
+| Jest tests | ✓ | — |
 | PHPUnit tests | ✓ | — |
 | Code coverage check and PR comment | ✓ | — |
+| Single Directory Component validation | ✓ | — |
 | Behat tests | ✓ (profile `p0`) | ✓ (profile `p1`, `p2`, ...) |
 
-PHPUnit and coverage reporting run exclusively on the first container
-to avoid duplicate work. Behat tests run on all containers using profile-based
+Everything except Behat runs exclusively on the first container to avoid
+duplicate work. Behat tests run on all containers using profile-based
 distribution.
+
+### Choosing which container runs what
+
+Each tool reads a `CI_IS_<TOOL>_RUNNER` variable that decides whether it runs on
+the current container. All of them are declared together at the top of the build
+job, so the whole distribution is visible and editable in one place:
+
+<Tabs queryString="ci-provider" groupId="ci-provider">
+<TabItem value="gha" label="GitHub Actions">
+
+```yaml title=".github/workflows/build-test-deploy.yml"
+env:
+  CI_RUNNER_INDEX: ${{ strategy.job-index }}
+  CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+  CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+  CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+  CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+  CI_IS_BEHAT_RUNNER: true
+```
+
+Each tool's step then reads its own flag:
+
+```yaml
+- name: Test with PHPUnit
+  if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
+```
+
+</TabItem>
+<TabItem value="circleci" label="CircleCI">
+
+```yaml title=".circleci/config.yml"
+- run:
+    name: Set test runner roles
+    command: |
+      {
+        echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+        echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+        echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+        echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+        echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+        echo "export CI_IS_BEHAT_RUNNER=1"
+      } >> "${BASH_ENV}"
+```
+
+Each tool's step then reads its own flag as its first line:
+
+```yaml
+- run:
+    name: Test with PHPUnit
+    command: |
+      [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
+```
+
+</TabItem>
+</Tabs>
+
+`CI_RUNNER_INDEX` and `CI_RUNNER_TOTAL` carry the current container's index and
+the container count under the same names on both providers.
+
+To run a tool of your own on a specific container, add one more flag alongside
+the others and reference it from your step:
+
+```yaml
+CI_IS_CYPRESS_RUNNER: ${{ matrix.instance == 1 }}
+```
+
+#### Giving a tool its own container
+
+Moving a tool onto a container of its own takes two edits - point its flag at
+that container, and exclude that container from Behat:
+
+```yaml
+CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 2 }}
+CI_IS_BEHAT_RUNNER: ${{ matrix.instance != 2 }}
+```
+
+:::warning
+
+Use the **last** container for this, never the first. Behat derives its profile
+name from the container index, and `p0` is the catch-all that runs every
+scenario without a `@pX` tag. Excluding container 0 from Behat means `p0` never
+runs and those scenarios silently stop being tested.
+
+:::
 
 ### Balancing Behat tests
 
@@ -194,11 +283,43 @@ duration of the longest single container rather than the sum of all tests.
 
 :::
 
-See the provider-specific pages for how to change the number of parallel
-containers:
+### Adding more containers
 
-- [CircleCI — Change test parallelism](/docs/continuous-integration/circleci#change-test-parallelism)
-- [GitHub Actions — Change test parallelism](/docs/continuous-integration/github-actions#change-test-parallelism)
+Raising the container count takes two changes that must stay in step - the
+container count itself, and a matching Behat profile for every new container.
+
+1. Increase the container count. See the provider-specific pages:
+
+   - [CircleCI — Change test parallelism](/docs/continuous-integration/circleci#change-test-parallelism)
+   - [GitHub Actions — Change test parallelism](/docs/continuous-integration/github-actions#change-test-parallelism)
+
+2. Add a profile to `behat.yml` for each new container. **Vortex** ships with
+   `p0` and `p1` only, and Behat fails with `profile 'p2' does not exist` if a
+   container has no profile named after its index:
+
+   ```yaml title="behat.yml"
+   p2:
+     gherkin:
+       cache: '/tmp/behat_gherkin_cache'
+       filters:
+         tags: '@smoke,@p2&&~@skipped'
+   ```
+
+3. Exclude the new tag from the `p0` catch-all, so its scenarios do not also run
+   on the first container:
+
+   ```yaml title="behat.yml"
+   p0:
+     gherkin:
+       cache: '/tmp/behat_gherkin_cache'
+       filters:
+         tags: '@smoke,~@p1&&~@p2&&~@skipped'
+   ```
+
+4. Tag scenarios with `@p2` to move them onto the new container.
+
+Scenarios tagged `@smoke` run on every container by design, so they stay out of
+the balancing arithmetic.
 
 ## Maintenance
 

--- a/.vortex/docs/content/continuous-integration/README.mdx
+++ b/.vortex/docs/content/continuous-integration/README.mdx
@@ -233,13 +233,24 @@ CI_IS_CYPRESS_RUNNER: ${{ matrix.instance == 1 }}
 
 #### Giving a tool its own container
 
-Moving a tool onto a container of its own takes two edits - point its flag at
-that container, and exclude that container from Behat:
+Start by [adding a container](#adding-more-containers) for the tool to move onto
+
+- the default configuration has containers `0` and `1` only. Then point the
+tool's flag at the new container and exclude that container from Behat. With a
+third container added, that is:
 
 ```yaml
 CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 2 }}
 CI_IS_BEHAT_RUNNER: ${{ matrix.instance != 2 }}
 ```
+
+:::warning
+
+Point the flag at a container that exists. A flag whose condition matches no
+container disables the tool everywhere, and nothing reports it - the steps are
+simply skipped and the job still passes.
+
+:::
 
 :::warning
 
@@ -293,9 +304,10 @@ container count itself, and a matching Behat profile for every new container.
    - [CircleCI — Change test parallelism](/docs/continuous-integration/circleci#change-test-parallelism)
    - [GitHub Actions — Change test parallelism](/docs/continuous-integration/github-actions#change-test-parallelism)
 
-2. Add a profile to `behat.yml` for each new container. **Vortex** ships with
-   `p0` and `p1` only, and Behat fails with `profile 'p2' does not exist` if a
-   container has no profile named after its index:
+2. Add a profile to `behat.yml` for each new container that runs Behat.
+   **Vortex** ships with `p0` and `p1` only, and Behat fails with
+   `profile 'p2' does not exist` if a container running Behat has no profile
+   named after its index. A container excluded from Behat needs no profile:
 
    ```yaml title="behat.yml"
    p2:

--- a/.vortex/docs/content/continuous-integration/circleci.mdx
+++ b/.vortex/docs/content/continuous-integration/circleci.mdx
@@ -82,13 +82,16 @@ build:
   parallelism: 4  # Run tests across 4 containers
 ```
 
-When adding more containers, distribute Behat scenarios across them using
-profile tags (`@p0`, `@p1`, `@p2`, etc.) in your feature files. Since the first
-container also runs linting, PHPUnit, and coverage, assign more Behat scenarios
+Every added container also needs a matching `pN` profile in `behat.yml` -
+without it, Behat fails with `profile 'p2' does not exist`. Then distribute
+Behat scenarios across the containers using profile tags (`@p0`, `@p1`, `@p2`,
+etc.) in your feature files. Since the first container also runs Jest, PHPUnit,
+coverage, and Single Directory Component validation, assign more Behat scenarios
 to the additional containers to keep build times balanced.
 
-See [Test parallelism](/docs/continuous-integration#test-parallelism) for details
-on how tests are distributed across containers.
+See [Adding more containers](/docs/continuous-integration#adding-more-containers)
+for the full procedure, and [Choosing which container runs what](/docs/continuous-integration#choosing-which-container-runs-what)
+to move a tool onto a different container.
 
 ### SSH access for debugging
 

--- a/.vortex/docs/content/continuous-integration/circleci.mdx
+++ b/.vortex/docs/content/continuous-integration/circleci.mdx
@@ -82,12 +82,13 @@ build:
   parallelism: 4  # Run tests across 4 containers
 ```
 
-Every added container also needs a matching `pN` profile in `behat.yml` -
-without it, Behat fails with `profile 'p2' does not exist`. Then distribute
-Behat scenarios across the containers using profile tags (`@p0`, `@p1`, `@p2`,
-etc.) in your feature files. Since the first container also runs Jest, PHPUnit,
-coverage, and Single Directory Component validation, assign more Behat scenarios
-to the additional containers to keep build times balanced.
+Every added container that runs Behat also needs a matching `pN` profile in
+`behat.yml` - without it, Behat fails with `profile 'p2' does not exist`. A
+container excluded from Behat needs no profile. Then distribute Behat scenarios
+across the containers using profile tags (`@p0`, `@p1`, `@p2`, etc.) in your
+feature files. Since the first container also runs Jest, PHPUnit, coverage, and
+Single Directory Component validation, assign more Behat scenarios to the
+additional containers to keep build times balanced.
 
 See [Adding more containers](/docs/continuous-integration#adding-more-containers)
 for the full procedure, and [Choosing which container runs what](/docs/continuous-integration#choosing-which-container-runs-what)

--- a/.vortex/docs/content/continuous-integration/github-actions.mdx
+++ b/.vortex/docs/content/continuous-integration/github-actions.mdx
@@ -109,12 +109,13 @@ strategy:
     instance: [0, 1, 2, 3]  # Run tests across 4 containers
 ```
 
-Every added container also needs a matching `pN` profile in `behat.yml` -
-without it, Behat fails with `profile 'p2' does not exist`. Then distribute
-Behat scenarios across the containers using profile tags (`@p0`, `@p1`, `@p2`,
-etc.) in your feature files. Since the first container also runs Jest, PHPUnit,
-coverage, and Single Directory Component validation, assign more Behat scenarios
-to the additional containers to keep build times balanced.
+Every added container that runs Behat also needs a matching `pN` profile in
+`behat.yml` - without it, Behat fails with `profile 'p2' does not exist`. A
+container excluded from Behat needs no profile. Then distribute Behat scenarios
+across the containers using profile tags (`@p0`, `@p1`, `@p2`, etc.) in your
+feature files. Since the first container also runs Jest, PHPUnit, coverage, and
+Single Directory Component validation, assign more Behat scenarios to the
+additional containers to keep build times balanced.
 
 See [Adding more containers](/docs/continuous-integration#adding-more-containers)
 for the full procedure, and [Choosing which container runs what](/docs/continuous-integration#choosing-which-container-runs-what)

--- a/.vortex/docs/content/continuous-integration/github-actions.mdx
+++ b/.vortex/docs/content/continuous-integration/github-actions.mdx
@@ -109,13 +109,16 @@ strategy:
     instance: [0, 1, 2, 3]  # Run tests across 4 containers
 ```
 
-When adding more containers, distribute Behat scenarios across them using
-profile tags (`@p0`, `@p1`, `@p2`, etc.) in your feature files. Since the first
-container also runs linting, PHPUnit, and coverage, assign more Behat scenarios
+Every added container also needs a matching `pN` profile in `behat.yml` -
+without it, Behat fails with `profile 'p2' does not exist`. Then distribute
+Behat scenarios across the containers using profile tags (`@p0`, `@p1`, `@p2`,
+etc.) in your feature files. Since the first container also runs Jest, PHPUnit,
+coverage, and Single Directory Component validation, assign more Behat scenarios
 to the additional containers to keep build times balanced.
 
-See [Test parallelism](/docs/continuous-integration#test-parallelism) for details
-on how tests are distributed across containers.
+See [Adding more containers](/docs/continuous-integration#adding-more-containers)
+for the full procedure, and [Choosing which container runs what](/docs/continuous-integration#choosing-which-container-runs-what)
+to move a tool onto a different container.
 
 ### Manual deployment
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -304,16 +304,16 @@ jobs:
       fail-fast: false
 
     env:
-      # Which tools run on this instance. The tools that only need to run once
-      # are pinned to the first instance, while Behat runs on every instance
-      # using the `p<instance index>` profile. Add a line for every additional
-      # tool and reference it in that tool's step.
+      # Which tools run on this instance. Tools that only need to run once are
+      # pinned to the first instance. Add a line for every additional tool and
+      # reference it in that tool's step.
       # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
       CI_RUNNER_INDEX: ${{ strategy.job-index }}
       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
       CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+      # Runs on every instance, using the `p<instance index>` profile.
       CI_IS_BEHAT_RUNNER: true
 
     container:

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -303,6 +303,19 @@ jobs:
         instance: [0, 1]
       fail-fast: false
 
+    env:
+      # Which tools run on this instance. The tools that only need to run once
+      # are pinned to the first instance, while Behat runs on every instance
+      # using the `p<instance index>` profile. Add a line for every additional
+      # tool and reference it in that tool's step.
+      # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+      CI_RUNNER_INDEX: ${{ strategy.job-index }}
+      CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+      CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+      CI_IS_BEHAT_RUNNER: true
+
     container:
       # https://hub.docker.com/r/drevops/ci-runner
       image: drevops/ci-runner:__VERSION__
@@ -419,17 +432,17 @@ jobs:
         timeout-minutes: 30
 
       - name: Test with Jest
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        if: ${{ env.CI_IS_JEST_RUNNER == 'true' }}
         run: docker compose exec -T cli bash -c "yarn test"
         continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
 
       - name: Test with PHPUnit
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         run: docker compose exec -T cli vendor/bin/phpunit
         continue-on-error: ${{ vars.VORTEX_CI_PHPUNIT_IGNORE_FAILURE == '1' }}
 
       - name: Process PHPUnit logs and coverage
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         run: |
           mkdir -p ".logs"
           if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
@@ -437,7 +450,7 @@ jobs:
           fi
 
       - name: Extract code coverage
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         run: |
           RATE=$(grep -om1 'line-rate="[0-9.]*"' .logs/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
           PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
@@ -455,7 +468,7 @@ jobs:
           VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 
       - name: Post coverage summary as PR comment
-        if: ${{ github.event_name == 'pull_request' && (matrix.instance == 0 || strategy.job-total == 1) && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
+        if: ${{ github.event_name == 'pull_request' && env.CI_IS_PHPUNIT_RUNNER == 'true' && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
         uses: marocchino/sticky-pull-request-comment@__HASH__ # __VERSION__
         with:
           header: coverage-gha
@@ -474,7 +487,7 @@ jobs:
           hide_and_recreate: true
 
       - name: Check code coverage threshold
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
         run: |
           if [ "${COVERAGE_PERCENT//.}" -lt "$((VORTEX_CI_CODE_COVERAGE_THRESHOLD*100))" ]; then
             echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD}%"
@@ -484,7 +497,7 @@ jobs:
           VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 
       - name: Validate Single Directory Components
-        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+        if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
         run: |
           [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
           output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
@@ -496,16 +509,15 @@ jobs:
         continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
 
       - name: Test with Behat
+        if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}
         run: |
           # shellcheck disable=SC2170
-          if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
+          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
           echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
           docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
         env:
           VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
-          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
-          STRATEGY_JOB_INDEX: ${{ strategy.job-index }}
         continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
         timeout-minutes: 30
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/behat.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/behat.yml
@@ -96,16 +96,20 @@ default:
     # Show explicit fail information and continue the test run.
     DrevOps\BehatFormatProgressFail\FormatExtension: ~
 
-# Profile for parallel testing.
-# Runs all tests not tagged with 'smoke' or '@p1' and not tagged with '@skipped'.
-# This is a 'catch-all' profile that runs any tests not tagged with '@pX'.
+# Profiles for parallel testing. CI runs the profile named after the index of
+# the runner it is on, so 'pN' requires a runner N. Adding a runner means adding
+# a matching profile here and excluding its tag from the 'p0' catch-all below.
+# https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+
+# Runs all tests tagged with '@smoke' or not tagged with '@p1', and not tagged
+# with '@skipped'. This is a 'catch-all' profile that runs any tests not tagged
+# with '@pX'.
 p0:
   gherkin:
     cache: '/tmp/behat_gherkin_cache'
     filters:
       tags: '@smoke,~@p1&&~@skipped'
 
-# Profile for parallel testing.
 # Runs all tests tagged with '@smoke' or '@p1' and not tagged with '@skipped'.
 p1:
   gherkin:

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -318,10 +318,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -329,6 +328,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -316,6 +316,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -378,18 +395,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -398,7 +417,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -407,14 +426,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -423,7 +442,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -435,7 +454,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
@@ -1,10 +1,10 @@
-@@ -473,6 +473,17 @@
+@@ -486,6 +486,17 @@
              </details>
            hide_and_recreate: true
  
 +      - name: Upload coverage report to Codecov
 +        uses: codecov/codecov-action@__HASH__ # __VERSION__
-+        if: ${{ (matrix.instance == 0 || strategy.job-total == 1) && env.CODECOV_TOKEN != '' }}
++        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' && env.CODECOV_TOKEN != '' }}
 +        continue-on-error: true
 +        with:
 +          directory: .logs/coverage
@@ -14,5 +14,5 @@
 +          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 +
        - name: Check code coverage threshold
-         if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+         if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
          run: |

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
@@ -318,10 +318,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -329,6 +328,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
@@ -316,6 +316,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -378,18 +395,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -398,7 +417,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -407,14 +426,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Upload code coverage reports to Codecov
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ -n "${CODECOV_TOKEN}" ] && [ -d /tmp/artifacts/coverage ] && ! echo "${CIRCLE_BRANCH}" | grep -q '^deps/'; then
               codecov -Z -s /tmp/artifacts/coverage;
             fi
@@ -422,7 +441,7 @@ jobs:
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -431,7 +450,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -443,7 +462,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -318,10 +318,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -329,6 +328,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -316,6 +316,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -378,18 +395,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -398,7 +417,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -407,14 +426,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -423,7 +442,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -435,7 +454,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
@@ -318,10 +318,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -329,6 +328,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
@@ -316,6 +316,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -378,18 +395,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -398,7 +417,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -407,14 +426,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -423,7 +442,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -435,7 +454,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -552,104 +552,3 @@
+@@ -564,104 +564,3 @@
          timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
          with:
            detached: true

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -318,10 +318,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -329,6 +328,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -316,6 +316,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -378,18 +395,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -398,7 +417,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -407,14 +426,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -423,7 +442,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -435,7 +454,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -318,10 +318,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -329,6 +328,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -316,6 +316,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -378,18 +395,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -398,7 +417,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -407,14 +426,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -423,7 +442,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -435,7 +454,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -414,6 +417,11 @@
+@@ -427,6 +430,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -321,6 +321,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -388,18 +405,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -408,7 +427,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -417,14 +436,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -433,7 +452,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -445,7 +464,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -323,10 +323,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -334,6 +333,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -414,6 +417,11 @@
+@@ -427,6 +430,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -414,6 +417,11 @@
+@@ -427,6 +430,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -414,6 +417,11 @@
+@@ -427,6 +430,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -414,6 +417,11 @@
+@@ -427,6 +430,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -414,6 +417,11 @@
+@@ -427,6 +430,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -414,6 +417,11 @@
+@@ -427,6 +430,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -414,6 +417,11 @@
+@@ -427,6 +430,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel/.github/workflows/build-test-deploy.yml
@@ -1,11 +1,11 @@
-@@ -313,7 +313,6 @@
+@@ -312,7 +312,6 @@
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       # Runs on every instance, using the `p<instance index>` profile.
        CI_IS_BEHAT_RUNNER: true
  
-     container:
 @@ -495,18 +494,6 @@
            fi
          env:

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel/.github/workflows/build-test-deploy.yml
@@ -1,9 +1,18 @@
-@@ -483,18 +483,6 @@
+@@ -313,7 +313,6 @@
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+@@ -495,18 +494,6 @@
+           fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
- 
+-
 -      - name: Validate Single Directory Components
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
 -          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
@@ -13,7 +22,6 @@
 -            exit 1
 -          fi
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
--
+ 
        - name: Test with Behat
-         run: |
-           # shellcheck disable=SC2170
+         if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel_generated_content/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel_generated_content/.github/workflows/build-test-deploy.yml
@@ -1,11 +1,11 @@
-@@ -313,7 +313,6 @@
+@@ -312,7 +312,6 @@
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       # Runs on every instance, using the `p<instance index>` profile.
        CI_IS_BEHAT_RUNNER: true
  
-     container:
 @@ -495,18 +494,6 @@
            fi
          env:

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel_generated_content/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel_generated_content/.github/workflows/build-test-deploy.yml
@@ -1,9 +1,18 @@
-@@ -483,18 +483,6 @@
+@@ -313,7 +313,6 @@
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+@@ -495,18 +494,6 @@
+           fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
- 
+-
 -      - name: Validate Single Directory Components
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
 -          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
@@ -13,7 +22,6 @@
 -            exit 1
 -          fi
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
--
+ 
        - name: Test with Behat
-         run: |
-           # shellcheck disable=SC2170
+         if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel_generated_content_testmode/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel_generated_content_testmode/.github/workflows/build-test-deploy.yml
@@ -1,11 +1,11 @@
-@@ -313,7 +313,6 @@
+@@ -312,7 +312,6 @@
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       # Runs on every instance, using the `p<instance index>` profile.
        CI_IS_BEHAT_RUNNER: true
  
-     container:
 @@ -495,18 +494,6 @@
            fi
          env:

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel_generated_content_testmode/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel_generated_content_testmode/.github/workflows/build-test-deploy.yml
@@ -1,9 +1,18 @@
-@@ -483,18 +483,6 @@
+@@ -313,7 +313,6 @@
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+@@ -495,18 +494,6 @@
+           fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
- 
+-
 -      - name: Validate Single Directory Components
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
 -          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
@@ -13,7 +22,6 @@
 -            exit 1
 -          fi
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
--
+ 
        - name: Test with Behat
-         run: |
-           # shellcheck disable=SC2170
+         if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.github/workflows/build-test-deploy.yml
@@ -1,11 +1,11 @@
-@@ -313,7 +313,6 @@
+@@ -312,7 +312,6 @@
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       # Runs on every instance, using the `p<instance index>` profile.
        CI_IS_BEHAT_RUNNER: true
  
-     container:
 @@ -495,18 +494,6 @@
            fi
          env:

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.github/workflows/build-test-deploy.yml
@@ -1,9 +1,18 @@
-@@ -483,18 +483,6 @@
+@@ -313,7 +313,6 @@
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+@@ -495,18 +494,6 @@
+           fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
- 
+-
 -      - name: Validate Single Directory Components
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
 -          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
@@ -13,7 +22,6 @@
 -            exit 1
 -          fi
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
--
+ 
        - name: Test with Behat
-         run: |
-           # shellcheck disable=SC2170
+         if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_none/.github/workflows/build-test-deploy.yml
@@ -1,11 +1,11 @@
-@@ -313,7 +313,6 @@
+@@ -312,7 +312,6 @@
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       # Runs on every instance, using the `p<instance index>` profile.
        CI_IS_BEHAT_RUNNER: true
  
-     container:
 @@ -495,18 +494,6 @@
            fi
          env:

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_none/.github/workflows/build-test-deploy.yml
@@ -1,9 +1,18 @@
-@@ -483,18 +483,6 @@
+@@ -313,7 +313,6 @@
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+@@ -495,18 +494,6 @@
+           fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
- 
+-
 -      - name: Validate Single Directory Components
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
 -          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
@@ -13,7 +22,6 @@
 -            exit 1
 -          fi
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
--
+ 
        - name: Test with Behat
-         run: |
-           # shellcheck disable=SC2170
+         if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -146,7 +146,7 @@
  
      permissions:
        contents: read
-@@ -316,14 +191,6 @@
+@@ -329,14 +204,6 @@
          VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"
          VORTEX_SSH_REMOVE_ALL_KEYS: "1"
          VORTEX_DEBUG: ${{ vars.VORTEX_DEBUG }}
@@ -161,7 +161,7 @@
  
      steps:
        # Frees disk space by removing preinstalled toolchains unused by this project. Steps run in a container, so the host is reached via the Docker socket.
-@@ -362,29 +229,6 @@
+@@ -375,29 +242,6 @@
        - name: Install Vortex tooling
          run: ./scripts/vortex-tooling.sh
  
@@ -191,7 +191,7 @@
        - name: Login to container registry
          run: ./vendor/bin/vortex-login-container-registry
  
-@@ -556,7 +400,6 @@
+@@ -568,7 +412,6 @@
    deploy:
      runs-on: ubuntu-latest
      needs: [build, lint]

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
@@ -10,13 +10,21 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -482,18 +477,6 @@
+@@ -313,7 +308,6 @@
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+@@ -495,18 +489,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 -
 -      - name: Validate Single Directory Components
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
 -          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
@@ -28,4 +36,4 @@
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
        - name: Test with Behat
-         run: |
+         if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
@@ -10,14 +10,14 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -313,7 +308,6 @@
+@@ -312,7 +307,6 @@
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       # Runs on every instance, using the `p<instance index>` profile.
        CI_IS_BEHAT_RUNNER: true
  
-     container:
 @@ -495,18 +489,6 @@
            fi
          env:

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
@@ -10,13 +10,21 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -482,18 +477,6 @@
+@@ -313,7 +308,6 @@
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+@@ -495,18 +489,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 -
 -      - name: Validate Single Directory Components
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
 -          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
@@ -28,4 +36,4 @@
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
        - name: Test with Behat
-         run: |
+         if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
@@ -10,14 +10,14 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -313,7 +308,6 @@
+@@ -312,7 +307,6 @@
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       # Runs on every instance, using the `p<instance index>` profile.
        CI_IS_BEHAT_RUNNER: true
  
-     container:
 @@ -495,18 +489,6 @@
            fi
          env:

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
@@ -10,13 +10,21 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -482,18 +477,6 @@
+@@ -313,7 +308,6 @@
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+@@ -495,18 +489,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 -
 -      - name: Validate Single Directory Components
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
 -          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
@@ -28,4 +36,4 @@
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
        - name: Test with Behat
-         run: |
+         if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
@@ -10,14 +10,14 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -313,7 +308,6 @@
+@@ -312,7 +307,6 @@
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       # Runs on every instance, using the `p<instance index>` profile.
        CI_IS_BEHAT_RUNNER: true
  
-     container:
 @@ -495,18 +489,6 @@
            fi
          env:

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -318,10 +318,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -329,6 +328,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -316,6 +316,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -378,18 +395,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -398,7 +417,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -407,14 +426,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -423,7 +442,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -435,7 +454,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -306,10 +306,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -317,6 +316,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -304,6 +304,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -366,18 +383,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -386,7 +405,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -395,14 +414,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -411,7 +430,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -423,7 +442,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -9,17 +9,18 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -312,9 +308,7 @@
+@@ -311,10 +307,7 @@
        CI_RUNNER_INDEX: ${{ strategy.job-index }}
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      # Runs on every instance, using the `p<instance index>` profile.
 -      CI_IS_BEHAT_RUNNER: true
  
      container:
        # https://hub.docker.com/r/drevops/ci-runner
-@@ -436,66 +430,6 @@
+@@ -436,66 +429,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -86,7 +87,7 @@
        - name: Validate Single Directory Components
          if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
          run: |
-@@ -508,19 +442,6 @@
+@@ -508,19 +441,6 @@
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
@@ -106,7 +107,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -537,16 +458,6 @@
+@@ -537,16 +457,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -9,17 +9,27 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -423,66 +419,6 @@
+@@ -312,9 +308,7 @@
+       CI_RUNNER_INDEX: ${{ strategy.job-index }}
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+       # https://hub.docker.com/r/drevops/ci-runner
+@@ -436,66 +430,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
 -      - name: Test with PHPUnit
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        run: docker compose exec -T cli vendor/bin/phpunit
 -        continue-on-error: ${{ vars.VORTEX_CI_PHPUNIT_IGNORE_FAILURE == '1' }}
 -
 -      - name: Process PHPUnit logs and coverage
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        run: |
 -          mkdir -p ".logs"
 -          if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
@@ -27,7 +37,7 @@
 -          fi
 -
 -      - name: Extract code coverage
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        run: |
 -          RATE=$(grep -om1 'line-rate="[0-9.]*"' .logs/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
 -          PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
@@ -45,7 +55,7 @@
 -          VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 -
 -      - name: Post coverage summary as PR comment
--        if: ${{ github.event_name == 'pull_request' && (matrix.instance == 0 || strategy.job-total == 1) && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
+-        if: ${{ github.event_name == 'pull_request' && env.CI_IS_PHPUNIT_RUNNER == 'true' && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
 -        uses: marocchino/sticky-pull-request-comment@__HASH__ # __VERSION__
 -        with:
 -          header: coverage-gha
@@ -64,7 +74,7 @@
 -          hide_and_recreate: true
 -
 -      - name: Check code coverage threshold
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        run: |
 -          if [ "${COVERAGE_PERCENT//.}" -lt "$((VORTEX_CI_CODE_COVERAGE_THRESHOLD*100))" ]; then
 -            echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD}%"
@@ -74,30 +84,29 @@
 -          VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 -
        - name: Validate Single Directory Components
-         if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+         if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
          run: |
-@@ -495,20 +431,6 @@
+@@ -508,19 +442,6 @@
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
 -      - name: Test with Behat
+-        if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}
 -        run: |
 -          # shellcheck disable=SC2170
--          if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
+-          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
 -          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
 -          docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
 -            docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
 -        env:
 -          VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
--          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
--          STRATEGY_JOB_INDEX: ${{ strategy.job-index }}
 -        continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
 -        timeout-minutes: 30
 -
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -525,16 +447,6 @@
+@@ -537,16 +458,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -314,10 +314,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -312,6 +312,21 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -374,12 +389,14 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
@@ -17,14 +17,14 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -311,7 +306,6 @@
+@@ -310,7 +305,6 @@
        # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
        CI_RUNNER_INDEX: ${{ strategy.job-index }}
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
 -      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       CI_IS_BEHAT_RUNNER: true
+       # Runs on every instance, using the `p<instance index>` profile.
 @@ -417,7 +411,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
@@ -17,7 +17,15 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -404,7 +399,6 @@
+@@ -311,7 +306,6 @@
+       # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+       CI_RUNNER_INDEX: ${{ strategy.job-index }}
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+-      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+@@ -417,7 +411,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -25,15 +33,15 @@
  
        - name: Provision site
          run: |
-@@ -417,11 +411,6 @@
+@@ -430,11 +423,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30
 -
 -      - name: Test with Jest
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_JEST_RUNNER == 'true' }}
 -        run: docker compose exec -T cli bash -c "yarn test"
 -        continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
        - name: Test with PHPUnit
-         if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+         if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
@@ -313,16 +313,16 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
               echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
@@ -311,6 +311,22 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -373,13 +389,13 @@ jobs:
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -388,7 +404,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -397,14 +413,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -413,7 +429,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -425,7 +441,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
@@ -22,16 +22,16 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -311,9 +301,7 @@
+@@ -310,9 +300,7 @@
        # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
        CI_RUNNER_INDEX: ${{ strategy.job-index }}
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
 -      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       # Runs on every instance, using the `p<instance index>` profile.
        CI_IS_BEHAT_RUNNER: true
  
-     container:
 @@ -417,7 +405,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
@@ -22,7 +22,17 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -404,7 +394,6 @@
+@@ -311,9 +301,7 @@
+       # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+       CI_RUNNER_INDEX: ${{ strategy.job-index }}
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+-      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+@@ -417,7 +405,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -30,25 +40,25 @@
  
        - name: Provision site
          run: |
-@@ -418,11 +407,6 @@
+@@ -431,11 +418,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30
  
 -      - name: Test with Jest
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_JEST_RUNNER == 'true' }}
 -        run: docker compose exec -T cli bash -c "yarn test"
 -        continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
 -
        - name: Test with PHPUnit
-         if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+         if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
          run: docker compose exec -T cli vendor/bin/phpunit
-@@ -482,18 +466,6 @@
+@@ -495,18 +477,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 -
 -      - name: Validate Single Directory Components
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
 -          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
@@ -60,4 +70,4 @@
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
        - name: Test with Behat
-         run: |
+         if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
@@ -307,15 +307,15 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
               echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
@@ -305,6 +305,21 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -367,13 +382,13 @@ jobs:
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -382,7 +397,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -391,14 +406,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -407,7 +422,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -9,22 +9,29 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -494,20 +490,6 @@
+@@ -314,7 +310,6 @@
+       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+       # https://hub.docker.com/r/drevops/ci-runner
+@@ -507,19 +502,6 @@
              exit 1
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
 -
 -      - name: Test with Behat
+-        if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}
 -        run: |
 -          # shellcheck disable=SC2170
--          if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
+-          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
 -          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
 -          docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
 -            docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
 -        env:
 -          VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
--          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
--          STRATEGY_JOB_INDEX: ${{ strategy.job-index }}
 -        continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
 -        timeout-minutes: 30
  

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -9,15 +9,16 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -314,7 +310,6 @@
+@@ -313,8 +309,6 @@
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      # Runs on every instance, using the `p<instance index>` profile.
 -      CI_IS_BEHAT_RUNNER: true
  
      container:
        # https://hub.docker.com/r/drevops/ci-runner
-@@ -507,19 +502,6 @@
+@@ -507,19 +501,6 @@
              exit 1
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -312,6 +312,22 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -374,18 +390,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -394,7 +412,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -403,14 +421,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -419,7 +437,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -314,10 +314,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/.circleci/config.yml
@@ -314,10 +314,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -325,6 +324,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/.circleci/config.yml
@@ -312,6 +312,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -374,18 +391,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -394,7 +413,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -403,14 +422,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -419,7 +438,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -431,7 +450,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/.circleci/config.yml
@@ -305,6 +305,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -367,18 +384,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -387,7 +406,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -396,14 +415,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -412,7 +431,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -424,7 +443,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/.circleci/config.yml
@@ -307,10 +307,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -318,6 +317,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
@@ -313,10 +313,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -324,6 +323,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
@@ -311,6 +311,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -373,18 +390,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -393,7 +412,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -402,14 +421,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -418,7 +437,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -430,7 +449,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
@@ -22,14 +22,14 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -313,7 +303,6 @@
+@@ -312,7 +302,6 @@
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       # Runs on every instance, using the `p<instance index>` profile.
        CI_IS_BEHAT_RUNNER: true
  
-     container:
 @@ -495,18 +484,6 @@
            fi
          env:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
@@ -22,13 +22,21 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -482,18 +472,6 @@
+@@ -313,7 +303,6 @@
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+@@ -495,18 +484,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 -
 -      - name: Validate Single Directory Components
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
 -          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
@@ -40,4 +48,4 @@
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
        - name: Test with Behat
-         run: |
+         if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/.circleci/config.yml
@@ -309,6 +309,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -371,18 +388,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -391,7 +410,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -400,14 +419,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -416,7 +435,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -428,7 +447,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/.circleci/config.yml
@@ -311,10 +311,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -322,6 +321,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
@@ -1,11 +1,11 @@
-@@ -311,7 +311,6 @@
+@@ -310,7 +310,6 @@
        # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
        CI_RUNNER_INDEX: ${{ strategy.job-index }}
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
 -      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       CI_IS_BEHAT_RUNNER: true
+       # Runs on every instance, using the `p<instance index>` profile.
 @@ -417,7 +416,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,12 @@
-@@ -404,7 +404,6 @@
+@@ -311,7 +311,6 @@
+       # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+       CI_RUNNER_INDEX: ${{ strategy.job-index }}
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+-      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+@@ -417,7 +416,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -6,15 +14,15 @@
  
        - name: Provision site
          run: |
-@@ -417,11 +416,6 @@
+@@ -430,11 +428,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30
 -
 -      - name: Test with Jest
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_JEST_RUNNER == 'true' }}
 -        run: docker compose exec -T cli bash -c "yarn test"
 -        continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
        - name: Test with PHPUnit
-         if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+         if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
@@ -318,16 +318,16 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
               echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
@@ -316,6 +316,22 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -378,13 +394,13 @@ jobs:
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -393,7 +409,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -402,14 +418,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -418,7 +434,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -430,7 +446,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -314,10 +314,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -325,6 +324,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -312,6 +312,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -374,18 +391,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -394,7 +413,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -403,14 +422,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -419,7 +438,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -431,7 +450,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -314,10 +314,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -325,6 +324,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -312,6 +312,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -374,18 +391,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -394,7 +413,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -403,14 +422,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -419,7 +438,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -431,7 +450,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -1,11 +1,11 @@
-@@ -312,7 +312,6 @@
+@@ -311,7 +311,6 @@
        CI_RUNNER_INDEX: ${{ strategy.job-index }}
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       # Runs on every instance, using the `p<instance index>` profile.
        CI_IS_BEHAT_RUNNER: true
- 
 @@ -436,66 +435,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -1,14 +1,22 @@
-@@ -423,66 +423,6 @@
+@@ -312,7 +312,6 @@
+       CI_RUNNER_INDEX: ${{ strategy.job-index }}
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+ 
+@@ -436,66 +435,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
 -      - name: Test with PHPUnit
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        run: docker compose exec -T cli vendor/bin/phpunit
 -        continue-on-error: ${{ vars.VORTEX_CI_PHPUNIT_IGNORE_FAILURE == '1' }}
 -
 -      - name: Process PHPUnit logs and coverage
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        run: |
 -          mkdir -p ".logs"
 -          if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
@@ -16,7 +24,7 @@
 -          fi
 -
 -      - name: Extract code coverage
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        run: |
 -          RATE=$(grep -om1 'line-rate="[0-9.]*"' .logs/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
 -          PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
@@ -34,7 +42,7 @@
 -          VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 -
 -      - name: Post coverage summary as PR comment
--        if: ${{ github.event_name == 'pull_request' && (matrix.instance == 0 || strategy.job-total == 1) && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
+-        if: ${{ github.event_name == 'pull_request' && env.CI_IS_PHPUNIT_RUNNER == 'true' && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
 -        uses: marocchino/sticky-pull-request-comment@__HASH__ # __VERSION__
 -        with:
 -          header: coverage-gha
@@ -53,7 +61,7 @@
 -          hide_and_recreate: true
 -
 -      - name: Check code coverage threshold
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        run: |
 -          if [ "${COVERAGE_PERCENT//.}" -lt "$((VORTEX_CI_CODE_COVERAGE_THRESHOLD*100))" ]; then
 -            echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD}%"
@@ -63,9 +71,9 @@
 -          VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 -
        - name: Validate Single Directory Components
-         if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+         if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
          run: |
-@@ -525,16 +465,6 @@
+@@ -537,16 +476,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -316,6 +316,22 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -378,12 +394,14 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -395,7 +413,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -318,16 +318,16 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
               echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -314,10 +314,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -325,6 +324,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -312,6 +312,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -374,18 +391,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -394,7 +413,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -403,14 +422,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -419,7 +438,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -431,7 +450,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
@@ -318,10 +318,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -329,6 +328,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
@@ -316,6 +316,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -378,18 +395,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -398,7 +417,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -407,14 +426,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -423,7 +442,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -435,7 +454,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
@@ -10,13 +10,21 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -482,18 +477,6 @@
+@@ -313,7 +308,6 @@
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+@@ -495,18 +489,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 -
 -      - name: Validate Single Directory Components
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
 -        run: |
 -          [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
 -          output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
@@ -28,4 +36,4 @@
 -        continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
        - name: Test with Behat
-         run: |
+         if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
@@ -10,14 +10,14 @@
    database:
      runs-on: ubuntu-latest
      if: ${{ !inputs.deploy_target && (github.event_name == 'push' || !startsWith(github.head_ref, 'project/')) }}
-@@ -313,7 +308,6 @@
+@@ -312,7 +307,6 @@
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       # Runs on every instance, using the `p<instance index>` profile.
        CI_IS_BEHAT_RUNNER: true
  
-     container:
 @@ -495,18 +489,6 @@
            fi
          env:

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
@@ -314,10 +314,9 @@ jobs:
       - run:
           name: Set test runner roles
           command: |
-            # Which tools run on this node. The tools that only need to run once
-            # are pinned to the first node, while Behat runs on every node using
-            # the `p<node index>` profile. Add a line for every additional tool
-            # and reference it in that tool's step.
+            # Which tools run on this node. Tools that only need to run once are
+            # pinned to the first node. Add a line for every additional tool and
+            # reference it in that tool's step.
             # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
             {
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
@@ -325,6 +324,7 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              # Runs on every node, using the `p<node index>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
             } >> "${BASH_ENV}"
 

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
@@ -312,6 +312,23 @@ jobs:
       - *load_variables_from_dotenv
 
       - run:
+          name: Set test runner roles
+          command: |
+            # Which tools run on this node. The tools that only need to run once
+            # are pinned to the first node, while Behat runs on every node using
+            # the `p<node index>` profile. Add a line for every additional tool
+            # and reference it in that tool's step.
+            # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+            {
+              echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
+              echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
+              echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
+              echo "export CI_IS_BEHAT_RUNNER=1"
+            } >> "${BASH_ENV}"
+
+      - run:
           name: Validate Composer configuration
           command: composer validate --strict || [ "${VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE:-0}" -eq 1 ]
 
@@ -374,18 +391,20 @@ jobs:
 
       - run:
           name: Test with Jest
-          command: docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
+          command: |
+            [ "${CI_IS_JEST_RUNNER:-1}" = "1" ] || exit 0
+            docker compose exec -T cli bash -c "yarn test" || [ "${VORTEX_CI_JEST_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Test with PHPUnit
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             docker compose exec -T cli vendor/bin/phpunit || [ "${VORTEX_CI_PHPUNIT_IGNORE_FAILURE:-0}" -eq 1 ]
 
       - run:
           name: Process PHPUnit logs and coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
                docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
@@ -394,7 +413,7 @@ jobs:
       - run:
           name: Extract code coverage
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             RATE=$(grep -om1 'line-rate="[0-9.]*"' /tmp/artifacts/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
             PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
             echo "Coverage: $PERCENT% (threshold: ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%)"
@@ -403,14 +422,14 @@ jobs:
       - run:
           name: Post coverage summary as PR comment
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP:-0}" = "1" ] && exit 0
             .circleci/post-coverage-comment.sh /tmp/artifacts/coverage/phpunit/coverage.txt
 
       - run:
           name: Check code coverage threshold
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             if [ "${COVERAGE_PERCENT//.}" -lt "$((${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}*100))" ]; then
               echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD:-90}%"
               exit 1
@@ -419,7 +438,7 @@ jobs:
       - run:
           name: Validate Single Directory Components
           command: |
-            [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0
+            [ "${CI_IS_SDC_DEVEL_RUNNER:-1}" = "1" ] || exit 0
             [ "${VORTEX_FRONTEND_BUILD_SKIP:-0}" -eq 1 ] && exit 0
             output=$(docker compose exec -T cli vendor/bin/drush sdc-devel:validate "${DRUPAL_THEME}" 2>&1)
             echo "${output}"
@@ -431,7 +450,8 @@ jobs:
       - run:
           name: Test with Behat
           command: |
-            if [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CIRCLE_NODE_INDEX}}"; fi
+            [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -53,18 +53,19 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -311,10 +275,7 @@
+@@ -310,11 +274,7 @@
        # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
        CI_RUNNER_INDEX: ${{ strategy.job-index }}
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
 -      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      # Runs on every instance, using the `p<instance index>` profile.
 -      CI_IS_BEHAT_RUNNER: true
  
      container:
        # https://hub.docker.com/r/drevops/ci-runner
-@@ -417,7 +378,6 @@
+@@ -417,7 +377,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -72,7 +73,7 @@
  
        - name: Provision site
          run: |
-@@ -431,71 +391,6 @@
+@@ -431,71 +390,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30
  
@@ -144,7 +145,7 @@
        - name: Validate Single Directory Components
          if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
          run: |
-@@ -508,19 +403,6 @@
+@@ -508,19 +402,6 @@
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
@@ -164,7 +165,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -537,16 +419,6 @@
+@@ -537,16 +418,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -53,7 +53,18 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -404,7 +368,6 @@
+@@ -311,10 +275,7 @@
+       # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+       CI_RUNNER_INDEX: ${{ strategy.job-index }}
+       CI_RUNNER_TOTAL: ${{ strategy.job-total }}
+-      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+       CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-      CI_IS_BEHAT_RUNNER: true
+ 
+     container:
+       # https://hub.docker.com/r/drevops/ci-runner
+@@ -417,7 +378,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -61,22 +72,22 @@
  
        - name: Provision site
          run: |
-@@ -418,71 +381,6 @@
+@@ -431,71 +391,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30
  
 -      - name: Test with Jest
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_JEST_RUNNER == 'true' }}
 -        run: docker compose exec -T cli bash -c "yarn test"
 -        continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
 -
 -      - name: Test with PHPUnit
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        run: docker compose exec -T cli vendor/bin/phpunit
 -        continue-on-error: ${{ vars.VORTEX_CI_PHPUNIT_IGNORE_FAILURE == '1' }}
 -
 -      - name: Process PHPUnit logs and coverage
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        run: |
 -          mkdir -p ".logs"
 -          if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
@@ -84,7 +95,7 @@
 -          fi
 -
 -      - name: Extract code coverage
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        run: |
 -          RATE=$(grep -om1 'line-rate="[0-9.]*"' .logs/coverage/phpunit/cobertura.xml | tr -cd '0-9.')
 -          PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
@@ -102,7 +113,7 @@
 -          VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 -
 -      - name: Post coverage summary as PR comment
--        if: ${{ github.event_name == 'pull_request' && (matrix.instance == 0 || strategy.job-total == 1) && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
+-        if: ${{ github.event_name == 'pull_request' && env.CI_IS_PHPUNIT_RUNNER == 'true' && vars.VORTEX_CI_CODE_COVERAGE_PR_COMMENT_SKIP != '1' }}
 -        uses: marocchino/sticky-pull-request-comment@__HASH__ # __VERSION__
 -        with:
 -          header: coverage-gha
@@ -121,7 +132,7 @@
 -          hide_and_recreate: true
 -
 -      - name: Check code coverage threshold
--        if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+-        if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
 -        run: |
 -          if [ "${COVERAGE_PERCENT//.}" -lt "$((VORTEX_CI_CODE_COVERAGE_THRESHOLD*100))" ]; then
 -            echo "FAIL: coverage ${COVERAGE_PERCENT}% is below threshold ${VORTEX_CI_CODE_COVERAGE_THRESHOLD}%"
@@ -131,30 +142,29 @@
 -          VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}
 -
        - name: Validate Single Directory Components
-         if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
+         if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
          run: |
-@@ -495,20 +393,6 @@
+@@ -508,19 +403,6 @@
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
 -      - name: Test with Behat
+-        if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}
 -        run: |
 -          # shellcheck disable=SC2170
--          if [ "${STRATEGY_JOB_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${STRATEGY_JOB_INDEX}}"; fi
+-          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
 -          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
 -          docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
 -            docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
 -        env:
 -          VORTEX_CI_BEHAT_PROFILE: ${{ vars.VORTEX_CI_BEHAT_PROFILE }}
--          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
--          STRATEGY_JOB_INDEX: ${{ strategy.job-index }}
 -        continue-on-error: ${{ vars.VORTEX_CI_BEHAT_IGNORE_FAILURE == '1' }}
 -        timeout-minutes: 30
 -
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -525,16 +409,6 @@
+@@ -537,16 +419,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/behat.yml
+++ b/behat.yml
@@ -96,16 +96,20 @@ default:
     # Show explicit fail information and continue the test run.
     DrevOps\BehatFormatProgressFail\FormatExtension: ~
 
-# Profile for parallel testing.
-# Runs all tests not tagged with 'smoke' or '@p1' and not tagged with '@skipped'.
-# This is a 'catch-all' profile that runs any tests not tagged with '@pX'.
+# Profiles for parallel testing. CI runs the profile named after the index of
+# the runner it is on, so 'pN' requires a runner N. Adding a runner means adding
+# a matching profile here and excluding its tag from the 'p0' catch-all below.
+# https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
+
+# Runs all tests tagged with '@smoke' or not tagged with '@p1', and not tagged
+# with '@skipped'. This is a 'catch-all' profile that runs any tests not tagged
+# with '@pX'.
 p0:
   gherkin:
     cache: '/tmp/behat_gherkin_cache'
     filters:
       tags: '@smoke,~@p1&&~@skipped'
 
-# Profile for parallel testing.
 # Runs all tests tagged with '@smoke' or '@p1' and not tagged with '@skipped'.
 p1:
   gherkin:


### PR DESCRIPTION
## Summary

Both CI providers repeated the same per-step condition to pin a tool to the first parallel runner: GitHub Actions checked `matrix.instance == 0 || strategy.job-total == 1` on 8 step `if:` conditions, and CircleCI checked `[ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] && exit 0` on 7 step commands. This PR declares each tool's role once, at the top of the build job, as a `CI_IS_<TOOL>_RUNNER` flag fenced by that tool's installer flag, plus `CI_RUNNER_INDEX`/`CI_RUNNER_TOTAL` as a shared vocabulary for the runner's own index and count that replaces GitHub Actions' step-level `STRATEGY_JOB_INDEX`/`STRATEGY_JOB_TOTAL` and CircleCI's raw `CIRCLE_NODE_*` reads; each step now reads only its own flag, and default behavior is unchanged - runner 0 runs the once-only tools plus Behat profile `p0`, runner 1 runs Behat profile `p1`.

Fixing the duplication surfaced three problems it had been masking: CircleCI's `Test with Jest` step had no runner guard at all, so Jest ran on every parallel node, while GitHub Actions already gated it to instance 0; the parallelism docs told readers to scale to more containers and tag scenarios `@p2`/`@p3`, but never mentioned that `behat.yml` needs matching `p2:`/`p3:` profile blocks and an updated `p0` catch-all filter, so following the docs as written produced `profile 'p2' does not exist`; and both provider docs pages claimed the first container also runs linting, which is wrong on both providers - linting is a separate `lint` job.

## Changes

- `.github/workflows/build-test-deploy.yml` - added an `env:` block on the test job declaring `CI_RUNNER_INDEX`, `CI_RUNNER_TOTAL`, and one `CI_IS_<TOOL>_RUNNER` flag per fenced tool (Jest, PHPUnit, Single Directory Component validation, Behat); changed each step's `if:` to read its own `env.CI_IS_*_RUNNER` flag instead of repeating the `matrix.instance == 0 || strategy.job-total == 1` expression; the Behat step now reads `CI_RUNNER_INDEX`/`CI_RUNNER_TOTAL` instead of the step-level `STRATEGY_JOB_INDEX`/`STRATEGY_JOB_TOTAL` env vars, which are removed.
- `.circleci/config.yml`, `.circleci/vortex-test-common.yml` - added a new `Set test runner roles` step that computes the same flags into `BASH_ENV` (CircleCI has no expression language, so this is the only place they can be computed once); changed each tool's step to guard on its own flag (for example `[ "${CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0`) instead of repeating the `CIRCLE_NODE_TOTAL`/`CIRCLE_NODE_INDEX` check; fixed the `Test with Jest` step, which previously ran unconditionally on every node, to guard on `CI_IS_JEST_RUNNER`; the Behat step now reads `CI_RUNNER_INDEX`/`CI_RUNNER_TOTAL` instead of the raw `CIRCLE_NODE_INDEX`/`CIRCLE_NODE_TOTAL`.
- `behat.yml` - corrected the `p0` profile's comment, which claimed smoke-tagged scenarios are excluded by the filter; they aren't - `@smoke` is one of the filter's OR terms, so smoke-tagged scenarios run under `p0` like every other untagged scenario; expanded the profile comments to link to the new `Adding more containers` docs section and to spell out that a new container needs both a `pN` profile and an updated `p0` exclusion.
- `.vortex/docs/content/continuous-integration/README.mdx` - added a `Choosing which container runs what` section with a tabbed GitHub Actions/CircleCI comparison of the new variables and an example of wiring in a tool of your own, including two callouts on giving a tool its own container - that the container must exist first, since a flag whose condition matches no container disables the tool everywhere and the job still passes green, and that it must be the *last* container, never the first, because Behat derives its profile from the runner index and container 0 is the `p0` catch-all; added an `Adding more containers` section with the full procedure for raising the container count (bump parallelism, add a matching `pN` profile to `behat.yml` for each container that runs Behat, exclude the new tag from `p0`, tag scenarios `@pN`); updated the task table to list Jest and Single Directory Component validation alongside PHPUnit as first-container-only work.
- `.vortex/docs/content/continuous-integration/circleci.mdx`, `.vortex/docs/content/continuous-integration/github-actions.mdx` - corrected "the first container also runs linting" to list the actual once-only tools (Jest, PHPUnit, coverage, Single Directory Component validation); added the missing step of adding a `behat.yml` profile for each added container that runs Behat when scaling up, noting that a container excluded from Behat needs none; linked to the new `Adding more containers` and `Choosing which container runs what` sections.
- 54 installer fixture files across 53 scenarios under `.vortex/installer/tests/Fixtures/handler_process/` - regenerated via `ahoy update-snapshots` to pick up the CI config and `behat.yml` changes.

## Screenshots

N/A - this is a CI configuration and documentation change with no visual surface.

## Before / After

BEFORE - every tool's step repeated the runner check inline (8 copies on GitHub Actions, 7 on CircleCI), and CircleCI's Jest step had no check at all:

```
┌─ GitHub Actions, repeated on 8 steps ────────────────────────┐
│ if: ${{ matrix.instance == 0 || strategy.job-total == 1 }}   │
└────────────────────────────────────────────────────────────┘

┌─ CircleCI, repeated on 7 steps ───────────────────────────────────────────┐
│ [ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ] && [ "${CIRCLE_NODE_INDEX:-0}" -ne 0 ] │
│   && exit 0                                                               │
└────────────────────────────────────────────────────────────────────────┘

┌─ CircleCI "Test with Jest" ─────┐
│ (no guard - ran on every node)  │
└──────────────────────────────────┘
```

AFTER - roles are declared once at the top of the job, and every step reads its own flag:

```
┌─ env: (GHA)  /  "Set test runner roles" step (CircleCI) ──────────┐
│ CI_RUNNER_INDEX, CI_RUNNER_TOTAL                                  │
│ CI_IS_JEST_RUNNER       -> runner 0                                │
│ CI_IS_PHPUNIT_RUNNER    -> runner 0                                │
│ CI_IS_SDC_DEVEL_RUNNER  -> runner 0                                │
│ CI_IS_BEHAT_RUNNER      -> every runner (profile p<runner index>)  │
└─────────────────────────────────────────────────────────────────┘
              │                │                  │
              ▼                ▼                  ▼
      Test with Jest    Test with PHPUnit    Test with Behat
      if: CI_IS_JEST_    if: CI_IS_PHPUNIT_   if: CI_IS_BEHAT_RUNNER
      RUNNER             RUNNER               profile p<CI_RUNNER_INDEX>
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parallel CI test execution across CircleCI and GitHub Actions.
  * Ensured Jest, PHPUnit, Behat, coverage, and component validation run on the appropriate build containers.
  * Improved Behat scenario distribution and profile selection for more balanced test workloads.

* **Documentation**
  * Expanded continuous integration guidance for parallel testing, container setup, runner assignments, and Behat profiles.
  * Added provider-specific examples and clarified profile tagging and catch-all behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
