### PR TITLE
[#3035] Added 'CI_BEHAT_PROFILE_OFFSET' to decouple the Behat profile from the runner index.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,8 +390,13 @@ jobs:
               #;> MODULE_SDC_DEVEL
               #;> DRUPAL_THEME
               #;< TOOL_BEHAT
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
               #;> TOOL_BEHAT
             } >> "${BASH_ENV}"
 
@@ -548,7 +553,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.circleci/vortex-test-common.yml
+++ b/.circleci/vortex-test-common.yml
@@ -225,8 +225,13 @@ jobs:
               #;> MODULE_SDC_DEVEL
               #;> DRUPAL_THEME
               #;< TOOL_BEHAT
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
               #;> TOOL_BEHAT
             } >> "${BASH_ENV}"
 
@@ -383,7 +388,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -369,8 +369,12 @@ jobs:
       #;> MODULE_SDC_DEVEL
       #;> DRUPAL_THEME
       #;< TOOL_BEHAT
-      # Runs on every instance, using the `p<instance index>` profile.
+      # Runs on every instance, using the `p<instance index - offset>` profile.
       CI_IS_BEHAT_RUNNER: true
+      # Subtracted from the instance index to derive the profile number. Raise
+      # it by one for every leading instance that does not run Behat, so the
+      # first Behat instance still selects the `p0` catch-all profile.
+      CI_BEHAT_PROFILE_OFFSET: 0
       #;> TOOL_BEHAT
 
     container:
@@ -604,7 +608,7 @@ jobs:
         if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}
         run: |
           # shellcheck disable=SC2170
-          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
           echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
           docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"

--- a/.vortex/docs/content/continuous-integration/parallelism.mdx
+++ b/.vortex/docs/content/continuous-integration/parallelism.mdx
@@ -46,6 +46,7 @@ env:
   CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
   CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
   CI_IS_BEHAT_RUNNER: true
+  CI_BEHAT_PROFILE_OFFSET: 0
 ```
 
 Each tool's step then reads its own flag:
@@ -69,6 +70,7 @@ Each tool's step then reads its own flag:
         echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
         echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
         echo "export CI_IS_BEHAT_RUNNER=1"
+        echo "export CI_BEHAT_PROFILE_OFFSET=0"
       } >> "${BASH_ENV}"
 ```
 
@@ -86,6 +88,9 @@ Each tool's step then reads its own flag as its first line:
 
 `CI_RUNNER_INDEX` and `CI_RUNNER_TOTAL` carry the current container's index and
 the container count under the same names on both providers.
+`CI_BEHAT_PROFILE_OFFSET` is subtracted from the container index to derive the
+Behat profile number - see
+[Giving a tool its own container](#giving-a-tool-its-own-container).
 
 To run a tool of your own on a specific container, add one more flag alongside
 the others and reference it from your step:
@@ -128,12 +133,39 @@ skipped and the job still passes.
 
 :::
 
+Behat derives its profile number from the container index minus
+`CI_BEHAT_PROFILE_OFFSET`, and `p0` is the catch-all that runs every scenario
+without a `@pX` tag. With the dedicated container at the end, the offset stays
+`0`: the containers before it keep their profiles.
+
+To dedicate a **leading** container instead - for example, pinning every
+once-only tool to container `0` and keeping Behat off it - raise the offset by
+one for each leading container excluded from Behat, so the first Behat
+container still selects the `p0` catch-all:
+
+```yaml
+CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 }}
+CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 }}
+CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 }}
+CI_IS_BEHAT_RUNNER: ${{ matrix.instance != 0 }}
+CI_BEHAT_PROFILE_OFFSET: 1
+```
+
+| Container | Role | Behat profile |
+|-----------|------|:---:|
+| 0 | Jest, PHPUnit, coverage, SDC validation | - |
+| 1 | Behat | `p0` (catch-all) |
+| 2 | Behat | `p1` |
+
+`behat.yml` stays untouched: the profiles remain numbered from `p0` and no
+feature file is re-tagged.
+
 :::warning
 
-Use the **last** container for this, never the first. Behat derives its profile
-name from the container index, and `p0` is the catch-all that runs every
-scenario without a `@pX` tag. Excluding container 0 from Behat means `p0` never
-runs and those scenarios silently stop being tested.
+The offset expresses one contiguous block of Behat containers starting at the
+offset. A Behat container below the offset derives a negative profile name and
+the run fails. A gap inside the block leaves the profile at the gap's position
+unselected, and its scenarios silently stop running.
 
 :::
 
@@ -189,7 +221,8 @@ container count itself, and a matching Behat profile for every new container.
 2. Add a profile to `behat.yml` for each new container that runs Behat.
    **Vortex** ships with `p0` and `p1` only, and Behat fails with
    `profile 'p2' does not exist` if a container running Behat has no profile
-   named after its index. A container excluded from Behat needs no profile:
+   named after its derived number (its index minus `CI_BEHAT_PROFILE_OFFSET`).
+   A container excluded from Behat needs no profile:
 
    ```yaml title="behat.yml"
    p2:

--- a/.vortex/docs/content/continuous-integration/parallelism.mdx
+++ b/.vortex/docs/content/continuous-integration/parallelism.mdx
@@ -162,10 +162,12 @@ feature file is re-tagged.
 
 :::warning
 
-The offset expresses one contiguous block of Behat containers starting at the
-offset. A Behat container below the offset derives a negative profile name and
-the run fails. A gap inside the block leaves the profile at the gap's position
-unselected, and its scenarios silently stop running.
+When `VORTEX_CI_BEHAT_PROFILE` is unset, the offset expresses one contiguous
+block of Behat containers starting at the offset. A Behat container below the
+offset derives a negative profile name and the run fails. A gap inside the
+block leaves the profile at the gap's position unselected, and its scenarios
+silently stop running. An explicitly set `VORTEX_CI_BEHAT_PROFILE` bypasses
+the derivation entirely.
 
 :::
 

--- a/.vortex/docs/content/development/behat.mdx
+++ b/.vortex/docs/content/development/behat.mdx
@@ -104,6 +104,12 @@ tag never orphans a test.
 You can add more `p*` profiles in your `behat.yml` by copying the existing `p1`
 profile and changing several lines of configuration.
 
+Profile numbers count from the first runner that runs Behat: the CI
+configuration subtracts `CI_BEHAT_PROFILE_OFFSET` (`0` by default) from the
+runner index to pick the profile, so dedicating leading runners to other tools
+requires no profile renumbering or feature re-tagging. See
+[Test parallelism](../continuous-integration/parallelism.mdx#giving-a-tool-its-own-container).
+
 If the pipeline has only one runner and `VORTEX_CI_BEHAT_PROFILE` is unset,
 the `default` profile is used and all tests run there except those tagged
 `@skipped`. An explicitly set `VORTEX_CI_BEHAT_PROFILE` stays active even on a

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -313,8 +313,12 @@ jobs:
       CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
       CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
       CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-      # Runs on every instance, using the `p<instance index>` profile.
+      # Runs on every instance, using the `p<instance index - offset>` profile.
       CI_IS_BEHAT_RUNNER: true
+      # Subtracted from the instance index to derive the profile number. Raise
+      # it by one for every leading instance that does not run Behat, so the
+      # first Behat instance still selects the `p0` catch-all profile.
+      CI_BEHAT_PROFILE_OFFSET: 0
 
     container:
       # https://hub.docker.com/r/drevops/ci-runner
@@ -512,7 +516,7 @@ jobs:
         if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}
         run: |
           # shellcheck disable=SC2170
-          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
           echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
           docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/behat.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/behat.yml
@@ -99,8 +99,8 @@ default:
 # Profiles for parallel testing. CI derives the profile number from the index
 # of the runner it is on minus 'CI_BEHAT_PROFILE_OFFSET', so profiles stay
 # numbered from 'p0' regardless of which runner Behat starts on. Adding a
-# runner means adding a matching profile here and excluding its tag from the
-# 'p0' catch-all below.
+# runner that runs Behat means adding a profile for its derived number and
+# excluding its tag from the 'p0' catch-all below.
 # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
 
 # Runs all tests tagged with '@smoke' or not tagged with '@p1', and not tagged

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/behat.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/behat.yml
@@ -96,9 +96,11 @@ default:
     # Show explicit fail information and continue the test run.
     DrevOps\BehatFormatProgressFail\FormatExtension: ~
 
-# Profiles for parallel testing. CI runs the profile named after the index of
-# the runner it is on, so 'pN' requires a runner N. Adding a runner means adding
-# a matching profile here and excluding its tag from the 'p0' catch-all below.
+# Profiles for parallel testing. CI derives the profile number from the index
+# of the runner it is on minus 'CI_BEHAT_PROFILE_OFFSET', so profiles stay
+# numbered from 'p0' regardless of which runner Behat starts on. Adding a
+# runner means adding a matching profile here and excluding its tag from the
+# 'p0' catch-all below.
 # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
 
 # Runs all tests tagged with '@smoke' or not tagged with '@p1', and not tagged

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -328,8 +328,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -455,7 +460,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -486,6 +486,17 @@
+@@ -490,6 +490,17 @@
              </details>
            hide_and_recreate: true
  

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
@@ -328,8 +328,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -463,7 +468,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -328,8 +328,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -455,7 +460,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
@@ -328,8 +328,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -455,7 +460,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_gha/.github/workflows/build-test-deploy.yml
@@ -1,4 +1,4 @@
-@@ -564,104 +564,3 @@
+@@ -568,104 +568,3 @@
          timeout-minutes: 120 # Cancel the action after 120 minutes, regardless of whether a connection has been established.
          with:
            detached: true

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -328,8 +328,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -455,7 +460,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -328,8 +328,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -455,7 +460,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -427,6 +430,11 @@
+@@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -333,8 +333,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -465,7 +470,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -427,6 +430,11 @@
+@@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -427,6 +430,11 @@
+@@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -427,6 +430,11 @@
+@@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -427,6 +430,11 @@
+@@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -427,6 +430,11 @@
+@@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -427,6 +430,11 @@
+@@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.github/workflows/build-test-deploy.yml
@@ -8,7 +8,7 @@
        - name: Export DB
          run: |
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
-@@ -427,6 +430,11 @@
+@@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel/.github/workflows/build-test-deploy.yml
@@ -3,10 +3,10 @@
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
+       # Runs on every instance, using the `p<instance index - offset>` profile.
        CI_IS_BEHAT_RUNNER: true
- 
-@@ -495,18 +494,6 @@
+       # Subtracted from the instance index to derive the profile number. Raise
+@@ -499,18 +498,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel_generated_content/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel_generated_content/.github/workflows/build-test-deploy.yml
@@ -3,10 +3,10 @@
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
+       # Runs on every instance, using the `p<instance index - offset>` profile.
        CI_IS_BEHAT_RUNNER: true
- 
-@@ -495,18 +494,6 @@
+       # Subtracted from the instance index to derive the profile number. Raise
+@@ -499,18 +498,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel_generated_content_testmode/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_devel_sdc_devel_generated_content_testmode/.github/workflows/build-test-deploy.yml
@@ -3,10 +3,10 @@
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
+       # Runs on every instance, using the `p<instance index - offset>` profile.
        CI_IS_BEHAT_RUNNER: true
- 
-@@ -495,18 +494,6 @@
+       # Subtracted from the instance index to derive the profile number. Raise
+@@ -499,18 +498,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_no_sdc_devel/.github/workflows/build-test-deploy.yml
@@ -3,10 +3,10 @@
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
+       # Runs on every instance, using the `p<instance index - offset>` profile.
        CI_IS_BEHAT_RUNNER: true
- 
-@@ -495,18 +494,6 @@
+       # Subtracted from the instance index to derive the profile number. Raise
+@@ -499,18 +498,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/modules_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/modules_none/.github/workflows/build-test-deploy.yml
@@ -3,10 +3,10 @@
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
+       # Runs on every instance, using the `p<instance index - offset>` profile.
        CI_IS_BEHAT_RUNNER: true
- 
-@@ -495,18 +494,6 @@
+       # Subtracted from the instance index to derive the profile number. Raise
+@@ -499,18 +498,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -146,7 +146,7 @@
  
      permissions:
        contents: read
-@@ -329,14 +204,6 @@
+@@ -333,14 +208,6 @@
          VORTEX_SSH_DISABLE_STRICT_HOST_KEY_CHECKING: "1"
          VORTEX_SSH_REMOVE_ALL_KEYS: "1"
          VORTEX_DEBUG: ${{ vars.VORTEX_DEBUG }}
@@ -161,7 +161,7 @@
  
      steps:
        # Frees disk space by removing preinstalled toolchains unused by this project. Steps run in a container, so the host is reached via the Docker socket.
-@@ -375,29 +242,6 @@
+@@ -379,29 +246,6 @@
        - name: Install Vortex tooling
          run: ./scripts/vortex-tooling.sh
  
@@ -191,7 +191,7 @@
        - name: Login to container registry
          run: ./vendor/bin/vortex-login-container-registry
  
-@@ -568,7 +412,6 @@
+@@ -572,7 +416,6 @@
    deploy:
      runs-on: ubuntu-latest
      needs: [build, lint]

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_claro/.github/workflows/build-test-deploy.yml
@@ -15,10 +15,10 @@
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
+       # Runs on every instance, using the `p<instance index - offset>` profile.
        CI_IS_BEHAT_RUNNER: true
- 
-@@ -495,18 +489,6 @@
+       # Subtracted from the instance index to derive the profile number. Raise
+@@ -499,18 +493,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_olivero/.github/workflows/build-test-deploy.yml
@@ -15,10 +15,10 @@
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
+       # Runs on every instance, using the `p<instance index - offset>` profile.
        CI_IS_BEHAT_RUNNER: true
- 
-@@ -495,18 +489,6 @@
+       # Subtracted from the instance index to derive the profile number. Raise
+@@ -499,18 +493,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/theme_stark/.github/workflows/build-test-deploy.yml
@@ -15,10 +15,10 @@
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
+       # Runs on every instance, using the `p<instance index - offset>` profile.
        CI_IS_BEHAT_RUNNER: true
- 
-@@ -495,18 +489,6 @@
+       # Subtracted from the instance index to derive the profile number. Raise
+@@ -499,18 +493,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -328,8 +328,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -455,7 +460,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -316,8 +316,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -443,7 +448,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -9,18 +9,22 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -311,10 +307,7 @@
+@@ -311,14 +307,7 @@
        CI_RUNNER_INDEX: ${{ strategy.job-index }}
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
--      # Runs on every instance, using the `p<instance index>` profile.
+-      # Runs on every instance, using the `p<instance index - offset>` profile.
 -      CI_IS_BEHAT_RUNNER: true
+-      # Subtracted from the instance index to derive the profile number. Raise
+-      # it by one for every leading instance that does not run Behat, so the
+-      # first Behat instance still selects the `p0` catch-all profile.
+-      CI_BEHAT_PROFILE_OFFSET: 0
  
      container:
        # https://hub.docker.com/r/drevops/ci-runner
-@@ -436,66 +429,6 @@
+@@ -440,66 +429,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -87,7 +91,7 @@
        - name: Validate Single Directory Components
          if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
          run: |
-@@ -508,19 +441,6 @@
+@@ -512,19 +441,6 @@
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
@@ -95,7 +99,7 @@
 -        if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}
 -        run: |
 -          # shellcheck disable=SC2170
--          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+-          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
 -          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
 -          docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
 -            docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
@@ -107,7 +111,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -537,16 +457,6 @@
+@@ -541,16 +457,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint/.github/workflows/build-test-deploy.yml
@@ -24,8 +24,8 @@
 -      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
-@@ -417,7 +411,6 @@
+       # Runs on every instance, using the `p<instance index - offset>` profile.
+@@ -421,7 +415,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -33,7 +33,7 @@
  
        - name: Provision site
          run: |
-@@ -430,11 +423,6 @@
+@@ -434,11 +427,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
@@ -322,8 +322,13 @@ jobs:
               echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -442,7 +447,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme/.github/workflows/build-test-deploy.yml
@@ -29,10 +29,10 @@
 -      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
+       # Runs on every instance, using the `p<instance index - offset>` profile.
        CI_IS_BEHAT_RUNNER: true
- 
-@@ -417,7 +405,6 @@
+       # Subtracted from the instance index to derive the profile number. Raise
+@@ -421,7 +409,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -40,7 +40,7 @@
  
        - name: Provision site
          run: |
-@@ -431,11 +418,6 @@
+@@ -435,11 +422,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30
  
@@ -52,7 +52,7 @@
        - name: Test with PHPUnit
          if: ${{ env.CI_IS_PHPUNIT_RUNNER == 'true' }}
          run: docker compose exec -T cli vendor/bin/phpunit
-@@ -495,18 +477,6 @@
+@@ -499,18 +481,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
@@ -315,8 +315,13 @@ jobs:
               echo "export CI_RUNNER_INDEX=${CIRCLE_NODE_INDEX:-0}"
               echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -423,7 +428,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat/.github/workflows/build-test-deploy.yml
@@ -9,16 +9,20 @@
        - name: Lint module code with NodeJS linters
          run: docker compose exec -T cli bash -c "yarn run lint"
          continue-on-error: ${{ vars.VORTEX_CI_NODEJS_LINT_IGNORE_FAILURE == '1' }}
-@@ -313,8 +309,6 @@
+@@ -313,12 +309,6 @@
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
--      # Runs on every instance, using the `p<instance index>` profile.
+-      # Runs on every instance, using the `p<instance index - offset>` profile.
 -      CI_IS_BEHAT_RUNNER: true
+-      # Subtracted from the instance index to derive the profile number. Raise
+-      # it by one for every leading instance that does not run Behat, so the
+-      # first Behat instance still selects the `p0` catch-all profile.
+-      CI_BEHAT_PROFILE_OFFSET: 0
  
      container:
        # https://hub.docker.com/r/drevops/ci-runner
-@@ -507,19 +501,6 @@
+@@ -511,19 +501,6 @@
              exit 1
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
@@ -27,7 +31,7 @@
 -        if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}
 -        run: |
 -          # shellcheck disable=SC2170
--          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+-          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
 -          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
 -          docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
 -            docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/.circleci/config.yml
@@ -324,8 +324,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -451,7 +456,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/.circleci/config.yml
@@ -317,8 +317,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -444,7 +449,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
@@ -323,8 +323,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -450,7 +455,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_no_theme/.github/workflows/build-test-deploy.yml
@@ -27,10 +27,10 @@
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
+       # Runs on every instance, using the `p<instance index - offset>` profile.
        CI_IS_BEHAT_RUNNER: true
- 
-@@ -495,18 +484,6 @@
+       # Subtracted from the instance index to derive the profile number. Raise
+@@ -499,18 +488,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/.circleci/config.yml
@@ -321,8 +321,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -448,7 +453,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest/.github/workflows/build-test-deploy.yml
@@ -5,8 +5,8 @@
 -      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
-@@ -417,7 +416,6 @@
+       # Runs on every instance, using the `p<instance index - offset>` profile.
+@@ -421,7 +420,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -14,7 +14,7 @@
  
        - name: Provision site
          run: |
-@@ -430,11 +428,6 @@
+@@ -434,11 +432,6 @@
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
@@ -327,8 +327,13 @@ jobs:
               echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -447,7 +452,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -324,8 +324,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -451,7 +456,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -324,8 +324,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -451,7 +456,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -4,9 +4,9 @@
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
+       # Runs on every instance, using the `p<instance index - offset>` profile.
        CI_IS_BEHAT_RUNNER: true
-@@ -436,66 +435,6 @@
+@@ -440,66 +439,6 @@
          run: docker compose exec -T cli bash -c "yarn test"
          continue-on-error: ${{ vars.VORTEX_CI_JEST_IGNORE_FAILURE == '1' }}
  
@@ -73,7 +73,7 @@
        - name: Validate Single Directory Components
          if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
          run: |
-@@ -537,16 +476,6 @@
+@@ -541,16 +480,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -327,8 +327,13 @@ jobs:
               echo "export CI_RUNNER_TOTAL=${CIRCLE_NODE_TOTAL:-1}"
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -414,7 +419,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -324,8 +324,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -451,7 +456,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
@@ -328,8 +328,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -455,7 +460,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_no_theme/.github/workflows/build-test-deploy.yml
@@ -15,10 +15,10 @@
        CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
-       # Runs on every instance, using the `p<instance index>` profile.
+       # Runs on every instance, using the `p<instance index - offset>` profile.
        CI_IS_BEHAT_RUNNER: true
- 
-@@ -495,18 +489,6 @@
+       # Subtracted from the instance index to derive the profile number. Raise
+@@ -499,18 +493,6 @@
            fi
          env:
            VORTEX_CI_CODE_COVERAGE_THRESHOLD: ${{ vars.VORTEX_CI_CODE_COVERAGE_THRESHOLD || '90' }}

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
@@ -324,8 +324,13 @@ jobs:
               echo "export CI_IS_JEST_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_PHPUNIT_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
               echo "export CI_IS_SDC_DEVEL_RUNNER=$([ "${CIRCLE_NODE_INDEX:-0}" -eq 0 ] && echo 1 || echo 0)"
-              # Runs on every node, using the `p<node index>` profile.
+              # Runs on every node, using the `p<node index - offset>` profile.
               echo "export CI_IS_BEHAT_RUNNER=1"
+              # Subtracted from the node index to derive the profile number.
+              # Raise it by one for every leading node that does not run
+              # Behat, so the first Behat node still selects the `p0`
+              # catch-all profile.
+              echo "export CI_BEHAT_PROFILE_OFFSET=0"
             } >> "${BASH_ENV}"
 
       - run:
@@ -451,7 +456,7 @@ jobs:
           name: Test with Behat
           command: |
             [ "${CI_IS_BEHAT_RUNNER:-1}" = "1" ] || exit 0
-            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+            if [ "${CI_RUNNER_TOTAL:-1}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
             echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
             docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
               docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -53,19 +53,23 @@
        - name: Lint theme code with NodeJS linters
          if: ${{ vars.VORTEX_FRONTEND_BUILD_SKIP != '1' }}
          run: docker compose exec -T cli bash -c "yarn --cwd=\${WEBROOT}/themes/custom/\${DRUPAL_THEME} run lint"
-@@ -310,11 +274,7 @@
+@@ -310,15 +274,7 @@
        # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
        CI_RUNNER_INDEX: ${{ strategy.job-index }}
        CI_RUNNER_TOTAL: ${{ strategy.job-total }}
 -      CI_IS_JEST_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
 -      CI_IS_PHPUNIT_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
        CI_IS_SDC_DEVEL_RUNNER: ${{ matrix.instance == 0 || strategy.job-total == 1 }}
--      # Runs on every instance, using the `p<instance index>` profile.
+-      # Runs on every instance, using the `p<instance index - offset>` profile.
 -      CI_IS_BEHAT_RUNNER: true
+-      # Subtracted from the instance index to derive the profile number. Raise
+-      # it by one for every leading instance that does not run Behat, so the
+-      # first Behat instance still selects the `p0` catch-all profile.
+-      CI_BEHAT_PROFILE_OFFSET: 0
  
      container:
        # https://hub.docker.com/r/drevops/ci-runner
-@@ -417,7 +377,6 @@
+@@ -421,7 +377,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c " \
              if [ -n \"\${PACKAGE_TOKEN:-}\" ]; then composer config --global --auth github-oauth.github.com \"\${PACKAGE_TOKEN}\"; fi && \
              COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
@@ -73,7 +77,7 @@
  
        - name: Provision site
          run: |
-@@ -431,71 +390,6 @@
+@@ -435,71 +390,6 @@
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
          timeout-minutes: 30
  
@@ -145,7 +149,7 @@
        - name: Validate Single Directory Components
          if: ${{ env.CI_IS_SDC_DEVEL_RUNNER == 'true' }}
          run: |
-@@ -508,19 +402,6 @@
+@@ -512,19 +402,6 @@
            fi
          continue-on-error: ${{ vars.VORTEX_CI_SDC_DEVEL_IGNORE_FAILURE == '1' }}
  
@@ -153,7 +157,7 @@
 -        if: ${{ env.CI_IS_BEHAT_RUNNER == 'true' }}
 -        run: |
 -          # shellcheck disable=SC2170
--          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p${CI_RUNNER_INDEX}}"; fi
+-          if [ "${CI_RUNNER_TOTAL}" -gt 1 ]; then export VORTEX_CI_BEHAT_PROFILE="${VORTEX_CI_BEHAT_PROFILE:-p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))}"; fi
 -          echo "Running with ${VORTEX_CI_BEHAT_PROFILE:-default} profile"
 -          docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --profile="${VORTEX_CI_BEHAT_PROFILE:-default}" || \
 -            docker compose exec -T -e BEHAT_SCREENSHOT_ANIMATION_SKIP=1 cli php -d memory_limit=-1 vendor/bin/behat --colors --strict --rerun --profile="${VORTEX_CI_BEHAT_PROFILE:-default}"
@@ -165,7 +169,7 @@
        - name: Process test logs and artifacts
          if: always()
          run: |
-@@ -537,16 +418,6 @@
+@@ -541,16 +418,6 @@
            path: .logs
            include-hidden-files: true
            if-no-files-found: error

--- a/behat.yml
+++ b/behat.yml
@@ -99,8 +99,8 @@ default:
 # Profiles for parallel testing. CI derives the profile number from the index
 # of the runner it is on minus 'CI_BEHAT_PROFILE_OFFSET', so profiles stay
 # numbered from 'p0' regardless of which runner Behat starts on. Adding a
-# runner means adding a matching profile here and excluding its tag from the
-# 'p0' catch-all below.
+# runner that runs Behat means adding a profile for its derived number and
+# excluding its tag from the 'p0' catch-all below.
 # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
 
 # Runs all tests tagged with '@smoke' or not tagged with '@p1', and not tagged

--- a/behat.yml
+++ b/behat.yml
@@ -96,9 +96,11 @@ default:
     # Show explicit fail information and continue the test run.
     DrevOps\BehatFormatProgressFail\FormatExtension: ~
 
-# Profiles for parallel testing. CI runs the profile named after the index of
-# the runner it is on, so 'pN' requires a runner N. Adding a runner means adding
-# a matching profile here and excluding its tag from the 'p0' catch-all below.
+# Profiles for parallel testing. CI derives the profile number from the index
+# of the runner it is on minus 'CI_BEHAT_PROFILE_OFFSET', so profiles stay
+# numbered from 'p0' regardless of which runner Behat starts on. Adding a
+# runner means adding a matching profile here and excluding its tag from the
+# 'p0' catch-all below.
 # https://www.vortextemplate.com/docs/continuous-integration#test-parallelism
 
 # Runs all tests tagged with '@smoke' or not tagged with '@p1', and not tagged


### PR DESCRIPTION
Closes #3035

## Summary

Both CI providers derived the Behat profile name directly from the runner index (`p${CI_RUNNER_INDEX}`), and `p0` is the catch-all profile that runs every untagged scenario, so a project that dedicated runner 0 to once-only tools and moved Behat to later runners never selected `p0` and its untagged scenarios silently stopped running while CI stayed green. This change adds `CI_BEHAT_PROFILE_OFFSET`, a value subtracted from the runner index before it becomes a profile number (`p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))`), declared alongside the existing `CI_IS_*_RUNNER` role flags. The default of `0` keeps behaviour byte-identical to before, so existing projects are unaffected. A project that frees leading runners for other tools sets the offset once and Behat runners map back to `p0`, `p1`, and so on, with no changes to `behat.yml` or feature file tags.

## Changes

- Declared `CI_BEHAT_PROFILE_OFFSET` in the GitHub Actions test job's `env:` block and used it in the Behat step's profile derivation.
- Exported `CI_BEHAT_PROFILE_OFFSET` in the CircleCI `Set test runner roles` step and used it in the Behat step, mirrored across `.circleci/config.yml` (consumer config) and `.circleci/vortex-test-common.yml` (the template's own test harness).
- Rewrote the `behat.yml` profiles header comment to describe the derived profile number and clarify that only runners which run Behat need a profile.
- Reworked the parallelism documentation page with a worked example (once-only tools pinned to runner 0, Behat on runners 1-2 mapped to `p0`/`p1` via offset `1`, with a role table), a note that `behat.yml` stays untouched, and a warning scoping the contiguity limitation to runs without an explicit `VORTEX_CI_BEHAT_PROFILE`.
- Added a note to the Behat development page linking profile numbering to the offset and the parallelism page.
- Regenerated the installer test fixtures under `.vortex/installer/tests/Fixtures/handler_process/` to match the CI config and `behat.yml` changes (unified-diff snapshots, tooling-generated).

## Before / After

```
BEFORE: profile hardwired to the runner index
+------------------------------------------------------------+
| profile = p${CI_RUNNER_INDEX}                              |
|                                                              |
| Runner 0 -> p0   (must run Behat, or p0 silently skipped)  |
| Runner 1 -> p1                                              |
| Runner 2 -> p2                                              |
+------------------------------------------------------------+

AFTER: profile derived via an offset, default 0 (identical to BEFORE)
+------------------------------------------------------------+
| profile = p$((CI_RUNNER_INDEX - CI_BEHAT_PROFILE_OFFSET))  |
|                                                              |
| CI_BEHAT_PROFILE_OFFSET=1 (opt-in, frees runner 0):         |
|   Runner 0 -> once-only tools (Jest, PHPUnit, SDC)          |
|   Runner 1 -> p0   (catch-all)                              |
|   Runner 2 -> p1                                            |
+------------------------------------------------------------+
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Parallel Behat test runs now support leading CI containers that perform other tasks, while preserving consistent profile numbering.

- **Documentation**
  - Added guidance and examples for configuring profile offsets across supported CI systems.
  - Clarified profile numbering, container roles, validation warnings, and setup requirements for additional runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->