### PR TITLE
Fixed 'window.gtag is not a function' in the docs dev server after a build.

### DIFF
--- a/.vortex/docs/.gitignore
+++ b/.vortex/docs/.gitignore
@@ -4,8 +4,10 @@
 # Production
 /build
 
-# Generated files
+# Generated files. `yarn start` writes to `.docusaurus-dev` so a concurrent
+# `yarn build` cannot overwrite the files the dev server compiles from.
 .docusaurus
+.docusaurus-dev
 .cache-loader
 
 # Assembled docs versions - created by the CI publish step (or a local

--- a/.vortex/docs/package.json
+++ b/.vortex/docs/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "DOCUSAURUS_GENERATED_FILES_DIR_NAME=.docusaurus-dev docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
-    "clear": "docusaurus clear",
+    "clear": "docusaurus clear && DOCUSAURUS_GENERATED_FILES_DIR_NAME=.docusaurus-dev docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",

--- a/.vortex/docs/tests/unit/generated-dir.test.js
+++ b/.vortex/docs/tests/unit/generated-dir.test.js
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+
+// 'docusaurus start' and 'docusaurus build' generate into the directory named
+// by 'DOCUSAURUS_GENERATED_FILES_DIR_NAME'. Sharing that directory lets a build
+// add its analytics client module to a running dev server, whose page never
+// defines 'window.gtag'.
+const DOCS_ROOT = path.resolve(__dirname, '../..');
+const GENERATED_DIR_VAR = 'DOCUSAURUS_GENERATED_FILES_DIR_NAME';
+const DEV_GENERATED_DIR = '.docusaurus-dev';
+
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(DOCS_ROOT, 'package.json'), 'utf8')
+);
+
+const gitignore = fs.readFileSync(path.join(DOCS_ROOT, '.gitignore'), 'utf8');
+
+const tokenize = script => (script || '').match(/"[^"]*"|\S+/g) || [];
+
+const generatedDirs = script =>
+  tokenize(script)
+    .filter(token => token.startsWith(`${GENERATED_DIR_VAR}=`))
+    .map(token => token.slice(GENERATED_DIR_VAR.length + 1));
+
+const countCommands = (script, command) =>
+  tokenize(script).filter(token => token === command).length;
+
+describe('Docusaurus generated files directory', () => {
+  test('the dev server generates outside the build directory', () => {
+    expect(generatedDirs(packageJson.scripts.start)).toEqual([
+      DEV_GENERATED_DIR,
+    ]);
+    expect(generatedDirs(packageJson.scripts.build)).toEqual([]);
+  });
+
+  test('clear removes both generated directories', () => {
+    expect(generatedDirs(packageJson.scripts.clear)).toEqual([
+      DEV_GENERATED_DIR,
+    ]);
+    expect(countCommands(packageJson.scripts.clear, 'clear')).toBe(2);
+  });
+
+  test('the dev server directory is ignored by git', () => {
+    expect(gitignore.split('\n')).toContain(DEV_GENERATED_DIR);
+  });
+});


### PR DESCRIPTION
## Summary

Running the Docusaurus dev server (`yarn start` in `.vortex/docs`) and then running `yarn build` while it was still up broke client-side navigation with `TypeError: window.gtag is not a function`, thrown from `@docusaurus/plugin-google-gtag`'s `onRouteDidUpdate` hook.

`docusaurus start` and `docusaurus build` both generate into the same `.docusaurus/` directory, and `@docusaurus/plugin-google-gtag` disables itself entirely outside `NODE_ENV=production`, so the dev server's HTML head never defines `window.gtag`.

Running `yarn build` against a live dev server writes the plugin's gtag client module into that shared directory, the dev server's webpack watcher hot-recompiles it into the running bundle, and the next client-side navigation calls a `window.gtag` that was never defined.

The `start` script now sets `DOCUSAURUS_GENERATED_FILES_DIR_NAME=.docusaurus-dev` so the dev server generates into its own directory, isolated from `.docusaurus`, while `build`, `serve`, and CI are unchanged and keep using the default location.

## Changes

- `.vortex/docs/package.json`: `start` sets `DOCUSAURUS_GENERATED_FILES_DIR_NAME=.docusaurus-dev` so the dev server's generated files no longer share `.docusaurus` with `build`; `clear` now runs both `docusaurus clear` and the `.docusaurus-dev` equivalent so it removes both directories.
- `.vortex/docs/.gitignore`: ignores `.docusaurus-dev`, with a comment explaining why the dev server writes to a second generated-files directory.
- `.vortex/docs/tests/unit/generated-dir.test.js`: new Jest regression test asserting `start` generates into `.docusaurus-dev`, `build` does not set the override and keeps generating into `.docusaurus`, `clear` clears both directories, and `.docusaurus-dev` is listed in `.gitignore`. It tokenizes the `package.json` script strings rather than using `String.matchAll`, because under this project's babel preset `matchAll` yields non-array match objects.

## Verification

- Reproduced the exact error via agent-browser by running `yarn build` against a live dev server.
- After the fix, running a build while the dev server was up left `.docusaurus-dev/client-modules.js` free of the gtag module while `.docusaurus/client-modules.js` correctly contained it.
- Six client-side navigations through the docs in a fresh browser produced zero page errors.
- The production `build/index.html` still emits the gtag snippet unchanged.
- `yarn clear` removes both generated directories.
- Docs Jest suite green: 194 tests across 11 suites.
- `yarn lint-js` (eslint + prettier check) clean.
- Confirmed the new test fails when the fix is reverted.

## Before / After

```
BEFORE - "start" and "build" share .docusaurus/
┌────────────────────────────────────────────────────────────────────┐
│  yarn start (dev server, NODE_ENV=development)                      │
│  plugin-google-gtag disabled -> no <script>gtag()</script> in head  │
│         │                                                            │
│         ▼ writes generated files to                                 │
│    .docusaurus/  ◄──────────────── writes gtag client module to     │
│                                              │                        │
│                                              │ yarn build             │
│                                              │ (NODE_ENV=production) │
│                                              │ plugin-google-gtag on │
└────────────────────────────────────────────────────────────────────┘
         │
         ▼ dev server webpack watcher hot-recompiles the gtag module
           into a bundle whose page still has no window.gtag defined
         ▼
   click a docs link -> onRouteDidUpdate() -> window.gtag is not a
   function -> TypeError thrown, navigation breaks until next refresh

AFTER - "start" and "build" generate into separate directories
┌────────────────────────────────────────────────────────────────────┐
│  yarn start (dev server)                                            │
│  DOCUSAURUS_GENERATED_FILES_DIR_NAME=.docusaurus-dev                │
│         │                                                            │
│         ▼ writes generated files to                                 │
│    .docusaurus-dev/   (gtag client module never lands here)         │
│                                                                        │
│  yarn build (unchanged)                                              │
│         │                                                            │
│         ▼ writes generated files to                                 │
│    .docusaurus/       (unchanged, gtag snippet intact for prod)     │
└────────────────────────────────────────────────────────────────────┘
         │
         ▼ dev server bundle never contains the gtag client module
   click a docs link -> onRouteDidUpdate() no-ops -> no error
```
