### PR TITLE
[#3053] Suppressed 'docker compose cp' progress output in CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,11 +310,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -439,7 +439,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -459,13 +459,13 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             #;< MIGRATION
             if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
               docker compose exec -T cli mkdir -p .data
-              docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
+              docker compose --progress quiet cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
               rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
             fi
             #;> MIGRATION
@@ -493,7 +493,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -566,9 +566,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.circleci/vortex-test-common.yml
+++ b/.circleci/vortex-test-common.yml
@@ -164,11 +164,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -274,7 +274,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -294,13 +294,13 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             #;< MIGRATION
             if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
               docker compose exec -T cli mkdir -p .data
-              docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
+              docker compose --progress quiet cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
               rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
             fi
             #;> MIGRATION
@@ -328,7 +328,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -401,9 +401,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -314,10 +314,10 @@ jobs:
           if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
           ./vendor/bin/vortex-login-container-registry
           docker compose up --detach && sleep 15
-          docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+          docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
           docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
           ./vendor/bin/vortex-export-db db.sql
-          docker compose cp -L cli:/app/.data/db.sql .data/db.sql
+          docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql
         timeout-minutes: 30
 
       # Save cache per default branch and the timestamp.
@@ -473,7 +473,7 @@ jobs:
         if: ${{ matrix.instance == 0 && !startsWith(github.head_ref || github.ref_name, 'deps/') && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
         run: |
           mkdir -p "/tmp/workspace/code" "/tmp/artifacts"
-          docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+          docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
           tar -C /tmp/workspace -cpf /tmp/artifacts/code.tar code
           du -sh "/tmp/artifacts"
 
@@ -492,13 +492,13 @@ jobs:
           # container to avoid holding two copies for the rest of the job.
           if [ -f .data/db.sql ]; then
             docker compose exec cli mkdir -p .data
-            docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
             rm -f .data/db.sql
           fi
           #;< MIGRATION
           if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
             docker compose exec -T cli mkdir -p .data
-            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
+            docker compose --progress quiet cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
             rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
           fi
           #;> MIGRATION
@@ -523,7 +523,7 @@ jobs:
         run: |
           mkdir -p ".logs"
           if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-             docker compose cp cli:/app/.logs/. ".logs/"
+             docker compose --progress quiet cp cli:/app/.logs/. ".logs/"
           fi
 
       - name: Extract code coverage
@@ -623,7 +623,7 @@ jobs:
         run: |
           mkdir -p ".logs"
           if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-             docker compose cp cli:/app/.logs/. ".logs/"
+             docker compose --progress quiet cp cli:/app/.logs/. ".logs/"
           fi
 
       - name: Upload test artifacts

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/workflows/build-test-deploy.yml
@@ -270,10 +270,10 @@ jobs:
           if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
           ./vendor/bin/vortex-login-container-registry
           docker compose up --detach && sleep 15
-          docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+          docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
           docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
           ./vendor/bin/vortex-export-db db.sql
-          docker compose cp -L cli:/app/.data/db.sql .data/db.sql
+          docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql
         timeout-minutes: 30
 
       # Save cache per default branch and the timestamp.
@@ -412,7 +412,7 @@ jobs:
         if: ${{ matrix.instance == 0 && !startsWith(github.head_ref || github.ref_name, 'deps/') && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
         run: |
           mkdir -p "/tmp/workspace/code" "/tmp/artifacts"
-          docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+          docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
           tar -C /tmp/workspace -cpf /tmp/artifacts/code.tar code
           du -sh "/tmp/artifacts"
 
@@ -429,7 +429,7 @@ jobs:
           # container to avoid holding two copies for the rest of the job.
           if [ -f .data/db.sql ]; then
             docker compose exec cli mkdir -p .data
-            docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+            docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
             rm -f .data/db.sql
           fi
           docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -450,7 +450,7 @@ jobs:
         run: |
           mkdir -p ".logs"
           if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-             docker compose cp cli:/app/.logs/. ".logs/"
+             docker compose --progress quiet cp cli:/app/.logs/. ".logs/"
           fi
 
       - name: Extract code coverage
@@ -530,7 +530,7 @@ jobs:
         run: |
           mkdir -p ".logs"
           if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-             docker compose cp cli:/app/.logs/. ".logs/"
+             docker compose --progress quiet cp cli:/app/.logs/. ".logs/"
           fi
 
       - name: Upload test artifacts

--- a/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/ciprovider_circleci/.circleci/config.yml
@@ -258,11 +258,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -374,7 +374,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -392,7 +392,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -416,7 +416,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -472,9 +472,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/code_coverage_provider_codecov_circleci/.circleci/config.yml
@@ -258,11 +258,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -374,7 +374,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -392,7 +392,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -416,7 +416,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -480,9 +480,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_all_circleci/.circleci/config.yml
@@ -258,11 +258,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -374,7 +374,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -392,7 +392,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -416,7 +416,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -472,9 +472,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deploy_types_none_circleci/.circleci/config.yml
@@ -258,11 +258,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -374,7 +374,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -392,7 +392,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -416,7 +416,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -472,9 +472,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/deps_updates_provider_ci_circleci/.circleci/config.yml
@@ -258,11 +258,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -374,7 +374,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -392,7 +392,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -416,7 +416,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -472,9 +472,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_disabled_circleci/.circleci/config.yml
@@ -258,11 +258,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -374,7 +374,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -392,7 +392,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -416,7 +416,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -472,9 +472,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/.github/workflows/build-test-deploy.yml
@@ -10,12 +10,12 @@
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
-             docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
-+            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            docker compose --progress quiet cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 +            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/.circleci/config.yml
@@ -263,11 +263,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -379,7 +379,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -397,12 +397,12 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
               docker compose exec -T cli mkdir -p .data
-              docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
+              docker compose --progress quiet cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
               rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -426,7 +426,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -482,9 +482,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/.github/workflows/build-test-deploy.yml
@@ -10,12 +10,12 @@
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
-             docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
-+            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            docker compose --progress quiet cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 +            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/.github/workflows/build-test-deploy.yml
@@ -10,12 +10,12 @@
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
-             docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
-+            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            docker compose --progress quiet cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 +            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/.github/workflows/build-test-deploy.yml
@@ -10,12 +10,12 @@
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
-             docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
-+            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            docker compose --progress quiet cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 +            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/.github/workflows/build-test-deploy.yml
@@ -10,12 +10,12 @@
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
-             docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
-+            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            docker compose --progress quiet cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 +            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/.github/workflows/build-test-deploy.yml
@@ -10,12 +10,12 @@
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
-             docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
-+            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            docker compose --progress quiet cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 +            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/.github/workflows/build-test-deploy.yml
@@ -10,12 +10,12 @@
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
-             docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
-+            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            docker compose --progress quiet cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 +            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/.github/workflows/build-test-deploy.yml
@@ -10,12 +10,12 @@
            if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 @@ -431,6 +434,11 @@
              docker compose exec cli mkdir -p .data
-             docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+             docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
              rm -f .data/db.sql
 +          fi
 +          if [ -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" ]; then
 +            docker compose exec -T cli mkdir -p .data
-+            docker compose cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
++            docker compose --progress quiet cp -L ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}" cli:"/app/.data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 +            rm -f ".data/${VORTEX_FETCH_DB2_FILE:-db2.sql}"
            fi
            docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision

--- a/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/provision_profile/.github/workflows/build-test-deploy.yml
@@ -122,10 +122,10 @@
 -          if [ ! -f /tmp/fetch-db-fresh ]; then echo "==> Database fetch semaphore file is missing. DB export will not proceed."; exit 0; fi
 -          ./vendor/bin/vortex-login-container-registry
 -          docker compose up --detach && sleep 15
--          docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+-          docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
 -          docker compose exec cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
 -          ./vendor/bin/vortex-export-db db.sql
--          docker compose cp -L cli:/app/.data/db.sql .data/db.sql
+-          docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql
 -        timeout-minutes: 30
 -
 -      # Save cache per default branch and the timestamp.

--- a/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/timezone_circleci/.circleci/config.yml
@@ -258,11 +258,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -374,7 +374,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -392,7 +392,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -416,7 +416,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -472,9 +472,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_lint_circleci/.circleci/config.yml
@@ -246,11 +246,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -362,7 +362,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -380,7 +380,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -404,7 +404,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -460,9 +460,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests/.github/workflows/build-test-deploy.yml
@@ -38,7 +38,7 @@
 -        run: |
 -          mkdir -p ".logs"
 -          if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
--             docker compose cp cli:/app/.logs/. ".logs/"
+-             docker compose --progress quiet cp cli:/app/.logs/. ".logs/"
 -          fi
 -
 -      - name: Extract code coverage

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_be_tests_circleci/.circleci/config.yml
@@ -254,11 +254,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -362,7 +362,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -380,7 +380,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -409,9 +409,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_circleci/.circleci/config.yml
@@ -253,11 +253,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -368,7 +368,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -385,7 +385,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -403,7 +403,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -459,9 +459,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_groups_no_fe_lint_no_theme_circleci/.circleci/config.yml
@@ -247,11 +247,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -361,7 +361,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -378,7 +378,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -396,7 +396,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -440,9 +440,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_behat_circleci/.circleci/config.yml
@@ -254,11 +254,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -363,7 +363,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -381,7 +381,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -405,7 +405,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -450,9 +450,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_dclint_circleci/.circleci/config.yml
@@ -254,11 +254,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -370,7 +370,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -388,7 +388,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -412,7 +412,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -468,9 +468,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_docker_linters_circleci/.circleci/config.yml
@@ -247,11 +247,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -363,7 +363,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -381,7 +381,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -405,7 +405,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -461,9 +461,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_eslint_circleci/.circleci/config.yml
@@ -253,11 +253,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -369,7 +369,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -387,7 +387,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -411,7 +411,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -467,9 +467,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_hadolint_circleci/.circleci/config.yml
@@ -251,11 +251,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -367,7 +367,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -385,7 +385,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -409,7 +409,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -465,9 +465,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_jest_circleci/.circleci/config.yml
@@ -258,11 +258,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -373,7 +373,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -390,7 +390,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -408,7 +408,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -464,9 +464,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpcs_circleci/.circleci/config.yml
@@ -254,11 +254,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -370,7 +370,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -388,7 +388,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -412,7 +412,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -468,9 +468,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpstan_circleci/.circleci/config.yml
@@ -254,11 +254,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -370,7 +370,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -388,7 +388,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -412,7 +412,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -468,9 +468,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit/.github/workflows/build-test-deploy.yml
@@ -20,7 +20,7 @@
 -        run: |
 -          mkdir -p ".logs"
 -          if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
--             docker compose cp cli:/app/.logs/. ".logs/"
+-             docker compose --progress quiet cp cli:/app/.logs/. ".logs/"
 -          fi
 -
 -      - name: Extract code coverage

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_phpunit_circleci/.circleci/config.yml
@@ -258,11 +258,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -373,7 +373,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -391,7 +391,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -431,9 +431,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_rector_circleci/.circleci/config.yml
@@ -254,11 +254,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -370,7 +370,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -388,7 +388,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -412,7 +412,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -468,9 +468,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_stylelint_circleci/.circleci/config.yml
@@ -258,11 +258,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -374,7 +374,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -392,7 +392,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -416,7 +416,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -472,9 +472,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_no_twig_circleci/.circleci/config.yml
@@ -254,11 +254,11 @@ jobs:
             [ ! -f /tmp/fetch-db-fresh ] && echo "==> Database fetch semaphore file is missing. DB export will not proceed." && exit 0
             ./vendor/bin/vortex-login-container-registry
             docker compose up --detach && sleep 15
-            docker compose exec cli mkdir -p .data && docker compose cp -L .data/db.sql cli:/app/.data/db.sql || true
+            docker compose exec cli mkdir -p .data && docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql || true
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli bash -c "VORTEX_PROVISION_POST_OPERATIONS_SKIP=1 ./vendor/bin/vortex-provision"
             grep -q ^VORTEX_DB_IMAGE .env && rm .data/db.sql || true
             ./vendor/bin/vortex-export-db db.sql
-            docker compose exec -T cli test -f /app/.data/db.sql && docker compose cp -L cli:/app/.data/db.sql .data/db.sql || true
+            docker compose exec -T cli test -f /app/.data/db.sql && docker compose --progress quiet cp -L cli:/app/.data/db.sql .data/db.sql || true
           no_output_timeout: 30m
 
       # Deploy the freshly-exported database image to the container registry.
@@ -370,7 +370,7 @@ jobs:
           command: |
             echo "${VORTEX_DEPLOY_TYPES:-}" | grep -vq "artifact" && exit 0 || true
             mkdir -p "/tmp/workspace/code"
-            docker compose cp -L cli:"/app/." "/tmp/workspace/code"
+            docker compose --progress quiet cp -L cli:"/app/." "/tmp/workspace/code"
             du -sh "/tmp/workspace/code"
 
       - run:
@@ -388,7 +388,7 @@ jobs:
             # container to avoid holding two copies for the rest of the job.
             if [ -f .data/db.sql ]; then
               docker compose exec cli mkdir -p .data
-              docker compose cp -L .data/db.sql cli:/app/.data/db.sql
+              docker compose --progress quiet cp -L .data/db.sql cli:/app/.data/db.sql
               rm -f .data/db.sql
             fi
             docker compose exec $(env | cut -f1 -d= | sed 's/^/-e /') -T cli ./vendor/bin/vortex-provision
@@ -412,7 +412,7 @@ jobs:
             [ "${VORTEX_CI_IS_PHPUNIT_RUNNER:-1}" = "1" ] || exit 0
             mkdir -p "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
             fi
 
       - run:
@@ -468,9 +468,9 @@ jobs:
           command: |
             mkdir -p "${VORTEX_CI_TEST_RESULTS}" "${VORTEX_CI_ARTIFACTS}"
             if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
-               docker compose cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
+               docker compose --progress quiet cp cli:/app/.logs/. "${VORTEX_CI_ARTIFACTS}/"
               if docker compose exec -T cli sh -c '[ -d /app/.logs/test_results/ ]'; then
-                 docker compose cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
+                 docker compose --progress quiet cp cli:/app/.logs/test_results/. "${VORTEX_CI_TEST_RESULTS}/"
               fi
             fi
           when: always

--- a/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/tools_none/.github/workflows/build-test-deploy.yml
@@ -96,7 +96,7 @@
 -        run: |
 -          mkdir -p ".logs"
 -          if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec cli test -d /app/.logs; then
--             docker compose cp cli:/app/.logs/. ".logs/"
+-             docker compose --progress quiet cp cli:/app/.logs/. ".logs/"
 -          fi
 -
 -      - name: Extract code coverage


### PR DESCRIPTION
Closes #3053

## Summary

Compose's progress writer prints two stderr lines per `docker compose cp` invocation - a `Copying <src> to <dst>` line and a `Copied` confirmation - and CI was leaving it on for every one of them. In the `Provision site` step, the two `cp` calls that stage `db.sql` and `db2.sql` into the `cli` container run first, so their four progress lines are the first thing printed in the step output, pushing the actual provisioning banner below the fold. The same chatter also heads the `Export DB`, `Export built codebase`, `Process PHPUnit logs and coverage`, and `Process test logs and artifacts` steps.

This adds a global `--progress quiet` flag to every `docker compose cp` invocation across both CI providers. The flag disables only Compose's progress writer - errors still reach stderr and exit codes are unchanged, verified against Compose v5.4.0, the version shipped in `drevops/ci-runner:26.8.0`. `docker compose up` keeps its default progress output, since that output is worth keeping.

## Changes

### Suppressed progress output on 'docker compose cp'

- `.github/workflows/build-test-deploy.yml` gains `--progress quiet` on its 7 `docker compose cp` invocations, across the `Export DB`, `Export built codebase`, `Provision site`, `Process PHPUnit logs and coverage`, and `Process test logs and artifacts` steps.
- `.circleci/config.yml` gains the same flag on its 8 `docker compose cp` invocations, across the equivalently named `Export DB`, `Export built codebase`, `Provision site`, `Process PHPUnit logs and coverage`, and `Process test logs and artifacts` steps.
- `.circleci/vortex-test-common.yml` is regenerated from `.circleci/config.yml` via `ahoy lint-ci-fix`, carrying the same flag into the mirrored test job definition.

### Regenerated installer snapshot fixtures

- 37 installer snapshot fixtures are regenerated via `ahoy update-snapshots`, updating the `_baseline` fixture and the per-scenario `.github/workflows/build-test-deploy.yml` / `.circleci/config.yml` files under `.vortex/installer/tests/Fixtures/` to match the source configuration changes above.

## Screenshots

N/A

## Before / After

```text
BEFORE: progress chatter heads the 'Provision site' step output

  Provision site
  ┌────────────────────────────────────────────────────────┐
  │  cli  Copying .data/db.sql to cli:/app/.data/db.sql    │
  │  cli  Copied                                           │
  │  cli  Copying .data/db2.sql to cli:/app/.data/db2.sql  │
  │  cli  Copied                                           │
  │  ==> Provisioning site...                              │
  └────────────────────────────────────────────────────────┘

AFTER: the provisioning banner is the first line

  Provision site
  ┌────────────────────────────────────────────────────────┐
  │  ==> Provisioning site...                              │
  └────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced Docker Compose file-copy command output during database exports, artifact handling, provisioning, and test-log collection.
  * Applied quieter progress reporting across automated build, test, and deployment workflows.
  * Workflow behavior and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->