### PR TITLE
Replaced the provision task completion marker '<' with '+'.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-00-enable-demo-modules.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-00-enable-demo-modules.sh
@@ -18,7 +18,7 @@ set -eu
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-10-enable-dev-modules.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-10-enable-dev-modules.sh
@@ -19,7 +19,7 @@ DRUPAL_GENERATED_CONTENT_SKIP="${DRUPAL_GENERATED_CONTENT_SKIP:-0}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-30-search-index.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-30-search-index.sh
@@ -16,7 +16,7 @@ DRUPAL_SEARCH_INDEX_SKIP="${DRUPAL_SEARCH_INDEX_SKIP:-0}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-40-example.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/scripts/provision-40-example.sh
@@ -21,7 +21,7 @@ set -eu
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled/scripts/provision-20-migration.sh
@@ -46,7 +46,7 @@ VORTEX_FETCH_DB2_FILE="${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_circleci/scripts/provision-20-migration.sh
@@ -46,7 +46,7 @@ VORTEX_FETCH_DB2_FILE="${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_enabled_lagoon/scripts/provision-20-migration.sh
@@ -46,7 +46,7 @@ VORTEX_FETCH_DB2_FILE="${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_acquia/scripts/provision-20-migration.sh
@@ -46,7 +46,7 @@ VORTEX_FETCH_DB2_FILE="${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_container_registry/scripts/provision-20-migration.sh
@@ -46,7 +46,7 @@ VORTEX_FETCH_DB2_FILE="${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_ftp/scripts/provision-20-migration.sh
@@ -46,7 +46,7 @@ VORTEX_FETCH_DB2_FILE="${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_lagoon/scripts/provision-20-migration.sh
@@ -46,7 +46,7 @@ VORTEX_FETCH_DB2_FILE="${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_s3/scripts/provision-20-migration.sh
@@ -46,7 +46,7 @@ VORTEX_FETCH_DB2_FILE="${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/scripts/provision-20-migration.sh
+++ b/.vortex/installer/tests/Fixtures/handler_process/migration_fetch_source_url/scripts/provision-20-migration.sh
@@ -46,7 +46,7 @@ VORTEX_FETCH_DB2_FILE="${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/scripts/provision-00-enable-demo-modules.sh
+++ b/scripts/provision-00-enable-demo-modules.sh
@@ -18,7 +18,7 @@ set -eu
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/scripts/provision-10-enable-dev-modules.sh
+++ b/scripts/provision-10-enable-dev-modules.sh
@@ -21,7 +21,7 @@ DRUPAL_GENERATED_CONTENT_SKIP="${DRUPAL_GENERATED_CONTENT_SKIP:-0}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/scripts/provision-20-migration.sh
+++ b/scripts/provision-20-migration.sh
@@ -48,7 +48,7 @@ VORTEX_FETCH_DB2_FILE="${VORTEX_FETCH_DB2_FILE:-db2.sql}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/scripts/provision-30-search-index.sh
+++ b/scripts/provision-30-search-index.sh
@@ -16,7 +16,7 @@ DRUPAL_SEARCH_INDEX_SKIP="${DRUPAL_SEARCH_INDEX_SKIP:-0}"
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 

--- a/scripts/provision-40-example.sh
+++ b/scripts/provision-40-example.sh
@@ -21,7 +21,7 @@ set -eu
 info() { printf "   ==> %s\n" "${1}"; }
 note() { printf "       %s\n" "${1}"; }
 task() { printf "     > %s\n" "${1}"; }
-pass() { printf "     < %s\n" "${1}"; }
+pass() { printf "     + %s\n" "${1}"; }
 fail() { printf "     ! %s\n" "${1}"; exit "${2:-1}"; }
 # @formatter:on
 


### PR DESCRIPTION
## Summary

The five custom provision scripts in `scripts/` share a block of output helpers, where `task()` opens a step by printing `>` and `pass()` closed it by printing `<`, so the closing marker read as a positive result only because it mirrored the opening one rather than stating anything on its own. This PR changes only the `pass()` line, replacing `<` with `+` across all five scripts, so the marker set becomes `>` opened, `+` succeeded, `!` failed: three independent, self-explanatory meanings. The same files also define `#;< TOKEN` / `#;> TOKEN` installer fences, where `<` opens a block and `>` closes it, the exact inverse of the logger's prior orientation, so one file carried two contradictory conventions for the same pair of glyphs; dropping `<` from the logger ends that collision. `<` and `>` are additionally shell redirection operators, so they read as noise in a shell script's own output, and a leading `>` turns into a Markdown blockquote when a log is pasted into GitHub. `+` was chosen over the alternatives because it is the only printable ASCII character with an inherent positive charge that needs no partner glyph to be read correctly, and every shell script in this repository is deliberately ASCII-only, which ruled out a Unicode check mark.

## Changes

- Changed `pass()` in `scripts/provision-00-enable-demo-modules.sh`, `scripts/provision-10-enable-dev-modules.sh`, `scripts/provision-20-migration.sh`, `scripts/provision-30-search-index.sh`, and `scripts/provision-40-example.sh` to print `+` instead of `<` when a provisioning step completes.
- Regenerated the 13 matching installer fixtures under `.vortex/installer/tests/Fixtures/handler_process/` with `ahoy update-snapshots` so they stay byte-identical copies of the five scripts above.

## Known follow-up

The recorded terminal demos `.vortex/docs/static/img/build.json` and `provision.json` (16 frames each) and their derived `.svg`/`.png` still show the old `<` marker. Re-recording them requires `ahoy update-videos build provision`, which `.vortex/installer/CLAUDE.md` gates behind explicit user permission, so that is left out of this PR.

## Before / After

Marker vocabulary:

| Marker | Meaning | Before | After |
|--------|---------|--------|-------|
| `>` | step opened | yes | yes |
| `<` | step succeeded | yes | removed |
| `+` | step succeeded | no | yes |
| `!` | step failed | yes | yes |

Sample provisioning output, before:

```
   ==> Started demo modules operations.
       Environment: local
     > Creating the content model.
 [OK] Basic page applied successfully
     < Created the content model.
     > Setting site name.
     < Set site name.
```

Sample provisioning output, after:

```
   ==> Started demo modules operations.
       Environment: local
     > Creating the content model.
 [OK] Basic page applied successfully
     + Created the content model.
     > Setting site name.
     + Set site name.
```
