### PR TITLE
Suppressed the 'git init' branch advice leaking into the installer output.

### DIFF
--- a/.vortex/docs/.utils/update-videos.php
+++ b/.vortex/docs/.utils/update-videos.php
@@ -486,4 +486,13 @@ function main(array $argv): int {
   return 0;
 }
 
-exit(main($argv));
+// A failure inside main() reports itself before it is thrown, so the message
+// alone is the whole error.
+try {
+  exit(main($argv));
+}
+catch (Throwable $exception) {
+  fwrite(STDERR, $exception->getMessage() . "\n");
+
+  exit(1);
+}

--- a/.vortex/installer/src/Utils/FileManager.php
+++ b/.vortex/installer/src/Utils/FileManager.php
@@ -130,7 +130,9 @@ class FileManager {
 
       // The destination arrives from a CLI option, the environment or a config
       // file, so it is escaped rather than interpolated into the shell string.
-      $command = sprintf('git --work-tree=%s --git-dir=%s init > /dev/null', escapeshellarg($destination), escapeshellarg($destination . '/.git'));
+      // 'git init' writes the initial branch advice to stderr when
+      // 'init.defaultBranch' is unset, and passthru() draws it inside the TUI.
+      $command = sprintf('git -c advice.defaultBranchName=false --work-tree=%s --git-dir=%s init > /dev/null', escapeshellarg($destination), escapeshellarg($destination . '/.git'));
       passthru($command, $exit_code);
 
       if ($exit_code !== 0 || !File::exists($destination . '/.git')) {


### PR DESCRIPTION
## Summary

A `vortex-release-docs` CI run failed while generating the installer demo video: `FileManager::prepareDestination()` initialises the new project's git repository with `git --work-tree=... --git-dir=... init > /dev/null`, and when the host has no `init.defaultBranch` configured, git writes its 13-line "Using 'master' as the name for the initial branch" advice to stderr, which the `> /dev/null` redirect never touches and `passthru()` draws straight into the installer's TUI transcript.  `VideoRecorder::assertNoIssues()` refuses to render a demo whose transcript contains a warning, so the advice text aborted the recording.  The `git init` invocation now adds `-c advice.defaultBranchName=false`, which silences only that advice line, leaves real stderr output and the host's own branch-naming configuration untouched.  `update-videos.php` also no longer lets a thrown exception surface as a raw PHP fatal error: the top-level `exit(main($argv))` call is now wrapped in a `try`/`catch` that prints the exception message to stderr and exits 1.

## Changes

1. `.vortex/installer/src/Utils/FileManager.php` - Added `-c advice.defaultBranchName=false` to the `git init` command built in `prepareDestination()`, so git's initial-branch-name advice never reaches the installer output, regardless of the host's `init.defaultBranch` setting.
2. `.vortex/docs/.utils/update-videos.php` - Wrapped the script's top-level `exit(main($argv))` in a `try`/`catch`, so a thrown `RuntimeException` (for example a missing-dependency guard failure) prints its message on its own line and exits with status 1, instead of producing an uncaught-exception fatal error, a stack trace, and exit code 255.

The advice only ever reached the `vortex-release-docs` job: `vortex-test-installer.yml` configures `init.defaultBranch` for its own tests, which archive a `main` ref from local fixture repos, so its copy of the video-generation step never saw the warning; that configuration is a genuine requirement of the installer's own test suite and is left in place.

Verified locally: `composer test -- --filter FileManagerTest` in `.vortex/installer` passes (23 tests, 50 assertions); the patched `git init` command was run under an isolated git config and emits nothing on stderr; `php -l` is clean on `update-videos.php`.

## Before / After

```
git init advice leaking into the installer TUI
────────────────────────────────────────────────────────────────────────
 BEFORE                              │ AFTER
─────────────────────────────────────┼────────────────────────────────────
 $ git --work-tree=... \             │ $ git -c advice.defaultBranchName=false \
     --git-dir=... init > /dev/null  │     --work-tree=... --git-dir=... init > /dev/null
                                      │
 stdout: (silenced)                  │ stdout: (silenced)
 stderr: hint: Using 'master' as     │ stderr: (empty)
   the name for the initial branch.  │
   This default branch name is       │
   subject to change. ... (13 lines) │
                                      │
 passthru() → drawn into installer   │ passthru() → nothing drawn into
   TUI transcript                    │   installer TUI transcript
                                      │
 VideoRecorder::assertNoIssues()     │ VideoRecorder::assertNoIssues()
   → transcript contains a warning   │   → transcript is clean
   → guard fails, recording aborts   │   → video renders normally
```

```
update-videos.php uncaught-exception handling
────────────────────────────────────────────────────────────────────────
 BEFORE                              │ AFTER
─────────────────────────────────────┼────────────────────────────────────
 exit(main($argv));                  │ try {
                                      │   exit(main($argv));
 main() throws RuntimeException      │ }
   → no top-level handler            │ catch (Throwable $exception) {
   → PHP Fatal error: Uncaught       │   fwrite(STDERR, $exception->getMessage() . "\n");
     RuntimeException: ...           │   exit(1);
     #0 {main}                       │ }
   → exit code 255                   │
                                      │ main() throws RuntimeException
                                      │   → message printed to stderr only
                                      │   → exit code 1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for video update operations by reporting failures clearly and returning an appropriate failure status.
  * Reduced unnecessary Git setup messages during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->