### PR TITLE
[#3077] Covered '.mjs' and '.cjs' by the '.editorconfig' line-length rule and removed the redundant 'eslint.config.mjs' section.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 # Matches the Prettier 'printWidth' in .prettierrc.json.
-[*.js]
+[*.{js,mjs,cjs}]
 max_line_length = 160
 
 [*.{json,lock}]
@@ -22,9 +22,6 @@ indent_size = 4
 
 [*.xml]
 indent_size = 4
-
-[eslint.config.mjs]
-indent_size = 2
 
 [.prettierrc.json]
 indent_size = 2

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.editorconfig
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.editorconfig
@@ -14,7 +14,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 # Matches the Prettier 'printWidth' in .prettierrc.json.
-[*.js]
+[*.{js,mjs,cjs}]
 max_line_length = 160
 
 [*.{json,lock}]
@@ -22,9 +22,6 @@ indent_size = 4
 
 [*.xml]
 indent_size = 4
-
-[eslint.config.mjs]
-indent_size = 2
 
 [.prettierrc.json]
 indent_size = 2


### PR DESCRIPTION
Closes #3077

## Summary

The `[eslint.config.mjs]` section in `.editorconfig` became a no-op after the 1.41.0 rename from `[.eslintrc.json]`, because its `indent_size = 2` is already inherited from `[*]` and `.mjs` matches no more specific glob than `[*]` itself. At the same time, `.mjs` and `.cjs` files fell outside the `max_line_length = 160` rule that mirrors Prettier's `printWidth`, since they matched neither `[*.js]` nor `[*.{json,lock}]`. This PR widens the JavaScript glob to `[*.{js,mjs,cjs}]` so the line-length rule applies uniformly, and removes the now-redundant `[eslint.config.mjs]` section.

## Changes

- Widened the `[*.js]` section in root `.editorconfig` to `[*.{js,mjs,cjs}]` so `max_line_length = 160` also applies to `.mjs` and `.cjs` files.
- Removed the redundant `[eslint.config.mjs]` section from root `.editorconfig`, since its `indent_size = 2` was already inherited from `[*]`.
- Regenerated the installer baseline fixture at `.vortex/installer/tests/Fixtures/handler_process/_baseline/.editorconfig` via the snapshots tooling to match the updated root file.
- Confirmed no theme-level `.editorconfig` exists under `web/`, so the root file is the only one affected by this change.

## Before / After

```
┌─ BEFORE ────────────────────────────────────────────────────┐
│ # Matches the Prettier 'printWidth' in .prettierrc.json.     │
│ [*.js]                                                        │
│ max_line_length = 160                                         │
│                                                                │
│ [eslint.config.mjs]      <- no max_line_length reaches here;  │
│ indent_size = 2             .mjs matches neither glob above,  │
│                              and indent_size just repeats [*] │
└────────────────────────────────────────────────────────────────┘

┌─ AFTER ─────────────────────────────────────────────────────┐
│ # Matches the Prettier 'printWidth' in .prettierrc.json.     │
│ [*.{js,mjs,cjs}]                                              │
│ max_line_length = 160    <- now also covers .mjs and .cjs     │
│                                                                │
│ (the [eslint.config.mjs] section is gone; nothing depended    │
│  on it once [*.{js,mjs,cjs}] and [*] cover the same ground)   │
└────────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated editor settings to consistently cover JavaScript, module, and CommonJS files.
  * Removed the dedicated editor settings section for the ESLint configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->