### PR TITLE
[#3079] Corrected the 'appying' spelling in the '.env' provision description.

### DIFF
--- a/.env
+++ b/.env
@@ -106,7 +106,7 @@ DRUPAL_CLAMAV_MODE=daemon
 ################################################################################
 
 # By "provision", we mean the process of initializing the database (from dump
-# or fresh install from profile), running updates, appying configuration
+# or fresh install from profile), running updates, applying configuration
 # changes, clearing caches and performing other tasks that prepare the site for
 # use.
 # @see https://www.vortextemplate.com/docs/development/provision

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.env
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.env
@@ -94,7 +94,7 @@ DRUPAL_CLAMAV_MODE=daemon
 ################################################################################
 
 # By "provision", we mean the process of initializing the database (from dump
-# or fresh install from profile), running updates, appying configuration
+# or fresh install from profile), running updates, applying configuration
 # changes, clearing caches and performing other tasks that prepare the site for
 # use.
 # @see https://www.vortextemplate.com/docs/development/provision


### PR DESCRIPTION
Closes #3079

## Summary

The PROVISION section comment in `.env` misspells `applying` as `appying`. This corrects the spelling in the root `.env` file and regenerates the installer test baseline fixture that mirrors it, so both copies of the comment stay identical.

## Changes

- Corrected `appying` to `applying` in the PROVISION section comment in `.env`
- Regenerated `.vortex/installer/tests/Fixtures/handler_process/_baseline/.env` to carry the same correction, via the installer snapshot tooling

## Before / After

```
┌───────────────────────────────────────────────────────────────────────────┐
│ BEFORE                                                                    │
│ # or fresh install from profile), running updates, appying configuration  │
│                                                                           │
│ AFTER                                                                     │
│ # or fresh install from profile), running updates, applying configuration │
└───────────────────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in the provisioning documentation comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->