### PR TITLE
[#3080] Ignored 'SC1090' through the actionlint configuration file.

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,6 @@
+paths:
+  .github/workflows/**/*.yml:
+    ignore:
+      # The steps that load '.env' source an environment snapshot from a path
+      # created at runtime, which shellcheck cannot resolve.
+      - 'shellcheck reported issue in this script: SC1090:.+'

--- a/.github/workflows/vortex-test-common.yml
+++ b/.github/workflows/vortex-test-common.yml
@@ -273,7 +273,7 @@ jobs:
         continue-on-error: ${{ vars.VORTEX_CI_YAMLLINT_IGNORE_FAILURE == '1' }}
 
       - name: Check coding standards with actionlint
-        run: docker run --rm -v "${GITHUB_WORKSPACE:-.}":/app --workdir /app rhysd/actionlint:1.7.12 -ignore 'SC2002:' -ignore 'SC2155:' -ignore 'SC2015:' -ignore 'SC2046:' -ignore 'SC1090:'
+        run: docker run --rm -v "${GITHUB_WORKSPACE:-.}":/app --workdir /app rhysd/actionlint:1.7.12 -ignore 'SC2002:' -ignore 'SC2155:' -ignore 'SC2015:' -ignore 'SC2046:'
         continue-on-error: ${{ vars.VORTEX_CI_ACTIONLINT_IGNORE_FAILURE == '1' }}
 
       - name: Check GitHub Actions security with Zizmor

--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/actionlint.yml
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/.github/actionlint.yml
@@ -1,0 +1,6 @@
+paths:
+  .github/workflows/**/*.yml:
+    ignore:
+      # The steps that load '.env' source an environment snapshot from a path
+      # created at runtime, which shellcheck cannot resolve.
+      - 'shellcheck reported issue in this script: SC1090:.+'


### PR DESCRIPTION
Closes #3080

## Summary

`actionlint` reports shellcheck `SC1090` on the workflow steps that source `.env`. The path being sourced is a `mktemp` file, so shellcheck cannot resolve it and cannot be made to, and the sourcing is intentional.

The suppression moves into `.github/actionlint.yml`, which `actionlint` reads automatically. Every `run:` value keeps the single-line scalar it has always had, no `# shellcheck` directive is introduced, and the ignore is scoped to the one rule rather than applied through a command-line flag that only the Vortex repository passes.

Because the configuration file ships with the template, a project scaffolded from Vortex inherits the same suppression instead of having to rediscover it. That is what the issue was actually about: the finding surfaced on a consumer project, not here.

## Changes

- Added `.github/actionlint.yml` with a single `paths` ignore for `SC1090`, scoped to `.github/workflows/**/*.yml`.
- Removed `-ignore 'SC1090:'` from the `actionlint` invocation in `vortex-test-common.yml`. The configuration file now covers it, so the suppression is declared once rather than in two places.
- Regenerated the installer fixtures. The new file is picked up automatically, and the `code_provider_other` scenario drops it along with the rest of `.github/`.

No workflow command changed. The `.env` loading steps in `audit.yml`, `build-test-deploy.yml`, `draft-release-notes.yml` and `.circleci/config.yml` are byte-identical to `main`.

## Screenshots

N/A

## Before / After

```
Before
┌────────────────────────────┐        ┌────────────────────────────┐
│ vortex-test-common.yml     │        │ consumer project           │
│                            │        │                            │
│ actionlint                 │        │ actionlint                 │
│   -ignore 'SC2002:'        │        │   (no flags)               │
│   -ignore 'SC2155:'        │        │                            │
│   -ignore 'SC2015:'        │        │   SC1090 x5  reported      │
│   -ignore 'SC2046:'        │        │                            │
│   -ignore 'SC1090:'  <--   │        │                            │
└────────────────────────────┘        └────────────────────────────┘
  Suppressed here only. The flag lives in a workflow the installer
  never ships, so every consumer sees the finding.

After
┌────────────────────────────┐        ┌────────────────────────────┐
│ .github/actionlint.yml     │───────>│ .github/actionlint.yml     │
│                            │ ships  │                            │
│ paths:                     │  with  │ paths:                     │
│   .github/workflows/**:    │  the   │   .github/workflows/**:    │
│     ignore:                │ template     ignore:                │
│       - '... SC1090:.+'    │        │       - '... SC1090:.+'    │
└────────────────────────────┘        └────────────────────────────┘
  Read automatically by actionlint, in this repository and in every
  project scaffolded from it. The command-line flag is dropped.
```
