### PR TITLE
[#3103] Corrected stale stage mail comment in 'dataProviderMailCollector()'.

### DIFF
--- a/.vortex/installer/tests/Fixtures/handler_process/_baseline/tests/phpunit/Drupal/SwitchableSettingsTest.php
+++ b/.vortex/installer/tests/Fixtures/handler_process/_baseline/tests/phpunit/Drupal/SwitchableSettingsTest.php
@@ -1112,7 +1112,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
       ],
     ];
 
-    // Stage: delivered to the original recipients.
+    // Stage: rerouted, then delivered to the rerouting address.
     yield [
       self::ENVIRONMENT_STAGE,
       [],

--- a/tests/phpunit/Drupal/SwitchableSettingsTest.php
+++ b/tests/phpunit/Drupal/SwitchableSettingsTest.php
@@ -1142,7 +1142,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
       ],
     ];
 
-    // Stage: delivered to the original recipients.
+    // Stage: rerouted, then delivered to the rerouting address.
     yield [
       self::ENVIRONMENT_STAGE,
       [],


### PR DESCRIPTION
Closes #3103

## Summary

This change corrects no behavior; it fixes a stale comment in `dataProviderMailCollector()` in `tests/phpunit/Drupal/SwitchableSettingsTest.php`, mirrored into the installer's snapshot fixture at the equivalent path under `.vortex/installer/tests/Fixtures/handler_process/_baseline/`.

The `ENVIRONMENT_STAGE` yield carried `// Stage: delivered to the original recipients.`, a description of the routing behavior from before `web/sites/default/includes/modules/settings.reroute_email.php` enabled `reroute_email` for every environment except `ENVIRONMENT_LOCAL`, `ENVIRONMENT_CI` and `ENVIRONMENT_PROD`, so `ENVIRONMENT_STAGE` has been taking the same rerouting branch as `ENVIRONMENT_DEV`.

The stage comment now reads `// Stage: rerouted, then delivered to the rerouting address.`, matching the `// Dev: rerouted, then delivered to the rerouting address.` comment a few yields above; the yield's assertion, the `ENVIRONMENT_PROD` comment, and the `test_mail_collector` configuration that `settings.system.php` sets only for `ENVIRONMENT_CI` are untouched.

## Before / After

```
┌───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┬───────────────────────────────┐
│ Environment       │ reroute_email │ dataProviderMailCollector() comment                          │ Note                          │
├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┼───────────────────────────────┤
│ ENVIRONMENT_DEV   │ enabled       │ // Dev: rerouted, then delivered to the rerouting address.   │ unchanged                     │
├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┼───────────────────────────────┤
│ ENVIRONMENT_STAGE │ enabled       │ // Stage: delivered to the original recipients.              │ BEFORE: contradicted the code │
│ ENVIRONMENT_STAGE │ enabled       │ // Stage: rerouted, then delivered to the rerouting address. │ AFTER: matches Dev            │
├───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┼───────────────────────────────┤
│ ENVIRONMENT_PROD  │ disabled      │ // Prod: delivered to the original recipients.               │ unchanged                     │
└───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┴───────────────────────────────┘
```

## Changes

- Updated the `ENVIRONMENT_STAGE` comment in `dataProviderMailCollector()` in `tests/phpunit/Drupal/SwitchableSettingsTest.php` to describe the rerouted behavior instead of the pre-rerouting behavior it described before stage rerouting was enabled.
- Mirrored the same one-line comment fix into the installer snapshot fixture at `.vortex/installer/tests/Fixtures/handler_process/_baseline/tests/phpunit/Drupal/SwitchableSettingsTest.php` by regenerating the installer's baseline snapshot.

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test wording to clarify that staged mail is rerouted and delivered to the configured rerouting address instead of the original recipients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->