### PR TITLE
[#3107] Replaced the drifted script snippet in '.vortex/CLAUDE.md' with a pointer to 'script-boilerplate.sh'.

### DIFF
--- a/.vortex/CLAUDE.md
+++ b/.vortex/CLAUDE.md
@@ -57,26 +57,20 @@ install it and run the shipped scripts from `vendor/bin/vortex-*`.
 - **Manual** - `tooling/playground/` holds scripts that hit live services
   (Slack, JIRA, New Relic). Not automated; see `tooling/playground/README.md`.
 
-**Script pattern** (shipped tooling scripts and `scripts/` provision subscripts):
+**Script pattern**: the structure, the variable block and the five output
+helpers live in the boilerplate at
+`.vortex/docs/content/contributing/maintenance/script-boilerplate.sh`. Copy
+them from there - every script in `tooling/src/` matches it byte for byte.
 
-```bash
-#!/usr/bin/env bash
-# Environment loading
-t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && rm "${t}"
+The boilerplate leaves out two things the repository's scripts carry:
 
-set -eu
-[ "${VORTEX_DEBUG-}" = "1" ] && set -x
-
-# Variables with defaults
-VAR="${VAR:-default}"
-
-# Helpers
-info() { printf "[INFO] %s\n" "${1}"; }
-task() { printf "    > %s\n" "${1}"; }
-note() { printf "      %s\n" "${1}"; }
-
-# Main execution
-```
+- Scripts in `tooling/src/` begin with an `.env` loading line placed above
+  `set -eu`. Copy it verbatim from any script in that directory.
+- The `scripts/provision-*.sh` subscripts define the same five helpers with
+  indented arrow prefixes instead of the boilerplate's `[INFO]`, `[TASK]`,
+  `[ OK ]` and `[FAIL]` labels. Copy them from an existing subscript such as
+  `scripts/provision-30-search-index.sh`; converting them to the boilerplate
+  form changes stdout that the tests assert on.
 
 **Output helpers** - every `task` MUST be closed by a `pass` or a `fail`. A
 task announces work that is starting, so it always reports its outcome; a `task`

--- a/.vortex/CLAUDE.md
+++ b/.vortex/CLAUDE.md
@@ -60,7 +60,8 @@ install it and run the shipped scripts from `vendor/bin/vortex-*`.
 **Script pattern**: the structure, the variable block and the five output
 helpers live in the boilerplate at
 `.vortex/docs/content/contributing/maintenance/script-boilerplate.sh`. Copy
-them from there - every script in `tooling/src/` matches it byte for byte.
+them from there - the five helper definitions are byte-identical in the
+boilerplate and in every script in `tooling/src/`.
 
 The boilerplate leaves out two things the repository's scripts carry:
 


### PR DESCRIPTION
Closes #3107

## Summary

The "Script pattern" subsection of `.vortex/CLAUDE.md` no longer inlines a `bash` snippet defining `info()`, `task()` and `note()`; it now points readers to `.vortex/docs/content/contributing/maintenance/script-boilerplate.sh` for the structure, the variable block and the five output helpers, plus two bullets naming what that file leaves out.

The removed snippet's `task()` printed a `    > ` prefix instead of the shipped colour-aware `[TASK] ` label, `note()` indented six spaces instead of seven, and `pass()`/`fail()` were missing entirely even though the very next paragraph requires every `task` to be closed by one of them; its env-loading line also dropped the `if [ -f ./.env.local ]` handling and the trailing `unset t` that every script in `.vortex/tooling/src/` carries. Because `.vortex/CLAUDE.md` is what contributors and AI agents read before writing shell in this repo, the divergent form was the one reached first.

Readers now copy the five helper definitions from `script-boilerplate.sh`, byte-identical with those in every script under `.vortex/tooling/src/`, instead of from a snippet that matched none of them. No shell script, no script output and no test changes: `script-boilerplate.sh`, `template.mdx` and the "Output helpers" prose describing the `task`/`pass`/`fail` contract are all untouched.

## Before / After

```text
BEFORE - the pattern lived in two places, and they disagreed

  .vortex/CLAUDE.md                    script-boilerplate.sh
  +--------------------------------+   +--------------------------------+
  | info() -> "[INFO] ", no colour |   | info() -> "[INFO] ", colour    |
  | task() -> "    > "             |   | task() -> "[TASK] ", colour    |
  | note() -> 6 spaces             |   | note() -> 7 spaces             |
  | pass() -> absent               |   | pass() -> "[ OK ] ", colour    |
  | fail() -> absent               |   | fail() -> "[FAIL] ", colour    |
  | .env line: no .env.local,      |   +---------------+----------------+
  |            no `unset t`        |                   | helpers byte for byte
  +--------------------------------+                   v
     read first, drifted silently      .vortex/tooling/src/* (42 scripts)


AFTER - one copy, and CLAUDE.md points at it

  .vortex/CLAUDE.md                    script-boilerplate.sh
  +--------------------------------+   +--------------------------------+
  | "the structure, the variable   |-->| info/note/task/pass/fail       |
  |  block and the five output     |   +---------------+----------------+
  |  helpers live in the           |                   | helpers byte for byte
  |  boilerplate at ..."           |                   v
  |                                |   .vortex/tooling/src/* (42 scripts)
  | + tooling/src/ adds an .env    |
  |   line above `set -eu`         |   scripts/provision-*.sh
  | + provision-*.sh keeps its     |   (indented arrow labels, untouched)
  |   arrow labels - do not convert|
  +--------------------------------+
```

## Changes

- `.vortex/CLAUDE.md`: replaced the inline `bash` snippet under "Script pattern" with a pointer to `.vortex/docs/content/contributing/maintenance/script-boilerplate.sh` as the single source for the structure, the variable block and the five output helpers (`info`, `note`, `task`, `pass`, `fail`).
- Added a bullet noting that scripts in `tooling/src/` begin with an `.env` loading line placed above `set -eu`, to be copied verbatim from any script in that directory. The line is named rather than reproduced: it is absent from the boilerplate and specific to `tooling/src/` (`hooks/library/*.sh` define no helpers and load no env), so a copy here would be a second thing to drift.
- Added a bullet noting that `scripts/provision-*.sh` subscripts define the same five helpers with indented arrow prefixes instead of the boilerplate's `[INFO]`, `[TASK]`, `[ OK ]` and `[FAIL]` labels, to be copied from an existing subscript such as `scripts/provision-30-search-index.sh`, and warning that converting them to the boilerplate form changes stdout that the tests assert on. The previous heading claimed one pattern governed both families.
- Left the "Output helpers" prose describing the `task`/`pass`/`fail` contract unchanged - it duplicates no removed definition and is this file's own contribution.
- Left `script-boilerplate.sh` and `template.mdx` untouched; both already match the shipped scripts. Rule 6 of `template.mdx` carries a second copy of the helper block, currently in sync and sitting on the same page as the `raw-loader` import of the boilerplate itself, so it is a known remaining duplicate rather than part of this change.

## Verification

- `ahoy lint-markdown` from `.vortex/` - 0 errors; `.vortex/CLAUDE.md` is an explicit target of that lint.
- `ahoy lint-scripts` from `.vortex/` - clean.
- Claims in the diff were checked against the working tree rather than taken from the issue: all 42 scripts in `.vortex/tooling/src/` share one `note()` definition (7 spaces), one colour-aware `info()`, and one identical `.env` loading line carrying both `.env.local` and `unset t`.
