### PR TITLE
[#3106] Added the missing marker space in negative BATS step assertions.

### DIFF
--- a/.vortex/tooling/tests/unit/notify-github.bats
+++ b/.vortex/tooling/tests/unit/notify-github.bats
@@ -112,7 +112,7 @@ load ../_helper.bash
     '@curl -X POST -H Authorization: token token12345 -H Accept: application/vnd.github.v3+json -s https://api.github.com/repos/myorg/myrepo/deployments -d {"ref":"nonexistingbranch","environment":"nonexistingbranch","auto_merge":false,"required_contexts":[]} # {"message": "No ref found for: nonexistingbranch","documentation_url": "https://docs.github.com/rest/deployments/deployments#create-a-deployment","status": "422"}'
     "Unable to get a deployment ID for a pre_deployment operation. Payload:"
     "Wait for GitHub checks to finish and try again."
-    "-Marked deployment as finished."
+    "- Marked deployment as finished."
   )
 
   mocks="$(steps_run "setup")"
@@ -210,7 +210,7 @@ load ../_helper.bash
     "@curl -X GET -H Authorization: token token12345 -H Accept: application/vnd.github.v3+json -s https://api.github.com/repos/myorg/myrepo/deployments?ref=nonexistingbranch # []"
     "Unable to get a deployment ID for a post_deployment operation. Payload:"
     "Check that a pre_deployment notification was dispatched."
-    "-Marked deployment as finished."
+    "- Marked deployment as finished."
   )
   mocks="$(steps_run "setup")"
 
@@ -311,7 +311,7 @@ load ../_helper.bash
     "@curl -X GET -H Authorization: token token12345 -H Accept: application/vnd.github.v3+json -s https://api.github.com/repos/myorg/myrepo/deployments?ref=existingbranch # [{\"id\": \"${app_id}\", \"othervar\": \"54321\"},{\"id\": \"98765432101\", \"othervar\": \"12345\"}]"
     "@curl -X POST -H Accept: application/vnd.github.v3+json -H Authorization: token token12345 https://api.github.com/repos/myorg/myrepo/deployments/${app_id}/statuses -s -d {\"state\":\"success\",\"environment_url\":\"https://develop.testproject.com\"} # {\"state\": \"notsuccess\", \"othervar\": \"54321\"}"
     "Previous deployment was found, but was unable to update the deployment status. Payload:"
-    "-Marked deployment as finished."
+    "- Marked deployment as finished."
   )
   mocks="$(steps_run "setup")"
 

--- a/.vortex/tooling/tests/unit/provision.bats
+++ b/.vortex/tooling/tests/unit/provision.bats
@@ -196,7 +196,7 @@ assert_provision_info() {
     "    > Performing an example operation."
     # Assert that VORTEX_PROVISION_OVERRIDE_DB is correctly passed to the script.
     "      Fresh database detected. Performing additional example operations."
-    "-      Existing database detected. Performing additional example operations."
+    "-       Existing database detected. Performing additional example operations."
     "  ==> Finished example operations."
     'Completed running of custom post-install script "./scripts/provision-40-example.sh".'
 
@@ -362,7 +362,7 @@ assert_provision_info() {
     "    > Performing an example operation."
     # Assert that VORTEX_PROVISION_OVERRIDE_DB is correctly passed to the script.
     "-       Fresh database detected. Performing additional example operations."
-    "Existing database detected. Performing additional example operations."
+    "      Existing database detected. Performing additional example operations."
     "  ==> Finished example operations."
     'Completed running of custom post-install script "./scripts/provision-40-example.sh".'
 
@@ -537,7 +537,7 @@ assert_provision_info() {
     "    > Performing an example operation."
     # Assert that VORTEX_PROVISION_OVERRIDE_DB is correctly passed to the script.
     "      Fresh database detected. Performing additional example operations."
-    "-      Existing database detected. Performing additional example operations."
+    "-       Existing database detected. Performing additional example operations."
     "  ==> Finished example operations."
     'Completed running of custom post-install script "./scripts/provision-40-example.sh".'
 
@@ -727,7 +727,7 @@ assert_provision_info() {
     "    > Performing an example operation."
     # Assert that VORTEX_PROVISION_OVERRIDE_DB is correctly passed to the script.
     "      Fresh database detected. Performing additional example operations."
-    "-      Existing database detected. Performing additional example operations."
+    "-       Existing database detected. Performing additional example operations."
     "  ==> Finished example operations."
     'Completed running of custom post-install script "./scripts/provision-40-example.sh".'
 
@@ -968,7 +968,7 @@ assert_provision_info() {
     "    > Performing an example operation."
     # Assert that VORTEX_PROVISION_OVERRIDE_DB is correctly passed to the script.
     "      Fresh database detected. Performing additional example operations."
-    "-      Existing database detected. Performing additional example operations."
+    "-       Existing database detected. Performing additional example operations."
     "  ==> Finished example operations."
     'Completed running of custom post-install script "./scripts/provision-40-example.sh".'
 
@@ -1137,7 +1137,7 @@ assert_provision_info() {
     "    > Performing an example operation."
     # Assert that VORTEX_PROVISION_OVERRIDE_DB is correctly passed to the script.
     "-       Fresh database detected. Performing additional example operations."
-    "Existing database detected. Performing additional example operations."
+    "      Existing database detected. Performing additional example operations."
     "  ==> Finished example operations."
     'Completed running of custom post-install script "./scripts/provision-40-example.sh".'
 
@@ -1313,7 +1313,7 @@ assert_provision_info() {
     "    > Performing an example operation."
     # Assert that VORTEX_PROVISION_OVERRIDE_DB is correctly passed to the script.
     "      Fresh database detected. Performing additional example operations."
-    "-      Existing database detected. Performing additional example operations."
+    "-       Existing database detected. Performing additional example operations."
     "  ==> Finished example operations."
     'Completed running of custom post-install script "./scripts/provision-40-example.sh".'
 
@@ -1672,7 +1672,7 @@ assert_provision_info() {
     "    > Performing an example operation."
     # Assert that VORTEX_PROVISION_OVERRIDE_DB is correctly passed to the script.
     "      Fresh database detected. Performing additional example operations."
-    "-      Existing database detected. Performing additional example operations."
+    "-       Existing database detected. Performing additional example operations."
     "  ==> Finished example operations."
     'Completed running of custom post-install script "./scripts/provision-40-example.sh".'
 
@@ -1845,7 +1845,7 @@ assert_provision_info() {
     "    > Performing an example operation."
     # Assert that VORTEX_PROVISION_OVERRIDE_DB is correctly passed to the script.
     "      Fresh database detected. Performing additional example operations."
-    "-      Existing database detected. Performing additional example operations."
+    "-       Existing database detected. Performing additional example operations."
     "  ==> Finished example operations."
     'Completed running of custom post-install script "./scripts/provision-40-example.sh".'
 
@@ -2138,7 +2138,7 @@ assert_provision_info() {
     "    > Performing an example operation."
     # Assert that VORTEX_PROVISION_OVERRIDE_DB is correctly passed to the script.
     "      Fresh database detected. Performing additional example operations."
-    "-      Existing database detected. Performing additional example operations."
+    "-       Existing database detected. Performing additional example operations."
     "  ==> Finished example operations."
     'Completed running of custom post-install script "./scripts/provision-40-example.sh".'
 
@@ -2329,7 +2329,7 @@ assert_provision_info() {
     "    > Performing an example operation."
     # Assert that VORTEX_PROVISION_OVERRIDE_DB is correctly passed to the script.
     "      Fresh database detected. Performing additional example operations."
-    "-      Existing database detected. Performing additional example operations."
+    "-       Existing database detected. Performing additional example operations."
     "  ==> Finished example operations."
     'Completed running of custom post-install script "./scripts/provision-40-example.sh".'
 
@@ -2572,7 +2572,7 @@ assert_provision_info() {
     "    > Performing an example operation."
     # Assert that VORTEX_PROVISION_OVERRIDE_DB is correctly passed to the script.
     "      Fresh database detected. Performing additional example operations."
-    "-      Existing database detected. Performing additional example operations."
+    "-       Existing database detected. Performing additional example operations."
     "  ==> Finished example operations."
     'Completed running of custom post-install script "./scripts/provision-40-example.sh".'
 
@@ -2902,7 +2902,7 @@ assert_provision_info() {
     "    > Performing an example operation."
     # Assert that VORTEX_PROVISION_OVERRIDE_DB is correctly passed to the script.
     "      Fresh database detected. Performing additional example operations."
-    "-      Existing database detected. Performing additional example operations."
+    "-       Existing database detected. Performing additional example operations."
     "  ==> Finished example operations."
     'Completed running of custom post-install script "./scripts/provision-40-example.sh".'
 


### PR DESCRIPTION
Closes #3106

## Summary

Negative step assertions in `notify-github.bats` and `provision.bats` now write the `-` marker followed by a space before the asserted substring, the separator `steps_run()`'s `${item:2}` slice assumes is always there.

`steps_run()`'s guard `[[ ${item} == "-"* ]]` matches a bare dash and `${item:2}` then unconditionally drops two characters, so a step written without the space loses its first content character; the three `notify-github.bats` entries read `"-Marked deployment as finished."`, so the suite asserted the absence of `arked deployment as finished.` and could never detect a regression in the real message, while the sibling branch's guard `[[ ${item} == "= "* ]]` checks for the space directly and never degrades this way.

In `provision.bats` the same missing marker space sat on 11 negative `Existing database detected` assertions, but there it consumed a leading space rather than a letter, so `assert_output_not_contains` matched the intended substring either way and that file's change is formatting-only: those 11 rows, together with the 2 positive `Existing` rows that carried no alignment at all, now use the 6-space indent the file's `Fresh database detected` rows already had. `steps_run()` in `bats-helpers` and every other `.bats`/`.bash` file in the repo are unchanged.

## Before / After

```
BEFORE - marker written without a space
──────────────────────────────────────────────────────
STEPS entry     "-Marked deployment as finished."
                       │
                       │  steps_run(): ${item:2}
                       ▼
asserted text   "arked deployment as finished."
                       │
                       ▼
assert_output_not_contains → always true, the real
message is never checked

AFTER - marker written with a space
──────────────────────────────────────────────────────
STEPS entry     "- Marked deployment as finished."
                       │
                       │  steps_run(): ${item:2}
                       ▼
asserted text   "Marked deployment as finished."
                       │
                       ▼
assert_output_not_contains → fails if the real message
reappears in the output
```

## Changes

1. `.vortex/tooling/tests/unit/notify-github.bats` - added the missing space after the `-` marker in the 3 negative `Marked deployment as finished.` assertions covering the pre-deployment, post-deployment, and deployment-status-update failure paths.
2. `.vortex/tooling/tests/unit/provision.bats` - added the same marker space to the 11 negative `Existing database detected...` assertions and aligned them to the file's 6-space indent; realigned the 2 positive `Existing database detected...` assertions to match their `Fresh database detected...` counterparts. No assertion changes meaning; this file's change is formatting-only.

## Screenshots

N/A
