### PR TITLE
[#3110] Reconciled comments and docblocks with the code they describe.

### DIFF
--- a/.vortex/installer/src/Command/InstallCommand.php
+++ b/.vortex/installer/src/Command/InstallCommand.php
@@ -32,8 +32,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Run command.
- *
  * Install command.
  */
 class InstallCommand extends Command implements CommandRunnerAwareInterface, ExecutableFinderAwareInterface {

--- a/.vortex/installer/src/Prompts/Handlers/CustomModules.php
+++ b/.vortex/installer/src/Prompts/Handlers/CustomModules.php
@@ -211,8 +211,8 @@ DOC;
   /**
    * Remove Behat feature files tagged with @demo.
    *
-   * Scans the Behat features directory for .feature files whose first line
-   * contains the @demo tag and removes them.
+   * Removes every file in the Behat features directory that contains
+   * the @demo tag anywhere in its contents.
    *
    * @param string $dir
    *   The base directory to search in.

--- a/.vortex/installer/src/Prompts/Handlers/HandlerInterface.php
+++ b/.vortex/installer/src/Prompts/Handlers/HandlerInterface.php
@@ -118,7 +118,7 @@ interface HandlerInterface {
    *   Array of collected responses.
    *
    * @return bool
-   *   The condition callback, or null if not conditional.
+   *   TRUE if the handler should run, FALSE otherwise.
    */
   public function shouldRun(array $responses): bool;
 
@@ -134,10 +134,10 @@ interface HandlerInterface {
   public function default(array $responses): null|string|bool|array;
 
   /**
-   * Discover the value from the environment.
+   * Discover the value from the existing codebase.
    *
    * @return null|string|bool|array
-   *   The value of the environment variable.
+   *   The discovered value, or NULL if it could not be discovered.
    */
   public function discover(): null|string|bool|array;
 
@@ -176,8 +176,7 @@ interface HandlerInterface {
   /**
    * Get a message to display when showing the resolved value.
    *
-   * This is used by handlerManager to show an appropriate message (via
-   * info(), ok(), etc.) when using a resolved value instead of handlering
+   * The message is shown when a resolved value is used instead of prompting
    * for input.
    *
    * @param array $responses

--- a/.vortex/installer/src/Prompts/PromptManager.php
+++ b/.vortex/installer/src/Prompts/PromptManager.php
@@ -119,8 +119,9 @@ class PromptManager {
   /**
    * Run prompts to get responses.
    *
-   * If non-interactive mode is used, the values provided by $this->default()
-   * method, including discovery from the existing codebase, will be used.
+   * In non-interactive mode, every prompt resolves to its default: the
+   * --prompts override, then the value discovered from the existing codebase,
+   * then the handler's own default.
    */
   public function runPrompts(): void {
     // Quiet the TUI output in non-interactive mode; the original verbosity is
@@ -628,9 +629,8 @@ class PromptManager {
   /**
    * Resolve prompt overrides from --prompts CLI option.
    *
-   * Reads the raw prompt array from Config, normalizes keys to handler IDs,
-   * validates values against handler types and options, and stores the
-   * validated overrides.
+   * Reads the raw prompt array from Config, validates values against handler
+   * types and options, and stores the validated overrides.
    *
    * @throws \RuntimeException
    *   If any prompt value is invalid.
@@ -650,7 +650,6 @@ class PromptManager {
       throw new \RuntimeException(sprintf('Invalid --prompts values: %s.', implode('; ', $messages)));
     }
 
-    // Use the resolved values which include defaults for missing prompts.
     foreach ($raw as $key => $value) {
       if (isset($this->handlers[$key])) {
         $this->promptOverrides[$key] = $value;
@@ -682,7 +681,6 @@ class PromptManager {
    *
    * @param string $handler_class
    *   The handler class name.
-   *   The handler id.
    * @param mixed $default_override
    *   Optional override for the default value (for response dependencies).
    * @param array $responses

--- a/.vortex/installer/src/Prompts/PromptManager.php
+++ b/.vortex/installer/src/Prompts/PromptManager.php
@@ -119,9 +119,8 @@ class PromptManager {
   /**
    * Run prompts to get responses.
    *
-   * In non-interactive mode, every prompt resolves to its default: the
-   * --prompts override, then the value discovered from the existing codebase,
-   * then the handler's own default.
+   * In non-interactive mode, each prompt returns its default, which includes
+   * values discovered from the existing codebase.
    */
   public function runPrompts(): void {
     // Quiet the TUI output in non-interactive mode; the original verbosity is

--- a/.vortex/installer/src/Schema/SchemaValidator.php
+++ b/.vortex/installer/src/Schema/SchemaValidator.php
@@ -37,10 +37,8 @@ class SchemaValidator {
     $warnings = [];
     $resolved = [];
 
-    $normalized = $this->normalizeConfig($config);
-
     $known_ids = array_keys($this->handlers);
-    foreach (array_keys($normalized) as $key) {
+    foreach (array_keys($config) as $key) {
       if (!in_array($key, $known_ids, TRUE)) {
         $errors[] = ['prompt' => $key, 'message' => sprintf('Unknown prompt "%s".', $key)];
       }
@@ -51,8 +49,8 @@ class SchemaValidator {
         continue;
       }
 
-      $has_value = array_key_exists($id, $normalized);
-      $value = $normalized[$id] ?? NULL;
+      $has_value = array_key_exists($id, $config);
+      $value = $config[$id] ?? NULL;
 
       if (!$has_value) {
         continue;
@@ -60,7 +58,7 @@ class SchemaValidator {
 
       $depends_on = $handler->dependsOn();
       if ($depends_on !== NULL) {
-        $dep_result = $this->checkDependency($depends_on, $normalized);
+        $dep_result = $this->checkDependency($depends_on, $config);
 
         if ($dep_result === 'skip') {
           $type_error = $this->validateType($handler, $value);
@@ -110,33 +108,12 @@ class SchemaValidator {
   }
 
   /**
-   * Normalize config keys to handler IDs.
-   *
-   * Supports both env var names (VORTEX_INSTALLER_PROMPT_*) and handler IDs.
-   *
-   * @param array<string, mixed> $config
-   *   The raw config array.
-   *
-   * @return array<string, mixed>
-   *   Config keyed by handler IDs.
-   */
-  protected function normalizeConfig(array $config): array {
-    $normalized = [];
-
-    foreach ($config as $key => $value) {
-      $normalized[$key] = $value;
-    }
-
-    return $normalized;
-  }
-
-  /**
    * Check if dependency conditions are met.
    *
    * @param array<string, array<mixed>> $depends_on
    *   The dependency conditions.
    * @param array<string, mixed> $config
-   *   The normalized config.
+   *   The config array, keyed by handler ID.
    *
    * @return bool|string
    *   TRUE if met, FALSE if not met, 'skip' for system dependencies.

--- a/.vortex/installer/src/Utils/FileManager.php
+++ b/.vortex/installer/src/Utils/FileManager.php
@@ -392,8 +392,7 @@ class FileManager {
    * Remove obsolete paths from previous Vortex versions.
    *
    * Removes paths that previous Vortex versions placed in the destination but
-   * the current version no longer ships. Runs after copyFiles() so legacy
-   * artifacts do not linger across upgrades.
+   * the current version no longer ships.
    */
   public function removeObsoletePaths(): void {
     $destination = $this->config->getDestination();

--- a/.vortex/installer/src/Utils/Git.php
+++ b/.vortex/installer/src/Utils/Git.php
@@ -53,7 +53,7 @@ class Git extends GitRepository {
         continue;
         // @codeCoverageIgnoreEnd
       }
-      // Remove the trailing (fetch) or (push) from the remote name.
+      // Remove the trailing (fetch) or (push) from the remote URL.
       $parts[1] = preg_replace('/ \(.*\)$/', '', $parts[1]);
       $remotes[$parts[0]] = $parts[1];
     }

--- a/.vortex/installer/src/Utils/Normalizer.php
+++ b/.vortex/installer/src/Utils/Normalizer.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace DrevOps\VortexInstaller\Utils;
 
-/**
- * Installer configuration.
- *
- * Installer config is a config of this installer script.
- */
 final class Normalizer {
 
   /**

--- a/.vortex/installer/src/Utils/OptionsResolver.php
+++ b/.vortex/installer/src/Utils/OptionsResolver.php
@@ -40,8 +40,9 @@ class OptionsResolver {
    *
    * Installer configuration is a set of internal installer variables
    * prefixed with "VORTEX_INSTALLER_" and used to control the installation.
-   * Each is read from the environment with Env::get() and stored in Config
-   * under the same name, so a config key and its environment variable match.
+   * Each is resolved from the CLI options, the --config JSON and the
+   * environment, and stored in Config under the name of its environment
+   * variable.
    *
    * @param array<mixed> $options
    *   Array of CLI options.

--- a/.vortex/installer/src/Utils/OptionsResolver.php
+++ b/.vortex/installer/src/Utils/OptionsResolver.php
@@ -40,10 +40,8 @@ class OptionsResolver {
    *
    * Installer configuration is a set of internal installer variables
    * prefixed with "VORTEX_INSTALLER_" and used to control the installation.
-   * They are read from the environment variables with $this->config->get().
-   *
-   * For simplicity of naming, internal installer config variables used in
-   * $this->config->get() match environment variables names.
+   * Each is read from the environment with Env::get() and stored in Config
+   * under the same name, so a config key and its environment variable match.
    *
    * @param array<mixed> $options
    *   Array of CLI options.

--- a/.vortex/installer/src/Utils/Validator.php
+++ b/.vortex/installer/src/Utils/Validator.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace DrevOps\VortexInstaller\Utils;
 
-/**
- * Converter.
- *
- * Convert strings to different formats.
- */
 class Validator {
 
   public static function isContainerImage(string $value): bool {
@@ -51,10 +46,11 @@ class Validator {
    * - Branch names: "main", "develop", "feature/my-feature"
    *
    * Follows git reference naming rules:
-   * - Can contain alphanumeric, dot, hyphen, underscore, slash
+   * - Can contain alphanumeric, dot, hyphen, underscore, slash, plus
    * - Cannot start with dot or hyphen
    * - Cannot contain: @, ^, ~, :, ?, *, [, space, \, @{
-   * - Cannot end with .lock or contain
+   * - Cannot contain .. or //
+   * - Cannot end with .lock or /
    *
    * @param string $value
    *   The reference string to validate.
@@ -73,11 +69,6 @@ class Validator {
       return TRUE;
     }
 
-    // Git ref naming rules (simplified):
-    // - Can contain alphanumeric, dot, hyphen, underscore, slash, plus.
-    // - Cannot start with dot or hyphen.
-    // - Cannot contain .. or end with .lock.
-    // - Cannot end with / or contain //.
     $pattern = '/^(?![.\-])(?!.*\.\.)[a-zA-Z0-9._\/+-]+(?<!\.lock)$/';
 
     if (!preg_match($pattern, $value)) {

--- a/.vortex/installer/tests/Functional/Command/BuildCommandTest.php
+++ b/.vortex/installer/tests/Functional/Command/BuildCommandTest.php
@@ -146,7 +146,7 @@ class BuildCommandTest extends FunctionalTestCase {
   }
 
   /**
-   * Data provider for testBuildWithMockedRunner.
+   * Data provider for testBuildCommand.
    *
    * @return \Iterator<string, array{exit_code_callback: \Closure, command_inputs: array<string, mixed>, expect_failure: bool, output_assertions: array<string>, requirements_exit_callback?: (\Closure | null), requirements_finder_callback?: (\Closure | null), docker_compose_url?: (string | null), url_service?: string, before?: (\Closure | null)}>
    */

--- a/.vortex/installer/tests/Unit/Utils/EnvTest.php
+++ b/.vortex/installer/tests/Unit/Utils/EnvTest.php
@@ -11,11 +11,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-/**
- * Class InstallerDotEnvTest.
- *
- * InstallerDotEnvTest fixture class.
- */
 #[CoversClass(Env::class)]
 #[RunTestsInSeparateProcesses]
 class EnvTest extends UnitTestCase {

--- a/.vortex/installer/tests/Unit/Utils/ValidatorTest.php
+++ b/.vortex/installer/tests/Unit/Utils/ValidatorTest.php
@@ -9,9 +9,6 @@ use DrevOps\VortexInstaller\Utils\Validator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * Class InstallerHelpersTest.
- */
 #[CoversClass(Validator::class)]
 class ValidatorTest extends UnitTestCase {
 

--- a/.vortex/tests/lint.ci.sh
+++ b/.vortex/tests/lint.ci.sh
@@ -23,3 +23,5 @@ else
   echo "Checking that .circleci/vortex-test-common.yml is up to date."
   php "${ROOT_DIR}/.vortex/tests/generate-vortex-dev-circleci" --check
 fi
+
+# LCOV_EXCL_STOP

--- a/.vortex/tests/lint.dockerfiles.sh
+++ b/.vortex/tests/lint.dockerfiles.sh
@@ -36,3 +36,5 @@ for file in "${targets[@]}"; do
     docker run --rm -i hadolint/hadolint:v2.15.1 <"${file}"
   fi
 done
+
+# LCOV_EXCL_STOP

--- a/.vortex/tests/lint.markdown.sh
+++ b/.vortex/tests/lint.markdown.sh
@@ -33,3 +33,5 @@ done
   "${ROOT_DIR}"/README.md \
   "${ROOT_DIR}"/README.dist.md \
   "${ROOT_DIR}"/SECURITY.md
+
+# LCOV_EXCL_STOP

--- a/.vortex/tests/lint.scripts.sh
+++ b/.vortex/tests/lint.scripts.sh
@@ -79,3 +79,5 @@ for file in "${targets[@]}"; do
     fi
   fi
 done
+
+# LCOV_EXCL_STOP

--- a/.vortex/tests/test.common.sh
+++ b/.vortex/tests/test.common.sh
@@ -39,3 +39,5 @@ bats() {
 }
 
 bats "${BATS_DIR}/unit"
+
+# LCOV_EXCL_STOP

--- a/.vortex/tooling/src/vortex-doctor
+++ b/.vortex/tooling/src/vortex-doctor
@@ -2,8 +2,8 @@
 #
 # Check project requirements or print info.
 #
-# doctor.sh - check project requirements.
-# doctor.sh info - show system information.
+# vortex-doctor - check project requirements.
+# vortex-doctor info - show system information.
 #
 # IMPORTANT! This script runs outside the container on the host system.
 #

--- a/.vortex/tooling/src/vortex-notify-email
+++ b/.vortex/tooling/src/vortex-notify-email
@@ -2,7 +2,8 @@
 ##
 # Notification dispatch to email recipients.
 #
-# Notification dispatch to email recipients.
+# Sends deployment notifications by email using the 'sendmail' or 'mail'
+# command.
 #
 # Usage:
 # VORTEX_NOTIFY_PROJECT="Site Name" \
@@ -10,7 +11,7 @@
 # VORTEX_NOTIFY_EMAIL_RECIPIENTS="to1@example.com|Jane Doe, to2@example.com|John Doe" \
 # VORTEX_NOTIFY_LABEL="main" \
 # VORTEX_NOTIFY_ENVIRONMENT_URL="https://environment-url-example.com" \
-# ./notify-email
+# vortex-notify-email
 #
 # shellcheck disable=SC1090,SC1091,SC2016
 

--- a/.vortex/tooling/tests/_helper.bash
+++ b/.vortex/tooling/tests/_helper.bash
@@ -26,6 +26,7 @@ setup() {
   # NOTE: If Docker tests fail, re-run with custom temporary directory
   # (must be pre-created): TMPDIR=${HOME}/.bats-tmp bats <testfile>'
 
+  # LCOV_EXCL_START
   if [ -n "${DOCKER_DEFAULT_PLATFORM:-}" ]; then
     if [ "${BATS_VERBOSE_RUN:-}" = "1" ] || [ "${TEST_VORTEX_DEBUG:-}" = "1" ]; then
       echo "Using ${DOCKER_DEFAULT_PLATFORM} platform architecture."

--- a/.vortex/tooling/tests/fixtures/fixture.sh
+++ b/.vortex/tooling/tests/fixtures/fixture.sh
@@ -6,3 +6,5 @@ set -eu
 curl -L -s -o /dev/null -w "%{http_code}" example.com
 
 curl example.com
+
+# LCOV_EXCL_STOP

--- a/.vortex/tooling/tests/unit/deploy-artifact.bats
+++ b/.vortex/tooling/tests/unit/deploy-artifact.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Test for CircleCI lifecycle.
+# Unit tests for the 'vortex-deploy-artifact' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2129,SC2155,SC2034
 

--- a/.vortex/tooling/tests/unit/deploy-lagoon.bats
+++ b/.vortex/tooling/tests/unit/deploy-lagoon.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Tests for .vortex/tooling/src/vortex-deploy-lagoon script.
+# Unit tests for the 'vortex-deploy-lagoon' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2129,SC2155
 

--- a/.vortex/tooling/tests/unit/deploy-webhook.bats
+++ b/.vortex/tooling/tests/unit/deploy-webhook.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Test for webhook deployments.
+# Unit tests for the 'vortex-deploy-webhook' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2129,SC2155
 

--- a/.vortex/tooling/tests/unit/deploy.bats
+++ b/.vortex/tooling/tests/unit/deploy.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Test for main deployment router script.
+# Unit tests for the 'vortex-deploy' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2129,SC2155
 

--- a/.vortex/tooling/tests/unit/export-db-file.bats
+++ b/.vortex/tooling/tests/unit/export-db-file.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for export-db-file worker script.
+# Unit tests for the 'vortex-export-db-file' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/export-db.bats
+++ b/.vortex/tooling/tests/unit/export-db.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for export-db router script.
+# Unit tests for the 'vortex-export-db' script.
 #
 # shellcheck disable=SC2030,SC2031
 

--- a/.vortex/tooling/tests/unit/fetch-db-acquia.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-acquia.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Unit tests for fetch-db-acquia.sh
+# Unit tests for the 'vortex-fetch-db-acquia' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/fetch-db-container-registry.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-container-registry.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for fetch-db-container-registry.sh
+# Unit tests for the 'vortex-fetch-db-container-registry' script.
 #
 # shellcheck disable=SC2030,SC2031
 

--- a/.vortex/tooling/tests/unit/fetch-db-ftp.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-ftp.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for fetch-db-ftp.sh
+# Unit tests for the 'vortex-fetch-db-ftp' script.
 #
 # shellcheck disable=SC2030,SC2031
 

--- a/.vortex/tooling/tests/unit/fetch-db-lagoon.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-lagoon.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Unit tests for fetch-db-lagoon.sh
+# Unit tests for the 'vortex-fetch-db-lagoon' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/fetch-db-s3.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-s3.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for fetch-db-s3.sh
+# Unit tests for the 'vortex-fetch-db-s3' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/fetch-db-url.bats
+++ b/.vortex/tooling/tests/unit/fetch-db-url.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for fetch-db-url.sh
+# Unit tests for the 'vortex-fetch-db-url' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2016
 

--- a/.vortex/tooling/tests/unit/fetch-db.bats
+++ b/.vortex/tooling/tests/unit/fetch-db.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for fetch-db.sh
+# Unit tests for the 'vortex-fetch-db' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2016
 

--- a/.vortex/tooling/tests/unit/helpers.bats
+++ b/.vortex/tooling/tests/unit/helpers.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Tests for Vortex Bats helpers.
+# Unit tests for the Vortex BATS helpers.
 #
 # shellcheck disable=SC2129
 

--- a/.vortex/tooling/tests/unit/import-db-file.bats
+++ b/.vortex/tooling/tests/unit/import-db-file.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for import-db-file worker script.
+# Unit tests for the 'vortex-import-db-file' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/import-db.bats
+++ b/.vortex/tooling/tests/unit/import-db.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for import-db router script.
+# Unit tests for the 'vortex-import-db' script.
 #
 # shellcheck disable=SC2030,SC2031
 

--- a/.vortex/tooling/tests/unit/login-container-registry.bats
+++ b/.vortex/tooling/tests/unit/login-container-registry.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Test for login-container-registry.sh.
+# Unit tests for the 'vortex-login-container-registry' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2129,SC2155
 

--- a/.vortex/tooling/tests/unit/notify-diffy.bats
+++ b/.vortex/tooling/tests/unit/notify-diffy.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for Diffy notifications (notify-diffy).
+# Unit tests for the 'vortex-notify-diffy' script.
 #
 #shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/notify-email.bats
+++ b/.vortex/tooling/tests/unit/notify-email.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for email notifications (notify.sh).
+# Unit tests for the 'vortex-notify-email' script.
 #
 #shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/notify-github.bats
+++ b/.vortex/tooling/tests/unit/notify-github.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for GitHub notifications (notify.sh).
+# Unit tests for the 'vortex-notify-github' script.
 #
 #shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/notify-jira.bats
+++ b/.vortex/tooling/tests/unit/notify-jira.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for JIRA notifications (notify.sh).
+# Unit tests for the 'vortex-notify-jira' script.
 #
 #shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/notify-newrelic.bats
+++ b/.vortex/tooling/tests/unit/notify-newrelic.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for NewRelic notifications (notify.sh).
+# Unit tests for the 'vortex-notify-newrelic' script.
 #
 #shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/notify-slack.bats
+++ b/.vortex/tooling/tests/unit/notify-slack.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for Slack notifications (notify.sh).
+# Unit tests for the 'vortex-notify-slack' script.
 #
 #shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/notify-webhook.bats
+++ b/.vortex/tooling/tests/unit/notify-webhook.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for webhook notifications (notify.sh).
+# Unit tests for the 'vortex-notify-webhook' script.
 #
 #shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/notify.bats
+++ b/.vortex/tooling/tests/unit/notify.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for general notify.sh functionality.
+# Unit tests for the 'vortex-notify' script.
 #
 # Notification-specific tests are in separate files:
 # - notify-email.bats

--- a/.vortex/tooling/tests/unit/post-coverage-comment.bats
+++ b/.vortex/tooling/tests/unit/post-coverage-comment.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for .circleci/post-coverage-comment.sh
+# Unit tests for the '.circleci/post-coverage-comment.sh' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/provision-enable-demo-modules.bats
+++ b/.vortex/tooling/tests/unit/provision-enable-demo-modules.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for provision-00-enable-demo-modules.sh
+# Unit tests for the 'scripts/provision-00-enable-demo-modules.sh' script.
 #
 # The environment-matching branch is covered end-to-end by 'provision.bats';
 # this file covers the boundary that those scenarios do not reach.

--- a/.vortex/tooling/tests/unit/provision-enable-dev-modules.bats
+++ b/.vortex/tooling/tests/unit/provision-enable-dev-modules.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for provision-10-enable-dev-modules.sh
+# Unit tests for the 'scripts/provision-10-enable-dev-modules.sh' script.
 #
 #
 # The mock side effects expand when the mock runs, not when the step is defined,

--- a/.vortex/tooling/tests/unit/provision-example.bats
+++ b/.vortex/tooling/tests/unit/provision-example.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for provision-40-example.sh
+# Unit tests for the 'scripts/provision-40-example.sh' script.
 #
 # The environment-matching branch is covered end-to-end by 'provision.bats';
 # this file covers the boundary that those scenarios do not reach.

--- a/.vortex/tooling/tests/unit/provision-migration.bats
+++ b/.vortex/tooling/tests/unit/provision-migration.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for provision-20-migration.sh
+# Unit tests for the 'scripts/provision-20-migration.sh' script.
 #
 #shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/provision-search-index.bats
+++ b/.vortex/tooling/tests/unit/provision-search-index.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for provision-30-search-index.sh
+# Unit tests for the 'scripts/provision-30-search-index.sh' script.
 #
 #shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/provision.bats
+++ b/.vortex/tooling/tests/unit/provision.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for provision.sh
+# Unit tests for the 'vortex-provision' script.
 #
 #shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/push-container-registry.bats
+++ b/.vortex/tooling/tests/unit/push-container-registry.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Tests for .vortex/tooling/src/vortex-push-container-registry script.
+# Unit tests for the 'vortex-push-container-registry' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2129,SC2155,SC2034
 

--- a/.vortex/tooling/tests/unit/push-db-image.bats
+++ b/.vortex/tooling/tests/unit/push-db-image.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for push-db-image script.
+# Unit tests for the 'vortex-push-db-image' script.
 #
 # The stub map markers use single quotes on purpose: the `${...}` must reach the
 # generated stub literally and expand when the stub runs, not when the test

--- a/.vortex/tooling/tests/unit/push-db-s3.bats
+++ b/.vortex/tooling/tests/unit/push-db-s3.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for push-db-s3.sh
+# Unit tests for the 'vortex-push-db-s3' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/reset.bats
+++ b/.vortex/tooling/tests/unit/reset.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for the reset script.
+# Unit tests for the 'vortex-reset' script.
 #
 # shellcheck disable=SC2030,SC2031
 

--- a/.vortex/tooling/tests/unit/setup-ssh.bats
+++ b/.vortex/tooling/tests/unit/setup-ssh.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Test for setup-ssh.sh script.
+# Unit tests for the 'vortex-setup-ssh' script.
 #
 # IMPORTANT! This test uses mocks for ssd-add, so do not try to assert
 # the actual key presence in the agent.

--- a/.vortex/tooling/tests/unit/task-purge-cache-acquia.bats
+++ b/.vortex/tooling/tests/unit/task-purge-cache-acquia.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for the Acquia cache purge task.
+# Unit tests for the 'vortex-task-purge-cache-acquia' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.vortex/tooling/tests/unit/task.bats
+++ b/.vortex/tooling/tests/unit/task.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for the task router.
+# Unit tests for the 'vortex-task' script.
 #
 # The router resolves a platform-agnostic operation to the
 # 'task-<operation>-<platform>' sibling that implements it; these tests cover

--- a/.vortex/tooling/tests/unit/update-vortex.bats
+++ b/.vortex/tooling/tests/unit/update-vortex.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 ##
-# Unit tests for update-vortex.sh
+# Unit tests for the 'vortex-update' script.
 #
 # shellcheck disable=SC2030,SC2031,SC2034
 


### PR DESCRIPTION
Closes #3110

## Summary

`SchemaValidator::validate()` in `.vortex/installer/src/Schema/SchemaValidator.php` now reads `$config` directly since the identity method `normalizeConfig()` is deleted, and `.vortex/tooling/tests/_helper.bash` plus six `.vortex/tests/` and `.vortex/tooling/tests/` scripts now pair their `LCOV_EXCL_START`/`LCOV_EXCL_STOP` coverage markers for the first time.

`normalizeConfig()` was documented as mapping `VORTEX_INSTALLER_PROMPT_*` environment variable names to handler IDs, but its body only copied `$config` into `$normalized` unchanged on every `validate()` call; 26 of the 40 `.vortex/tooling/tests/unit/*.bats` headers named a script Vortex does not ship, such as `fetch-db.sh`, `update-vortex.sh` and `notify.sh` on every `notify-*` file, instead of the extensionless `vortex-*` binary each test actually runs; and `.vortex/tooling/tests/_helper.bash` carried an `LCOV_EXCL_STOP` with no matching `START` since commit 92d66fa53 deleted the arm64 platform-override block the pair bracketed.

After merge, `Validator::isGitRef()`'s docblock lists the complete git-ref rule set including the `+` character the pattern already accepted, all 40 tooling BATS headers converge on `# Unit tests for the '<script>' script.` naming the real file under test, and `HandlerInterface::discover()` and `resolvedMessage()` describe their actual contracts instead of a nonexistent `handlerManager`; `--prompts` CLI parsing, environment discovery and file/directory discovery behave exactly as before, and `.vortex/docs/content/development/variables.mdx` is untouched.

## Before / After

```
┌───────────────────────────┬──────────────────────────────┬───────────────────────────┐
│ Location                  │ Docblock said                │ Code does                 │
├───────────────────────────┼──────────────────────────────┼───────────────────────────┤
│ CustomModules::           │ .feature files whose         │ '@demo' matched anywhere  │
│ removeDemoBehatFeatures() │ FIRST LINE has '@demo'       │ in the file's contents    │
├───────────────────────────┼──────────────────────────────┼───────────────────────────┤
│ HandlerInterface::        │ The condition callback,      │ bool: TRUE to run,        │
│ shouldRun()               │ or null if not conditional   │ FALSE to skip             │
├───────────────────────────┼──────────────────────────────┼───────────────────────────┤
│ Validator::isGitRef()     │ Rule list ends mid-sentence, │ Allows '+'; rejects '..', │
│                           │ omits '+' from allowed chars │ '//', and a trailing '/'  │
└───────────────────────────┴──────────────────────────────┴───────────────────────────┘

SchemaValidator::validate() call path

Before:
  validate($config)
  ├─ normalizeConfig($config)
  │    └─ foreach ($config as $key => $value) { $normalized[$key] = $value; }   (identity, no-op)
  ├─ foreach (array_keys($normalized) as $key) { ... }
  └─ checkDependency($depends_on, $normalized)

After:
  validate($config)
  ├─ foreach (array_keys($config) as $key) { ... }
  └─ checkDependency($depends_on, $config)
```

## Changes

- `.vortex/installer/src/Command/InstallCommand.php`: removed the stray `Run command.` summary line above `Install command.`, matching `BuildCommand` and `CheckRequirementsCommand`.
- `.vortex/installer/src/Utils/Validator.php`, `.vortex/installer/src/Utils/Normalizer.php`: deleted class docblocks copied from other classes (`Converter.`/`Convert strings to different formats.` and `Installer configuration.`/`Installer config is a config of this installer script.`); `Drupal.Commenting.ClassComment` is excluded in `.vortex/installer/phpcs.xml` and 8 of the 16 `Utils/` classes already carry no class docblock.
- `.vortex/installer/src/Prompts/Handlers/HandlerInterface.php`: `shouldRun()`'s `@return` now describes its `bool` result instead of a nonexistent condition callback; `discover()`'s summary and `@return` now cover discovery from `composer.json`, `.env`, files and directories, not only environment variables; `resolvedMessage()`'s reference to a nonexistent `handlerManager` and the garbled "handlering" are removed.
- `.vortex/installer/src/Prompts/Handlers/CustomModules.php`: `removeDemoBehatFeatures()`'s docblock now says the `@demo` tag is matched anywhere in a `.feature` file's contents, matching what `File::findContainingInDir()` does.
- `.vortex/installer/src/Prompts/PromptManager.php`: `runPrompts()` now says each prompt returns its default in non-interactive mode; `resolvePromptOverrides()` drops the claim that it normalizes keys to handler IDs and the inline comment claiming `$raw` reads resolved defaults for missing prompts; `args()` drops an orphaned `The handler id.` line left under the `@param $handler_class` tag.
- `.vortex/installer/src/Utils/OptionsResolver.php`: `resolve()`'s docblock now says each installer variable is resolved from the CLI options, the `--config` JSON and the environment, replacing the claim that values come from `$this->config->get()` alone.
- `.vortex/installer/src/Utils/Git.php`: `listRemotes()`'s inline comment now says the trailing `(fetch)`/`(push)` suffix is stripped from `$parts[1]`, the remote URL, not from the remote name.
- `.vortex/installer/src/Utils/FileManager.php`: `removeObsoletePaths()`'s docblock drops the sentence describing that it runs after `copyFiles()`, keeping the docblock caller-agnostic.
- `.vortex/installer/src/Utils/Validator.php`: `isGitRef()`'s rule list is completed (adds `+` to the allowed characters, adds the `..`/`//`/trailing-`/` rejections) and the duplicate six-line inline comment restating the same rules is deleted.
- `.vortex/installer/src/Schema/SchemaValidator.php`: deletes `normalizeConfig()`; `validate()` iterates `$config` directly and passes it to `checkDependency()`, whose `@param` now describes "The config array, keyed by handler ID" instead of "The normalized config".
- `.vortex/installer/tests/Unit/Utils/EnvTest.php`, `.vortex/installer/tests/Unit/Utils/ValidatorTest.php`: deleted class docblocks naming `InstallerDotEnvTest`/`InstallerHelpersTest`, classes that do not exist in these files, matching the other 10 classes in `tests/Unit/Utils/` that already carry no class docblock.
- `.vortex/installer/tests/Functional/Command/BuildCommandTest.php`: the data-provider docblock now names `testBuildCommand`, the method that consumes it, instead of `testBuildWithMockedRunner`.
- `.vortex/tooling/tests/unit/*.bats` (40 files): every header now names the script the file actually executes and converges on `# Unit tests for the '<script>' script.`; `provision-*.bats` and `post-coverage-comment.bats` already named real files and keep their subject.
- `.vortex/tooling/src/vortex-doctor`: usage lines cite `vortex-doctor` and `vortex-doctor info` instead of `doctor.sh`.
- `.vortex/tooling/src/vortex-notify-email`: the description line states the send mechanism (`sendmail` or `mail`) instead of repeating the summary, and the usage line cites `vortex-notify-email` instead of `./notify-email`.
- `.vortex/tooling/tests/_helper.bash`: restores the `LCOV_EXCL_START` above the `DOCKER_DEFAULT_PLATFORM` reporting branch, pairing it with the `LCOV_EXCL_STOP` orphaned when commit 92d66fa53 removed the arm64 override block.
- `.vortex/tests/lint.ci.sh`, `lint.dockerfiles.sh`, `lint.markdown.sh`, `lint.scripts.sh`, `test.common.sh`, `.vortex/tooling/tests/fixtures/fixture.sh`: each closes its whole-file `LCOV_EXCL_START` with a trailing `LCOV_EXCL_STOP`.

## Verification

- `.vortex/installer`: `composer lint` (phpcs, phpstan, rector) exit 0; `composer test` green, 1658 tests / 5490 assertions.
- `.vortex`: `ahoy lint-scripts` exit 0; `ahoy test-bats tooling/tests/unit` exit 0, 338 tests.
- `ahoy update-docs` regenerates no changes, so `.vortex/docs/content/development/variables.mdx` is unaffected.
