### PR TITLE
[#3127] Restored the process environment after every installer test.

### DIFF
--- a/.vortex/installer/tests/Functional/Prompts/Handlers/AbstractHandlerProcessTestCase.php
+++ b/.vortex/installer/tests/Functional/Prompts/Handlers/AbstractHandlerProcessTestCase.php
@@ -36,11 +36,7 @@ abstract class AbstractHandlerProcessTestCase extends FunctionalTestCase {
   protected function setUp(): void {
     parent::setUp();
 
-    static::envUnsetPrefix('VORTEX_');
-    static::envUnsetPrefix('DRUPAL_');
-    static::envUnsetPrefix('LAGOON_');
-    static::envUnset('WEBROOT');
-    static::envUnset('TZ');
+    static::envUnsetProjectVars();
 
     static::applicationInitFromCommand(InstallCommand::class);
 

--- a/.vortex/installer/tests/Unit/Prompts/Handlers/AbstractHandlerDiscoveryTestCase.php
+++ b/.vortex/installer/tests/Unit/Prompts/Handlers/AbstractHandlerDiscoveryTestCase.php
@@ -68,6 +68,8 @@ abstract class AbstractHandlerDiscoveryTestCase extends UnitTestCase {
   protected function setUp(): void {
     parent::setUp();
 
+    static::envUnsetProjectVars();
+
     static::tuiSetUp();
 
     static::$sut = File::mkdir(static::$sut . DIRECTORY_SEPARATOR . 'myproject');

--- a/.vortex/installer/tests/Unit/SelfTest.php
+++ b/.vortex/installer/tests/Unit/SelfTest.php
@@ -14,14 +14,25 @@ class SelfTest extends UnitTestCase {
 
   const LEAKED_VAR = 'VORTEX_TEST_LEAKED_VAR';
 
+  /**
+   * @var string|false
+   */
+  protected static $ambientOriginal;
+
   public static function setUpBeforeClass(): void {
     parent::setUpBeforeClass();
 
+    static::$ambientOriginal = getenv(self::AMBIENT_VAR);
     putenv(self::AMBIENT_VAR . '=ambient');
   }
 
   public static function tearDownAfterClass(): void {
-    putenv(self::AMBIENT_VAR);
+    if (static::$ambientOriginal === FALSE) {
+      putenv(self::AMBIENT_VAR);
+    }
+    else {
+      putenv(self::AMBIENT_VAR . '=' . static::$ambientOriginal);
+    }
 
     parent::tearDownAfterClass();
   }

--- a/.vortex/installer/tests/Unit/SelfTest.php
+++ b/.vortex/installer/tests/Unit/SelfTest.php
@@ -10,6 +10,22 @@ use PHPUnit\Framework\Attributes\Depends;
 #[CoversClass(UnitTestCase::class)]
 class SelfTest extends UnitTestCase {
 
+  const AMBIENT_VAR = 'VORTEX_TEST_AMBIENT_VAR';
+
+  const LEAKED_VAR = 'VORTEX_TEST_LEAKED_VAR';
+
+  public static function setUpBeforeClass(): void {
+    parent::setUpBeforeClass();
+
+    putenv(self::AMBIENT_VAR . '=ambient');
+  }
+
+  public static function tearDownAfterClass(): void {
+    putenv(self::AMBIENT_VAR);
+
+    parent::tearDownAfterClass();
+  }
+
   public function testEnvCleanup1SetVariables(): void {
     static::envSet('VORTEX_TEST_VAR_1', 'value1');
     static::envSet('VORTEX_TEST_VAR_2', 'value2');
@@ -32,6 +48,26 @@ class SelfTest extends UnitTestCase {
     $this->assertFalse(getenv('VORTEX_TEST_VAR_2'), 'VORTEX_TEST_VAR_2 should be cleaned up after previous test');
     $this->assertFalse(getenv('VORTEX_TEST_VAR_3'), 'VORTEX_TEST_VAR_3 should be cleaned up after previous test');
     $this->assertFalse(getenv('VORTEX_TEST_VAR_4'), 'VORTEX_TEST_VAR_4 should be cleaned up after previous test');
+  }
+
+  public function testEnvRestore1WriteRawValues(): void {
+    // envSet() is bypassed here to reproduce what production code does when it
+    // writes the environment directly.
+    putenv(self::LEAKED_VAR . '=leaked');
+    putenv(self::AMBIENT_VAR . '=changed');
+    $_ENV[self::LEAKED_VAR] = 'leaked';
+    $_SERVER[self::LEAKED_VAR] = 'leaked';
+
+    $this->assertSame('leaked', getenv(self::LEAKED_VAR));
+    $this->assertSame('changed', getenv(self::AMBIENT_VAR));
+  }
+
+  #[Depends('testEnvRestore1WriteRawValues')]
+  public function testEnvRestore2VerifyRestored(): void {
+    $this->assertFalse(getenv(self::LEAKED_VAR), 'A variable added by the previous test should not outlive it');
+    $this->assertSame('ambient', getenv(self::AMBIENT_VAR), 'A variable changed by the previous test should be back to its original value');
+    $this->assertArrayNotHasKey(self::LEAKED_VAR, $_ENV);
+    $this->assertArrayNotHasKey(self::LEAKED_VAR, $_SERVER);
   }
 
 }

--- a/.vortex/installer/tests/Unit/UnitTestCase.php
+++ b/.vortex/installer/tests/Unit/UnitTestCase.php
@@ -26,9 +26,34 @@ abstract class UnitTestCase extends UpstreamUnitTestCase {
   use EnvTrait;
 
   /**
+   * The process environment before the test ran.
+   *
+   * @var array<string,string>
+   */
+  protected array $processEnvBackup;
+
+  /**
+   * The $_ENV superglobal before the test ran.
+   *
+   * @var array<string,mixed>
+   */
+  protected array $globalEnvBackup;
+
+  /**
+   * The $_SERVER superglobal before the test ran.
+   *
+   * @var array<string,mixed>
+   */
+  protected array $globalServerBackup;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
+    $this->processEnvBackup = getenv();
+    $this->globalEnvBackup = $_ENV;
+    $this->globalServerBackup = $_SERVER;
+
     $cwd = getcwd();
     if ($cwd === FALSE) {
       throw new \RuntimeException('Failed to determine current working directory.');
@@ -43,7 +68,47 @@ abstract class UnitTestCase extends UpstreamUnitTestCase {
    */
   protected function tearDown(): void {
     static::envReset();
+    $this->envRestore();
     parent::tearDown();
+  }
+
+  /**
+   * Restore the process environment captured before the test ran.
+   *
+   * envReset() only reverses names recorded by envSet(). Code under test can
+   * call putenv() directly, and those values would otherwise be read by every
+   * later test in the same process.
+   */
+  protected function envRestore(): void {
+    foreach (array_keys(getenv()) as $name) {
+      if (!array_key_exists($name, $this->processEnvBackup)) {
+        putenv($name);
+      }
+    }
+
+    foreach ($this->processEnvBackup as $name => $value) {
+      if (getenv($name) !== $value) {
+        putenv($name . '=' . $value);
+      }
+    }
+
+    $_ENV = $this->globalEnvBackup;
+    $_SERVER = $this->globalServerBackup;
+  }
+
+  /**
+   * Unset the environment variables that a project's .env file defines.
+   *
+   * Handlers read the environment before the project's .env file, so a
+   * variable exported by the shell running the suite would win over the
+   * fixture.
+   */
+  protected static function envUnsetProjectVars(): void {
+    static::envUnsetPrefix('VORTEX_');
+    static::envUnsetPrefix('DRUPAL_');
+    static::envUnsetPrefix('LAGOON_');
+    static::envUnset('WEBROOT');
+    static::envUnset('TZ');
   }
 
   /**

--- a/.vortex/installer/tests/Unit/UnitTestCase.php
+++ b/.vortex/installer/tests/Unit/UnitTestCase.php
@@ -75,9 +75,9 @@ abstract class UnitTestCase extends UpstreamUnitTestCase {
   /**
    * Restore the process environment captured before the test ran.
    *
-   * envReset() only reverses names recorded by envSet(). Code under test can
-   * call putenv() directly, and those values would otherwise be read by every
-   * later test in the same process.
+   * EnvTrait::envReset() only reverses names recorded by envSet(). Code under
+   * test can call putenv() directly, and those values would otherwise be read
+   * by every later test in the same process.
    */
   protected function envRestore(): void {
     foreach (array_keys(getenv()) as $name) {

--- a/.vortex/installer/tests/Unit/Utils/EnvTest.php
+++ b/.vortex/installer/tests/Unit/Utils/EnvTest.php
@@ -15,30 +15,6 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 #[RunTestsInSeparateProcesses]
 class EnvTest extends UnitTestCase {
 
-  /**
-   * @var array
-   */
-  protected $backupServer;
-
-  /**
-   * @var array
-   */
-  protected $backupEnv;
-
-  protected function setUp(): void {
-    $this->backupEnv = $GLOBALS['_ENV'];
-    $this->backupServer = $GLOBALS['_SERVER'];
-
-    parent::setUp();
-  }
-
-  protected function tearDown(): void {
-    $GLOBALS['_ENV'] = $this->backupEnv;
-    $GLOBALS['_SERVER'] = $this->backupServer;
-
-    parent::tearDown();
-  }
-
   #[DataProvider('dataProviderGet')]
   public function testGet(string $name, string $value, ?string $default, ?string $expected): void {
     static::envSet($name, $expected);


### PR DESCRIPTION
Closes #3127

## Summary

`UnitTestCase::setUp()` (`.vortex/installer/tests/Unit/UnitTestCase.php`) now snapshots `getenv()`, `$_ENV` and `$_SERVER`, and a new `envRestore()` called from `tearDown()` unsets every name the test added, resets every name whose value it changed, and reassigns both superglobals.

`EnvTrait::envReset()` reverses only names recorded through `envSet()`, so when a functional test's `runNonInteractiveInstall()` drove `OptionsResolver::resolve()` into `Env::putFromDotenv()`, the raw `putenv()` that method issues for each variable in the installed project's `.env` went untracked; any later test in the same process whose handler called `Env::getFromDotenv()` then read `VORTEX_PROJECT=sut` ahead of its own fixture, and `machine_name`, `domain`, `module_prefix` and `theme` came back as `sut`.

`AbstractHandlerDiscoveryTestCase` and `AbstractHandlerProcessTestCase` now share one `UnitTestCase::envUnsetProjectVars()` covering the `VORTEX_`, `DRUPAL_` and `LAGOON_` prefixes plus `WEBROOT` and `TZ`, `EnvTest` drops its own `$_ENV`/`$_SERVER` backup as redundant, and `SelfTest` gains a `#[Depends]` pair proving a raw `putenv()` does not outlive the test that issued it; nothing under `src/` changes, and no fixture or snapshot is regenerated.

## Before / After

```
Before
──────

  functional test                        unit test (same PHP process)
  ───────────────                        ───────────────────────────
  Env::putFromDotenv()
    putenv('VORTEX_PROJECT=sut')  ───┐
                                     │  process env still holds 'sut'
  tearDown()                         │
    envReset()  ─ reverses only      │
                  envSet() names,    │
                  so 'sut' survives  │
                                     └─▶ Env::getFromDotenv('VORTEX_PROJECT')
                                           returns 'sut', not the fixture
                                           machine_name / domain /
                                           module_prefix / theme  ->  'sut'   ✗

After
─────

  functional test                        unit test (same PHP process)
  ───────────────                        ───────────────────────────
  setUp()
    snapshot getenv(), $_ENV, $_SERVER

  Env::putFromDotenv()
    putenv('VORTEX_PROJECT=sut')

  tearDown()
    envReset()
    envRestore()  ─ unsets added names,
                    resets changed ones,
                    so 'sut' is gone   ──▶ Env::getFromDotenv('VORTEX_PROJECT')
                                             reads the fixture's own .env       ✓
```

## Root cause

`.vortex/installer/phpunit.xml` sets `executionOrder="depends,defects"`. Defect ordering is driven by the PHPUnit result cache at `.phpunit.cache/test-results`, which `.vortex/installer/.gitignore:3` excludes from version control. CI checks out fresh with no cache, so the suite runs in declaration order, `tests/Unit` before `tests/Functional` in the `default` testsuite, and no functional test ever executes before a unit test. Locally the cache persists, so once any test is recorded as defective PHPUnit hoists it to the front and interleaves unit tests after functional ones, which is why the leak reproduced on a developer machine and never in CI.

The leak was never limited to `VORTEX_`. The template `.env` also defines `WEBROOT`, `TZ`, `DRUPAL_PROFILE`, `DRUPAL_THEME`, `DRUPAL_STAGE_FILE_PROXY_ORIGIN` and `LAGOON_PROJECT`, and handlers read every one of them through `Env::getFromDotenv()`. The four values that surfaced as failures were only the ones where the system under test differed from the fixture; the rest coincided and would have broken on the next fixture change.

## Changes

- `.vortex/installer/tests/Unit/UnitTestCase.php`: backs up `getenv()`, `$_ENV` and `$_SERVER` in `setUp()`; adds `envRestore()`, called from `tearDown()`, which unsets names added during the test, resets names whose value changed, and reassigns both superglobals; adds `envUnsetProjectVars()` stating once the variables a project `.env` can define.
- `.vortex/installer/tests/Unit/Prompts/Handlers/AbstractHandlerDiscoveryTestCase.php`: calls `envUnsetProjectVars()` in `setUp()`, so no discovery test can read a variable exported by the shell running the suite.
- `.vortex/installer/tests/Functional/Prompts/Handlers/AbstractHandlerProcessTestCase.php`: replaces its five inline `envUnsetPrefix()` and `envUnset()` calls with the shared `envUnsetProjectVars()`.
- `.vortex/installer/tests/Unit/Utils/EnvTest.php`: drops the `$backupEnv`/`$backupServer` fields and the `setUp()`/`tearDown()` pair that maintained them.
- `.vortex/installer/tests/Unit/SelfTest.php`: adds a `#[Depends]` pair (`testEnvRestore1WriteRawValues` / `testEnvRestore2VerifyRestored`) that writes with raw `putenv()`, mutates a variable seeded in `setUpBeforeClass()`, and asserts the added name is gone and the changed one restored; `setUpBeforeClass()` captures the seeded variable's prior value and `tearDownAfterClass()` puts it back, unsetting it only when it was originally absent.

## Verification

- Full installer suite: 1666 tests, 0 failures, with the result cache primed to the defect ordering that previously produced 221 failures.
- Full installer suite with the result cache cleared, so tests run in CI's declaration order: 1666 tests, 0 failures.
- `composer lint` in `.vortex/installer`: clean across phpcs, phpstan and rector.

## Screenshots

N/A
